### PR TITLE
Fix JPQL joins in pharmaceutical item search queries

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -167,8 +167,10 @@ public class PharmaceuticalItemApiService implements Serializable {
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.VmpDto(")
                 .append("i.id, i.name, i.code, i.descreption, i.retired, i.inactive, ")
-                .append("i.vtm.id, i.vtm.name, i.dosageForm.id, i.dosageForm.name) ")
+                .append("vtm.id, vtm.name, df.id, df.name) ")
                 .append("FROM Vmp i ")
+                .append("LEFT JOIN i.vtm vtm ")
+                .append("LEFT JOIN i.dosageForm df ")
                 .append("WHERE i.retired = false ")
                 .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
 
@@ -190,9 +192,11 @@ public class PharmaceuticalItemApiService implements Serializable {
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.AmpDto(")
                 .append("i.id, i.name, i.code, i.barcode, i.inactive, ")
-                .append("i.vmp.id, i.vmp.name, i.category.id, i.category.name, ")
+                .append("vmp.id, vmp.name, cat.id, cat.name, ")
                 .append("df.id, df.name) ")
                 .append("FROM Amp i ")
+                .append("LEFT JOIN i.vmp vmp ")
+                .append("LEFT JOIN i.category cat ")
                 .append("LEFT JOIN i.dosageForm df ")
                 .append("WHERE i.retired = false ")
                 .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
@@ -215,8 +219,9 @@ public class PharmaceuticalItemApiService implements Serializable {
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.VmppDto(")
                 .append("i.id, i.name, i.code, i.retired, i.inactive, ")
-                .append("i.vmp.id, i.vmp.name) ")
+                .append("vmp.id, vmp.name) ")
                 .append("FROM Vmpp i ")
+                .append("LEFT JOIN i.vmp vmp ")
                 .append("WHERE i.retired = false ")
                 .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
 
@@ -238,8 +243,10 @@ public class PharmaceuticalItemApiService implements Serializable {
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.AmppDto(")
                 .append("i.id, i.name, i.code, i.retired, i.inactive, ")
-                .append("i.dblValue, i.packUnit.name, i.amp.id, i.amp.name) ")
+                .append("i.dblValue, pu.name, amp.id, amp.name) ")
                 .append("FROM Ampp i ")
+                .append("LEFT JOIN i.packUnit pu ")
+                .append("LEFT JOIN i.amp amp ")
                 .append("WHERE i.retired = false ")
                 .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
 


### PR DESCRIPTION
## Summary
Refactored JPQL queries in `PharmaceuticalItemApiService` to use explicit `LEFT JOIN` clauses instead of relying on implicit relationship navigation in the SELECT clause. This improves query clarity and ensures proper handling of null relationships.

## Key Changes
- **searchVmps()**: Added explicit `LEFT JOIN` for `vtm` and `dosageForm` relationships; updated SELECT clause to use join aliases
- **searchAmps()**: Added explicit `LEFT JOIN` for `vmp` and `category` relationships; updated SELECT clause to use join aliases (dosageForm join already existed)
- **searchVmpps()**: Added explicit `LEFT JOIN` for `vmp` relationship; updated SELECT clause to use join alias
- **searchAmpps()**: Added explicit `LEFT JOIN` for `packUnit` and `amp` relationships; updated SELECT clause to use join aliases

## Implementation Details
- All joins use `LEFT JOIN` to preserve records even when related entities are null
- Join aliases are consistently named (e.g., `vtm`, `df`, `vmp`, `cat`, `pu`, `amp`) for readability
- SELECT clause now references join aliases instead of navigating through entity properties (e.g., `vtm.id` instead of `i.vtm.id`)
- This pattern aligns with JPQL best practices and improves query maintainability

https://claude.ai/code/session_01A38r2eC75R5h4dy3ZVApnK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized pharmaceutical search queries for improved response times and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->