### PR TITLE
perf(pharmacy): convert pre_bill.xhtml search composite to DTO pattern

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4696,6 +4696,12 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PharmacyPre: use lightweight DTO query (issue #21009 / #20299).
+        if (billType == BillType.PharmacyPre) {
+            pharmacyBillSearch.fetchPreBillSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4562,6 +4562,14 @@ public class SearchController implements Serializable {
             JsfUtil.addErrorMessage("Please Select Bill Type");
             return;
         }
+
+        // PharmacyPre atomics: redirect to DTO fetch so the pre_bill.xhtml composite
+        // (which binds to preBillSearchDtos) shows results from the atomic search path.
+        if (billTypeAtomic.getBillType() == BillType.PharmacyPre) {
+            pharmacyBillSearch.fetchPreBillSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4981,12 +4981,15 @@ public class PharmacyBillSearch implements Serializable {
         m.put("td", searchController.getToDate());
         m.put("dep", sessionController.getLoggedUser().getDepartment());
 
+        // LEFT JOIN referenceBill to avoid implicit INNER JOIN that would drop
+        // unsettled pre-bills (referenceBill is nullable on PharmacyPre bills).
         String sql = "SELECT new com.divudi.core.data.dto.PharmacyPreBillSearchDTO("
-                + "b.id, b.referenceBill.id, b.deptId, b.createdAt, "
+                + "b.id, refBill.id, b.deptId, b.createdAt, "
                 + "b.cancelled, cb.createdAt, "
                 + "COALESCE(creatorPerson.name, ''), COALESCE(cancellerPerson.name, ''), '', "
                 + "b.billTypeAtomic, b.paymentMethod, b.netTotal) "
                 + "FROM BilledBill b "
+                + "LEFT JOIN b.referenceBill refBill "
                 + "LEFT JOIN b.creater creater "
                 + "LEFT JOIN creater.webUserPerson creatorPerson "
                 + "LEFT JOIN b.cancelledBill cb "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -186,6 +186,7 @@ public class PharmacyBillSearch implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> transferRequestSearchDtos;
     private List<PharmacyTransferIssueSearchDTO> transferIssueSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyTransferReceivedListDTO> transferReceiveSearchDtos;
+    private List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO> preBillSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -4961,6 +4962,67 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (transferReceiveSearchDtos == null) {
             transferReceiveSearchDtos = new ArrayList<>();
+        }
+    }
+
+    public List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO> getPreBillSearchDtos() {
+        return preBillSearchDtos;
+    }
+
+    public void setPreBillSearchDtos(List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO> preBillSearchDtos) {
+        this.preBillSearchDtos = preBillSearchDtos;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void fetchPreBillSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyPre);
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        m.put("dep", sessionController.getLoggedUser().getDepartment());
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyPreBillSearchDTO("
+                + "b.id, b.referenceBill.id, b.deptId, b.createdAt, "
+                + "b.cancelled, cb.createdAt, "
+                + "COALESCE(creatorPerson.name, ''), COALESCE(cancellerPerson.name, ''), '', "
+                + "b.billTypeAtomic, b.paymentMethod, b.netTotal) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "LEFT JOIN b.cancelledBill cb "
+                + "LEFT JOIN cb.creater canceller "
+                + "LEFT JOIN canceller.webUserPerson cancellerPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false";
+
+        if (searchController.getSearchKeyword().getBillNo() != null
+                && !searchController.getSearchKeyword().getBillNo().trim().isEmpty()) {
+            sql += " AND b.deptId LIKE :billNo";
+            m.put("billNo", "%" + searchController.getSearchKeyword().getBillNo().trim() + "%");
+        }
+        if (searchController.getSearchKeyword().getNetTotal() != null
+                && !searchController.getSearchKeyword().getNetTotal().trim().isEmpty()) {
+            try {
+                sql += " AND b.netTotal = :netTotal";
+                m.put("netTotal", Double.parseDouble(searchController.getSearchKeyword().getNetTotal().trim()));
+            } catch (NumberFormatException e) {
+                // skip invalid input
+            }
+        }
+
+        sql += " ORDER BY b.createdAt DESC";
+
+        if (maxResult > 0) {
+            preBillSearchDtos = (List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            preBillSearchDtos = (List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (preBillSearchDtos == null) {
+            preBillSearchDtos = new ArrayList<>();
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4976,27 +4976,27 @@ public class PharmacyBillSearch implements Serializable {
     @SuppressWarnings("unchecked")
     public void fetchPreBillSearchDtos(int maxResult) {
         Map<String, Object> m = new HashMap<>();
-        m.put("bt", com.divudi.core.data.BillType.PharmacyPre);
         m.put("fd", searchController.getFromDate());
         m.put("td", searchController.getToDate());
         m.put("dep", sessionController.getLoggedUser().getDepartment());
 
-        // LEFT JOIN referenceBill to avoid implicit INNER JOIN that would drop
-        // unsettled pre-bills (referenceBill is nullable on PharmacyPre bills).
+        // Use PreBill (the actual JPA subtype for pharmacy pre-bills) rather than
+        // BilledBill; BilledBill has a different discriminator and returns zero rows
+        // for pre-bills. LEFT JOIN referenceBill to avoid an implicit INNER JOIN that
+        // would drop unsettled pre-bills (referenceBill is nullable).
         String sql = "SELECT new com.divudi.core.data.dto.PharmacyPreBillSearchDTO("
                 + "b.id, refBill.id, b.deptId, b.createdAt, "
                 + "b.cancelled, cb.createdAt, "
                 + "COALESCE(creatorPerson.name, ''), COALESCE(cancellerPerson.name, ''), '', "
                 + "b.billTypeAtomic, b.paymentMethod, b.netTotal) "
-                + "FROM BilledBill b "
+                + "FROM PreBill b "
                 + "LEFT JOIN b.referenceBill refBill "
                 + "LEFT JOIN b.creater creater "
                 + "LEFT JOIN creater.webUserPerson creatorPerson "
                 + "LEFT JOIN b.cancelledBill cb "
                 + "LEFT JOIN cb.creater canceller "
                 + "LEFT JOIN canceller.webUserPerson cancellerPerson "
-                + "WHERE b.billType = :bt "
-                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "WHERE b.createdAt BETWEEN :fd AND :td "
                 + "AND b.department = :dep "
                 + "AND b.retired = false";
 

--- a/src/main/webapp/resources/pharmacy/search/pre_bill.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/pre_bill.xhtml
@@ -11,125 +11,100 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based pre-bill search composite (issue #21009 / #20299).
+        Binds to pharmacyBillSearch.preBillSearchDtos
+        (List<PharmacyPreBillSearchDTO>) populated by
+        SearchController.createTableByBillType() when
+        billType == PharmacyPre.
+        COALESCE on creatorPerson.name prevents silent row drops.
+        Canceller details omitted from list view per DTO guidelines;
+        available via the View action.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="4">         
+        <h:panelGrid columns="2" styleClass="mb-2">
             <h:outputLabel value="Bill No"/>
             <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
+            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.billNo}"/>
             <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
         </h:panelGrid>
-        <p:dataTable 
-            id="tblBills"
-            rowIndexVar="i"  
-            value="#{searchController.bills}" 
-            var="bill"
-            paginator="true"
-            rows="10"
-            paginatorPosition="bottom"
-            paginatorTemplate="{FirstPageLink} {PreviousPageLink} {CurrentPageReport} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-            rowsPerPageTemplate="10,25,50,100" >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         styleClass="ui-button-success mb-2">
+            <p:dataExporter target="tblPreBill" type="xlsx" fileName="pre_bill_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblPreBill"
+                     widgetVar="tblPreBill"
+                     value="#{pharmacyBillSearch.preBillSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Pre Bills Found">
+
             <f:facet name="header">
                 <h:outputLabel value="PRE BILL SEARCH"/>
             </f:facet>
 
-            <p:column headerText="BILL NO"  >
-                <h:outputLabel value="#{bill.deptId}"/>
-            </p:column>    
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    value="Pre Bill"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-success ui-button-sm"
+                    title="View Pre Bill"
+                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.id)}"/>
+                <p:commandButton
+                    ajax="false"
+                    value="Paid Bill"
+                    icon="fa fa-check-circle"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View Paid Bill"
+                    rendered="#{dto.referenceBillId != null}"
+                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.referenceBillId)}"/>
+            </p:column>
 
-            <p:column headerText="Retired " >
-                <h:outputLabel value="#{bill.retired}"/>
-            </p:column>    
+            <p:column headerText="Bill No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
+            </p:column>
 
-            <p:column headerText="Billed At"  >
-                <h:outputLabel value="#{bill.createdAt}" >
+            <p:column headerText="Billed At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                 </h:outputLabel>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>                 
-            <p:column headerText="Billed By" >
-                <h:outputLabel value="#{bill.creater.webUserPerson.name}"/>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}"/>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.creater.webUserPerson.name}"/>
-                </h:panelGroup>
-            </p:column>       
-            <p:column headerText="Payment Method">
-                <h:outputLabel value="#{bill.paymentMethod}"/>
-            </p:column>                               
-            <p:column headerText="Net Value" style="text-align: right;" sortBy="#{bill.netTotal}" >
-                <h:outputLabel value="#{bill.netTotal}" >
+            </p:column>
+
+            <p:column headerText="Billed By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Payment Method"
+                      sortBy="#{dto.paymentMethod}"
+                      filterBy="#{dto.paymentMethod}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.paymentMethod}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" style="text-align: right;">
+                <h:outputLabel value="#{dto.netTotal}">
                     <f:convertNumber pattern="#,##0.00"/>
                 </h:outputLabel>
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
-                </h:outputLabel>
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
             </p:column>
 
-            <p:column id="colActions" headerText="Actions">
-                <div class="btn-group-vertical" role="group" style="width: 100%;">
-                    <p:commandButton 
-                        value="Pre Bill" 
-                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.id)}"
-                        styleClass="ui-button-success btn-sm"
-                        icon="fa fa-eye"
-                        style="margin-bottom: 2px;">
-                    </p:commandButton>
-                    
-                    <p:commandButton 
-                        value="Paid Bill" 
-                        rendered="#{bill.referenceBill ne null}"
-                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(bill.referenceBill.id)}"
-                        styleClass="ui-button-info btn-sm"
-                        icon="fa fa-check-circle"
-                        style="margin-bottom: 2px;">
-                    </p:commandButton>
-
-                    <p:commandButton 
-                        value="Cancelled" 
-                        action="pharmacy_reprint_bill_pre?faces-redirect=true" 
-                        styleClass="ui-button-danger btn-sm"
-                        icon="fa fa-times-circle"
-                        rendered="#{bill.cancelled}"
-                        style="margin-bottom: 2px;">
-                        <f:setPropertyActionListener value="#{bill.cancelledBill}" target="#{pharmacyBillSearch.bill}"/>
-                    </p:commandButton>
-
-                    <p:commandButton 
-                        value="Refunded" 
-                        action="pharmacy_reprint_bill_pre?faces-redirect=true" 
-                        styleClass="ui-button-warning btn-sm"
-                        icon="fa fa-undo"
-                        rendered="#{bill.refunded}"
-                        style="margin-bottom: 2px;">
-                        <f:setPropertyActionListener value="#{bill.refundedBill}" target="#{pharmacyBillSearch.bill}"/>
-                    </p:commandButton>
-                </div>
-            </p:column>
         </p:dataTable>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary

- Replaces full Bill entity loading in the PharmacyPre search table with a lightweight JPQL constructor-query DTO, eliminating N+1 EclipseLink query storms (sub-issue #21009 of #20299)
- fetchPreBillSearchDtos() uses FROM BilledBill with LEFT JOINs for creator and canceller; COALESCE on nullable name fields prevents silent row drops
- SearchController.createTableByBillType() dispatches PharmacyPre early to the DTO fetch method
- pre_bill.xhtml rewritten: DTO binding, paginator, per-column sort/filter, date/number format, cancelled badge, Pre Bill and Paid Bill action buttons, Excel download

## Test plan

- [ ] Pharmacy search, select Pre Bill type, search by date range — table loads correctly
- [ ] Bill No, Billed At, Billed By, Payment Method, Net Value columns populate correctly
- [ ] Cancelled bills show the red Cancelled badge
- [ ] Pre Bill button navigates to pre bill view page
- [ ] Paid Bill button appears only when referenceBillId is not null, navigates correctly
- [ ] Column filters work
- [ ] Excel download produces correct file

Closes #21009

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added export to download pre-bill search results as XLSX.

* **Improvements**
  * Simplified pre-bill search UI to focus on Bill Number and Net Total filters.
  * Faster, lighter pre-bill search for large result sets.
  * Streamlined results table with clearer columns, updated actions, and improved pagination/empty-state behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->