### PR TITLE
perf(pharmacy): convert po_request and po_approve search composites to DTO pattern

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4577,6 +4577,20 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PHARMACY_ORDER atomic: redirect to DTO fetch so po_request.xhtml composite
+        // (which binds to poRequestSearchDtos) shows results from the atomic search path.
+        if (billTypeAtomic == BillTypeAtomic.PHARMACY_ORDER) {
+            pharmacyBillSearch.fetchPoRequestSearchDtos(maxResult);
+            return;
+        }
+
+        // PHARMACY_ORDER_APPROVAL atomic: redirect to DTO fetch so po_approve.xhtml composite
+        // (which binds to poApproveSearchDtos) shows results from the atomic search path.
+        if (billTypeAtomic == BillTypeAtomic.PHARMACY_ORDER_APPROVAL) {
+            pharmacyBillSearch.fetchPoApproveSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 
@@ -4720,6 +4734,18 @@ public class SearchController implements Serializable {
         // PharmacyWholeSale: use lightweight DTO query (issue #21010 / #20299).
         if (billType == BillType.PharmacyWholeSale) {
             pharmacyBillSearch.fetchWholeSaleSearchDtos(maxResult);
+            return;
+        }
+
+        // PharmacyOrder (PO request): use lightweight DTO query (issue #21011 / #20299).
+        if (billType == BillType.PharmacyOrder) {
+            pharmacyBillSearch.fetchPoRequestSearchDtos(maxResult);
+            return;
+        }
+
+        // PharmacyOrderApprove (PO approval): use lightweight DTO query (issue #21011 / #20299).
+        if (billType == BillType.PharmacyOrderApprove) {
+            pharmacyBillSearch.fetchPoApproveSearchDtos(maxResult);
             return;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -188,6 +188,8 @@ public class PharmacyBillSearch implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyTransferReceivedListDTO> transferReceiveSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyPreBillSearchDTO> preBillSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyWholeSaleSearchDTO> wholeSaleSearchDtos;
+    private List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poRequestSearchDtos;
+    private List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poApproveSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -250,6 +252,20 @@ public class PharmacyBillSearch implements Serializable {
             return null;
         }
         return "/pharmacy/pharmacy_reprint_po?faces-redirect=true";
+    }
+
+    public String navigateToReprintPharmacyOrderRequestById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        Bill tb = billBean.fetchBillWithItemsAndFees(billId);
+        if (tb == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        bill = tb;
+        return "/pharmacy/pharmacy_reprint_order_request?faces-redirect=true";
     }
 
     public String navigateToImportBillsFromJson() {
@@ -5081,6 +5097,100 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (wholeSaleSearchDtos == null) {
             wholeSaleSearchDtos = new ArrayList<>();
+        }
+    }
+
+    public List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> getPoRequestSearchDtos() {
+        return poRequestSearchDtos;
+    }
+
+    public void setPoRequestSearchDtos(List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poRequestSearchDtos) {
+        this.poRequestSearchDtos = poRequestSearchDtos;
+    }
+
+    public void fetchPoRequestSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyOrder);
+        m.put("dep", sessionController.getDepartment());
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyPurchaseOrderDTO("
+                + "b.id, "
+                + "COALESCE(b.insId, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.createdAt, "
+                + "COALESCE(b.department.name, ''), "
+                + "COALESCE(b.toInstitution.name, ''), "
+                + "b.paymentMethod, "
+                + "b.cancelled, "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "b.netTotal) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false";
+        if (maxResult > 0) {
+            poRequestSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            poRequestSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (poRequestSearchDtos == null) {
+            poRequestSearchDtos = new ArrayList<>();
+        }
+    }
+
+    public List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> getPoApproveSearchDtos() {
+        return poApproveSearchDtos;
+    }
+
+    public void setPoApproveSearchDtos(List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poApproveSearchDtos) {
+        this.poApproveSearchDtos = poApproveSearchDtos;
+    }
+
+    public void fetchPoApproveSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyOrderApprove);
+        m.put("dep", sessionController.getDepartment());
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyPurchaseOrderDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "refBill.id, "
+                + "COALESCE(refBill.insId, ''), "
+                + "b.createdAt, "
+                + "COALESCE(b.department.name, ''), "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "COALESCE(b.toInstitution.name, ''), "
+                + "b.paymentMethod, "
+                + "b.cancelled, "
+                + "b.netTotal) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.referenceBill refBill "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false";
+        if (maxResult > 0) {
+            poApproveSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            poApproveSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (poApproveSearchDtos == null) {
+            poApproveSearchDtos = new ArrayList<>();
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -5131,7 +5131,8 @@ public class PharmacyBillSearch implements Serializable {
                 + "WHERE b.billType = :bt "
                 + "AND b.createdAt BETWEEN :fd AND :td "
                 + "AND b.department = :dep "
-                + "AND b.retired = false";
+                + "AND b.retired = false "
+                + "ORDER BY b.createdAt DESC";
         if (maxResult > 0) {
             poRequestSearchDtos =
                     (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)
@@ -5179,7 +5180,8 @@ public class PharmacyBillSearch implements Serializable {
                 + "WHERE b.billType = :bt "
                 + "AND b.createdAt BETWEEN :fd AND :td "
                 + "AND b.department = :dep "
-                + "AND b.retired = false";
+                + "AND b.retired = false "
+                + "ORDER BY b.createdAt DESC";
         if (maxResult > 0) {
             poApproveSearchDtos =
                     (List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO>)

--- a/src/main/java/com/divudi/core/data/dto/PharmacyPurchaseOrderDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyPurchaseOrderDTO.java
@@ -240,6 +240,61 @@ public class PharmacyPurchaseOrderDTO implements Serializable {
         this.checkedByName = checkedByName != null ? checkedByName.toString() : null;
     }
 
+    // Constructor for PO request search list (issue #21011 / #20299)
+    // Fields: billId, insId (req number), deptId, createdAt, departmentName, supplierName,
+    //         paymentMethod, cancelled, creatorName, netTotal
+    public PharmacyPurchaseOrderDTO(
+            Long billId,
+            String insId,
+            String deptId,
+            Date createdAt,
+            String departmentName,
+            String supplierName,
+            Object paymentMethod,
+            Boolean cancelled,
+            String creatorName,
+            Double netTotal) {
+        this.billId = billId;
+        this.billNumber = insId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.departmentName = departmentName;
+        this.supplierName = supplierName;
+        this.paymentMethod = paymentMethod != null ? paymentMethod.toString() : null;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.creatorName = creatorName;
+        this.netTotal = netTotal;
+    }
+
+    // Constructor for PO approval search list (issue #21011 / #20299)
+    // Fields: billId, deptId, referenceBillId, referenceBillDeptId, createdAt,
+    //         departmentName, approverName, supplierName, paymentMethod, cancelled, netTotal
+    public PharmacyPurchaseOrderDTO(
+            Long billId,
+            String deptId,
+            Long referenceBillId,
+            String referenceBillDeptId,
+            Date createdAt,
+            String departmentName,
+            String approverName,
+            String supplierName,
+            Object paymentMethod,
+            Boolean cancelled,
+            Double netTotal) {
+        this.billId = billId;
+        this.billNumber = deptId;
+        this.deptId = deptId;
+        this.referenceBillId = referenceBillId;
+        this.referenceBillDeptId = referenceBillDeptId;
+        this.createdAt = createdAt;
+        this.departmentName = departmentName;
+        this.approverName = approverName;
+        this.supplierName = supplierName;
+        this.paymentMethod = paymentMethod != null ? paymentMethod.toString() : null;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.netTotal = netTotal;
+    }
+
     // Constructor for pending purchase orders (to finalize) - 10 parameters without checkedBy fields
     // Used for fillOnlySavedPharmacyPo() JPQL query
     public PharmacyPurchaseOrderDTO(

--- a/src/main/webapp/resources/pharmacy/search/po_approve.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/po_approve.xhtml
@@ -11,96 +11,120 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based PO approval search composite (issue #21011 / #20299).
+        Binds to pharmacyBillSearch.poApproveSearchDtos
+        (List<PharmacyPurchaseOrderDTO>) populated by
+        SearchController.createTableByBillType() when billType == PharmacyOrderApprove,
+        and by SearchController.processPharmacyBillSearch() for
+        PHARMACY_ORDER_APPROVAL atomic searches.
+        LEFT JOIN on referenceBill and creater prevents silent row drops.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="6">         
-            <h:outputLabel value="Po No"/> 
-            <h:outputLabel value="Requested No"/>  
-            <h:outputLabel value="Supplier Name"/>
-            <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.refBillNo}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.toInstitution}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
-        </h:panelGrid>
-        <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.bills}" var="bill"  >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         styleClass="ui-button-success mb-2">
+            <p:dataExporter target="tblPoApprove" type="xlsx" fileName="po_approval_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblPoApprove"
+                     widgetVar="tblPoApprove"
+                     value="#{pharmacyBillSearch.poApproveSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Purchase Order Approvals Found">
+
             <f:facet name="header">
                 <h:outputLabel value="PURCHASE ORDER APPROVED"/>
             </f:facet>
 
-            <p:column headerText="PO NO"  >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_po?faces-redirect=true" value="#{bill.deptId}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>
-            <p:column headerText="Requested No"  >
-                <h:commandLink action="/pharmacy/pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.referenceBill.deptId}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>            
-            <p:column headerText="Requested From" > 
-                    <h:outputLabel value="#{bill.department.name}" ></h:outputLabel>
-            </p:column>   
-            <p:column headerText="Requested Person" >
-                    <h:outputLabel value="#{bill.referenceBill.creater.webUserPerson.name}" ></h:outputLabel>
-            </p:column>
-            <p:column headerText="Delaor Name" >
-                    <h:outputLabel value="#{bill.toInstitution.name}" ></h:outputLabel>
-            </p:column>
-            <p:column headerText="Billed At"  >
-                    <h:outputLabel value="#{bill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>                 
-            <p:column headerText="Approved By" >
-                    <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
-                    </h:outputLabel>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.creater.webUserPerson.name}" >
-
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>        
-            <p:column headerText="Payment Method">
-                    <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
-            </p:column>                               
-            <p:column headerText="Net Value" >
-                    <h:outputLabel value="#{bill.netTotal}" >
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
+            <!-- PO view action (not exported) -->
+            <p:column headerText="PO" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View PO Approval"
+                    action="#{pharmacyBillSearch.navigateToReprintPharmacyPurchaseOrderFromDto()}">
+                    <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
+                </p:commandButton>
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
+            <!-- Request view action (not exported) -->
+            <p:column headerText="Request" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-file-text-o"
+                    styleClass="ui-button-secondary ui-button-sm"
+                    title="View PO Request"
+                    rendered="#{dto.referenceBillId ne null}"
+                    action="#{pharmacyBillSearch.navigateToReprintPharmacyOrderRequestById()}">
+                    <f:setPropertyActionListener value="#{dto.referenceBillId}" target="#{pharmacyBillSearch.billId}"/>
+                </p:commandButton>
+            </p:column>
+
+            <p:column headerText="PO No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
+            </p:column>
+
+            <p:column headerText="Request No"
+                      sortBy="#{dto.referenceBillDeptId}"
+                      filterBy="#{dto.referenceBillDeptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.referenceBillDeptId}"/>
+            </p:column>
+
+            <p:column headerText="Requested From"
+                      sortBy="#{dto.departmentName}"
+                      filterBy="#{dto.departmentName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.departmentName}"/>
+            </p:column>
+
+            <p:column headerText="Dealer Name"
+                      sortBy="#{dto.supplierName}"
+                      filterBy="#{dto.supplierName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.supplierName}"/>
+            </p:column>
+
+            <p:column headerText="Billed At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                 </h:outputLabel>
             </p:column>
+
+            <p:column headerText="Approved By"
+                      sortBy="#{dto.approverName}"
+                      filterBy="#{dto.approverName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.approverName}"/>
+            </p:column>
+
+            <p:column headerText="Payment Method"
+                      sortBy="#{dto.paymentMethod}"
+                      filterBy="#{dto.paymentMethod}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.paymentMethod}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" sortBy="#{dto.netTotal}" style="text-align:right;">
+                <h:outputLabel value="#{dto.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+            </p:column>
+
         </p:dataTable>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/pharmacy/search/po_request.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/po_request.xhtml
@@ -11,106 +11,100 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based PO request search composite (issue #21011 / #20299).
+        Binds to pharmacyBillSearch.poRequestSearchDtos
+        (List<PharmacyPurchaseOrderDTO>) populated by
+        SearchController.createTableByBillType() when billType == PharmacyOrder,
+        and by SearchController.processPharmacyBillSearch() for
+        PHARMACY_ORDER atomic searches.
+        COALESCE on person names and nullable fields prevents silent row drops.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="5">         
-            <h:outputLabel value="Req No"/>
-            <h:outputLabel value="Supplier Name"/>
-            <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.requestNo}" />
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.toInstitution}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
-        </h:panelGrid>
-        <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.bills}" var="bill" >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         styleClass="ui-button-success mb-2">
+            <p:dataExporter target="tblPoRequest" type="xlsx" fileName="po_request_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblPoRequest"
+                     widgetVar="tblPoRequest"
+                     value="#{pharmacyBillSearch.poRequestSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Purchase Order Requests Found">
+
             <f:facet name="header">
                 <h:outputLabel value="PURCHASE ORDER REQUEST"/>
             </f:facet>
-            
-            <p:column headerText="Req No" >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.insId}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
+
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View PO Request"
+                    action="#{pharmacyBillSearch.navigateToReprintPharmacyOrderRequestById()}">
+                    <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
+                </p:commandButton>
             </p:column>
 
-            
-            <p:column headerText="Requested From"  >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.department.name}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>                 
-            <p:column headerText="Delaor Name"  >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" value="#{bill.toInstitution.name}">
-                    <h:outputLabel  ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>
-            <p:column headerText="Billed At"  >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.createdAt}" >
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.createdAt}" >
-                        <f:convertDateTime pattern="dd MMM yyyy hh mm a"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>                 
-            <p:column headerText="Requested By" >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.creater.webUserPerson.name}" >                                      
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{bill.refunded}" >
-                    <h:outputLabel style="color: red;" value="Refunded By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.refunded}" value="#{bill.refundedBill.creater.webUserPerson.name}" >
-
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>                       
-
-            <p:column headerText="Payment Method">
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.paymentMethod}" ></h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
-            </p:column>                               
-            <p:column headerText="Net Value" filterBy="#{bill.netTotal}" style="text-align: right;"  >
-                <h:commandLink action="pharmacy_reprint_order_request?faces-redirect=true" >
-                    <h:outputLabel value="#{bill.netTotal}" >
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputLabel>
-                    <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}"/>
-                </h:commandLink>
+            <p:column headerText="Req No"
+                      sortBy="#{dto.billNumber}"
+                      filterBy="#{dto.billNumber}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.billNumber}"/>
             </p:column>
 
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
+            <p:column headerText="Requested From"
+                      sortBy="#{dto.departmentName}"
+                      filterBy="#{dto.departmentName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.departmentName}"/>
+            </p:column>
+
+            <p:column headerText="Dealer Name"
+                      sortBy="#{dto.supplierName}"
+                      filterBy="#{dto.supplierName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.supplierName}"/>
+            </p:column>
+
+            <p:column headerText="Billed At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                 </h:outputLabel>
             </p:column>
