### PR TITLE
perf(pharmacy): convert purchase.xhtml search composite to DTO pattern

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4598,6 +4598,13 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PHARMACY_DIRECT_PURCHASE atomics: redirect to DTO fetch so purchase.xhtml
+        // composite (which binds to purchaseSearchDtos) shows results from the atomic search path.
+        if (billTypeAtomic.getBillType() == BillType.PharmacyPurchaseBill) {
+            pharmacyBillSearch.fetchPurchaseSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 
@@ -4759,6 +4766,12 @@ public class SearchController implements Serializable {
         // PharmacyGrnBill: use lightweight DTO query (issue #21012 / #20299).
         if (billType == BillType.PharmacyGrnBill) {
             pharmacyBillSearch.fetchGrnSearchDtos(maxResult);
+            return;
+        }
+
+        // PharmacyPurchaseBill: use lightweight DTO query (issue #21013 / #20299).
+        if (billType == BillType.PharmacyPurchaseBill) {
+            pharmacyBillSearch.fetchPurchaseSearchDtos(maxResult);
             return;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -191,6 +191,7 @@ public class PharmacyBillSearch implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poRequestSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyPurchaseOrderDTO> poApproveSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyGrnSearchDTO> grnSearchDtos;
+    private List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO> purchaseSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -320,6 +321,23 @@ public class PharmacyBillSearch implements Serializable {
             return "/pharmacy/pharmacy_reprint_grn_with_costing?faces-redirect=true";
         }
         return "/pharmacy/pharmacy_reprint_grn?faces-redirect=true";
+    }
+
+    public String navigateToPharmacyPurchaseReprintById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        Bill tb = billBean.fetchBillWithItemsAndFees(billId);
+        if (tb == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        bill = tb;
+        if (tb.getBillType() == com.divudi.core.data.BillType.PurchaseReturn) {
+            return "/pharmacy/pharmacy_reprint_purchase_return?faces-redirect=true";
+        }
+        return "/pharmacy/pharmacy_reprint_purchase?faces-redirect=true";
     }
 
     /**
@@ -5261,6 +5279,77 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (grnSearchDtos == null) {
             grnSearchDtos = new ArrayList<>();
+        }
+    }
+
+    public List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO> getPurchaseSearchDtos() {
+        return purchaseSearchDtos;
+    }
+
+    public void setPurchaseSearchDtos(List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO> purchaseSearchDtos) {
+        this.purchaseSearchDtos = purchaseSearchDtos;
+    }
+
+    /**
+     * Fetches PharmacyPurchaseBill bills as lightweight DTOs (issue #21013 / #20299).
+     * LEFT JOINs on cancelledBill and refundedBill capture cancel/refund metadata
+     * without triggering N+1 lazy loads.
+     *
+     * @param maxResult maximum rows to return; 0 or negative means unlimited
+     */
+    @SuppressWarnings("unchecked")
+    public void fetchPurchaseSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyPurchaseBill);
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        m.put("dep", sessionController.getLoggedUser().getDepartment());
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "COALESCE(b.invoiceNumber, ''), "
+                + "b.invoiceDate, "
+                + "b.createdAt, "
+                + "COALESCE(creatorPerson.name, ''), "
+                + "COALESCE(b.fromInstitution.name, ''), "
+                + "b.paymentMethod, "
+                + "b.netTotal, "
+                + "b.saleValue, "
+                + "b.cancelled, "
+                + "cb.createdAt, "
+                + "COALESCE(cancellerPerson.name, ''), "
+                + "COALESCE(cb.comments, ''), "
+                + "b.refunded, "
+                + "rb.createdAt, "
+                + "COALESCE(refunderPerson.name, ''), "
+                + "COALESCE(rb.comments, '')) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson creatorPerson "
+                + "LEFT JOIN b.cancelledBill cb "
+                + "LEFT JOIN cb.creater canceller "
+                + "LEFT JOIN canceller.webUserPerson cancellerPerson "
+                + "LEFT JOIN b.refundedBill rb "
+                + "LEFT JOIN rb.creater refunder "
+                + "LEFT JOIN refunder.webUserPerson refunderPerson "
+                + "WHERE b.billType = :bt "
+                + "AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep "
+                + "AND b.retired = false "
+                + "ORDER BY b.createdAt DESC";
+
+        if (maxResult > 0) {
+            purchaseSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            purchaseSearchDtos =
+                    (List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (purchaseSearchDtos == null) {
+            purchaseSearchDtos = new ArrayList<>();
         }
     }
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyDirectPurchaseSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyDirectPurchaseSearchDTO.java
@@ -1,0 +1,128 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for pharmacy direct purchase bill search (issue #21013 / #20299).
+ * Eliminates N+1 lazy-load storms from the old Bill-entity approach.
+ */
+public class PharmacyDirectPurchaseSearchDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String deptId;
+    private String invoiceNumber;
+    private Date invoiceDate;
+    private Date createdAt;
+    private String creatorName;
+    private String fromInstitutionName;
+    private String paymentMethod;
+    private Double netTotal;
+    private Double saleValue;
+    private boolean cancelled;
+    private Date cancelledAt;
+    private String cancelledBy;
+    private String cancelComments;
+    private boolean refunded;
+    private Date refundedAt;
+    private String refundedBy;
+    private String refundComments;
+
+    public PharmacyDirectPurchaseSearchDTO() {
+    }
+
+    public PharmacyDirectPurchaseSearchDTO(
+            Long id,
+            String deptId,
+            String invoiceNumber,
+            Date invoiceDate,
+            Date createdAt,
+            String creatorName,
+            String fromInstitutionName,
+            Object paymentMethod,
+            Double netTotal,
+            Double saleValue,
+            Boolean cancelled,
+            Date cancelledAt,
+            String cancelledBy,
+            String cancelComments,
+            Boolean refunded,
+            Date refundedAt,
+            String refundedBy,
+            String refundComments) {
+        this.id = id;
+        this.deptId = deptId;
+        this.invoiceNumber = invoiceNumber;
+        this.invoiceDate = invoiceDate;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.fromInstitutionName = fromInstitutionName;
+        this.paymentMethod = paymentMethod != null ? paymentMethod.toString() : null;
+        this.netTotal = netTotal;
+        this.saleValue = saleValue;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.cancelledAt = cancelledAt;
+        this.cancelledBy = cancelledBy;
+        this.cancelComments = cancelComments;
+        this.refunded = refunded != null ? refunded : false;
+        this.refundedAt = refundedAt;
+        this.refundedBy = refundedBy;
+        this.refundComments = refundComments;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+
+    public Date getInvoiceDate() { return invoiceDate; }
+    public void setInvoiceDate(Date invoiceDate) { this.invoiceDate = invoiceDate; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+
+    public String getFromInstitutionName() { return fromInstitutionName; }
+    public void setFromInstitutionName(String fromInstitutionName) { this.fromInstitutionName = fromInstitutionName; }
+
+    public String getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(String paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public Double getNetTotal() { return netTotal; }
+    public void setNetTotal(Double netTotal) { this.netTotal = netTotal; }
+
+    public Double getSaleValue() { return saleValue; }
+    public void setSaleValue(Double saleValue) { this.saleValue = saleValue; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+
+    public Date getCancelledAt() { return cancelledAt; }
+    public void setCancelledAt(Date cancelledAt) { this.cancelledAt = cancelledAt; }
+
+    public String getCancelledBy() { return cancelledBy; }
+    public void setCancelledBy(String cancelledBy) { this.cancelledBy = cancelledBy; }
+
+    public String getCancelComments() { return cancelComments; }
+    public void setCancelComments(String cancelComments) { this.cancelComments = cancelComments; }
+
+    public boolean isRefunded() { return refunded; }
+    public void setRefunded(boolean refunded) { this.refunded = refunded; }
+
+    public Date getRefundedAt() { return refundedAt; }
+    public void setRefundedAt(Date refundedAt) { this.refundedAt = refundedAt; }
+
+    public String getRefundedBy() { return refundedBy; }
+    public void setRefundedBy(String refundedBy) { this.refundedBy = refundedBy; }
+
+    public String getRefundComments() { return refundComments; }
+    public void setRefundComments(String refundComments) { this.refundComments = refundComments; }
+}

--- a/src/main/webapp/resources/pharmacy/search/purchase.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/purchase.xhtml
@@ -11,151 +11,141 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based direct purchase search composite (issue #21013 / #20299).
+        Binds to pharmacyBillSearch.purchaseSearchDtos
+        (List<PharmacyDirectPurchaseSearchDTO>) populated by
+        SearchController.createTableByBillType() when billType == PharmacyPurchaseBill,
+        and by SearchController.processPharmacyBillSearch() for all
+        PharmacyPurchaseBill atomics.
+        LEFT JOIN on cancelledBill and refundedBill prevents silent row drops
+        and captures cancel/refund metadata without N+1 lazy loads.
+    -->
     <cc:implementation>
-        <p:panel>
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         styleClass="ui-button-success mb-2">
+            <p:dataExporter target="tblPurchase" type="xlsx" fileName="purchase_bill_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblPurchase"
+                     widgetVar="tblPurchase"
+                     value="#{pharmacyBillSearch.purchaseSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Purchase Bills Found">
+
             <f:facet name="header">
-                <div class="d-flex justify-content-between">
-                    <h:outputText value="Pharmacy Direct Purchase Bill Search" class="mt-2"/>
-                    <p:commandButton 
-                        class="ui-button-success"
-                        ajax="false" 
-                        icon="pi pi-download"
-                        style="width: 12em;"
-                        value="Download" >
-                        <p:dataExporter target="tbl" type="xlsx" fileName="Pharmacy_Purchase_Bill_List" ></p:dataExporter>
-                    </p:commandButton>
-                </div>
+                <h:outputLabel value="PHARMACY DIRECT PURCHASE BILLS"/>
             </f:facet>
 
-            <p:panelGrid 
-                id="gridDirectPurchaseFilters" 
-                columns="5" 
-                layout="tabular"
-                styleClass="w-100">
-                <h:panelGroup>
-                    <h:outputLabel value="Bill No" styleClass="w-100"/>
-                    <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" styleClass="w-100"/>
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View Bill"
+                    action="#{pharmacyBillSearch.navigateToPharmacyPurchaseReprintById()}">
+                    <f:setPropertyActionListener value="#{dto.id}" target="#{pharmacyBillSearch.billId}"/>
+                </p:commandButton>
+            </p:column>
+
+            <p:column headerText="Bill No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
+            </p:column>
+
+            <p:column headerText="Invoice No"
+                      sortBy="#{dto.invoiceNumber}"
+                      filterBy="#{dto.invoiceNumber}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.invoiceNumber}"/>
+            </p:column>
+
+            <p:column headerText="Invoice Date" sortBy="#{dto.invoiceDate}">
+                <h:outputLabel value="#{dto.invoiceDate}">
+                    <f:convertDateTime timeZone="Asia/Colombo"
+                                       pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Billed At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime timeZone="Asia/Colombo"
+                                       pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Billed By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Supplier"
+                      sortBy="#{dto.fromInstitutionName}"
+                      filterBy="#{dto.fromInstitutionName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.fromInstitutionName}"/>
+            </p:column>
+
+            <p:column headerText="Payment Method"
+                      sortBy="#{dto.paymentMethod}"
+                      filterBy="#{dto.paymentMethod}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.paymentMethod}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" sortBy="#{dto.netTotal}" style="text-align:right;">
+                <h:outputLabel value="#{dto.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Sale Value" sortBy="#{dto.saleValue}" style="text-align:right;">
+                <h:outputLabel value="#{dto.saleValue}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Status">
+                <h:outputText value="Cancelled" rendered="#{dto.cancelled}" style="display:none;"/>
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+                <h:outputText value="Refunded" rendered="#{dto.refunded}" style="display:none;"/>
+                <p:badge value="Refunded" severity="warning" rendered="#{dto.refunded}"/>
+            </p:column>
+
+            <p:column headerText="Cancel / Refund Details">
+                <h:panelGroup rendered="#{dto.cancelled}">
+                    <h:outputText style="color:red;" value="Cancelled At: "/>
+                    <h:outputText style="color:red;" value="#{dto.cancelledAt}">
+                        <f:convertDateTime timeZone="Asia/Colombo"
+                                           pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                    </h:outputText>
+                    <h:outputText style="color:red;" value=" By: #{dto.cancelledBy}"/>
+                    <h:outputText rendered="#{not empty dto.cancelComments}"
+                                  style="color:red;" value=" | #{dto.cancelComments}"/>
                 </h:panelGroup>
-                <h:panelGroup>
-                    <h:outputLabel value="Net Total" styleClass="w-100"/>
-                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}" styleClass="w-100"/>
+                <h:panelGroup rendered="#{dto.refunded}">
+                    <h:outputText style="color:orange;" value="Refunded At: "/>
+                    <h:outputText style="color:orange;" value="#{dto.refundedAt}">
+                        <f:convertDateTime timeZone="Asia/Colombo"
+                                           pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                    </h:outputText>
+                    <h:outputText style="color:orange;" value=" By: #{dto.refundedBy}"/>
+                    <h:outputText rendered="#{not empty dto.refundComments}"
+                                  style="color:orange;" value=" | #{dto.refundComments}"/>
                 </h:panelGroup>
-                <h:panelGroup>
-                    <h:outputLabel value="Item Name" styleClass="w-100"/>
-                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}" styleClass="w-100"/>
-                </h:panelGroup>
-                <h:panelGroup>
-                    <h:outputLabel value="Item Code" styleClass="w-100"/>
-                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}" styleClass="w-100"/>
-                </h:panelGroup>
-                <h:panelGroup>
-                    <h:outputLabel value="Supplier Name" styleClass="w-100"/>
-                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.fromInstitution}" styleClass="w-100"/>
-                </h:panelGroup>
-            </p:panelGrid>
+            </p:column>
 
-            <p:dataTable 
-                rowIndexVar="i" 
-                id="tbl"  
-                widgetVar="tbl"
-                class="mt-3"
-                value="#{searchController.bills}" 
-                var="bill" 
-                paginator="true"
-                rows="10"
-                paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                rowsPerPageTemplate="10,20,50,100"
-                emptyMessage="No Bills Found"
-                filteredValue="#{searchController.filteredBills}">
-                <p:column headerText="#"  style="padding: 8px; width:2em;">
-                    <h:outputText  value="#{i+1}" ></h:outputText>
-                </p:column>
-
-                <p:column headerText="Bill No" style="padding: 8px;" sortBy="#{bill.deptId}" filterBy="#{bill.deptId}" filterMatchMode="contains">
-                    <h:outputText value="#{bill.deptId}">
-                    </h:outputText>
-                </p:column> 
-
-                <p:column headerText="Invoice No" filterBy="#{bill.invoiceNumber}" filterMatchMode="contains"  style="padding: 8px; width:8em;" sortBy="#{bill.invoiceNumber}">
-                    <h:outputText  value="#{bill.invoiceNumber}" ></h:outputText>
-                </p:column>  
-
-                <p:column headerText="Invoice Date" style="padding: 8px;" width="10em;" sortBy="#{bill.invoiceDate}">
-                    <h:outputText value="#{bill.invoiceDate}" >
-                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
-                    </h:outputText>
-                </p:column>  
-
-                <p:column headerText="Billed At" style="padding: 8px;" sortBy="#{bill.createdAt}">
-                    <h:outputText value="#{bill.createdAt}" >
-                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
-                    </h:outputText>
-
-                    <h:outputText rendered="#{bill.cancelled}" style="color: red;" value=" | Cancelled At " />
-                    <h:outputText rendered="#{bill.cancelled}" style="color: red;" value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
-                    </h:outputText>
-
-                    <h:outputText rendered="#{bill.refunded}" style="color: orange;" value=" | Refunded At " />
-                    <h:outputText rendered="#{bill.refunded}" style="color: orange;" value="#{bill.refundedBill.createdAt}" >
-                        <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
-                    </h:outputText>
-                </p:column>  
-
-                <p:column headerText="Billed By" style="padding: 8px;" sortBy="#{bill.creater.webUserPerson.name}" filterBy="#{bill.creater.webUserPerson.name}" filterMatchMode="contains">
-                    <h:outputText value="#{bill.creater.webUserPerson.name}" ></h:outputText>
-
-                    <h:outputText rendered="#{bill.cancelled}" style="color: red;"  value=" | Cancelled By " />
-                    <h:outputText rendered="#{bill.cancelled}" style="color: red;"  value="#{bill.cancelledBill.creater.webUserPerson.name}"></h:outputText>
-
-                    <h:outputText rendered="#{bill.refunded}" style="color: orange;"  value=" | Refunded By " />
-                    <h:outputText rendered="#{bill.refunded}" style="color: orange;"  value="#{bill.refundedBill.creater.webUserPerson.name}"></h:outputText>
-                </p:column>
-
-                <p:column headerText="Payment Method" style="padding: 8px;" width="10em;" sortBy="#{bill.paymentMethod}" filterBy="#{bill.paymentMethod}" filterMatchMode="exact">
-                    <f:facet name="filter">
-                        <p:selectOneMenu onchange="PF('tbl').filter()" styleClass="custom-filter">
-                            <f:selectItem itemLabel="All" itemValue="#{null}" noSelectionOption="true" />
-                            <f:selectItems value="#{enumController.paymentMethods}" />
-                        </p:selectOneMenu>
-                    </f:facet>
-                    <h:outputText value="#{bill.paymentMethod}" ></h:outputText>
-                </p:column>   
-
-                <p:column headerText="Supplier" style="padding: 8px; width: 16em;" sortBy="#{bill.fromInstitution.name}" filterBy="#{bill.fromInstitution.name}" filterMatchMode="contains">
-                    <h:outputText value="#{bill.fromInstitution.name}" ></h:outputText>
-                </p:column> 
-
-                <p:column headerText="Net Value" style="text-align: right; padding: 8px;" width="8em;" sortBy="#{bill.netTotal}">
-                    <h:outputText value="#{bill.netTotal}" >
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-
-                <p:column headerText="Sale Value"  style="text-align: right; padding: 8px;" width="8em;" sortBy="#{bill.saleValue}">
-                    <h:outputText value="#{bill.saleValue}" >
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-
-                <p:column headerText="Comments"  style="padding: 8px;">
-                    <h:outputText rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" ></h:outputText>
-                    <h:outputText  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" ></h:outputText>
-                </p:column>
-
-                <p:column headerText="Actions" exportable="false" style="padding: 8px; text-align:center;">
-                    <p:commandButton 
-                        icon="fa fa-eye" 
-                        title="View" 
-                        action="/pharmacy/pharmacy_reprint_purchase?faces-redirect=true" 
-                        ajax="false"
-                        styleClass="ui-button-info">
-                        <f:setPropertyActionListener value="#{bill}" target="#{pharmacyBillSearch.bill}" />
-                    </p:commandButton>
-                </p:column>
-
-            </p:dataTable>
-
-        </p:panel>
+        </p:dataTable>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary
- Add `PharmacyDirectPurchaseSearchDTO` (18 fields including cancel/refund metadata via LEFT JOIN)
- Add `fetchPurchaseSearchDtos()` in `PharmacyBillSearch` with cancel/refund LEFT JOINs, `ORDER BY createdAt DESC`
- Add `navigateToPharmacyPurchaseReprintById()` routing to purchase or purchase_return reprint based on bill type
- Dispatch `PharmacyPurchaseBill` in `SearchController` (both `createTableByBillType` and `processPharmacyBillSearch`)
- Rewrite `purchase.xhtml` to bind to `purchaseSearchDtos`; Status + Cancel/Refund Details columns; hidden `outputText` for XLSX export

Closes #21013

## Test plan
- [ ] Open pharmacy bill search, select bill type **Pharmacy Direct Purchase** — table loads without N+1 storms
- [ ] Cancelled bill shows badge + cancel details (date, user, comments)
- [ ] Refunded bill shows badge + refund details (date, user, comments)
- [ ] View button navigates to correct reprint page (purchase or purchase_return)
- [ ] Download XLSX includes Status and Cancel/Refund Details columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pharmacy direct purchase bill search functionality with streamlined interface
  * Search results now display invoice details including invoice number, date, creator, supplier, payment method, and financial totals
  * Quick navigation to reprint pages with cancellation and refund status tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->