### PR TITLE
fix(pharmacy): fast-receive now sets referenceBill_ID so received transfers appear on issued list

### DIFF
--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -217,6 +217,21 @@ Rules:
 - Honour configuration toggles (feature flags, color schemes) via `configOptionApplicationController`.
 - Prefer server-side sanitised data and avoid embedding secrets or hard-coded environment values.
 
+### Accessibility-first development (required)
+
+We drive Chrome via the Playwright MCP server for end-to-end verification. Playwright's accessibility snapshot is the primary way Claude and tooling identify elements, so every interactive component must carry an accessible name. **Do this while writing the page, not after.**
+
+**On every new or modified page:**
+
+- Give the `p:dataTable` an `id`, `widgetVar`, `summary`, `rowKey="#{row.id}"`, and `rowIndexVar="rowIndex"`. The `summary` becomes the table's accessible description; `rowKey` makes specific rows targetable.
+- Every `p:commandButton`, `p:commandLink`, and `p:button` must have an interpolated `title` that includes the row's identifier — e.g. `title="Fast receive items from #{p.deptId}"`, `title="View bill #{b.deptId}"`. The button's visible label alone (`"Fast Receive"`, `"View"`) is identical across rows and useless to Playwright.
+- For buttons that render only an icon (no `value`), add `title="…"` with the action AND the row identifier. Without it the accessibility tree falls back to the base CSS class (`"ui-button"`) and the row becomes anonymous.
+- Wrap row-level buttons that depend on a value in `<h:panelGroup rendered="#{not empty value}">` so an empty value doesn't render a button with no accessible name.
+- Add `id` to every form input, calendar, and dropdown — Playwright `browser_fill_form` needs stable ids. Inside iterating components (column inside dataTable, `ui:repeat`) JSF auto-prefixes ids with the iteration index, which is fine — just give them a stable suffix.
+- For status badges and other read-only indicators, prefer text + colour over colour alone, and surface the status in a `title` if the badge is icon-only.
+
+When you finish a UI change, mentally check: "If I asked Playwright to click the Fast Receive button on row PHPHTI/2878, can it identify that row uniquely from the accessibility snapshot?" If not, add titles until it can.
+
 ---
 
 ## Troubleshooting Checklist

