### PR TITLE
fix(reports): switch Process buttons to AJAX to prevent request timeout

### DIFF
--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -209,7 +209,10 @@
                             <p:commandButton class="ui-button-warning mx-1"
                                              icon="fas fa-cogs"
                                              value="Process"
-                                             update="@form"
+                                             widgetVar="wBtnProcess"
+                                             update="@form :growl"
+                                             onstart="PF('wBtnProcess').disable()"
+                                             oncomplete="PF('wBtnProcess').enable()"
                                              action="#{pharmacyController.createConsumptionReportTable()}">
                             </p:commandButton>
                             <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -208,8 +208,8 @@
                         <div class="d-flex align-items-center mt-3">
                             <p:commandButton class="ui-button-warning mx-1"
                                              icon="fas fa-cogs"
-                                             ajax="false"
                                              value="Process"
+                                             update="@form"
                                              action="#{pharmacyController.createConsumptionReportTable()}">
                             </p:commandButton>
                             <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -199,10 +199,10 @@
                         </p:panelGrid>
 
                         <div class="d-flex align-items-center">
-                            <p:commandButton class="ui-button-warning mx-1" 
-                                             icon="fas fa-cogs" 
-                                             ajax="false"  
-                                             value="Process" 
+                            <p:commandButton class="ui-button-warning mx-1"
+                                             icon="fas fa-cogs"
+                                             value="Process"
+                                             update="@form"
                                              action="#{pharmacyReportController.processCostOfGoodSoldReport()}">
                             </p:commandButton>
                            

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -202,7 +202,10 @@
                             <p:commandButton class="ui-button-warning mx-1"
                                              icon="fas fa-cogs"
                                              value="Process"
-                                             update="@form"
+                                             widgetVar="wBtnProcess"
+                                             update="@form :growl"
+                                             onstart="PF('wBtnProcess').disable()"
+                                             oncomplete="PF('wBtnProcess').enable()"
                                              action="#{pharmacyReportController.processCostOfGoodSoldReport()}">
                             </p:commandButton>
                            


### PR DESCRIPTION
## Summary

- `consumption.xhtml` and `cost_of_goods_sold.xhtml` Process buttons used `ajax="false"`, causing synchronous HTTP form submits that are cut off by the server/proxy read timeout when reports take too long
- Switched both buttons to PrimeFaces AJAX mode (default `timeout=0` = no client-side limit) with `update="@form"` so results refresh in-place and the XHR stays open as long as the server needs

## Pages fixed

- `reports/inventoryReports/consumption.xhtml` — Consumption report
- `reports/inventoryReports/cost_of_goods_sold.xhtml` — Cost of Goods Sold report

Closes #21068

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Submission behavior updated on consumption and cost-of-goods-sold inventory reports: actions now use partial updates to refresh the form and notifications without full page reloads, improving responsiveness and preserving existing disable/enable button behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->