+
+            <p:column headerText="Requested By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Payment Method"
+                      sortBy="#{dto.paymentMethod}"
+                      filterBy="#{dto.paymentMethod}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.paymentMethod}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" sortBy="#{dto.netTotal}" style="text-align:right;">
+                <h:outputLabel value="#{dto.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Status" exportable="false">
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+            </p:column>
+
         </p:dataTable>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary
- Replaces full `Bill` entity loading in `po_request.xhtml` and `po_approve.xhtml` with JPQL constructor queries returning `PharmacyPurchaseOrderDTO`, eliminating N+1 lazy-load storms across PO search date ranges
- Adds two new constructors to `PharmacyPurchaseOrderDTO` (existing constructors untouched per project rules)
- `po_approve.xhtml` gains a second action button to navigate directly to the linked PO request bill without loading the full entity graph
- Wires early-exit dispatch in `SearchController` for both `createTableByBillType()` and `processPharmacyBillSearch()` for all PO bill types / atomics

## Test plan
- [ ] Search PO requests via pharmacy search page — table populates with Req No, Dept, Dealer, date, requester, payment method, net value
- [ ] View button on po_request row navigates to `pharmacy_reprint_order_request`
- [ ] Search PO approvals — table shows PO No, Request No (from reference bill), Dept, Dealer, date, approver, payment method, net value
- [ ] View PO button navigates to `pharmacy_reprint_po`; View Request button navigates to `pharmacy_reprint_order_request`
- [ ] Excel download works on both composites
- [ ] Cancelled badge renders correctly on cancelled bills
- [ ] Search via atomic search path (PHARMACY_ORDER / PHARMACY_ORDER_APPROVAL) also routes to DTO composites

Closes #21011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Excel/XLSX download for pharmacy order request and approval search results
  * Direct reprint action for pharmacy order requests by bill ID
  * New PO Request and PO Approval view actions from search results

* **Improvements**
  * Redesigned pharmacy order request/approval search tables with streamlined columns and status badges
  * Cleaner, more focused search results and faster list-backed navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->