### PR TITLE
Sanitize AI chat markdown before assigning innerHTML

### DIFF
--- a/src/main/webapp/ai_chat.xhtml
+++ b/src/main/webapp/ai_chat.xhtml
@@ -886,6 +886,7 @@
 
                 <!-- ══ Markdown renderer ═════════════════════════════════ -->
                 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+                <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
 
                 <!-- ══ Scripts ═══════════════════════════════════════════ -->
                 <h:outputScript>
@@ -894,7 +895,12 @@
                             if (el.getAttribute('data-md-rendered')) return;
                             var raw = el.textContent || '';
                             if (!raw.trim()) return;
-                            el.innerHTML = marked.parse(raw);
+                            var rendered = marked.parse(raw);
+                            el.innerHTML = DOMPurify.sanitize(rendered, {
+                                USE_PROFILES: { html: true },
+                                FORBID_TAGS: ['style', 'script'],
+                                FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick']
+                            });
                             el.setAttribute('data-md-rendered', 'true');
                         });
                     }

--- a/src/main/webapp/ai_chat.xhtml
+++ b/src/main/webapp/ai_chat.xhtml
@@ -886,7 +886,7 @@
 
                 <!-- ══ Markdown renderer ═════════════════════════════════ -->
                 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-                <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+                <script src="https://cdn.jsdelivr.net/npm/dompurify@3.3.2/dist/purify.min.js"></script>
 
                 <!-- ══ Scripts ═══════════════════════════════════════════ -->
                 <h:outputScript>


### PR DESCRIPTION
### Motivation
- Fix a stored XSS risk where parsed markdown was assigned directly to `innerHTML` in `src/main/webapp/ai_chat.xhtml` without sanitization. 
- Prevent assistant messages containing raw HTML or event attributes from executing script in the HMIS session when rendered.

### Description
- Added a DOMPurify script include next to the existing Marked dependency in `ai_chat.xhtml`.
- Updated `renderMarkdown()` to parse with `marked.parse` and then sanitize the result with `DOMPurify.sanitize` before assigning to `innerHTML` for elements with the `.ai-bub` selector. 
- Applied stricter sanitizer options: `USE_PROFILES: { html: true }`, `FORBID_TAGS: ['style','script']`, and `FORBID_ATTR: ['style','onerror','onload','onclick']`.
- Change is an XHTML/JS frontend-only modification confined to `src/main/webapp/ai_chat.xhtml`.

### Testing
- No automated tests were executed because this is a JSF/XHTML-only frontend change with no Java/backend modifications; manual/runtime verification is recommended to validate rendering and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17cb1ed6ec832f99beccf77513f414)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat security by sanitizing rendered Markdown in messages. Potentially dangerous tags and attributes (e.g., script/style and inline event/style attributes) are now blocked before inserting content, preventing unsafe content injection while preserving formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->