### PR TITLE
feat(sap): billing inbound webhook — SAP payment confirmation

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/sap/SapPaymentConfirmationDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/sap/SapPaymentConfirmationDTO.java
@@ -1,0 +1,47 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.sap;
+
+/**
+ * Inbound SAP payment confirmation payload.
+ * SAP Integration Suite / BTP posts this to HMIS when a payment is posted in SAP FI.
+ */
+public class SapPaymentConfirmationDTO {
+
+    /** SAP FI accounting document number (e.g. "1800000012"). */
+    private String sapDocumentNumber;
+
+    /** HMIS bill reference — matches {@code Bill.deptId}. */
+    private String hmsBillReference;
+
+    /** Confirmed payment amount. */
+    private double amount;
+
+    /** Currency code (e.g. "LKR"). */
+    private String currency;
+
+    /** SAP posting date (yyyy-MM-dd). */
+    private String postingDate;
+
+    /** Optional free-text note from SAP. */
+    private String note;
+
+    public SapPaymentConfirmationDTO() {
+    }
+
+    public String getSapDocumentNumber() { return sapDocumentNumber; }
+    public void setSapDocumentNumber(String sapDocumentNumber) { this.sapDocumentNumber = sapDocumentNumber; }
+    public String getHmsBillReference() { return hmsBillReference; }
+    public void setHmsBillReference(String hmsBillReference) { this.hmsBillReference = hmsBillReference; }
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public String getPostingDate() { return postingDate; }
+    public void setPostingDate(String postingDate) { this.postingDate = postingDate; }
+    public String getNote() { return note; }
+    public void setNote(String note) { this.note = note; }
+}

