### PR TITLE
Fix AI chat attachment upload handling

### DIFF
--- a/src/main/java/com/divudi/bean/common/AiChatController.java
+++ b/src/main/java/com/divudi/bean/common/AiChatController.java
@@ -74,6 +74,7 @@ public class AiChatController implements Serializable {
 
     // Input state
     private String userInput;
+    private transient UploadedFile pendingAttachmentFile;
     private String pendingAttachmentBase64;
     private String pendingAttachmentMimeType;
     private String pendingAttachmentName;
@@ -167,6 +168,9 @@ public class AiChatController implements Serializable {
         LOG.info("sendMessage() called");
         if (currentConversation == null) {
             startNewConversation();
+        }
+        if (!readPendingAttachmentFile()) {
+            return;
         }
         if ((userInput == null || userInput.trim().isEmpty()) && pendingAttachmentBase64 == null) {
             JsfUtil.addErrorMessage("Please enter a message or attach a file.");
@@ -264,23 +268,41 @@ public class AiChatController implements Serializable {
     }
 
     public void handleFileUpload(FileUploadEvent event) {
-        UploadedFile file = event.getFile();
-        if (file == null) {
+        if (event == null) {
             return;
         }
+        storeAttachment(event.getFile());
+    }
+
+    private boolean readPendingAttachmentFile() {
+        if (pendingAttachmentFile == null || pendingAttachmentFile.getSize() <= 0) {
+            return true;
+        }
+        return storeAttachment(pendingAttachmentFile);
+    }
+
+    private boolean storeAttachment(UploadedFile file) {
+        if (file == null) {
+            return true;
+        }
         if (file.getSize() > MAX_ATTACHMENT_BYTES) {
+            clearPendingAttachment();
             JsfUtil.addErrorMessage("Attachment is too large. Maximum allowed size is 5 MB.");
-            return;
+            return false;
         }
         try (InputStream is = file.getInputStream()) {
             byte[] bytes = is.readAllBytes();
             pendingAttachmentBase64 = Base64.getEncoder().encodeToString(bytes);
             pendingAttachmentMimeType = file.getContentType();
             pendingAttachmentName = file.getFileName();
+            pendingAttachmentFile = null;
             JsfUtil.addSuccessMessage("File attached: " + file.getFileName());
+            return true;
         } catch (IOException e) {
+            clearPendingAttachment();
             LOG.log(Level.SEVERE, "Error reading uploaded file", e);
             JsfUtil.addErrorMessage("Failed to read uploaded file: " + e.getMessage());
+            return false;
         }
     }
 
@@ -367,6 +389,7 @@ public class AiChatController implements Serializable {
     }
 
     private void clearPendingAttachment() {
+        pendingAttachmentFile = null;
         pendingAttachmentBase64 = null;
         pendingAttachmentMimeType = null;
         pendingAttachmentName = null;
@@ -423,6 +446,14 @@ public class AiChatController implements Serializable {
 
     public void setUserInput(String userInput) {
         this.userInput = userInput;
+    }
+
+    public UploadedFile getPendingAttachmentFile() {
+        return pendingAttachmentFile;
+    }
+
+    public void setPendingAttachmentFile(UploadedFile pendingAttachmentFile) {
+        this.pendingAttachmentFile = pendingAttachmentFile;
     }
 
     public String getPendingAttachmentName() {

--- a/src/main/webapp/ai_chat.xhtml
+++ b/src/main/webapp/ai_chat.xhtml
@@ -784,7 +784,7 @@
 
                         <!-- Input -->
                         <div class="aic-input-wrap">
-                            <h:form id="inputForm">
+                            <h:form id="inputForm" enctype="multipart/form-data">
 
                                 <h:panelGroup layout="block"
                                               rendered="#{aiChatController.hasAttachment()}"
@@ -813,16 +813,14 @@
                                     <div class="aic-input-btns">
                                         <h:panelGroup styleClass="aic-file-btn">
                                             <p:fileUpload
+                                                value="#{aiChatController.pendingAttachmentFile}"
                                                 mode="simple"
                                                 auto="false"
                                                 skinSimple="true"
                                                 label=""
                                                 chooseIcon="pi pi-paperclip"
                                                 title="Attach image or document"
-                                                allowTypes="/(\.|\/)(gif|jpe?g|png|pdf|txt|csv|md)$/"
-                                                fileUploadListener="#{aiChatController.handleFileUpload}"
-                                                update="inputForm :growl"
-                                                process="@this" />
+                                                allowTypes="/(\.|\/)(gif|jpe?g|png|pdf|txt|csv|md)$/" />
                                         </h:panelGroup>
                                         <h:panelGroup styleClass="aic-send-btn">
                                             <p:commandButton
@@ -831,8 +829,7 @@
                                                 title="Send (Enter)"
                                                 disabled="#{aiChatController.sending}"
                                                 action="#{aiChatController.sendMessage()}"
-                                                update=":messagesPanel :inputForm :growl"
-                                                process="inputForm" />
+                                                ajax="false" />
                                         </h:panelGroup>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- make the AI chat input form multipart for simple file uploads
- bind the selected PrimeFaces uploaded file to the controller
- read and validate the selected attachment before sending the chat message

## Testing
- git diff --check
- Not run: Maven compile/tests per repository instructions unless explicitly requested.

Closes #21044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file attachment handling with improved error management and 5MB size limit enforcement in the AI chat interface
  * Refined form submission process for more reliable file upload support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->