### PR TITLE
Add admin tool to bulk-enable Service Charge Allowed (marginAllowed) on inpatient fees

### DIFF
--- a/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
+++ b/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
@@ -165,10 +165,17 @@ public class FeeMarginAllowedController implements Serializable {
         private final Item item;
         private final String type;
         private final List<FeeRow> feeRows = new ArrayList<>();
+        private boolean allSelected;
 
         public ItemFeeMarginGroup(Item item, String type) {
             this.item = item;
             this.type = type;
+        }
+
+        public void toggleAllFees() {
+            for (FeeRow row : feeRows) {
+                row.setSelected(allSelected);
+            }
         }
 
         public Item getItem() {
@@ -182,6 +189,14 @@ public class FeeMarginAllowedController implements Serializable {
         public List<FeeRow> getFeeRows() {
             return feeRows;
         }
+
+        public boolean isAllSelected() {
+            return allSelected;
+        }
+
+        public void setAllSelected(boolean allSelected) {
+            this.allSelected = allSelected;
+        }
     }
 
     public static class FeeRow implements Serializable {
@@ -191,7 +206,7 @@ public class FeeMarginAllowedController implements Serializable {
 
         public FeeRow(ItemFee itemFee) {
             this.itemFee = itemFee;
-            this.selected = !Boolean.TRUE.equals(itemFee.getMarginAllowed());
+            this.selected = false;
         }
 
         public ItemFee getItemFee() {

--- a/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
+++ b/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
@@ -130,6 +130,7 @@ public class FeeMarginAllowedController implements Serializable {
             return;
         }
         for (ItemFeeMarginGroup group : groups) {
+            group.setAllSelected(value);
             for (FeeRow row : group.getFeeRows()) {
                 row.setSelected(value);
             }

--- a/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
+++ b/src/main/java/com/divudi/bean/inward/FeeMarginAllowedController.java
@@ -1,0 +1,209 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.ItemFee;
+import com.divudi.core.entity.Service;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.facade.ItemFeeFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Admin tool to bulk-enable the fee-level "Service Charge Allowed"
+ * (marginAllowed) flag on base item fees. Fees where marginAllowed is FALSE are
+ * skipped during inward service-charge calculation, so this screen lets an admin
+ * flip selected fees to allowed in one pass.
+ */
+@Named
+@ViewScoped
+public class FeeMarginAllowedController implements Serializable {
+
+    @EJB
+    private ItemFeeFacade itemFeeFacade;
+    @Inject
+    private SessionController sessionController;
+
+    private Department department;
+    private String itemType = "Service";
+    private List<ItemFeeMarginGroup> groups;
+
+    public String navigateToManageFeeMarginAllowed() {
+        department = null;
+        itemType = "Service";
+        groups = null;
+        return "/inward/inward_fee_margin_allowed?faces-redirect=true";
+    }
+
+    public void process() {
+        groups = new ArrayList<>();
+        if (department == null) {
+            JsfUtil.addErrorMessage("Please select a department.");
+            return;
+        }
+        Class<? extends Item> typeClass = "Investigation".equals(itemType) ? Investigation.class : Service.class;
+
+        String jpql = "select f from ItemFee f "
+                + " where f.retired = false "
+                + " and f.forInstitution is null "
+                + " and f.forCategory is null "
+                + " and f.item.department = :dept "
+                + " and type(f.item) = :t "
+                + " order by f.item.name, f.name";
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("dept", department);
+        m.put("t", typeClass);
+
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql, m);
+
+        Map<Long, ItemFeeMarginGroup> grouped = new LinkedHashMap<>();
+        for (ItemFee f : fees) {
+            if (f.getItem() == null || f.getItem().getId() == null) {
+                continue;
+            }
+            ItemFeeMarginGroup group = grouped.get(f.getItem().getId());
+            if (group == null) {
+                group = new ItemFeeMarginGroup(f.getItem(), itemType);
+                grouped.put(f.getItem().getId(), group);
+            }
+            group.getFeeRows().add(new FeeRow(f));
+        }
+        groups = new ArrayList<>(grouped.values());
+
+        if (groups.isEmpty()) {
+            JsfUtil.addErrorMessage("No fees found for the selected department and item type.");
+        } else {
+            JsfUtil.addSuccessMessage(groups.size() + " items loaded.");
+        }
+    }
+
+    public void updateSelectedFees() {
+        if (groups == null || groups.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing to update. Process first.");
+            return;
+        }
+        int updated = 0;
+        Date now = new Date();
+        for (ItemFeeMarginGroup group : groups) {
+            for (FeeRow row : group.getFeeRows()) {
+                if (!row.isSelected()) {
+                    continue;
+                }
+                ItemFee f = row.getItemFee();
+                if (Boolean.TRUE.equals(f.getMarginAllowed())) {
+                    continue;
+                }
+                f.setMarginAllowed(true);
+                f.setEditedAt(now);
+                f.setEditer(sessionController.getLoggedUser());
+                itemFeeFacade.edit(f);
+                updated++;
+            }
+        }
+        if (updated == 0) {
+            JsfUtil.addErrorMessage("No fees selected (or all selected fees are already allowed).");
+        } else {
+            JsfUtil.addSuccessMessage(updated + " fees updated to Service Charge Allowed.");
+        }
+    }
+
+    public void selectAll() {
+        setAllSelected(true);
+    }
+
+    public void deselectAll() {
+        setAllSelected(false);
+    }
+
+    private void setAllSelected(boolean value) {
+        if (groups == null) {
+            return;
+        }
+        for (ItemFeeMarginGroup group : groups) {
+            for (FeeRow row : group.getFeeRows()) {
+                row.setSelected(value);
+            }
+        }
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public String getItemType() {
+        return itemType;
+    }
+
+    public void setItemType(String itemType) {
+        this.itemType = itemType;
+    }
+
+    public List<ItemFeeMarginGroup> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<ItemFeeMarginGroup> groups) {
+        this.groups = groups;
+    }
+
+    public static class ItemFeeMarginGroup implements Serializable {
+
+        private final Item item;
+        private final String type;
+        private final List<FeeRow> feeRows = new ArrayList<>();
+
+        public ItemFeeMarginGroup(Item item, String type) {
+            this.item = item;
+            this.type = type;
+        }
+
+        public Item getItem() {
+            return item;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public List<FeeRow> getFeeRows() {
+            return feeRows;
+        }
+    }
+
+    public static class FeeRow implements Serializable {
+
+        private final ItemFee itemFee;
+        private boolean selected;
+
+        public FeeRow(ItemFee itemFee) {
+            this.itemFee = itemFee;
+            this.selected = !Boolean.TRUE.equals(itemFee.getMarginAllowed());
+        }
+
+        public ItemFee getItemFee() {
+            return itemFee;
+        }
+
+        public boolean isSelected() {
+            return selected;
+        }
+
+        public void setSelected(boolean selected) {
+            this.selected = selected;
+        }
+    }
+}

--- a/src/main/webapp/inward/inward_administration.xhtml
+++ b/src/main/webapp/inward/inward_administration.xhtml
@@ -72,6 +72,7 @@
                                             <p:commandButton ajax="false" value="Inward Price Adjustment - Investigation " class="w-100" action="/inward/inward_price_adjustment_investigation?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
                                             <p:commandButton ajax="false" value="Inward Price Adjustment - Pharmacy " class="w-100" action="/inward/inward_price_adjustment_pharmacy?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
                                             <p:commandButton ajax="false" value="Inward Price Adjustment - Store " class="w-100" action="/inward/inward_price_adjustment_store?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
+                                            <p:commandButton ajax="false" value="Service Charge Allowed - Fee Update " class="w-100" action="#{feeMarginAllowedController.navigateToManageFeeMarginAllowed()}"></p:commandButton>
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
+++ b/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
@@ -64,7 +64,7 @@
                             </div>
                         </p:panel>
 
-                        <p:panel class="mt-2" rendered="#{feeMarginAllowedController.groups ne null}">
+                        <p:panel class="mt-2" rendered="#{not empty feeMarginAllowedController.groups}">
                             <f:facet name="header">
                                 <h:outputLabel value="Items and Fees" class="mt-2" />
                                 <div class="d-flex gap-2" style="float: right;">

--- a/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
+++ b/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
@@ -1,0 +1,168 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="/inward/inward_administration.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="form">
+
+                    <p:panel header="Service Charge Allowed - Fee Update" class="row w-100">
+
+                        <p:panel>
+                            <f:facet name="header">
+                                <h:outputText styleClass="fas fa-filter" />
+                                <h:outputLabel value="Filter" class="mx-2" />
+                            </f:facet>
+
+                            <div class="row">
+                                <div class="col-2">
+                                    <h:outputLabel value="Department" class="mt-2" />
+                                </div>
+                                <div class="col-10">
+                                    <p:autoComplete
+                                        id="department"
+                                        value="#{feeMarginAllowedController.department}"
+                                        forceSelection="true"
+                                        completeMethod="#{departmentController.completeDept}"
+                                        var="dep"
+                                        inputStyleClass="form-control"
+                                        class="w-100"
+                                        itemLabel="#{dep.name}"
+                                        itemValue="#{dep}">
+                                        <p:column>
+                                            <h:outputLabel value="#{dep.name}" />
+                                        </p:column>
+                                        <p:column>
+                                            <h:outputLabel value="#{dep.institution.name}" />
+                                        </p:column>
+                                    </p:autoComplete>
+                                </div>
+                            </div>
+
+                            <div class="row mt-2">
+                                <div class="col-2">
+                                    <h:outputLabel value="Item Type" class="mt-2" />
+                                </div>
+                                <div class="col-10">
+                                    <p:selectOneMenu id="itemType" value="#{feeMarginAllowedController.itemType}" class="w-100">
+                                        <f:selectItem itemLabel="Service" itemValue="Service" />
+                                        <f:selectItem itemLabel="Investigation" itemValue="Investigation" />
+                                    </p:selectOneMenu>
+                                </div>
+                            </div>
+
+                            <div class="row mt-3">
+                                <div class="col-2"></div>
+                                <div class="col-10">
+                                    <p:commandButton
+                                        value="Process"
+                                        icon="fa fa-search"
+                                        class="ui-button-success"
+                                        ajax="false"
+                                        action="#{feeMarginAllowedController.process()}" />
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <p:panel class="mt-2" rendered="#{feeMarginAllowedController.groups ne null}">
+                            <f:facet name="header">
+                                <h:outputLabel value="Items and Fees" class="mt-2" />
+                                <div class="d-flex gap-2" style="float: right;">
+                                    <p:commandButton
+                                        value="Select All"
+                                        icon="fa fa-check-double"
+                                        class="ui-button-secondary"
+                                        ajax="false"
+                                        action="#{feeMarginAllowedController.selectAll()}" />
+                                    <p:commandButton
+                                        value="Clear"
+                                        icon="fa fa-times"
+                                        class="ui-button-warning mx-2"
+                                        ajax="false"
+                                        action="#{feeMarginAllowedController.deselectAll()}" />
+                                    <p:commandButton
+                                        value="Update Fees"
+                                        icon="fa fa-save"
+                                        class="ui-button-success"
+                                        ajax="false"
+                                        onclick="if (!confirm('Set Service Charge Allowed = Yes for all selected fees?')) return false;"
+                                        action="#{feeMarginAllowedController.updateSelectedFees()}" />
+                                </div>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="items"
+                                value="#{feeMarginAllowedController.groups}"
+                                var="g"
+                                rowIndexVar="itemIndex"
+                                emptyMessage="No items to display."
+                                class="w-100">
+
+                                <p:column headerText="No" width="3em">
+                                    <h:outputLabel value="#{itemIndex + 1}" />
+                                </p:column>
+                                <p:column headerText="Item Code" width="10em">
+                                    <h:outputLabel value="#{g.item.code}" />
+                                </p:column>
+                                <p:column headerText="Name">
+                                    <h:outputLabel value="#{g.item.name}" />
+                                </p:column>
+                                <p:column headerText="Type" width="10em">
+                                    <h:outputLabel value="#{g.type}" />
+                                </p:column>
+
+                                <p:column headerText="Fees">
+                                    <p:dataTable
+                                        value="#{g.feeRows}"
+                                        var="fr"
+                                        rowIndexVar="feeIndex"
+                                        class="w-100">
+
+                                        <p:column headerText="No" width="3em">
+                                            <h:outputLabel value="#{feeIndex + 1}" />
+                                        </p:column>
+                                        <p:column headerText="Fee Name">
+                                            <h:outputLabel value="#{fr.itemFee.name}" />
+                                        </p:column>
+                                        <p:column headerText="Fee Type" width="10em">
+                                            <h:outputLabel value="#{fr.itemFee.feeType.label}" />
+                                        </p:column>
+                                        <p:column headerText="Local Fee" width="8em" class="text-end">
+                                            <h:outputLabel value="#{fr.itemFee.fee}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Foreigner Fee" width="8em" class="text-end">
+                                            <h:outputLabel value="#{fr.itemFee.ffee}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Margin Allowed" width="9em">
+                                            <p:badge value="Allowed" styleClass="ui-badge-success" rendered="#{fr.itemFee.marginAllowed}" />
+                                            <p:badge value="Not Allowed" styleClass="ui-badge-danger" rendered="#{!fr.itemFee.marginAllowed}" />
+                                        </p:column>
+                                        <p:column headerText="Discount Allowed" width="9em">
+                                            <p:badge value="Allowed" styleClass="ui-badge-success" rendered="#{fr.itemFee.discountAllowed}" />
+                                            <p:badge value="Not Allowed" styleClass="ui-badge-danger" rendered="#{!fr.itemFee.discountAllowed}" />
+                                        </p:column>
+                                        <p:column headerText="Select" width="5em">
+                                            <p:selectBooleanCheckbox value="#{fr.selected}" />
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
+++ b/src/main/webapp/inward/inward_fee_margin_allowed.xhtml
@@ -11,6 +11,9 @@
         <ui:composition template="/inward/inward_administration.xhtml">
 
             <ui:define name="subcontent">
+                <style>
+                    .fee-margin-table td { padding: 8px !important; }
+                </style>
                 <h:form id="form">
 
                     <p:panel header="Service Charge Allowed - Fee Update" class="row w-100">
@@ -21,46 +24,36 @@
                                 <h:outputLabel value="Filter" class="mx-2" />
                             </f:facet>
 
-                            <div class="row">
-                                <div class="col-2">
-                                    <h:outputLabel value="Department" class="mt-2" />
-                                </div>
-                                <div class="col-10">
+                            <div class="d-flex align-items-end flex-wrap gap-3">
+                                <div>
+                                    <h:outputLabel value="Department" class="d-block mb-1" />
                                     <p:autoComplete
                                         id="department"
                                         value="#{feeMarginAllowedController.department}"
                                         forceSelection="true"
+                                        placeholder="Select Department"
                                         completeMethod="#{departmentController.completeDept}"
                                         var="dep"
                                         inputStyleClass="form-control"
-                                        class="w-100"
+                                        style="width: 24em;"
                                         itemLabel="#{dep.name}"
                                         itemValue="#{dep}">
-                                        <p:column>
+                                        <p:column style="padding: 8px;">
                                             <h:outputLabel value="#{dep.name}" />
                                         </p:column>
-                                        <p:column>
+                                        <p:column style="padding: 8px;">
                                             <h:outputLabel value="#{dep.institution.name}" />
                                         </p:column>
                                     </p:autoComplete>
                                 </div>
-                            </div>
-
-                            <div class="row mt-2">
-                                <div class="col-2">
-                                    <h:outputLabel value="Item Type" class="mt-2" />
-                                </div>
-                                <div class="col-10">
-                                    <p:selectOneMenu id="itemType" value="#{feeMarginAllowedController.itemType}" class="w-100">
+                                <div>
+                                    <h:outputLabel value="Item Type" class="d-block mb-1" />
+                                    <p:selectOneMenu id="itemType" value="#{feeMarginAllowedController.itemType}" style="width: 12em;">
                                         <f:selectItem itemLabel="Service" itemValue="Service" />
                                         <f:selectItem itemLabel="Investigation" itemValue="Investigation" />
                                     </p:selectOneMenu>
                                 </div>
-                            </div>
-
-                            <div class="row mt-3">
-                                <div class="col-2"></div>
-                                <div class="col-10">
+                                <div>
                                     <p:commandButton
                                         value="Process"
                                         icon="fa fa-search"
@@ -103,19 +96,21 @@
                                 var="g"
                                 rowIndexVar="itemIndex"
                                 emptyMessage="No items to display."
-                                class="w-100">
+                                class="w-100 fee-margin-table">
 
-                                <p:column headerText="No" width="3em">
+                                <p:column headerText="No" width="2em" class="text-center">
                                     <h:outputLabel value="#{itemIndex + 1}" />
                                 </p:column>
-                                <p:column headerText="Item Code" width="10em">
-                                    <h:outputLabel value="#{g.item.code}" />
-                                </p:column>
-                                <p:column headerText="Name">
+                                <p:column headerText="Name" width="16em">
                                     <h:outputLabel value="#{g.item.name}" />
                                 </p:column>
-                                <p:column headerText="Type" width="10em">
+                                <p:column headerText="Type" width="7em">
                                     <h:outputLabel value="#{g.type}" />
+                                </p:column>
+                                <p:column headerText="Select All Fees" width="6em" class="text-center">
+                                    <p:selectBooleanCheckbox value="#{g.allSelected}">
+                                        <p:ajax listener="#{g.toggleAllFees}" update="@(.fee-margin-table)" />
+                                    </p:selectBooleanCheckbox>
                                 </p:column>
 
                                 <p:column headerText="Fees">
@@ -125,34 +120,34 @@
                                         rowIndexVar="feeIndex"
                                         class="w-100">
 
-                                        <p:column headerText="No" width="3em">
+                                        <p:column headerText="No" width="2em" class="text-center">
                                             <h:outputLabel value="#{feeIndex + 1}" />
                                         </p:column>
-                                        <p:column headerText="Fee Name">
+                                        <p:column headerText="Fee Name" width="12em">
                                             <h:outputLabel value="#{fr.itemFee.name}" />
                                         </p:column>
-                                        <p:column headerText="Fee Type" width="10em">
+                                        <p:column headerText="Fee Type" width="4em">
                                             <h:outputLabel value="#{fr.itemFee.feeType.label}" />
                                         </p:column>
-                                        <p:column headerText="Local Fee" width="8em" class="text-end">
+                                        <p:column headerText="Local Fee" width="7em" class="text-end">
                                             <h:outputLabel value="#{fr.itemFee.fee}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Foreigner Fee" width="8em" class="text-end">
+                                        <p:column headerText="Foreigner Fee" width="7em" class="text-end">
                                             <h:outputLabel value="#{fr.itemFee.ffee}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Margin Allowed" width="9em">
+                                        <p:column headerText="Margin Allowed" width="8em" class="text-center">
                                             <p:badge value="Allowed" styleClass="ui-badge-success" rendered="#{fr.itemFee.marginAllowed}" />
                                             <p:badge value="Not Allowed" styleClass="ui-badge-danger" rendered="#{!fr.itemFee.marginAllowed}" />
                                         </p:column>
-                                        <p:column headerText="Discount Allowed" width="9em">
+                                        <p:column headerText="Discount Allowed" width="8em" class="text-center">
                                             <p:badge value="Allowed" styleClass="ui-badge-success" rendered="#{fr.itemFee.discountAllowed}" />
                                             <p:badge value="Not Allowed" styleClass="ui-badge-danger" rendered="#{!fr.itemFee.discountAllowed}" />
                                         </p:column>
-                                        <p:column headerText="Select" width="5em">
+                                        <p:column headerText="Select" width="3em" class="text-center">
                                             <p:selectBooleanCheckbox value="#{fr.selected}" />
                                         </p:column>
                                     </p:dataTable>


### PR DESCRIPTION
## Summary
  Adds an admin tool to bulk-enable the fee-level **Service Charge Allowed** (`marginAllowed`) flag on inpatient fees. During inward billing the service charge/margin is skipped whenever a fee's  `marginAllowed` is `false`, and currently every `ItemFee` has it set to `false` — so no margin is  calculated for added items. This tool lets staff review fees by Department + Item Type and flip selected fees to allowed in one pass.

  ## Changes
  - **New page** `inward/inward_fee_margin_allowed.xhtml` — filter by Department + Item Type (Service / Investigation), Process to load items, each with a fees sub-table (fee name, type, local & foreigner fee, Margin/Discount Allowed badges, per-fee select checkbox).
  - **New bean** `FeeMarginAllowedController` — loads base fees (`forInstitution`/`forCategory` null, matching what inward billing reads), groups them by item, and on **Update Fees** sets `marginAllowed = true` for selected fees only, stamping `editer`/`editedAt` and skipping fees already allowed.
  - **Navigation** — adds the **"Service Charge Allowed - Fee Update"** button to the Price Matrix tab in `inward/inward_administration.xhtml`.
  - Row-level **Select All Fees** (per item) plus global **Select All / Clear**; fees start unselected after Process.

  ## Test plan
  - [ ] Open Administration → Manage Inpatient Services → Price Matrix → **Service Charge Allowed - Fee Update**.
  - [ ] Select a Department + Item Type and press **Process**; verify the correct items/fees load and all checkboxes are unselected.
  - [ ] Verify the row-level **Select All Fees** toggles only that item's fees; verify global **Select All / Clear**.
  - [ ] Select some fees, press **Update Fees**, confirm; verify only selected fees flip to `marginAllowed = true` and already-allowed fees are untouched.
  - [ ] Re-run Process and confirm the updated fees now show **Allowed**.
  - [ ] In inward billing (`inward/inward_bill_service.xhtml`), add an item whose fees were updated and confirm the service charge/margin is calculated again.

  Closes #21063 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Service Charge Allowed - Fee Update" admin UI for bulk-enabling service charge on item fees.
  * Filter by department and item type (Service/Investigation), process to load applicable items, and per-item/group fee selection.
  * Select all / clear controls, confirmation on update, and success/error reporting after updates.
* **UI**
  * Navigation added from the Price Matrix actions to the new management page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->