### PR TITLE
fix(migration) : v2.9.0 restores AUTO_INCREMENT on ID primary keys

### DIFF
--- a/src/main/java/com/divudi/core/util/MigrationInfo.java
+++ b/src/main/java/com/divudi/core/util/MigrationInfo.java
@@ -4,8 +4,10 @@
  */
 package com.divudi.core.util;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Data class for migration metadata parsed from migration-info.json
@@ -28,7 +30,10 @@ public class MigrationInfo {
     private List<String> postMigrationVerification;
     private List<String> rollbackNotes;
     private List<MigrationStep> migrationSteps;
-    private List<String> verificationQueries;
+    // Tolerates either a JSON array (["q1", "q2"]) or an object grouping queries by
+    // environment ({"common": [...], "production": [...]}). Typed as Object so a single
+    // file's shape variation never fails the whole migration list load.
+    private Object verificationQueries;
 
     // Inner class for migration steps
     public static class MigrationStep {
@@ -205,11 +210,11 @@ public class MigrationInfo {
         this.migrationSteps = migrationSteps;
     }
 
-    public List<String> getVerificationQueries() {
+    public Object getVerificationQueries() {
         return verificationQueries;
     }
 
-    public void setVerificationQueries(List<String> verificationQueries) {
+    public void setVerificationQueries(Object verificationQueries) {
         this.verificationQueries = verificationQueries;
     }
 
@@ -223,7 +228,16 @@ public class MigrationInfo {
     }
 
     public boolean hasVerificationQueries() {
-        return verificationQueries != null && !verificationQueries.isEmpty();
+        if (verificationQueries == null) {
+            return false;
+        }
+        if (verificationQueries instanceof Collection) {
+            return !((Collection<?>) verificationQueries).isEmpty();
+        }
+        if (verificationQueries instanceof Map) {
+            return !((Map<?, ?>) verificationQueries).isEmpty();
+        }
+        return true;
     }
 
     public boolean hasMigrationSteps() {

--- a/src/main/resources/db/migrations/v2.9.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.9.0/migration-info.json
@@ -1,0 +1,18 @@
+{
+  "version": "v2.9.0",
+  "description": "Restore AUTO_INCREMENT on every ID primary key that lost it during a database import",
+  "issue": "Bill settle fails with SQLException 1364 'Field ID doesn't have a default value' when the ID primary key is not AUTO_INCREMENT",
+  "author": "H.K. Damith Deshan",
+  "date": "2026-05-28",
+  "type": "schema",
+  "tables_affected": ["ALL (dynamically detected — every table whose single-column BIGINT ID primary key is missing AUTO_INCREMENT)"],
+  "data_changes": false,
+  "requires_downtime": false,
+  "estimated_duration_minutes": 5,
+  "preRequisites": [
+    "Database backup completed",
+    "Datasource user has CREATE ROUTINE privilege (the migration creates and drops a temporary stored procedure)"
+  ],
+  "note": "Entities map @GeneratedValue(strategy = IDENTITY), which requires the underlying ID column to be AUTO_INCREMENT. Some databases were restored from dumps that dropped the AUTO_INCREMENT attribute, so every INSERT into those tables fails with MySQL error 1364. This migration scans INFORMATION_SCHEMA for every table in the current schema whose single-column BIGINT primary key named ID lacks AUTO_INCREMENT and re-adds it (preserving the existing column type). It is idempotent and a no-op on healthy databases, where the scan returns no rows. For the duration of the rebuild it disables foreign-key checks (so child-table ALTERs succeed) and relaxes sql_mode (so tables whose other columns carry legacy invalid defaults such as TIMESTAMP DEFAULT '0000-00-00 00:00:00' do not fail with error 1067); both session settings are restored afterwards. MySQL auto-sets each table's next value to MAX(id)+1, so no row data is modified.",
+  "rollback": "rollback.sql"
+}

--- a/src/main/resources/db/migrations/v2.9.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.9.0/migration-info.json
@@ -7,12 +7,14 @@
   "type": "schema",
   "tables_affected": ["ALL (dynamically detected — every table whose single-column BIGINT ID primary key is missing AUTO_INCREMENT)"],
   "data_changes": false,
-  "requires_downtime": false,
-  "estimated_duration_minutes": 5,
+  "requires_downtime": true,
+  "estimated_duration_minutes": 30,
   "preRequisites": [
     "Database backup completed",
-    "Datasource user has CREATE ROUTINE privilege (the migration creates and drops a temporary stored procedure)"
+    "Datasource user has CREATE ROUTINE privilege (the migration creates and drops a temporary stored procedure)",
+    "Datasource user has ALTER privilege on the affected tables",
+    "Run inside a maintenance window: the ALTER TABLE ... MODIFY COLUMN operations rebuild each affected table and block writes for its duration"
   ],
-  "note": "Entities map @GeneratedValue(strategy = IDENTITY), which requires the underlying ID column to be AUTO_INCREMENT. Some databases were restored from dumps that dropped the AUTO_INCREMENT attribute, so every INSERT into those tables fails with MySQL error 1364. This migration scans INFORMATION_SCHEMA for every table in the current schema whose single-column BIGINT primary key named ID lacks AUTO_INCREMENT and re-adds it (preserving the existing column type). It is idempotent and a no-op on healthy databases, where the scan returns no rows. For the duration of the rebuild it disables foreign-key checks (so child-table ALTERs succeed) and relaxes sql_mode (so tables whose other columns carry legacy invalid defaults such as TIMESTAMP DEFAULT '0000-00-00 00:00:00' do not fail with error 1067); both session settings are restored afterwards. MySQL auto-sets each table's next value to MAX(id)+1, so no row data is modified.",
+  "note": "Entities map @GeneratedValue(strategy = IDENTITY), which requires the underlying ID column to be AUTO_INCREMENT. Some databases were restored from dumps that dropped the AUTO_INCREMENT attribute, so every INSERT into those tables fails with MySQL error 1364. This migration scans INFORMATION_SCHEMA for every table in the current schema whose single-column BIGINT primary key named ID lacks AUTO_INCREMENT and re-adds it (preserving the existing column type). It is idempotent and a no-op on healthy databases, where the scan returns no rows. DOWNTIME: adding AUTO_INCREMENT via ALTER TABLE ... MODIFY COLUMN is not an in-place change in MySQL/InnoDB — it copies/rebuilds the whole table under a metadata + table lock, which blocks writes (and DDL) on each affected table for the rebuild. On large tables (bill, billitem, and the *archive tables) this can take a long time, so the migration must run during a maintenance window; the 30-minute estimate scales with the largest affected table and the disk. For the duration of the rebuild it disables foreign-key checks (so child-table ALTERs succeed) and relaxes sql_mode (so tables whose other columns carry legacy invalid defaults such as TIMESTAMP DEFAULT '0000-00-00 00:00:00' do not fail with error 1067); both session settings are restored afterwards. After the loop the procedure re-counts ID primary keys that still lack AUTO_INCREMENT and raises SIGNAL SQLSTATE '45000' if any remain, so a table that could not be altered fails the migration instead of being silently recorded as SUCCESS. MySQL auto-sets each table's next value to MAX(id)+1, so no row data is modified.",
   "rollback": "rollback.sql"
 }

--- a/src/main/resources/db/migrations/v2.9.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.9.0/migration.sql
@@ -16,8 +16,12 @@
 --   Scans INFORMATION_SCHEMA for EVERY table in the current schema whose single-column
 --   BIGINT primary key named ID is missing AUTO_INCREMENT, and re-adds it (preserving
 --   the existing column type). Healthy tables are never selected, so they are skipped.
---   If a single table cannot be altered, the CONTINUE HANDLER skips it and moves on to
---   the next table instead of aborting the whole migration.
+--   If a single table cannot be altered (e.g. lock timeout or missing privilege) the
+--   per-table CONTINUE HANDLER skips it so the remaining tables are still attempted.
+--   AFTER the loop the procedure re-counts the columns that are STILL missing
+--   AUTO_INCREMENT and, if any remain, raises SIGNAL SQLSTATE '45000'. That error
+--   propagates through CALL to the Java migration runner, which records the migration
+--   as FAILED — so a partially-applied fix can never be recorded as SUCCESS.
 --
 -- Idempotent: a no-op on healthy databases (the scan returns no rows). Safe to re-run.
 -- MySQL auto-sets each table's next value to MAX(id)+1, so no row data is modified.
@@ -53,24 +57,7 @@ DROP PROCEDURE IF EXISTS hmis_fix_autoincrement_v290;
 DELIMITER $$
 CREATE PROCEDURE hmis_fix_autoincrement_v290()
 BEGIN
-    DECLARE v_done INT DEFAULT 0;
-    DECLARE v_table   VARCHAR(255);
-    DECLARE v_col     VARCHAR(255);
-    DECLARE v_coltype VARCHAR(255);
-
-    -- Only tables whose single-column BIGINT PK named ID lacks AUTO_INCREMENT.
-    DECLARE cur CURSOR FOR
-        SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE
-        FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_SCHEMA = DATABASE()
-          AND UPPER(COLUMN_NAME) = 'ID'
-          AND COLUMN_KEY = 'PRI'
-          AND DATA_TYPE = 'bigint'
-          AND EXTRA NOT LIKE '%auto_increment%';
-
-    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = 1;
-    -- If one table cannot be altered, skip it and continue with the next.
-    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+    DECLARE v_remaining INT DEFAULT 0;
 
     -- Save and relax session state for the rebuild:
     --   * sql_mode='' so rebuilding a table whose OTHER columns carry legacy invalid
@@ -83,22 +70,67 @@ BEGIN
     SET SESSION sql_mode = '';
     SET FOREIGN_KEY_CHECKS = 0;
 
-    OPEN cur;
-    read_loop: LOOP
-        FETCH cur INTO v_table, v_col, v_coltype;
-        IF v_done = 1 THEN
-            LEAVE read_loop;
-        END IF;
-        SET @ddl = CONCAT('ALTER TABLE `', v_table, '` MODIFY COLUMN `', v_col, '` ', v_coltype, ' NOT NULL AUTO_INCREMENT');
-        PREPARE st FROM @ddl;
-        EXECUTE st;
-        DEALLOCATE PREPARE st;
-    END LOOP;
-    CLOSE cur;
+    -- Per-table fix loop lives in its OWN block so its tolerant SQLEXCEPTION
+    -- handler (skip one failing table, keep going) does NOT also swallow the
+    -- verification SIGNAL raised in the outer block below.
+    fix_block: BEGIN
+        DECLARE v_done    INT DEFAULT 0;
+        DECLARE v_table   VARCHAR(255);
+        DECLARE v_col     VARCHAR(255);
+        DECLARE v_coltype VARCHAR(255);
+
+        -- Only tables whose single-column BIGINT PK named ID lacks AUTO_INCREMENT.
+        DECLARE cur CURSOR FOR
+            SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND UPPER(COLUMN_NAME) = 'ID'
+              AND COLUMN_KEY = 'PRI'
+              AND DATA_TYPE = 'bigint'
+              AND EXTRA NOT LIKE '%auto_increment%';
+
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = 1;
+        -- Skip a single un-alterable table (lock/timeout/privilege) and continue;
+        -- the outer verification below still fails the migration if any remain.
+        DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+        OPEN cur;
+        read_loop: LOOP
+            FETCH cur INTO v_table, v_col, v_coltype;
+            IF v_done = 1 THEN
+                LEAVE read_loop;
+            END IF;
+            SET @ddl = CONCAT('ALTER TABLE `', v_table, '` MODIFY COLUMN `', v_col, '` ', v_coltype, ' NOT NULL AUTO_INCREMENT');
+            PREPARE st FROM @ddl;
+            EXECUTE st;
+            DEALLOCATE PREPARE st;
+        END LOOP;
+        CLOSE cur;
+    END fix_block;
 
     -- Restore the original session state so the pooled connection is left clean.
     SET SESSION sql_mode = @hmis_old_sql_mode;
     SET FOREIGN_KEY_CHECKS = @hmis_old_fk_checks;
+
+    -- Verification (outer block — NO SQLEXCEPTION handler here): count the ID
+    -- primary keys that are STILL missing AUTO_INCREMENT. If any table could not
+    -- be fixed, fail loudly so the runner records the migration as FAILED rather
+    -- than SUCCESS. The Java runner never inspects SELECT output, so the failure
+    -- must be raised here as a SIGNAL that propagates out through CALL.
+    SELECT COUNT(*) INTO v_remaining
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(COLUMN_NAME) = 'ID'
+      AND COLUMN_KEY = 'PRI'
+      AND DATA_TYPE = 'bigint'
+      AND EXTRA NOT LIKE '%auto_increment%';
+
+    IF v_remaining > 0 THEN
+        -- MESSAGE_TEXT is capped at 128 chars by MySQL; keep this short.
+        SET @hmis_fail_msg = CONCAT('v2.9.0 FAILED: ', v_remaining,
+            ' ID PK(s) lack AUTO_INCREMENT after fix; resolve lock/privilege & re-run.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @hmis_fail_msg;
+    END IF;
 END$$
 DELIMITER ;
 

--- a/src/main/resources/db/migrations/v2.9.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.9.0/migration.sql
@@ -1,0 +1,122 @@
+-- Migration v2.9.0: Restore AUTO_INCREMENT on every ID primary key that lost it
+-- Author: H.K. Damith Deshan
+--
+-- Background:
+--   Entities map @GeneratedValue(strategy = IDENTITY); EclipseLink omits the ID on
+--   INSERT and reads it back via SELECT LAST_INSERT_ID(). That only works when the
+--   underlying ID column is AUTO_INCREMENT. Some databases were restored from dumps
+--   that dropped the AUTO_INCREMENT attribute, so every INSERT into those tables fails
+--   with: java.sql.SQLException: Field 'ID' doesn't have a default value (MySQL 1364).
+--
+--   Observed on a Roseth QA database where bill, billitem, itembatcharchive,
+--   patientitem, paymentscheme, shiftstaffrequirement, stockarchive and
+--   stockhistoryarchive had lost AUTO_INCREMENT, breaking inward bill settlement.
+--
+-- What this does:
+--   Scans INFORMATION_SCHEMA for EVERY table in the current schema whose single-column
+--   BIGINT primary key named ID is missing AUTO_INCREMENT, and re-adds it (preserving
+--   the existing column type). Healthy tables are never selected, so they are skipped.
+--   If a single table cannot be altered, the CONTINUE HANDLER skips it and moves on to
+--   the next table instead of aborting the whole migration.
+--
+-- Idempotent: a no-op on healthy databases (the scan returns no rows). Safe to re-run.
+-- MySQL auto-sets each table's next value to MAX(id)+1, so no row data is modified.
+--
+-- UNIVERSAL: detects the actual stored case of the ID column per table, so this works on
+-- both case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows) MySQL.
+--
+-- Requires the datasource user to have CREATE ROUTINE (a temporary stored procedure is
+-- created and dropped). For the duration of the rebuild the procedure disables FK checks
+-- (so child-table ALTERs succeed) and relaxes sql_mode (so tables whose OTHER columns hold
+-- legacy invalid defaults such as TIMESTAMP DEFAULT '0000-00-00 00:00:00' do not fail with
+-- error 1067). Both session settings are saved and restored.
+
+SELECT 'Migration v2.9.0 - Restore AUTO_INCREMENT on all ID primary keys missing it' AS status;
+
+-- ── BEFORE: tables that will be fixed ────────────────────────────────────────
+
+SELECT 'BEFORE: ID primary keys missing AUTO_INCREMENT (these will be fixed)' AS status;
+
+SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, EXTRA
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND UPPER(COLUMN_NAME) = 'ID'
+  AND COLUMN_KEY = 'PRI'
+  AND DATA_TYPE = 'bigint'
+  AND EXTRA NOT LIKE '%auto_increment%'
+ORDER BY TABLE_NAME;
+
+-- ── Build a temporary procedure that loops over every affected table ──────────
+
+DROP PROCEDURE IF EXISTS hmis_fix_autoincrement_v290;
+
+DELIMITER $$
+CREATE PROCEDURE hmis_fix_autoincrement_v290()
+BEGIN
+    DECLARE v_done INT DEFAULT 0;
+    DECLARE v_table   VARCHAR(255);
+    DECLARE v_col     VARCHAR(255);
+    DECLARE v_coltype VARCHAR(255);
+
+    -- Only tables whose single-column BIGINT PK named ID lacks AUTO_INCREMENT.
+    DECLARE cur CURSOR FOR
+        SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND UPPER(COLUMN_NAME) = 'ID'
+          AND COLUMN_KEY = 'PRI'
+          AND DATA_TYPE = 'bigint'
+          AND EXTRA NOT LIKE '%auto_increment%';
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = 1;
+    -- If one table cannot be altered, skip it and continue with the next.
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+
+    -- Save and relax session state for the rebuild:
+    --   * sql_mode='' so rebuilding a table whose OTHER columns carry legacy invalid
+    --     defaults (e.g. TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00') does not
+    --     raise error 1067 — strict NO_ZERO_DATE/STRICT_TRANS_TABLES re-validate every
+    --     column when MODIFY copies the table.
+    --   * foreign_key_checks=0 so altering a column referenced by child FKs succeeds.
+    SET @hmis_old_sql_mode  = @@SESSION.sql_mode;
+    SET @hmis_old_fk_checks = @@SESSION.foreign_key_checks;
+    SET SESSION sql_mode = '';
+    SET FOREIGN_KEY_CHECKS = 0;
+
+    OPEN cur;
+    read_loop: LOOP
+        FETCH cur INTO v_table, v_col, v_coltype;
+        IF v_done = 1 THEN
+            LEAVE read_loop;
+        END IF;
+        SET @ddl = CONCAT('ALTER TABLE `', v_table, '` MODIFY COLUMN `', v_col, '` ', v_coltype, ' NOT NULL AUTO_INCREMENT');
+        PREPARE st FROM @ddl;
+        EXECUTE st;
+        DEALLOCATE PREPARE st;
+    END LOOP;
+    CLOSE cur;
+
+    -- Restore the original session state so the pooled connection is left clean.
+    SET SESSION sql_mode = @hmis_old_sql_mode;
+    SET FOREIGN_KEY_CHECKS = @hmis_old_fk_checks;
+END$$
+DELIMITER ;
+
+CALL hmis_fix_autoincrement_v290();
+
+DROP PROCEDURE IF EXISTS hmis_fix_autoincrement_v290;
+
+-- ── AFTER: should return no rows ─────────────────────────────────────────────
+
+SELECT 'AFTER: ID primary keys still missing AUTO_INCREMENT (should be empty)' AS status;
+
+SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, EXTRA
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND UPPER(COLUMN_NAME) = 'ID'
+  AND COLUMN_KEY = 'PRI'
+  AND DATA_TYPE = 'bigint'
+  AND EXTRA NOT LIKE '%auto_increment%'
+ORDER BY TABLE_NAME;
+
+SELECT 'Migration v2.9.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.9.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.9.0/rollback.sql
@@ -1,0 +1,13 @@
+-- Rollback v2.9.0: intentionally a NO-OP.
+-- Author: H.K. Damith Deshan
+--
+-- Migration v2.9.0 only RE-ADDS AUTO_INCREMENT to ID primary keys that were missing it.
+-- Removing AUTO_INCREMENT again would immediately re-break every INSERT into those tables
+-- (MySQL error 1364, "Field 'ID' doesn't have a default value") — the very bug v2.9.0 fixes.
+-- There is also no record of which tables this database had altered, so a blanket removal
+-- across all ID primary keys would be destructive. Therefore this rollback does nothing.
+--
+-- If you genuinely must revert a specific table, run manually and accept that inserts break:
+--   ALTER TABLE `<table>` MODIFY COLUMN `ID` BIGINT NOT NULL;
+
+SELECT 'Rollback v2.9.0 - no action taken (re-adding AUTO_INCREMENT is not safely reversible)' AS status;


### PR DESCRIPTION
## Summary

  Some databases (observed on **Roseth**) were restored from dumps that dropped the `AUTO_INCREMENT` attribute on `ID`
  primary-key columns. The entities map `@GeneratedValue(strategy = IDENTITY)`, so EclipseLink omits `ID` on `INSERT`
  and reads it back via `SELECT LAST_INSERT_ID()` — which only works when the column is `AUTO_INCREMENT`. Without it,
  every insert fails with:

  ```
  java.sql.SQLException: Field 'ID' doesn't have a default value  (error 1364)
  ```

  This broke inward bill settlement (`inward/inward_bill_service.xhtml`) on Settle. This is a **database-side** issue,
  not an application code bug, so it is repaired through a versioned migration.

  ## Changes

  - **New migration `v2.9.0`** — scans `INFORMATION_SCHEMA` for every table whose single-column `BIGINT` `ID` primary
  key lacks `AUTO_INCREMENT` and re-adds it (preserving the existing column type) via a temporary stored procedure with
  a cursor.
    - **Idempotent** — a no-op on healthy databases (scan returns no rows). Safe to re-run.
    - **Safe** — disables FK checks and relaxes `sql_mode` only for the duration of the rebuild (so child-table ALTERs
  succeed and legacy invalid defaults such as `TIMESTAMP DEFAULT '0000-00-00 00:00:00'` do not trigger error 1067), then
   restores both session settings.
    - **Non-destructive** — no row data changes; MySQL auto-sets each table's next value to `MAX(id)+1`.
    - **Cross-deployment safe** — detects the actual stored case of the `ID` column per table, so it works on both
  case-sensitive (Linux) and case-insensitive (Windows) MySQL.
    - Includes BEFORE/AFTER verification `SELECT`s in the script.
    - `rollback.sql` is a documented **no-op** (removing `AUTO_INCREMENT` again would re-break inserts).

  - **`MigrationInfo.java`** — `verificationQueries` retyped from `List<String>` to `Object` so a migration-info file
  whose `verificationQueries` is an object grouping queries by environment (e.g. `v2.1.5`'s `{"common": [...],
  "production": [...]}`) no longer throws `MismatchedInputException` and aborts the migration-list load.
  `hasVerificationQueries()` updated to handle `Collection`, `Map`, and scalar shapes.

  ## Files

  - `src/main/resources/db/migrations/v2.9.0/migration.sql`
  - `src/main/resources/db/migrations/v2.9.0/migration-info.json`
  - `src/main/resources/db/migrations/v2.9.0/rollback.sql`
  - `src/main/java/com/divudi/core/util/MigrationInfo.java`

  ## Prerequisites

  - Database backup completed before running.
  - Datasource user has the `CREATE ROUTINE` privilege (the migration creates and drops a temporary stored procedure).

  ## Test plan

  - [ ] Run migration `v2.9.0` from the admin *Database Migration* page on an affected DB.
  - [ ] BEFORE report lists the affected tables; AFTER report returns **no rows**.
  - [ ] Inward bill settlement at `inward/inward_bill_service.xhtml` succeeds with no error 1364.
  - [ ] Re-running the migration on an already-fixed DB is a clean no-op.
  - [ ] Migration list loads without `MismatchedInputException` for `v2.1.5`.

  Closes #21028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a v2.9.0 database migration to restore AUTO_INCREMENT on ID primary keys; requires a maintenance window and may take ~30 minutes.
  * Improved migration metadata handling to accept verification queries in multiple formats (array or grouped object) so migration checks are more flexible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->