### PR TITLE
feat(sap): SAP config keys & OAuth 2.0 token service (#21093)

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -119,6 +119,7 @@ public class ConfigOptionApplicationController implements Serializable {
             loadDatabaseVersionConfigurationDefaults();
             loadAiChatConfigurationDefaults();
             loadStockHistoryArchiveConfigurationDefaults();
+            loadSapIntegrationConfigurationDefaults();
             enumController.resetPaymentMethods();
         } finally {
             isLoadingApplicationOptions = false;
@@ -1571,6 +1572,16 @@ public class ConfigOptionApplicationController implements Serializable {
 
     public void listApplicationOptions() {
         options = getApplicationOptions();
+    }
+
+    private void loadSapIntegrationConfigurationDefaults() {
+        getBooleanValueByKey("SAP Integration - Enabled", false);
+        getShortTextValueByKey("SAP Integration - Base URL", "");
+        getShortTextValueByKey("SAP Integration - Token URL", "");
+        getShortTextValueByKey("SAP Integration - Client ID", "");
+        getShortTextValueByKey("SAP Integration - Client Secret", "");
+        getShortTextValueByKey("SAP Integration - Material Code Field", "code");
+        getShortTextValueByKey("SAP Integration - Inventory Last Sync", "");
     }
 
 }

--- a/src/main/java/com/divudi/service/sap/SapIntegrationException.java
+++ b/src/main/java/com/divudi/service/sap/SapIntegrationException.java
@@ -1,0 +1,22 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.sap;
+
+/**
+ * Thrown when an SAP integration operation fails (token fetch, API call, etc.).
+ * Callers should catch this and return a graceful error response rather than
+ * letting it propagate as an unchecked exception that would roll back transactions.
+ */
+public class SapIntegrationException extends Exception {
+
+    public SapIntegrationException(String message) {
+        super(message);
+    }
+
+    public SapIntegrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/divudi/service/sap/SapTokenService.java
+++ b/src/main/java/com/divudi/service/sap/SapTokenService.java
@@ -11,6 +11,7 @@ import java.io.StringReader;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.util.Base64;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
@@ -129,9 +130,15 @@ public class SapTokenService implements Serializable {
                     .connectTimeout(Duration.ofSeconds(15))
                     .build();
 
+            String basicCredentials = Base64.getEncoder().encodeToString(
+                    (URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                            + ":" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8))
+                            .getBytes(StandardCharsets.UTF_8));
+
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(tokenUrl))
                     .header("Content-Type", "application/x-www-form-urlencoded")
+                    .header("Authorization", "Basic " + basicCredentials)
                     .POST(HttpRequest.BodyPublishers.ofString(body))
                     .timeout(Duration.ofSeconds(15))
                     .build();
@@ -152,9 +159,11 @@ public class SapTokenService implements Serializable {
 
                 cachedToken = json.getString("access_token");
 
-                // expires_in is in seconds; subtract 30s buffer to refresh before actual expiry
+                // expires_in is in seconds; subtract 30s buffer so we refresh before actual expiry.
+                // Use 0 as the floor (not 30) so short-lived tokens don't get cached past their real expiry.
                 int expiresIn = json.containsKey("expires_in") ? json.getInt("expires_in") : 3600;
-                tokenExpiresAt = Instant.now().plusSeconds(Math.max(expiresIn - 30, 30));
+                long refreshIn = Math.max(expiresIn - 30L, 0L);
+                tokenExpiresAt = Instant.now().plusSeconds(refreshIn);
 
                 LOG.log(Level.INFO, "SAP bearer token refreshed, expires in {0}s", expiresIn);
                 return cachedToken;

--- a/src/main/java/com/divudi/service/sap/SapTokenService.java
+++ b/src/main/java/com/divudi/service/sap/SapTokenService.java
@@ -1,0 +1,170 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.sap;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.Lock;
+import javax.ejb.LockType;
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+/**
+ * Fetches and caches SAP S/4HANA Cloud OAuth 2.0 client-credentials tokens.
+ *
+ * Singleton so the cached token survives across requests. Refreshes automatically
+ * when the token has expired or when the caller signals a 401 via {@link #invalidate()}.
+ */
+@Singleton
+public class SapTokenService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(SapTokenService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    // Config keys — values stored in ConfigOption, never hard-coded
+    public static final String KEY_BASE_URL     = "SAP Integration - Base URL";
+    public static final String KEY_TOKEN_URL    = "SAP Integration - Token URL";
+    public static final String KEY_CLIENT_ID    = "SAP Integration - Client ID";
+    public static final String KEY_CLIENT_SECRET = "SAP Integration - Client Secret";
+    public static final String KEY_ENABLED      = "SAP Integration - Enabled";
+
+    @Inject
+    private ConfigOptionApplicationController configController;
+
+    private String cachedToken;
+    private Instant tokenExpiresAt;
+
+    @PostConstruct
+    public void init() {
+        cachedToken = null;
+        tokenExpiresAt = Instant.EPOCH;
+    }
+
+    /**
+     * Returns a valid bearer token, fetching a new one if the cache is empty or expired.
+     *
+     * @return bearer token string, or null if SAP integration is disabled or config is incomplete
+     * @throws SapIntegrationException if the token fetch fails
+     */
+    @Lock(LockType.WRITE)
+    public String getBearerToken() throws SapIntegrationException {
+        if (!isEnabled()) {
+            return null;
+        }
+        if (isTokenValid()) {
+            return cachedToken;
+        }
+        return fetchNewToken();
+    }
+
+    /**
+     * Forces token eviction so the next {@link #getBearerToken()} call fetches a fresh one.
+     * Call this when a downstream SAP API returns 401.
+     */
+    @Lock(LockType.WRITE)
+    public void invalidate() {
+        cachedToken = null;
+        tokenExpiresAt = Instant.EPOCH;
+    }
+
+    /**
+     * Returns true if SAP integration is toggled on and all required config keys are non-empty.
+     */
+    @Lock(LockType.READ)
+    public boolean isEnabled() {
+        if (!configController.getBooleanValueByKey(KEY_ENABLED, false)) {
+            return false;
+        }
+        String tokenUrl  = configController.getShortTextValueByKey(KEY_TOKEN_URL, "");
+        String clientId  = configController.getShortTextValueByKey(KEY_CLIENT_ID, "");
+        String clientSecret = configController.getShortTextValueByKey(KEY_CLIENT_SECRET, "");
+        return !tokenUrl.trim().isEmpty() && !clientId.trim().isEmpty() && !clientSecret.trim().isEmpty();
+    }
+
+    /**
+     * Returns the configured SAP base URL (e.g. {@code https://{tenant}.s4hana.cloud.sap}).
+     */
+    @Lock(LockType.READ)
+    public String getBaseUrl() {
+        return configController.getShortTextValueByKey(KEY_BASE_URL, "");
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private boolean isTokenValid() {
+        return cachedToken != null && Instant.now().isBefore(tokenExpiresAt);
+    }
+
+    private String fetchNewToken() throws SapIntegrationException {
+        String tokenUrl    = configController.getShortTextValueByKey(KEY_TOKEN_URL, "");
+        String clientId    = configController.getShortTextValueByKey(KEY_CLIENT_ID, "");
+        String clientSecret = configController.getShortTextValueByKey(KEY_CLIENT_SECRET, "");
+
+        String body = "grant_type=client_credentials"
+                + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(15))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(tokenUrl))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .timeout(Duration.ofSeconds(15))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new SapIntegrationException("SAP token endpoint returned HTTP " + response.statusCode()
+                        + ": " + response.body());
+            }
+
+            try (JsonReader reader = Json.createReader(new StringReader(response.body()))) {
+                JsonObject json = reader.readObject();
+
+                if (!json.containsKey("access_token")) {
+                    throw new SapIntegrationException("SAP token response missing access_token: " + response.body());
+                }
+
+                cachedToken = json.getString("access_token");
+
+                // expires_in is in seconds; subtract 30s buffer to refresh before actual expiry
+                int expiresIn = json.containsKey("expires_in") ? json.getInt("expires_in") : 3600;
+                tokenExpiresAt = Instant.now().plusSeconds(Math.max(expiresIn - 30, 30));
+
+                LOG.log(Level.INFO, "SAP bearer token refreshed, expires in {0}s", expiresIn);
+                return cachedToken;
+            }
+
+        } catch (SapIntegrationException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to fetch SAP bearer token", e);
+            throw new SapIntegrationException("Failed to fetch SAP bearer token: " + e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Foundation layer for the SAP S/4HANA Cloud integration (parent: #21092).

- **`SapTokenService`** (`@Singleton` EJB) — fetches and caches SAP OAuth 2.0 client-credentials bearer tokens. Token refreshes automatically when expired (30-second safety buffer) or when `invalidate()` is called after a downstream 401.
- **`SapIntegrationException`** — checked exception so SAP call failures propagate cleanly without rolling back HMIS JTA transactions.
- **`ConfigOptionApplicationController`** — new `loadSapIntegrationConfigurationDefaults()` registers 7 SAP config keys in the DB on startup (created with safe defaults; all credentials default to empty / disabled):

| Config Key | Default | Purpose |
|---|---|---|
| `SAP Integration - Enabled` | `false` | Master toggle |
| `SAP Integration - Base URL` | `` | S/4HANA tenant URL |
| `SAP Integration - Token URL` | `` | BTP OAuth endpoint |
| `SAP Integration - Client ID` | `` | OAuth client ID |
| `SAP Integration - Client Secret` | `` | OAuth client secret |
| `SAP Integration - Material Code Field` | `code` | HMIS Item field for SAP material number |
| `SAP Integration - Inventory Last Sync` | `` | Timestamp of last MM sync |

## Design Notes

- Credentials are **never hard-coded** — always read from `ConfigOption` at runtime
- `@Singleton` + `@Lock(READ/WRITE)` ensures thread-safe token caching without synchronization boilerplate
- `isEnabled()` short-circuits before any HTTP call when the toggle is off or credentials are blank
- `getBearerToken()` is the only entry point needed by downstream services (billing, inventory)

## Test Plan

- [ ] Deploy to local Payara — verify 7 new config keys appear in admin config UI
- [ ] With `SAP Integration - Enabled = false`: `getBearerToken()` returns `null` (no HTTP call)
- [ ] With valid SAP BTP sandbox credentials: token is fetched and cached
- [ ] Second call within expiry window returns cached token (no second HTTP call)
- [ ] `invalidate()` followed by `getBearerToken()` triggers a fresh fetch
- [ ] With invalid credentials: `SapIntegrationException` is thrown (not a runtime exception)

## Closes

Closes #21093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SAP S/4HANA Cloud integration framework with authentication and token management.
  * Added explicit error handling for SAP integration failures.
* **Chores**
  * Initialized default SAP integration configuration values during application startup to enable connectivity out of the box.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->