### PR TITLE
fix(hr): fix salary advance not being deducted from main salary

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffSalaryAdvanceController.java
@@ -498,14 +498,16 @@ public class StaffSalaryAdvanceController implements Serializable {
 
     private StaffSalaryComponant createStaffSalaryComponant(PaysheetComponentType paysheetComponentType) {
         StaffSalaryComponant ss = new StaffSalaryComponant();
-//        ss.setStaffSalary(getCurrent());
         ss.setCreatedAt(new Date());
         ss.setSalaryCycle(salaryCycle);
         ss.setCreater(getSessionController().getLoggedUser());
-        ss.setStaffPaysheetComponent(getHumanResourceBean().getComponent(getCurrent().getStaff(), getSessionController().getLoggedUser(), paysheetComponentType));
-        getHumanResourceBean().setEpf(ss, getHrmVariablesController().getCurrent().getEpfRate(), getHrmVariablesController().getCurrent().getEpfCompanyRate());
-        getHumanResourceBean().setEtf(ss, getHrmVariablesController().getCurrent().getEtfRate(), getHrmVariablesController().getCurrent().getEtfCompanyRate());
-
+        ss.setStaff(getCurrent().getStaff()); // ← ADD THIS LINE
+        ss.setStaffPaysheetComponent(getHumanResourceBean().getComponent(
+                getCurrent().getStaff(), getSessionController().getLoggedUser(), paysheetComponentType));
+        getHumanResourceBean().setEpf(ss, getHrmVariablesController().getCurrent().getEpfRate(),
+                getHrmVariablesController().getCurrent().getEpfCompanyRate());
+        getHumanResourceBean().setEtf(ss, getHrmVariablesController().getCurrent().getEtfRate(),
+                getHrmVariablesController().getCurrent().getEtfCompanyRate());
         return ss;
     }
 

--- a/src/main/java/com/divudi/ejb/HumanResourceBean.java
+++ b/src/main/java/com/divudi/ejb/HumanResourceBean.java
@@ -3545,7 +3545,8 @@ public class HumanResourceBean {
         String sql = "Select s From StaffSalary s "
                 + " where s.retired=false "
                 + " and s.staff=:s "
-                + " and s.salaryCycle=:sal ";
+                + " and s.salaryCycle=:sal "
+                + " and s.transAdvanceSalary=0 ";
 
         HashMap hm = new HashMap<>();
         hm.put("sal", salaryCycle);


### PR DESCRIPTION
- Set staff field on StaffSalaryComponant in createStaffSalaryComponant() so advance components are findable by fetchAndSetSalaryAdvance()
- Filter transAdvanceSalary=0 in getStaffSalary() to prevent advance salary records from being loaded as main salary during generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed staff information assignment during salary component creation to ensure accurate staff data linkage.
  * Refined salary record filtering to properly exclude advance salary transactions from standard salary calculations, improving the accuracy of salary processing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->