### PR TITLE
fix(pharmacy): correct GRN-return stock-quantity signs (#21052)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -697,6 +697,19 @@ public class GrnReturnWorkflowController implements Serializable {
             // Process zero quantity items before approval
             processZeroQuantityItems();
 
+            // Approve re-submits the same form, so JSF rebinds fd.quantity / fd.freeQuantity
+            // to the positive number shown in the inputs. Re-apply the stock-out sign and
+            // persist each line so the approved bill keeps the correct sign. (hmislk/hmis#21052)
+            normalizeReturnFinanceSigns();
+            if (billItems != null) {
+                for (BillItem bi : billItems) {
+                    if (bi == null || bi.isRetired() || bi.getId() == null) {
+                        continue;
+                    }
+                    billItemFacade.edit(bi);
+                }
+            }
+
             // Mark the current bill as completed (approved)
             currentBill.setCompleted(true);
             currentBill.setCompletedBy(sessionController.getLoggedUser());
@@ -932,6 +945,12 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
+        // The qty / free-qty inputs are bound directly to fd.quantity / fd.freeQuantity,
+        // so JSF rewrites them as the positive number the user typed on submit, undoing
+        // the negative sign calculateLineTotal() applied during the blur ajax. Re-apply
+        // the stock-out sign here, immediately before persistence. (hmislk/hmis#21052)
+        normalizeReturnFinanceSigns();
+
         for (BillItem bi : billItems) {
             if (bi == null) {
                 continue;
@@ -972,6 +991,43 @@ public class GrnReturnWorkflowController implements Serializable {
                 pharmaceuticalBillItemFacade.create(phi);
             } else {
                 pharmaceuticalBillItemFacade.edit(phi);
+            }
+        }
+    }
+
+    /**
+     * Normalises the stock-direction sign on the user-entered quantity fields of
+     * every return line.
+     *
+     * The "Returning Qty" / "Returning Free Qty" inputs are value-bound directly to
+     * {@code BillItemFinanceDetails.quantity} / {@code freeQuantity}. JSF's
+     * UPDATE_MODEL_VALUES phase therefore rewrites them as the positive number the
+     * user typed on every submit, overwriting the negative value
+     * {@link #calculateLineTotal(BillItem)} set during the blur ajax. A GRN return
+     * moves stock OUT of the department, so these fields must be negative. Re-applying
+     * {@code abs().negate()} right before persistence keeps them consistent with the
+     * other stock-direction fields ({@code quantityByUnits}, {@code totalQuantity},
+     * {@code bi.qty}, {@code pbi.qty}). (hmislk/hmis#21052)
+     *
+     * Financial fields are intentionally left untouched here.
+     */
+    private void normalizeReturnFinanceSigns() {
+        if (billItems == null) {
+            return;
+        }
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired()) {
+                continue;
+            }
+            BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+            if (fd == null) {
+                continue;
+            }
+            if (fd.getQuantity() != null) {
+                fd.setQuantity(fd.getQuantity().abs().negate());
+            }
+            if (fd.getFreeQuantity() != null) {
+                fd.setFreeQuantity(fd.getFreeQuantity().abs().negate());
             }
         }
     }

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -279,18 +279,20 @@
                                                 title="Create a GRN for Selected Approved PO with costing"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
                                                 action="#{grnCostingController.navigateToResiveCostingWithSaveApprove()}"
+                                                onclick="return confirm('Create GRN for PO #{p.deptId}? This will start a new Goods Receipt with costing.');"
                                                 disabled="#{p.cancelled or p.billClosed or p.fullyIssued}">
                                                 <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                             </p:commandButton>
 
-                                            <p:commandButton 
-                                                ajax="false" 
+                                            <p:commandButton
+                                                ajax="false"
                                                 class="ui-button-info  w-100"
                                                 icon="fas fa-store"
-                                                value="Wholesale GRN" 
+                                                value="Wholesale GRN"
                                                 title="Create Wholesale GRN"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Pharmacy Wholesales', true)}"
-                                                action="#{grnController.navigateToReceiveWholesale()}" 
+                                                action="#{grnController.navigateToReceiveWholesale()}"
+                                                onclick="return confirm('Create Wholesale GRN for PO #{p.deptId}? This will start a new Wholesale Goods Receipt.');"
                                                 disabled="#{p.cancelled or p.billClosed or p.fullyIssued}"
                                                 style="min-width: 120px;">
                                                 <f:setPropertyActionListener target="#{grnController.approveBill}" value="#{p}"/>


### PR DESCRIPTION
## Summary

Fixes the GRN-return writer so the user-entered quantity fields persist with the correct **stock-out (negative)** sign, matching the canonical stock-direction rule from #21032.

The "Returning Qty" / "Returning Free Qty" inputs are value-bound directly to `BillItemFinanceDetails.quantity` / `freeQuantity`. JSF's UPDATE_MODEL_VALUES phase rewrites them as the positive number the user typed on every submit, undoing the negative sign `calculateLineTotal()` applies during the blur ajax. The save path never re-normalised, so these two fields persisted **positive** while every other stock-direction field (`quantityByUnits`, `totalQuantity`, `bi.qty`, `pbi.qty`) was correctly negative.

### Fix
- New `normalizeReturnFinanceSigns()` helper re-applies `abs().negate()` to `fd.quantity` and `fd.freeQuantity` for every non-retired return line.
- Invoked in `saveBillItems()` (covers Save-Request + Finalize-Request) and in `approve()` (which re-submits the same form and persists via cascade without going through `saveBillItems()`).
- Financial fields are intentionally left unchanged — the broader financial-sign inconsistency is tracked separately in #21070.

This PR also includes a small UX commit: a `confirm()` prompt before creating a GRN / Wholesale GRN from an approved PO, to prevent accidental Goods Receipts.

## Test plan
Verified end-to-end on local (create → finalize → approve, `completed=1`):
- [x] Paid-item return (`RURP//26/000005`): `fd.QUANTITY` now −100/−200 (was +); `fd.QUANTITYBYUNITS`, `fd.TOTALQUANTITY`, `bi.qty`, `pbi.QTY`, `fd.VALUEATPURCHASERATE` all consistently negative.
- [x] Free-item return (`RURP//26/000007`): `fd.FREEQUANTITY` now −10/−10 (was +); `fd.QUANTITY` correctly 0.
- [x] Magnitudes unchanged — only the sign flips.

## Related
- Closes #21052
- Master tracking issue: #21032
- Financial-total sign convention (separate, deferred): #21070
- PHARMACY_ISSUE valuation sign (separate): #21054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved financial data handling in goods receipt return approval workflows to ensure return quantities and amounts consistently maintain the correct negative values needed for accurate stock inventory tracking and management.
  * Enhanced the goods receipt creation process with confirmation dialogs for both standard and wholesale purchase order options to help prevent accidental submissions and improve overall workflow reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->