### PR TITLE
perf(pharmacy): convert pharmacy_issue.xhtml search composite to DTO pattern (#21015)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4619,6 +4619,13 @@ public class SearchController implements Serializable {
             return;
         }
 
+        // PharmacyIssue atomics: redirect to DTO fetch so pharmacy_issue.xhtml composite
+        // (which binds to issueSearchDtos) shows results from the atomic search path.
+        if (billTypeAtomic.getBillType() == BillType.PharmacyIssue) {
+            pharmacyBillSearch.fetchIssueSearchDtos(maxResult);
+            return;
+        }
+
         String jpql;
         Map params = new HashMap();
 
@@ -4798,6 +4805,12 @@ public class SearchController implements Serializable {
         // PharmacyReturnWithoutTraising: use lightweight DTO query (issue #21014 / #20299).
         if (billType == BillType.PharmacyReturnWithoutTraising) {
             pharmacyBillSearch.fetchReturnWithoutTraisingSearchDtos(maxResult);
+            return;
+        }
+
+        // PharmacyIssue: use lightweight DTO query (issue #21015 / #20299).
+        if (billType == BillType.PharmacyIssue) {
+            pharmacyBillSearch.fetchIssueSearchDtos(maxResult);
             return;
         }
 

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4621,7 +4621,11 @@ public class SearchController implements Serializable {
 
         // PharmacyIssue atomics: redirect to DTO fetch so pharmacy_issue.xhtml composite
         // (which binds to issueSearchDtos) shows results from the atomic search path.
-        if (billTypeAtomic.getBillType() == BillType.PharmacyIssue) {
+        // ISSUE_MEDICINE_ON_REQUEST_INWARD is excluded: the atomic search page renders
+        // pharmacy_issue_for_inpatients.xhtml for that atomic, which still reads
+        // searchController.bills and must fall through to the generic query below.
+        if (billTypeAtomic.getBillType() == BillType.PharmacyIssue
+                && billTypeAtomic != BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD) {
             pharmacyBillSearch.fetchIssueSearchDtos(maxResult);
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -197,6 +197,7 @@ public class PharmacyBillSearch implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyDirectPurchaseSearchDTO> purchaseSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyGrnReturnSearchDTO> grnReturnSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyReturnWithoutTraisingSearchDTO> returnWithoutTraisingSearchDtos;
+    private List<com.divudi.core.data.dto.PharmacyIssueSearchDTO> issueSearchDtos;
 
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -5471,6 +5472,44 @@ public class PharmacyBillSearch implements Serializable {
         }
         if (returnWithoutTraisingSearchDtos == null) {
             returnWithoutTraisingSearchDtos = new ArrayList<>();
+        }
+    }
+
+    public List<com.divudi.core.data.dto.PharmacyIssueSearchDTO> getIssueSearchDtos() {
+        return issueSearchDtos;
+    }
+
+    public void setIssueSearchDtos(List<com.divudi.core.data.dto.PharmacyIssueSearchDTO> issueSearchDtos) {
+        this.issueSearchDtos = issueSearchDtos;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void fetchIssueSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("bt", com.divudi.core.data.BillType.PharmacyIssue);
+        m.put("fd", searchController.getFromDate());
+        m.put("td", searchController.getToDate());
+        m.put("dep", sessionController.getDepartment());
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacyIssueSearchDTO("
+                + "b.id, COALESCE(b.deptId, ''), COALESCE(b.insId, ''), "
+                + "COALESCE(b.toDepartment.name, ''), b.createdAt, COALESCE(creatorPerson.name, ''), "
+                + "b.cancelled, cb.createdAt, COALESCE(cancellerPerson.name, ''), "
+                + "COALESCE(cb.comments, ''), b.netTotal) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.creater creater LEFT JOIN creater.webUserPerson creatorPerson "
+                + "LEFT JOIN b.cancelledBill cb LEFT JOIN cb.creater canceller "
+                + "LEFT JOIN canceller.webUserPerson cancellerPerson "
+                + "WHERE b.billType = :bt AND b.createdAt BETWEEN :fd AND :td "
+                + "AND b.department = :dep AND b.retired = false ORDER BY b.createdAt DESC";
+        if (maxResult > 0) {
+            issueSearchDtos = (List<com.divudi.core.data.dto.PharmacyIssueSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            issueSearchDtos = (List<com.divudi.core.data.dto.PharmacyIssueSearchDTO>)
+                    billFacade.findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (issueSearchDtos == null) {
+            issueSearchDtos = new ArrayList<>();
         }
     }
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyIssueSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyIssueSearchDTO.java
@@ -1,0 +1,86 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for pharmacy issue bill search (issue #21015 / #20299).
+ * Eliminates N+1 lazy-load storms from the old Bill-entity approach.
+ */
+public class PharmacyIssueSearchDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String deptId;
+    private String insId;
+    private String toDepartmentName;
+    private Date createdAt;
+    private String creatorName;
+    private boolean cancelled;
+    private Date cancelledAt;
+    private String cancelledBy;
+    private String cancelComments;
+    private Double netTotal;
+
+    public PharmacyIssueSearchDTO() {
+    }
+
+    public PharmacyIssueSearchDTO(
+            Long id,
+            String deptId,
+            String insId,
+            String toDepartmentName,
+            Date createdAt,
+            String creatorName,
+            Boolean cancelled,
+            Date cancelledAt,
+            String cancelledBy,
+            String cancelComments,
+            Double netTotal) {
+        this.id = id;
+        this.deptId = deptId;
+        this.insId = insId;
+        this.toDepartmentName = toDepartmentName;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.cancelled = cancelled != null ? cancelled : false;
+        this.cancelledAt = cancelledAt;
+        this.cancelledBy = cancelledBy;
+        this.cancelComments = cancelComments;
+        this.netTotal = netTotal;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+
+    public String getInsId() { return insId; }
+    public void setInsId(String insId) { this.insId = insId; }
+
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+
+    public Date getCancelledAt() { return cancelledAt; }
+    public void setCancelledAt(Date cancelledAt) { this.cancelledAt = cancelledAt; }
+
+    public String getCancelledBy() { return cancelledBy; }
+    public void setCancelledBy(String cancelledBy) { this.cancelledBy = cancelledBy; }
+
+    public String getCancelComments() { return cancelComments; }
+    public void setCancelComments(String cancelComments) { this.cancelComments = cancelComments; }
+
+    public Double getNetTotal() { return netTotal; }
+    public void setNetTotal(Double netTotal) { this.netTotal = netTotal; }
+}

--- a/src/main/webapp/resources/pharmacy/search/pharmacy_issue.xhtml
+++ b/src/main/webapp/resources/pharmacy/search/pharmacy_issue.xhtml
@@ -11,79 +11,107 @@
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
+    <!--
+        DTO-based pharmacy issue bill search composite (issue #21015 / #20299).
+        Binds to pharmacyBillSearch.issueSearchDtos
+        (List<PharmacyIssueSearchDTO>) populated by
+        SearchController.createTableByBillType() when billType == PharmacyIssue,
+        and by SearchController.processPharmacyBillSearch() for all
+        PharmacyIssue atomics.
+        LEFT JOIN on cancelledBill prevents silent row drops and captures
+        cancellation metadata without N+1 lazy loads.
+    -->
     <cc:implementation>
-        <h:panelGrid columns="5">         
-            <h:outputLabel value="Req No"/>
-            <h:outputLabel value="Supplier Name"/>
-            <h:outputLabel value="Net Total"/>
-            <h:outputLabel value="Item Name"/>
-            <h:outputLabel value="Item Code"/>
-            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.department}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}"/>
-            <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
-        </h:panelGrid>
-        <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.bills}" var="bill" >
+
+        <p:commandButton ajax="false" value="Download" icon="fa fa-download"
+                         styleClass="ui-button-success mb-2">
+            <p:dataExporter target="tblPharmacyIssue" type="xlsx" fileName="pharmacy_issue_bill_list"/>
+        </p:commandButton>
+
+        <p:dataTable rowIndexVar="i"
+                     id="tblPharmacyIssue"
+                     widgetVar="tblPharmacyIssue"
+                     value="#{pharmacyBillSearch.issueSearchDtos}"
+                     var="dto"
+                     paginator="true"
+                     rows="10"
+                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                     rowsPerPageTemplate="10,20,50,100"
+                     emptyMessage="No Pharmacy Issue Bills Found">
+
             <f:facet name="header">
-                <h:outputLabel value="Pharmacy Issue"/>
+                <h:outputLabel value="PHARMACY ISSUE"/>
             </f:facet>
 
-
-            <p:column headerText="Order No">                        
-                <h:outputLabel value="#{bill.deptId}"/>                          
-            </p:column>
-
-            <p:column headerText="Issue No">                        
-                <h:outputLabel value="#{bill.insId}"/>                          
-            </p:column>
-
-            <p:column headerText="To Department">                       
-                <h:outputLabel value="#{bill.toDepartment.name}"/>                          
-            </p:column>  
-            <p:column headerText="Issued By">
-                <h:outputLabel value="#{bill.creater.webUserPerson.name}"/>     
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled By " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>
-            <p:column headerText="Issued At">                      
-                <h:outputLabel value="#{bill.createdAt}" >
-                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
-                </h:outputLabel>                     
-                <br/>
-                <h:panelGroup rendered="#{bill.cancelled}" >
-                    <h:outputLabel style="color: red;" value="Cancelled at " />
-                    <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" 
-                                   value="#{bill.cancelledBill.createdAt}" >
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
-                    </h:outputLabel>
-                </h:panelGroup>
-            </p:column>
-
-            <p:column headerText="Net Value" style="text-align: right;"  >             
-                <h:outputLabel value="#{bill.netTotal}" >
-                    <f:convertNumber pattern="#,##0.00"/>
-                </h:outputLabel>                  
-            </p:column>
-
-            <p:column headerText="Comments" >
-                <h:outputLabel rendered="#{bill.refundedBill ne null}" value="#{bill.refundedBill.comments}" >
-                </h:outputLabel>
-                <h:outputLabel  rendered="#{bill.cancelledBill ne null}" value="#{bill.cancelledBill.comments}" >
-                </h:outputLabel>
-            </p:column>
-
-            <p:column headerText="Actions">
-                <!--                <p:commandButton ajax="false" value="View Bill" action="/pharmacy/pharmacy_reprint_transfer_isssue?faces-redirect=true">
-                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{bill}"/>
-                                </p:commandButton>-->
-                <p:commandButton ajax="false" value="View Bill" action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferIssueById}">
-                    <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{bill.id}"/>
+            <!-- Actions (not exported) -->
+            <p:column headerText="Actions" exportable="false" style="white-space:nowrap;">
+                <p:commandButton
+                    ajax="false"
+                    icon="fa fa-eye"
+                    styleClass="ui-button-info ui-button-sm"
+                    title="View Bill"
+                    action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferIssueById()}">
+                    <f:setPropertyActionListener value="#{dto.id}" target="#{pharmacyBillSearch.billId}"/>
                 </p:commandButton>
+            </p:column>
+
+            <p:column headerText="Order No"
+                      sortBy="#{dto.deptId}"
+                      filterBy="#{dto.deptId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.deptId}"/>
+            </p:column>
+
+            <p:column headerText="Issue No"
+                      sortBy="#{dto.insId}"
+                      filterBy="#{dto.insId}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.insId}"/>
+            </p:column>
+
+            <p:column headerText="To Department"
+                      sortBy="#{dto.toDepartmentName}"
+                      filterBy="#{dto.toDepartmentName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.toDepartmentName}"/>
+            </p:column>
+
+            <p:column headerText="Issued At" sortBy="#{dto.createdAt}">
+                <h:outputLabel value="#{dto.createdAt}">
+                    <f:convertDateTime timeZone="Asia/Colombo"
+                                       pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Issued By"
+                      sortBy="#{dto.creatorName}"
+                      filterBy="#{dto.creatorName}"
+                      filterMatchMode="contains">
+                <h:outputLabel value="#{dto.creatorName}"/>
+            </p:column>
+
+            <p:column headerText="Net Value" sortBy="#{dto.netTotal}" style="text-align:right;">
+                <h:outputLabel value="#{dto.netTotal}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputLabel>
+            </p:column>
+
+            <p:column headerText="Status">
+                <h:outputText value="Cancelled" rendered="#{dto.cancelled}" style="display:none;"/>
+                <p:badge value="Cancelled" severity="danger" rendered="#{dto.cancelled}"/>
+            </p:column>
+
+            <p:column headerText="Cancellation Details">
+                <h:panelGroup rendered="#{dto.cancelled}">
+                    <h:outputText style="color:red;" value="Cancelled At: "/>
+                    <h:outputText style="color:red;" value="#{dto.cancelledAt}">
+                        <f:convertDateTime timeZone="Asia/Colombo"
+                                           pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                    </h:outputText>
+                    <h:outputText style="color:red;" value=" By: #{dto.cancelledBy}"/>
+                    <h:outputText rendered="#{not empty dto.cancelComments}"
+                                  style="color:red;" value=" | #{dto.cancelComments}"/>
+                </h:panelGroup>
             </p:column>
 
         </p:dataTable>


### PR DESCRIPTION
## Summary

- Converts `pharmacy_issue.xhtml` from full `Bill` entity loading (`searchController.bills`) to a lightweight JPQL constructor-query DTO, eliminating N+1 lazy-load storms on `cancelledBill`, `creater.webUserPerson`, and `toDepartment` chains
- Adds `PharmacyIssueSearchDTO` with 11 fields: `id`, `deptId` (Order No), `insId` (Issue No), `toDepartmentName`, `createdAt`, `creatorName`, `cancelled`, `cancelledAt`, `cancelledBy`, `cancelComments`, `netTotal`
- Adds `fetchIssueSearchDtos()` in `PharmacyBillSearch` using `BilledBill` + LEFT JOINs on `cancelledBill` chain; reuses existing `navigateToReprintPharmacyTransferIssueById()` for the View button
- Adds early-exit dispatch in `SearchController.createTableByBillType()` and `processPharmacyBillSearch()` for `BillType.PharmacyIssue` (covers all atomics: `PHARMACY_ISSUE`, `PHARMACY_ISSUE_CANCELLED`, `PHARMACY_ISSUE_RETURN`, `PHARMACY_DIRECT_ISSUE`, `PHARMACY_DIRECT_ISSUE_CANCELLED`, and inward variants)
- Rewrites the composite as a paginated `p:dataTable` with sort/filter columns, a Status badge column, and a Cancellation Details column

## Test plan

- [ ] Search pharmacy issues by date range — table shows results from `issueSearchDtos`, not `searchController.bills`
- [ ] Order No, Issue No, To Department, Issued By columns show correct data
- [ ] View button navigates to `pharmacy_reprint_transfer_isssue` with bill loaded
- [ ] Cancelled bills show badge + cancellation details (timestamp, actor, comments)
- [ ] XLSX download exports the table correctly
- [ ] Atomic search path (`pharmacy_search_by_bill_type_atomic.xhtml`) also uses DTO fetch correctly

Closes #21015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pharmacy issue search with optimized data retrieval and improved result display.
  * Added XLSX export capability for pharmacy issue search results.
  * Updated search results interface to display issue details, destination departments, creation timestamps, creator information, and cancellation status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->