--- a/src/main/java/com/divudi/service/sap/SapOutboundService.java
+++ b/src/main/java/com/divudi/service/sap/SapOutboundService.java
@@ -314,12 +314,15 @@ public class SapOutboundService implements Serializable {
 
         // Record the confirmation — must succeed before returning 200 to SAP.
         // If this throws, the exception propagates as a 5xx so SAP can retry.
+        // Use GSON serialization to avoid JSON injection from user-supplied fields.
         String confirmedAt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
-        String value = "{\"sapDocNumber\":\"" + dto.getSapDocumentNumber().trim()
-                + "\",\"amount\":" + dto.getAmount()
-                + ",\"currency\":\"" + (dto.getCurrency() != null ? dto.getCurrency() : "")
-                + "\",\"postingDate\":\"" + (dto.getPostingDate() != null ? dto.getPostingDate() : "")
-                + "\",\"confirmedAt\":\"" + confirmedAt + "\"}";
+        Map<String, Object> record = new HashMap<>();
+        record.put("sapDocNumber", dto.getSapDocumentNumber().trim());
+        record.put("amount", dto.getAmount());
+        record.put("currency", dto.getCurrency() != null ? dto.getCurrency() : "");
+        record.put("postingDate", dto.getPostingDate() != null ? dto.getPostingDate() : "");
+        record.put("confirmedAt", confirmedAt);
+        String value = GSON.toJson(record);
         configController.saveShortTextOption("SAP Bill Confirm - " + bill.getId(), value);
 
         Map<String, Object> result = new HashMap<>();
@@ -345,10 +348,11 @@ public class SapOutboundService implements Serializable {
 
     private void recordPush(Long billId, SapJournalEntryResponseDTO resp) {
         try {
-            String value = "{\"sapDocNumber\":\"" + resp.getAccountingDocument()
-                    + "\",\"fiscalYear\":\"" + resp.getFiscalYear()
-                    + "\",\"sentAt\":\"" + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()) + "\"}";
-            configController.saveShortTextOption("SAP Bill Push - " + billId, value);
+            Map<String, Object> record = new HashMap<>();
+            record.put("sapDocNumber", resp.getAccountingDocument());
+            record.put("fiscalYear", resp.getFiscalYear());
+            record.put("sentAt", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
+            configController.saveShortTextOption("SAP Bill Push - " + billId, GSON.toJson(record));
         } catch (Exception e) {
             // Non-fatal: log but do not fail the push
             LOG.log(Level.WARNING, "Could not record SAP push result for bill " + billId, e);

--- a/src/main/java/com/divudi/service/sap/SapOutboundService.java
+++ b/src/main/java/com/divudi/service/sap/SapOutboundService.java
@@ -8,6 +8,7 @@ package com.divudi.service.sap;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.dto.sap.SapErrorResponseDTO;
 import com.divudi.core.data.dto.sap.SapJournalEntryDTO;
+import com.divudi.core.data.dto.sap.SapPaymentConfirmationDTO;
 import com.divudi.core.data.dto.sap.SapJournalEntryDTO.SapJournalEntryItemDTO;
 import com.divudi.core.data.dto.sap.SapJournalEntryResponseDTO;
 import com.divudi.core.entity.BillItem;
@@ -268,6 +269,80 @@ public class SapOutboundService implements Serializable {
         Map<String, Object> result = new HashMap<>();
         result.put("billId", billId);
         result.put("pushRecord", stored);
+        return result;
+    }
+
+    /**
+     * Records an inbound SAP payment confirmation against the HMIS bill identified by
+     * {@code dto.hmsBillReference} (matches {@code Bill.deptId}).
+     *
+     * <p>Idempotent: re-confirming an already-confirmed bill returns a map with
+     * {@code status=already_confirmed} instead of an error.
+     *
+     * @return result map with {@code billId}, {@code billReference}, {@code sapDocumentNumber},
+     *         {@code confirmedAt}, and {@code status}
+     * @throws SapIntegrationException if required fields are missing or bill is not found
+     */
+    public Map<String, Object> confirmPayment(SapPaymentConfirmationDTO dto) throws SapIntegrationException {
+        if (dto == null) {
+            throw new SapIntegrationException("Confirmation payload is required");
+        }
+        if (dto.getSapDocumentNumber() == null || dto.getSapDocumentNumber().trim().isEmpty()) {
+            throw new SapIntegrationException("sapDocumentNumber is required");
+        }
+        if (dto.getHmsBillReference() == null || dto.getHmsBillReference().trim().isEmpty()) {
+            throw new SapIntegrationException("hmsBillReference is required");
+        }
+
+        String billRef = dto.getHmsBillReference().trim();
+
+        // Look up bill by deptId (HMIS bill reference number)
+        String jpql = "SELECT b FROM Bill b WHERE b.deptId = :ref AND b.retired = false";
+        java.util.Map<String, Object> params = new HashMap<>();
+        params.put("ref", billRef);
+        Bill bill = billFacade.findFirstByJpql(jpql, params);
+        if (bill == null) {
+            throw new SapIntegrationException("Bill not found for reference: " + billRef);
+        }
+
+        // Idempotency: return existing record if already confirmed
+        Map<String, Object> existing = getConfirmStatus(bill.getId());
+        if (existing != null) {
+            existing.put("status", "already_confirmed");
+            return existing;
+        }
+
+        // Record the confirmation
+        String confirmedAt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+        String value = "{\"sapDocNumber\":\"" + dto.getSapDocumentNumber().trim()
+                + "\",\"amount\":" + dto.getAmount()
+                + ",\"currency\":\"" + (dto.getCurrency() != null ? dto.getCurrency() : "")
+                + "\",\"postingDate\":\"" + (dto.getPostingDate() != null ? dto.getPostingDate() : "")
+                + "\",\"confirmedAt\":\"" + confirmedAt + "\"}";
+        try {
+            configController.saveShortTextOption("SAP Bill Confirm - " + bill.getId(), value);
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Could not record SAP confirmation for bill " + bill.getId(), e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("billId", bill.getId());
+        result.put("billReference", billRef);
+        result.put("sapDocumentNumber", dto.getSapDocumentNumber().trim());
+        result.put("confirmedAt", confirmedAt);
+        result.put("status", "confirmed");
+        return result;
+    }
+
+    /**
+     * Returns the stored SAP confirmation record for {@code billId}, or {@code null} if not yet confirmed.
+     */
+    public Map<String, Object> getConfirmStatus(Long billId) {
+        String stored = configController.getShortTextValueByKey("SAP Bill Confirm - " + billId, "");
+        if (stored == null || stored.isBlank()) return null;
+        Map<String, Object> result = new HashMap<>();
+        result.put("billId", billId);
+        result.put("confirmRecord", stored);
         return result;
     }
 

--- a/src/main/java/com/divudi/service/sap/SapOutboundService.java
+++ b/src/main/java/com/divudi/service/sap/SapOutboundService.java
@@ -312,18 +312,15 @@ public class SapOutboundService implements Serializable {
             return existing;
         }
 
-        // Record the confirmation
+        // Record the confirmation — must succeed before returning 200 to SAP.
+        // If this throws, the exception propagates as a 5xx so SAP can retry.
         String confirmedAt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
         String value = "{\"sapDocNumber\":\"" + dto.getSapDocumentNumber().trim()
                 + "\",\"amount\":" + dto.getAmount()
                 + ",\"currency\":\"" + (dto.getCurrency() != null ? dto.getCurrency() : "")
                 + "\",\"postingDate\":\"" + (dto.getPostingDate() != null ? dto.getPostingDate() : "")
                 + "\",\"confirmedAt\":\"" + confirmedAt + "\"}";
-        try {
-            configController.saveShortTextOption("SAP Bill Confirm - " + bill.getId(), value);
-        } catch (Exception e) {
-            LOG.log(Level.WARNING, "Could not record SAP confirmation for bill " + bill.getId(), e);
-        }
+        configController.saveShortTextOption("SAP Bill Confirm - " + bill.getId(), value);
 
         Map<String, Object> result = new HashMap<>();
         result.put("billId", bill.getId());

--- a/src/main/java/com/divudi/ws/sap/SapBillingApi.java
+++ b/src/main/java/com/divudi/ws/sap/SapBillingApi.java
@@ -6,18 +6,21 @@
 package com.divudi.ws.sap;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.sap.SapPaymentConfirmationDTO;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.WebUser;
 import com.divudi.service.sap.SapIntegrationException;
 import com.divudi.service.sap.SapOutboundService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -28,12 +31,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
- * REST API for SAP S/4HANA Cloud billing outbound integration.
+ * REST API for SAP S/4HANA Cloud billing integration (outbound and inbound).
  *
  * <p>Endpoints:
  * <ul>
- *   <li>{@code POST /api/sap/billing/push/{billId}} — push a finalized HMIS bill to SAP FI</li>
+ *   <li>{@code POST /api/sap/billing/push/{billId}}   — push a finalized HMIS bill to SAP FI</li>
  *   <li>{@code GET  /api/sap/billing/status/{billId}} — check whether a bill has been pushed</li>
+ *   <li>{@code POST /api/sap/billing/confirm}         — inbound: SAP posts payment confirmation</li>
+ *   <li>{@code GET  /api/sap/billing/confirm/status/{billId}} — check confirmation record</li>
  * </ul>
  *
  * <p>Auth: {@code Finance} header with a valid HMIS API key.
@@ -101,6 +106,62 @@ public class SapBillingApi {
             Map<String, Object> status = sapOutboundService.getPushStatus(billId);
             if (status == null) {
                 return errorResponse("Bill " + billId + " has not been pushed to SAP", 404);
+            }
+            return successResponse(status);
+        } catch (Exception e) {
+            return errorResponse("Unexpected error: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Inbound: SAP posts a payment confirmation after posting in SAP FI.
+     * Looks up the HMIS bill by reference and records the confirmation.
+     * Idempotent: re-confirming returns 200 with status=already_confirmed.
+     */
+    @POST
+    @Path("/confirm")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response confirmPayment(String requestBody) {
+        WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+        if (user == null) {
+            return errorResponse("Not a valid key", 401);
+        }
+        SapPaymentConfirmationDTO dto;
+        try {
+            dto = GSON.fromJson(requestBody, SapPaymentConfirmationDTO.class);
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON: " + e.getMessage(), 400);
+        }
+        try {
+            Map<String, Object> result = sapOutboundService.confirmPayment(dto);
+            return successResponse(result);
+        } catch (SapIntegrationException e) {
+            int code = e.getMessage() != null && e.getMessage().contains("not found") ? 404 : 400;
+            return errorResponse(e.getMessage(), code);
+        } catch (Exception e) {
+            return errorResponse("Unexpected error: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Returns the SAP confirmation record for a bill, or 404 if not yet confirmed.
+     */
+    @GET
+    @Path("/confirm/status/{billId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response confirmStatus(@PathParam("billId") Long billId) {
+        WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+        if (user == null) {
+            return errorResponse("Not a valid key", 401);
+        }
+        if (billId == null || billId <= 0) {
+            return errorResponse("Invalid bill ID", 400);
+        }
+        try {
+            Map<String, Object> status = sapOutboundService.getConfirmStatus(billId);
+            if (status == null) {
+                return errorResponse("Bill " + billId + " has not received a SAP payment confirmation", 404);
             }
             return successResponse(status);
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

- Adds `POST /api/sap/billing/confirm` — inbound webhook for SAP to post payment confirmations to HMIS
- Adds `GET /api/sap/billing/confirm/status/{billId}` — check confirmation record for a bill
- Adds `SapPaymentConfirmationDTO` for the inbound payload
- Confirmation handler: looks up HMIS bill by `deptId` reference, records SAP doc number + amount + posting date in `ConfigOption`
- Idempotent: re-confirming returns 200 with `status=already_confirmed`
- Bill not found → 404; missing required fields → 400; invalid JSON → 400

## Files Changed

| File | Change |
|---|---|
| `dto/sap/SapPaymentConfirmationDTO.java` | NEW — inbound payload DTO |
| `service/sap/SapOutboundService.java` | Added `confirmPayment()` and `getConfirmStatus()` |
| `ws/sap/SapBillingApi.java` | Added `POST /confirm` and `GET /confirm/status/{billId}` endpoints |

## Depends On
Part of #21092. Requires #21094 (billing API class).

## Test plan
- [ ] Valid payload with known bill reference → 200, `status=confirmed`, `sapDocumentNumber` in response
- [ ] Same payload again → 200, `status=already_confirmed`
- [ ] Unknown bill reference → 404
- [ ] Missing `sapDocumentNumber` → 400
- [ ] Missing `hmsBillReference` → 400
- [ ] Invalid JSON body → 400
- [ ] Invalid/missing API key → 401
- [ ] `GET /confirm/status/{billId}` before confirm → 404; after confirm → 200 with record

Closes #21095

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST endpoints to accept SAP inbound payment confirmations and to retrieve confirmation status for a bill.
  * Confirmations are recorded idempotently and return a standardized success payload (including bill reference, SAP document, timestamp, and status).
  * API returns 400 for invalid payloads and 404 when a requested confirmation is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->