--- a/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
@@ -449,13 +449,24 @@ public class TransferReceiveNativeSqlService {
                 .setParameter(3, billId)
                 .executeUpdate();
 
-        // Step 8: Link backwardReferenceBill and forwardReferenceBills
+        // Step 8: Link backwardReferenceBill, referenceBill (both directions), and forwardReferenceBills
         if (bill.getBackwardReferenceBill() != null && bill.getBackwardReferenceBill().getId() != null) {
             long issuedBillId = bill.getBackwardReferenceBill().getId();
 
-            em.createNativeQuery("UPDATE " + billTable() + " SET backwardReferenceBill_ID=? WHERE ID=?")
+            // The Received column on pharmacy_transfer_issued_list joins on the receive
+            // bill's referenceBill_ID (see SearchController.fetchReceivedBillsForIssuedIds).
+            // The regular TransferReceiveController.settle path sets both sides — mirror
+            // that here so fast-receive bills also appear in the Received column.
+            em.createNativeQuery("UPDATE " + billTable()
+                    + " SET backwardReferenceBill_ID=?, referenceBill_ID=? WHERE ID=?")
                     .setParameter(1, issuedBillId)
-                    .setParameter(2, billId)
+                    .setParameter(2, issuedBillId)
+                    .setParameter(3, billId)
+                    .executeUpdate();
+
+            em.createNativeQuery("UPDATE " + billTable() + " SET referenceBill_ID=? WHERE ID=?")
+                    .setParameter(1, billId)
+                    .setParameter(2, issuedBillId)
                     .executeUpdate();
 
             // Insert into the Bill.forwardReferenceBills join table

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -13,7 +13,7 @@
             <p:panel>
 
                 <f:facet name="header">
-                    <p:outputLabel value="Select Request For Department : #{sessionController.department.name}"/>
+                    <p:outputLabel value="Select Request For Department : #{sessionController.department.name}" id="pageHeaderLabel"/>
 
 
                     <!-- Admin Config Button (Admin Only) -->
@@ -69,16 +69,22 @@
                     </div>
                     <div class='col-10'>
                         <p:dataTable
+                            id="transferIssuedListTable"
+                            widgetVar="transferIssuedListTable"
                             value="#{searchController.transferIssuedListDtos}"
                             var="p"
+                            rowIndexVar="rowIndex"
+                            rowKey="#{p.billId}"
                             paginator="true" paginatorPosition="bottom"
                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                             rowsPerPageTemplate="5,10,15"
+                            summary="Pharmacy transfer issues awaiting receive at this department"
                             >
                             <p:column headerText="Issue No">
                                 <p:commandLink
                                     ajax="false"
                                     value="#{p.deptId}"
+                                    title="View issue #{p.deptId}"
                                     styleClass="#{p.cancelled ? 'text-danger text-decoration-line-through' : ''}"
                                     action="#{transferIssueNativeSqlController.viewByBillId(p.billId)}"/>
                             </p:column>
@@ -120,6 +126,7 @@
                                     id="btnToReceive"
                                     ajax="false"
                                     value="Receive"
+                                    title="Receive items from #{p.deptId}"
                                     class="ui-button-warning mx-1"
                                     action="#{transferReceiveController.navigateToRecieveRequest()}"
                                     disabled="#{p.cancelled or p.fullyIssued}">
@@ -130,6 +137,7 @@
                                     id="btnToReceiveFast"
                                     ajax="false"
                                     value="Fast Receive"
+                                    title="Fast receive items from #{p.deptId}"
                                     class="ui-button-success mx-1"
                                     action="#{transferReceiveNativeSqlController.navigateToReceiveRequestNative()}"
                                     disabled="#{p.cancelled or p.fullyIssued}">
@@ -140,13 +148,16 @@
                             <p:column headerText="Received">
                                 <div class="d-flex flex-wrap gap-1">
                                     <ui:repeat value="#{p.receivedBills}" var="b" varStatus="loop">
-                                        <p:commandButton
-                                            ajax="false"
-                                            value="#{b.deptId}"
-                                            styleClass="#{b.cancelled ? 'ui-button-danger' : 'ui-button-secondary'}"
-                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeBySelectedId}">
-                                            <f:setPropertyActionListener value="#{b.billId}" target="#{billSearch.selectedBillId}"/>
-                                        </p:commandButton>
+                                        <h:panelGroup rendered="#{not empty b.deptId}">
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="#{b.deptId}"
+                                                title="View receive bill #{b.deptId}"
+                                                styleClass="#{b.cancelled ? 'ui-button-danger' : 'ui-button-secondary'}"
+                                                action="#{billSearch.navigateToViewBillByAtomicBillTypeBySelectedId}">
+                                                <f:setPropertyActionListener value="#{b.billId}" target="#{billSearch.selectedBillId}"/>
+                                            </p:commandButton>
+                                        </h:panelGroup>
                                     </ui:repeat>
                                 </div>
                             </p:column>


### PR DESCRIPTION
## Summary

- `TransferReceiveNativeSqlService.settle()` Step 8 now writes `referenceBill_ID` on the new PHARMACY_RECEIVE bill and mirrors it back onto the issued bill, matching the regular `TransferReceiveController.settle()` path. Without this, bills received via the Fast Receive button were marked `fullyIssued=1` but never showed up in the **Received** column on `pharmacy_transfer_issued_list.xhtml`, because that column joins on `b.referenceBill.id`.
- `pharmacy_transfer_issued_list.xhtml`: receive-bill buttons are now wrapped in `<h:panelGroup rendered="#{not empty b.deptId}">` so orphan/draft receive bills (no `deptId` yet) don't render an empty button — previously the accessibility tree leaked the base CSS class `ui-button` as the button's name.
- Added `id`, `widgetVar`, `rowKey`, `rowIndexVar`, `summary` on the dataTable and `title="…#{p.deptId}"` on the action / received-bill buttons and the Issue No link, so Playwright / screen-reader users can identify rows by bill number.

Three already-affected production rows on rmh (STPHTI/6138, STPHTI/6139, STPHTI/6140 and their RPPHTI receive bills) have already been patched in-place via SQL — the native fast-receive flow has not been deployed elsewhere yet, so no general backfill is needed.

Closes #21039

## Test plan

- [ ] Issue a transfer to a department in the staging app
- [ ] Click **Fast Receive** on the issued list and settle
- [ ] Reload the issued list and confirm:
  - [ ] The receive bill number appears in the **Received** column for that row
  - [ ] Clicking the receive button opens the receive bill
- [ ] Repeat with **Receive** (regular flow) to make sure that path still works
- [ ] Inspect the page with Playwright / accessibility tools and verify each action button is labelled e.g. `"Fast receive items from PHPHTI/2878"` rather than just `"Fast Receive"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bidirectional linking between issued and received transfer bills to ensure consistent behavior across settlement methods.

* **UI/UX Improvements**
  * Added descriptive titles to transfer actions (Issue, Receive, Fast Receive) and improved conditional display of received-bill actions.
  * Improved table and row identifiers for more reliable row-level interaction and clarity.

* **Documentation**
  * Added accessibility-first UI guidelines to ensure stable identifiers and accessible labels for interactive elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->