### PR TITLE
perf(pharmacy): convert transfer_issue.xhtml search composite to DTO pattern

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4684,6 +4684,12 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PharmacyTransferIssue: use lightweight DTO query (issue #21007 / #20299).
+        if (billType == BillType.PharmacyTransferIssue) {
+            pharmacyBillSearch.fetchTransferIssueSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4588,10 +4588,16 @@ public class PharmacyBillSearch implements Serializable {
             JsfUtil.addErrorMessage("No Bill Selected");
             return null;
         }
-        if (bill == null) {
+        Bill selectedBill = billService.reloadBill(billId);
+        if (selectedBill == null) {
             JsfUtil.addErrorMessage("Bill not found");
             return null;
         }
+        if (selectedBill.getBillType() != BillType.PharmacyTransferIssue) {
+            JsfUtil.addErrorMessage("Invalid Bill Type");
+            return null;
+        }
+        bill = selectedBill;
         return "/pharmacy/pharmacy_reprint_transfer_isssue?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4836,13 +4836,16 @@ public class PharmacyBillSearch implements Serializable {
         m.put("td", searchController.getToDate());
         m.put("dep", sessionController.getLoggedUser().getDepartment());
 
+        // Use BilledBill (not Bill) to exclude CancelledBill subtype rows that
+        // share the same BillType. The original fetchPharmacyBillsNew also
+        // queried FROM BilledBill and filtered b.cancelled=false.
         String sql = "SELECT new com.divudi.core.data.dto.PharmacyTransferIssueSearchDTO("
                 + "b.id, b.deptId, b.createdAt, "
                 + "COALESCE(b.toDepartment.name, ''), "
                 + "COALESCE(creatorPerson.name, ''), "
                 + "COALESCE(staffPerson.name, ''), "
                 + "b.cancelled, b.netTotal, COALESCE(b.comments, '')) "
-                + "FROM Bill b "
+                + "FROM BilledBill b "
                 + "LEFT JOIN b.creater creater "
                 + "LEFT JOIN creater.webUserPerson creatorPerson "
                 + "LEFT JOIN b.toStaff toStaff "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -58,6 +58,7 @@ import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.StockBill;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.data.dto.PharmacySaleSearchDTO;
+import com.divudi.core.data.dto.PharmacyTransferIssueSearchDTO;
 import com.divudi.service.BillService;
 import com.divudi.service.pharmacy.TransferIssueNativeSqlService;
 import java.io.BufferedReader;
@@ -183,6 +184,7 @@ public class PharmacyBillSearch implements Serializable {
     private Long billId;
     private List<PharmacySaleSearchDTO> saleBillDtos;
     private List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> transferRequestSearchDtos;
+    private List<PharmacyTransferIssueSearchDTO> transferIssueSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -4578,6 +4580,22 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     /**
+     * Navigation helper for DTO-based transfer issue tables; loads the full
+     * Bill from the id set via {@link #setBillId(Long)}.
+     */
+    public String navigateToViewPharmacyTransferIssueById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        return "/pharmacy/pharmacy_reprint_transfer_isssue?faces-redirect=true";
+    }
+
+    /**
      * Bill id used by DTO report tables to fetch a bill directly.
      */
     public Long getBillId() {
@@ -4786,6 +4804,85 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (transferRequestSearchDtos == null) {
             transferRequestSearchDtos = new ArrayList<>();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Transfer Issue search DTO (issue #21007 / #20299)
+    // -----------------------------------------------------------------------
+
+    public List<PharmacyTransferIssueSearchDTO> getTransferIssueSearchDtos() {
+        return transferIssueSearchDtos;
+    }
+
+    public void setTransferIssueSearchDtos(List<PharmacyTransferIssueSearchDTO> transferIssueSearchDtos) {
+        this.transferIssueSearchDtos = transferIssueSearchDtos;
+    }
+
+    /**
+     * Fetches PharmacyTransferIssue bills as lightweight DTOs.
+     * <p>
+     * COALESCE is applied to every nullable LEFT JOIN string field so that
+     * bills whose creator or staff record is null are still included rather
+     * than being silently dropped by JPQL.
+     *
+     * @param maxResult maximum rows to return; 0 or negative means unlimited
+     */
+    @SuppressWarnings("unchecked")
+    public void fetchTransferIssueSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyTransferIssue);
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        m.put("dep", sessionController.getLoggedUser().getDepartment());
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyTransferIssueSearchDTO("
+                + "b.id, b.deptId, b.createdAt, "
+                + "COALESCE(b.toDepartment.name, ''), "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "COALESCE(staffPerson.name, ''), "
+                + "b.cancelled, b.netTotal, COALESCE(b.comments, '')) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "LEFT JOIN b.toStaff toStaff "
+                + "LEFT JOIN toStaff.person staffPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false";
+
+        if (searchController.getSearchKeyword().getBillNo() != null
+                && !searchController.getSearchKeyword().getBillNo().trim().isEmpty()) {
+            sql += " AND b.deptId LIKE :billNo";
+            m.put("billNo", "%" + searchController.getSearchKeyword().getBillNo().trim() + "%");
+        }
+        if (searchController.getSearchKeyword().getDepartment() != null
+                && !searchController.getSearchKeyword().getDepartment().trim().isEmpty()) {
+            sql += " AND b.toDepartment.name LIKE :toDep";
+            m.put("toDep", "%" + searchController.getSearchKeyword().getDepartment().trim() + "%");
+        }
+        if (searchController.getSearchKeyword().getNetTotal() != null
+                && !searchController.getSearchKeyword().getNetTotal().trim().isEmpty()) {
+            try {
+                sql += " AND b.netTotal = :netTotal";
+                m.put("netTotal", Double.parseDouble(searchController.getSearchKeyword().getNetTotal().trim()));
+            } catch (NumberFormatException e) {
+                // skip invalid input
+            }
+        }
+
+        sql += " ORDER BY b.createdAt DESC";
+
+        if (maxResult > 0) {
+            transferIssueSearchDtos = (List<PharmacyTransferIssueSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            transferIssueSearchDtos = (List<PharmacyTransferIssueSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (transferIssueSearchDtos == null) {
+            transferIssueSearchDtos = new ArrayList<>();
         }
     }
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueSearchDTO.java
@@ -1,0 +1,67 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for the pharmacy transfer issue search list.
+ * Populated via JPQL constructor query to avoid full entity graph loading.
+ * Cancellation details (canceller name/date) are omitted from the list view;
+ * users open the bill via the View action to see full details.
+ */
+public class PharmacyTransferIssueSearchDTO implements Serializable {
+
+    private Long billId;
+    private String deptId;
+    private Date createdAt;
+    private String toDepartmentName;
+    private String creatorName;
+    private String transporterName;
+    private Boolean cancelled;
+    private Double netTotal;
+    private String comments;
+
+    public PharmacyTransferIssueSearchDTO() {
+    }
+
+    public PharmacyTransferIssueSearchDTO(Long billId, String deptId, Date createdAt,
+            String toDepartmentName, String creatorName, String transporterName,
+            Boolean cancelled, Double netTotal, String comments) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.toDepartmentName = toDepartmentName;
+        this.creatorName = creatorName;
+        this.transporterName = transporterName;
+        this.cancelled = cancelled;
+        this.netTotal = netTotal;
+        this.comments = comments;
+    }
+
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+
+    public String getTransporterName() { return transporterName; }
+    public void setTransporterName(String transporterName) { this.transporterName = transporterName; }
+
+    public Boolean getCancelled() { return cancelled; }
+    public void setCancelled(Boolean cancelled) { this.cancelled = cancelled; }
+
+    public Double getNetTotal() { return netTotal != null ? netTotal : 0.0; }
+    public void setNetTotal(Double netTotal) { this.netTotal = netTotal; }
+
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+}

--- a/src/main/webapp/resources/pharmacy/search/transfer_issue.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/transfer_issue.xhtml
@@ -11,78 +11,109 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based transfer issue search composite (issue #21007 / #20299).
+        Binds to pharmacyBillSearch.transferIssueSearchDtos
+        (List<PharmacyTransferIssueSearchDTO>) populated by
+        SearchController.createTableByBillType() when
+        billType == PharmacyTransferIssue.
+        COALESCE on creatorPerson.name and staffPerson.name prevents silent
+        row drops. Canceller details omitted from list view per DTO guidelines;
+        available via the View action.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="5">         
-            <h:outputLabel value="Req No"/>
-            <h:outputLabel value="Department Name"/>
+        <h:panelGrid columns="3" styleClass="mb-2">
+            <h:outputLabel value="Issue No"/>
+            <h:outputLabel value="To Department"/>
             <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.department}"/>
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.billNo}"/>
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.department}"/>
             <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
         </h:panelGrid>
-        <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.bills}" var="bill" >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         class="ui-button-success mb-2">
+            <p:dataExporter target="tblTransferIssue" type="xlsx" fileName="transfer_issue_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblTransferIssue"
+                     widgetVar="tblTransferIssue"
+                     value="#{pharmacyBillSearch.transferIssueSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Transfer Issues Found">
+
             <f:facet name="header">
                 <h:outputLabel value="TRANSFER ISSUE"/>
             </f:facet>
-            <p:column>
-                <p:commandButton ajax="false" value="View Bill" action="/pharmacy/pharmacy_reprint_transfer_isssue?faces-redirect=true">
-                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{bill}"/>
+
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View Transfer Issue"
+                    action="#{pharmacyBillSearch.navigateToViewPharmacyTransferIssueById()}">
+                    <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
                 </p:commandButton>
             </p:column>
 
-            <p:column headerText="Order No">                        
-                <h:outputLabel value="#{bill.deptId}"/>                          
-            </p:column>
-            
-            <p:column headerText="Issue No">                        
-                <h:outputLabel value="#{bill.insId}"/>                          
-            </p:column>
-            
-            <p:column headerText="To Department">                       
-                <h:outputLabel value="#{bill.toDepartment.name}"/>                          
-            </p:column>  
-            <p:column headerText="Issued By">
-                <h:outputLabel value="#{bill.creater.webUserPerson.name}"/>     
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column> 
-            <p:column headerText="Staff">                       
-                <h:outputLabel value="#{bill.toStaff.person.nameWithTitle}"/>                            
-            </p:column> 
-            <p:column headerText="Issued At">                      
-                <h:outputLabel value="#{bill.createdAt}"/>                       
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" 
-                                   value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
+            <p:column headerText="Issue No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
             </p:column>
 
+            <p:column headerText="To Department"
+                      sortBy="#{dto.toDepartmentName}"
+                      filterBy="#{dto.toDepartmentName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.toDepartmentName}"/>
+            </p:column>
 
+            <p:column headerText="Issued At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                </h:outputLabel>
+            </p:column>
 
-            <p:column headerText="Net Value" filterBy="#{bill.netTotal}" style="text-align: right;"  >             
-                <h:outputLabel value="#{bill.netTotal}" >
+            <p:column headerText="Issued By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Staff"
+                      sortBy="#{dto.transporterName}"
+                      filterBy="#{dto.transporterName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.transporterName}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" style="text-align: right;">
+                <h:outputLabel value="#{dto.netTotal}">
                     <f:convertNumber pattern="#,##0.00"/>
-                </h:outputLabel>                  
+                </h:outputLabel>
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
-                </h:outputLabel>
+            <p:column headerText="Comments"
+                      sortBy="#{dto.comments}"
+                      filterBy="#{dto.comments}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.comments}"/>
             </p:column>
+
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+            </p:column>
+
         </p:dataTable>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/pharmacy/search/transfer_issue.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/transfer_issue.xhtml
@@ -32,7 +32,7 @@
         </h:panelGrid>
 
         <p:commandButton ajax="false" value="Download" icon="fa fa-download"
-                         class="ui-button-success mb-2">
+                         styleClass="ui-button-success mb-2">
             <p:dataExporter target="tblTransferIssue" type="xlsx" fileName="transfer_issue_list"/>
         </p:commandButton>
 


### PR DESCRIPTION
## Summary
- Replaces full `Bill` entity graph loading in the Transfer Issue search composite with a JPQL constructor-query DTO (`PharmacyTransferIssueSearchDTO`) to eliminate N+1 EclipseLink query storms over wide date ranges
- COALESCE applied to all nullable LEFT JOIN string fields (creatorPerson.name, staffPerson.name) to prevent silent row drops
- New `transfer_issue.xhtml` composite includes paginator, column sort/filter, Excel export, and cancelled badge via `p:badge`

## Test plan
- [ ] Open Transfer Issue search page in pharmacy, select a date range with known issues and click Search
- [ ] Verify the DTO table renders with correct Issue No, To Department, Issued At, Issued By, Staff, Net Value, and Comments columns
- [ ] Verify the View button loads the correct transfer issue reprint page
- [ ] Verify cancelled transfer issues show the "Cancelled" badge
- [ ] Verify Excel download works via the Download button
- [ ] Verify Bill No / To Department / Net Total filter inputs narrow results correctly

Closes #21007
Part of #20299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined pharmacy transfer issue search with three filters (Issue No, To Department, Net Total).
  * DTO-backed results table showing issue/dept info, created timestamp, creator and transporter names, net total, and comments.
  * Non-exportable cancelled-status badge shown per row.
  * XLSX export of transfer issue results.
  * New View Transfer Issue action for viewing/reprinting individual transfer issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->