### PR TITLE
perf(pharmacy): convert transfer_request.xhtml search composite to DTO pattern

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4678,6 +4678,12 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PharmacyTransferRequest: use lightweight DTO query (issue #21006 / #20299).
+        if (billType == BillType.PharmacyTransferRequest) {
+            pharmacyBillSearch.fetchTransferRequestSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4738,11 +4738,15 @@ public class PharmacyBillSearch implements Serializable {
         m.put("td", searchController.getToDate());
         m.put("dep", sessionController.getLoggedUser().getDepartment());
 
+        // 8-param constructor: (billId, deptId, createdAt, fromDepartmentName,
+        // creatorName, cancelled, cancelledAt, cancellerName).
+        // NULL literal for cancelledAt; '' for cancellerName — list view shows
+        // only the cancelled badge; full details available via View action.
         String sql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
                 + "b.id, b.deptId, b.createdAt, "
                 + "COALESCE(b.toDepartment.name, ''), "
                 + "COALESCE(creatorPerson.name, ''), "
-                + "b.cancelled) "
+                + "b.cancelled, NULL, '') "
                 + "FROM Bill b "
                 + "LEFT JOIN b.creater creater "
                 + "LEFT JOIN creater.webUserPerson creatorPerson "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -182,6 +182,7 @@ public class PharmacyBillSearch implements Serializable {
     // Bill id used when navigating directly from DTO tables
     private Long billId;
     private List<PharmacySaleSearchDTO> saleBillDtos;
+    private List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> transferRequestSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -4704,6 +4705,84 @@ public class PharmacyBillSearch implements Serializable {
     @Deprecated
     public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
         fetchSaleSearchDtosFromNativeBills(maxNum ? 25 : 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Transfer Request search DTO (issue #21006 / #20299)
+    // -----------------------------------------------------------------------
+
+    public List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> getTransferRequestSearchDtos() {
+        return transferRequestSearchDtos;
+    }
+
+    public void setTransferRequestSearchDtos(List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> transferRequestSearchDtos) {
+        this.transferRequestSearchDtos = transferRequestSearchDtos;
+    }
+
+    /**
+     * Fetches PharmacyTransferRequest bills as lightweight DTOs.
+     * <p>
+     * Uses COALESCE on the creator name (nullable LEFT JOIN) so that bills
+     * whose creator has no linked Person record are still included.
+     * Cancellation date and canceller details are intentionally omitted from
+     * the list view to avoid multi-hop nullable LEFT JOINs; users can open the
+     * bill via the View action to see full cancellation information.
+     *
+     * @param maxResult maximum rows to return; 0 or negative means unlimited
+     */
+    @SuppressWarnings("unchecked")
+    public void fetchTransferRequestSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyTransferRequest);
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        m.put("dep", sessionController.getLoggedUser().getDepartment());
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
+                + "b.id, b.deptId, b.createdAt, "
+                + "COALESCE(b.toDepartment.name, ''), "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "b.cancelled) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false";
+
+        if (searchController.getSearchKeyword().getBillNo() != null
+                && !searchController.getSearchKeyword().getBillNo().trim().isEmpty()) {
+            sql += " AND b.deptId LIKE :billNo";
+            m.put("billNo", "%" + searchController.getSearchKeyword().getBillNo().trim() + "%");
+        }
+        if (searchController.getSearchKeyword().getDepartment() != null
+                && !searchController.getSearchKeyword().getDepartment().trim().isEmpty()) {
+            sql += " AND b.toDepartment.name LIKE :toDep";
+            m.put("toDep", "%" + searchController.getSearchKeyword().getDepartment().trim() + "%");
+        }
+        if (searchController.getSearchKeyword().getNetTotal() != null
+                && !searchController.getSearchKeyword().getNetTotal().trim().isEmpty()) {
+            try {
+                sql += " AND b.netTotal = :netTotal";
+                m.put("netTotal", Double.parseDouble(searchController.getSearchKeyword().getNetTotal().trim()));
+            } catch (NumberFormatException e) {
+                // skip invalid input
+            }
+        }
+
+        sql += " ORDER BY b.createdAt DESC";
+
+        if (maxResult > 0) {
+            transferRequestSearchDtos = (List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            transferRequestSearchDtos = (List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (transferRequestSearchDtos == null) {
+            transferRequestSearchDtos = new ArrayList<>();
+        }
     }
 
 }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
@@ -134,34 +134,6 @@ public class PharmacyTransferRequestListDTO implements Serializable {
         this.cancellerName = "";
     }
 
-    /**
-     * Constructor for the pharmacy_search.xhtml transfer-request composite
-     * (issue #21006 / #20299). Includes the {@code cancelled} boolean flag so
-     * cancelled bills appear in the list with a badge, while avoiding nullable
-     * multi-hop LEFT JOINs through {@code cancelledBill.creater.webUserPerson}
-     * which would silently drop non-cancelled rows per JPQL behaviour.
-     *
-     * @param billId          bill primary key — used for navigation (ID-only pattern)
-     * @param deptId          department-scoped bill number
-     * @param createdAt       bill creation timestamp
-     * @param toDepartmentName name of the department the stock is requested for
-     * @param creatorName     name of the user who raised the request
-     * @param cancelled       whether the bill has been cancelled
-     */
-    public PharmacyTransferRequestListDTO(Long billId, String deptId, Date createdAt,
-            String toDepartmentName, String creatorName, Boolean cancelled) {
-        this.billId = billId;
-        this.deptId = deptId;
-        this.createdAt = createdAt;
-        this.fromDepartmentName = toDepartmentName; // stored in fromDepartmentName field
-        this.creatorName = creatorName != null ? creatorName : "";
-        this.cancelled = cancelled != null ? cancelled : false;
-        this.cancelledAt = null;
-        this.cancellerName = null;
-        this.completed = false;
-        this.fullyIssued = false;
-    }
-
     // ------------------------------------------------------------------
     // Getters & Setters
     // ------------------------------------------------------------------

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
@@ -123,7 +123,7 @@ public class PharmacyTransferRequestListDTO implements Serializable {
     // Basic constructor without cancellation details
     public PharmacyTransferRequestListDTO(Long billId, Object deptId, Date createdAt,
             Object fromDepartmentName, Object creatorName) {
-        
+
         this.billId = billId;
         this.deptId = deptId != null ? deptId.toString() : "";
         this.createdAt = createdAt;
@@ -132,6 +132,34 @@ public class PharmacyTransferRequestListDTO implements Serializable {
         this.cancelled = false;  // Default to not cancelled
         this.cancelledAt = null;
         this.cancellerName = "";
+    }
+
+    /**
+     * Constructor for the pharmacy_search.xhtml transfer-request composite
+     * (issue #21006 / #20299). Includes the {@code cancelled} boolean flag so
+     * cancelled bills appear in the list with a badge, while avoiding nullable
+     * multi-hop LEFT JOINs through {@code cancelledBill.creater.webUserPerson}
+     * which would silently drop non-cancelled rows per JPQL behaviour.
+     *
+     * @param billId          bill primary key — used for navigation (ID-only pattern)
+     * @param deptId          department-scoped bill number
+     * @param createdAt       bill creation timestamp
+     * @param toDepartmentName name of the department the stock is requested for
+     * @param creatorName     name of the user who raised the request
+     * @param cancelled       whether the bill has been cancelled
+     */
+    public PharmacyTransferRequestListDTO(Long billId, String deptId, Date createdAt,
+            String toDepartmentName, String creatorName, Boolean cancelled) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.fromDepartmentName = toDepartmentName; // stored in fromDepartmentName field
+        this.creatorName = creatorName != null ? creatorName : "";
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.cancelledAt = null;
+        this.cancellerName = null;
+        this.completed = false;
+        this.fullyIssued = false;
     }
 
     // ------------------------------------------------------------------

--- a/src/main/webapp/resources/pharmacy/search/transfer_request.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/transfer_request.xhtml
@@ -11,74 +11,89 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based transfer request search composite (issue #21006 / #20299).
+        Binds to pharmacyBillSearch.transferRequestSearchDtos
+        (List<PharmacyTransferRequestListDTO>) populated by
+        SearchController.createTableByBillType() when
+        billType == PharmacyTransferRequest.
+        COALESCE on creatorPerson.name prevents silent row drops.
+        Canceller details omitted from list view per DTO guidelines;
+        available via the View action.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="5">         
-            <h:outputLabel value="Req No"/>
+        <h:panelGrid columns="3" styleClass="mb-2">
+            <h:outputLabel value="Request No"/>
             <h:outputLabel value="To Department"/>
             <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.billNo}"/>
             <p:inputText autocomplete="off" value="#{searchController.searchKeyword.department}"/>
             <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
         </h:panelGrid>
-        <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.bills}" var="bill" >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         class="ui-button-success mb-2">
+            <p:dataExporter target="tblTransferRequest" type="xlsx" fileName="transfer_request_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblTransferRequest"
+                     widgetVar="tblTransferRequest"
+                     value="#{pharmacyBillSearch.transferRequestSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Transfer Requests Found">
+
             <f:facet name="header">
                 <h:outputLabel value="TRANSFER REQUEST"/>
             </f:facet>
 
-            <p:column headerText="Request No">                      
-                <h:commandLink action="pharmacy_reprint_transfer_request?faces-redirect=true" value="#{bill.deptId}">
-                    <h:outputLabel ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View Transfer Request"
+                    action="#{pharmacyBillSearch.navigateToViewPharmacyTransferRequestById()}">
+                    <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
+                </p:commandButton>
             </p:column>
 
-            
+            <p:column headerText="Request No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
+            </p:column>
 
-            <p:column headerText="From Department">                      
-                <h:outputLabel value="#{bill.toDepartment.name}"/>                          
-            </p:column> 
-            <p:column headerText="Requested At"  >
+            <p:column headerText="To Department"
+                      sortBy="#{dto.fromDepartmentName}"
+                      filterBy="#{dto.fromDepartmentName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.fromDepartmentName}"/>
+            </p:column>
 
-                <h:outputLabel value="#{bill.createdAt}" >
+            <p:column headerText="Requested At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                 </h:outputLabel>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" 
-                                   value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-
-            </p:column>                 
-            <p:column headerText="Requested By" >
-                <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
-                </h:outputLabel>                          
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>  
-
-            <p:column headerText="Net Value" filterBy="#{bill.netTotal}" style="text-align: right;"  >               
-                <h:outputLabel value="#{bill.netTotal}" >
-                    <f:convertNumber pattern="#,##0.00"/>
-                </h:outputLabel>                  
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
-                </h:outputLabel>
+            <p:column headerText="Requested By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
             </p:column>
+
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+            </p:column>
+
         </p:dataTable>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary
Converts the **PharmacyTransferRequest** composite panel in `pharmacy_search.xhtml` from a full `List<Bill>` entity load to a lightweight `PharmacyTransferRequestListDTO` JPQL constructor query. Sub-issue #21006, part of the pharmacy bill search DTO migration (#20299).

## Changes

### `PharmacyTransferRequestListDTO`
- Added new 6-param constructor `(billId, deptId, createdAt, toDepartmentName, creatorName, cancelled)`. Cancellation date and canceller name intentionally omitted — boolean `cancelled` flag sufficient for list display per DTO guidelines; users navigate to the bill for full details.

### `PharmacyBillSearch`
- Added `transferRequestSearchDtos` field (`List<PharmacyTransferRequestListDTO>`) with getter/setter.
- Added `fetchTransferRequestSearchDtos(int maxResult)`: JPQL constructor query with COALESCE on `creatorPerson.name` to prevent silent row drops from nullable LEFT JOIN.

### `SearchController.createTableByBillType()`
- Early-exit branch for `BillType.PharmacyTransferRequest` — calls `fetchTransferRequestSearchDtos(maxResult)` and returns; no entity query runs.

### `resources/pharmacy/search/transfer_request.xhtml`
- Switched to `#{pharmacyBillSearch.transferRequestSearchDtos}` (DTO, not entities).
- Navigation via `billId` (ID-only, entity loaded on demand).
- Cancelled status shown as `p:badge`.
- Fixed column label: was **"From Department"** but was actually showing `bill.toDepartment.name` — corrected to **"To Department"**.
- Item-name/code filters removed (were subqueries — no subqueries per DTO guidelines).
- Added Excel download via `p:dataExporter`.

Closes #21006
Part of #20299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pharmacy transfer request bill search with configurable filters (bill number, destination department, net total)
  * Added export search results to XLSX file capability for transfer requests
  * Simplified transfer request display showing request number, destination department, timestamp, and requester name

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->