### PR TITLE
fix(reports): switch Process buttons to AJAX to prevent timeout

### DIFF
--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -208,8 +208,8 @@
                         <div class="d-flex align-items-center mt-3">
                             <p:commandButton class="ui-button-warning mx-1"
                                              icon="fas fa-cogs"
-                                             ajax="false"
                                              value="Process"
+                                             update="@form"
                                              action="#{pharmacyController.createConsumptionReportTable()}">
                             </p:commandButton>
                             <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -199,10 +199,10 @@
                         </p:panelGrid>
 
                         <div class="d-flex align-items-center">
-                            <p:commandButton class="ui-button-warning mx-1" 
-                                             icon="fas fa-cogs" 
-                                             ajax="false"  
-                                             value="Process" 
+                            <p:commandButton class="ui-button-warning mx-1"
+                                             icon="fas fa-cogs"
+                                             value="Process"
+                                             update="@form"
                                              action="#{pharmacyReportController.processCostOfGoodSoldReport()}">
                             </p:commandButton>
                            


### PR DESCRIPTION
## Summary

- `consumption.xhtml` and `cost_of_goods_sold.xhtml` Process buttons used `ajax="false"`, causing synchronous HTTP form submits that are cut off by the server/proxy read timeout when reports take too long
- Switched both buttons to PrimeFaces AJAX mode (default `timeout=0` = no client-side limit) with `update="@form"` so results refresh in-place and the XHR stays open as long as the server needs

## Pages fixed

- `reports/inventoryReports/consumption.xhtml` — Consumption report
- `reports/inventoryReports/cost_of_goods_sold.xhtml` — Cost of Goods Sold report

## Test plan

- [ ] Open https://rh.carecode.org/rh/faces/reports/inventoryReports/consumption.xhtml, select a wide date range and click Process — should not time out
- [ ] Open https://rh.carecode.org/rh/faces/reports/inventoryReports/cost_of_goods_sold.xhtml, select a wide date range and click Process — should not time out
- [ ] Verify results still render correctly after the AJAX response

🤖 Generated with [Claude Code](https://claude.com/claude-code)