### PR TITLE
Add pagination support to pharmaceutical item search API

### DIFF
--- a/src/main/java/com/divudi/core/facade/AbstractFacade.java
+++ b/src/main/java/com/divudi/core/facade/AbstractFacade.java
@@ -836,6 +836,36 @@ public abstract class AbstractFacade<T> {
         return resultList;
     }
 
+    public List<?> findLightsByJpql(String jpql, Map<String, Object> parameters, TemporalType tt, int maxRecords, int firstResult) {
+        Query qry = getEntityManager().createQuery(jpql);
+        Set<Map.Entry<String, Object>> entries = parameters.entrySet();
+
+        for (Map.Entry<String, Object> entry : entries) {
+            String paramName = entry.getKey();
+            Object paramValue = entry.getValue();
+
+            if (paramValue instanceof Date) {
+                qry.setParameter(paramName, (Date) paramValue, tt);
+            } else {
+                qry.setParameter(paramName, paramValue);
+            }
+        }
+
+        if (firstResult > 0) {
+            qry.setFirstResult(firstResult);
+        }
+        qry.setMaxResults(maxRecords);
+
+        List<?> resultList;
+        try {
+            resultList = qry.getResultList();
+        } catch (Exception e) {
+            resultList = new ArrayList<>();
+        }
+
+        return resultList;
+    }
+
     public List<T> findByJpql(String jpql, int maxResults) {
         TypedQuery<T> qry = getEntityManager().createQuery(jpql, entityClass);
         qry.setMaxResults(maxResults);

--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -81,10 +81,8 @@ public class PharmaceuticalItemApiService implements Serializable {
 
     // ==================== SEARCH ====================
 
-    public List<?> searchItems(String type, String query, String departmentTypeStr, Integer limit) throws Exception {
-        if (query == null || query.trim().isEmpty()) {
-            throw new Exception("Query parameter is required");
-        }
+    public List<?> searchItems(String type, String query, String departmentTypeStr, Integer limit, Integer offset) throws Exception {
+        boolean hasQuery = query != null && !query.trim().isEmpty();
 
         DepartmentType deptType = null;
         if (departmentTypeStr != null && !departmentTypeStr.trim().isEmpty()) {
@@ -95,37 +93,46 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
         }
 
+        if (!hasQuery && deptType == null) {
+            throw new Exception("query or departmentType is required");
+        }
+
         int resultLimit = (limit != null && limit > 0 && limit <= 100) ? limit : 20;
+        int resultOffset = (offset != null && offset > 0) ? offset : 0;
+        String trimmedQuery = hasQuery ? query.trim() : null;
 
         switch (type) {
             case "vtm":
-                return searchVtms(query.trim(), deptType, resultLimit);
+                return searchVtms(trimmedQuery, deptType, resultLimit, resultOffset);
             case "atm":
-                return searchAtms(query.trim(), deptType, resultLimit);
+                return searchAtms(trimmedQuery, deptType, resultLimit, resultOffset);
             case "vmp":
-                return searchVmps(query.trim(), deptType, resultLimit);
+                return searchVmps(trimmedQuery, deptType, resultLimit, resultOffset);
             case "amp":
-                return searchAmps(query.trim(), deptType, resultLimit);
+                return searchAmps(trimmedQuery, deptType, resultLimit, resultOffset);
             case "vmpp":
-                return searchVmpps(query.trim(), deptType, resultLimit);
+                return searchVmpps(trimmedQuery, deptType, resultLimit, resultOffset);
             case "ampp":
-                return searchAmpps(query.trim(), deptType, resultLimit);
+                return searchAmpps(trimmedQuery, deptType, resultLimit, resultOffset);
             default:
                 throw new Exception("Invalid item type: " + type);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private List<VtmDto> searchVtms(String query, DepartmentType deptType, int limit) {
+    private List<VtmDto> searchVtms(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.VtmDto(")
                 .append("i.id, i.name, i.code, i.descreption, i.instructions, i.retired, i.inactive) ")
                 .append("FROM Vtm i ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -134,20 +141,23 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<VtmDto>) vtmFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<VtmDto>) vtmFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     @SuppressWarnings("unchecked")
-    private List<AtmDto> searchAtms(String query, DepartmentType deptType, int limit) {
+    private List<AtmDto> searchAtms(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.AtmDto(")
                 .append("i.id, i.name, i.code, i.descreption, i.retired, i.inactive) ")
                 .append("FROM Atm i ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -156,13 +166,12 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<AtmDto>) atmFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<AtmDto>) atmFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     @SuppressWarnings("unchecked")
-    private List<VmpDto> searchVmps(String query, DepartmentType deptType, int limit) {
+    private List<VmpDto> searchVmps(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.VmpDto(")
@@ -171,8 +180,12 @@ public class PharmaceuticalItemApiService implements Serializable {
                 .append("FROM Vmp i ")
                 .append("LEFT JOIN i.vtm vtm ")
                 .append("LEFT JOIN i.dosageForm df ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -181,13 +194,12 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<VmpDto>) vmpFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<VmpDto>) vmpFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     @SuppressWarnings("unchecked")
-    private List<AmpDto> searchAmps(String query, DepartmentType deptType, int limit) {
+    private List<AmpDto> searchAmps(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.AmpDto(")
@@ -198,8 +210,12 @@ public class PharmaceuticalItemApiService implements Serializable {
                 .append("LEFT JOIN i.vmp vmp ")
                 .append("LEFT JOIN i.category cat ")
                 .append("LEFT JOIN i.dosageForm df ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -208,13 +224,12 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<AmpDto>) ampFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<AmpDto>) ampFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     @SuppressWarnings("unchecked")
-    private List<VmppDto> searchVmpps(String query, DepartmentType deptType, int limit) {
+    private List<VmppDto> searchVmpps(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.VmppDto(")
@@ -222,8 +237,12 @@ public class PharmaceuticalItemApiService implements Serializable {
                 .append("vmp.id, vmp.name) ")
                 .append("FROM Vmpp i ")
                 .append("LEFT JOIN i.vmp vmp ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -232,13 +251,12 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<VmppDto>) vmppFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<VmppDto>) vmppFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     @SuppressWarnings("unchecked")
-    private List<AmppDto> searchAmpps(String query, DepartmentType deptType, int limit) {
+    private List<AmppDto> searchAmpps(String query, DepartmentType deptType, int limit, int offset) {
         Map<String, Object> params = new HashMap<>();
-        params.put("query", "%" + query.toUpperCase() + "%");
 
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.AmppDto(")
@@ -247,8 +265,12 @@ public class PharmaceuticalItemApiService implements Serializable {
                 .append("FROM Ampp i ")
                 .append("LEFT JOIN i.packUnit pu ")
                 .append("LEFT JOIN i.amp amp ")
-                .append("WHERE i.retired = false ")
-                .append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+                .append("WHERE i.retired = false ");
+
+        if (query != null) {
+            jpql.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.toUpperCase() + "%");
+        }
 
         if (deptType != null) {
             jpql.append("AND i.departmentType = :deptType ");
@@ -257,7 +279,7 @@ public class PharmaceuticalItemApiService implements Serializable {
 
         jpql.append("ORDER BY i.name");
 
-        return (List<AmppDto>) amppFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit);
+        return (List<AmppDto>) amppFacade.findLightsByJpql(jpql.toString(), params, javax.persistence.TemporalType.TIMESTAMP, limit, offset);
     }
 
     // ==================== GET BY ID ====================

--- a/src/main/java/com/divudi/ws/pharmacy/PharmaceuticalItemApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmaceuticalItemApi.java
@@ -74,10 +74,7 @@ public class PharmaceuticalItemApi {
             String query = uriInfo.getQueryParameters().getFirst("query");
             String departmentType = uriInfo.getQueryParameters().getFirst("departmentType");
             String limitStr = uriInfo.getQueryParameters().getFirst("limit");
-
-            if (query == null || query.trim().isEmpty()) {
-                return errorResponse("Query parameter is required", 400);
-            }
+            String offsetStr = uriInfo.getQueryParameters().getFirst("offset");
 
             Integer limit = null;
             if (limitStr != null && !limitStr.trim().isEmpty()) {
@@ -88,7 +85,16 @@ public class PharmaceuticalItemApi {
                 }
             }
 
-            List<?> results = itemService.searchItems(type, query.trim(), departmentType, limit);
+            Integer offset = null;
+            if (offsetStr != null && !offsetStr.trim().isEmpty()) {
+                try {
+                    offset = Integer.parseInt(offsetStr.trim());
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid offset format", 400);
+                }
+            }
+
+            List<?> results = itemService.searchItems(type, query, departmentType, limit, offset);
             return successResponse(results);
 
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
Enhanced the pharmaceutical item search functionality to support pagination through an `offset` parameter, allowing clients to retrieve results in pages rather than all at once. Also made the `query` parameter optional when filtering by `departmentType`.

## Key Changes

- **Added offset parameter**: New `offset` query parameter enables pagination alongside the existing `limit` parameter
  - Defaults to 0 if not provided or invalid
  - Passed through to all search methods and facade calls

- **Made query parameter optional**: 
  - Removed strict requirement for `query` parameter
  - Now allows filtering by `departmentType` alone
  - Validation ensures at least one of `query` or `departmentType` is provided

- **Updated all search methods**: Modified `searchVtms`, `searchAtms`, `searchVmps`, `searchAmps`, `searchVmpps`, and `searchAmpps` to:
  - Accept `offset` parameter
  - Conditionally add query filter to JPQL only when query is provided
  - Pass offset to facade's `findLightsByJpql` method

- **Extended AbstractFacade**: Added overloaded `findLightsByJpql` method that accepts both `maxRecords` and `firstResult` parameters for pagination support

- **Updated REST endpoint**: Modified `PharmaceuticalItemApi.searchItems` to:
  - Parse optional `offset` query parameter
  - Remove premature validation of query parameter
  - Pass offset to service layer

## Implementation Details

- Query parameter validation moved from REST layer to service layer for better separation of concerns
- Offset defaults to 0 and is only applied if greater than 0
- Query string is trimmed once and reused across all search methods to avoid redundant operations
- All six pharmaceutical item types (VTM, ATM, VMP, AMP, VMPP, AMPP) support the same pagination behavior

https://claude.ai/code/session_01StpSttDbe9eLBCyjzJu8Jb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pharmaceutical item search now supports pagination with an offset parameter for retrieving specific result ranges.
  * Search filtering by department type is now available as an alternative to text-based queries.
  * Query parameter is now optional—users can search exclusively by department type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->