### PR TITLE
feat(sap): inventory sync — pull SAP MM goods receipts into HMIS Pharmacy

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1582,6 +1582,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getShortTextValueByKey("SAP Integration - Client Secret", "");
         getShortTextValueByKey("SAP Integration - Material Code Field", "code");
         getShortTextValueByKey("SAP Integration - Inventory Last Sync", "");
+        getShortTextValueByKey("SAP Integration - Inventory Sync From Days", "7");
         getShortTextValueByKey("SAP Integration - Company Code", "");
         getShortTextValueByKey("SAP Integration - AR Account", "");
         getShortTextValueByKey("SAP Integration - Revenue Account", "");

--- a/src/main/java/com/divudi/core/data/dto/sap/SapInventorySyncResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/sap/SapInventorySyncResultDTO.java
@@ -1,0 +1,46 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.sap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Summary result returned after a SAP → HMIS inventory sync run.
+ */
+public class SapInventorySyncResultDTO {
+
+    private int totalDocumentItems;
+    private int matchedItems;
+    private int unmatchedItems;
+    private String syncFromDate;
+    private String syncToDate;
+    private String lastSyncTimestamp;
+    private List<String> unmatchedMaterials = new ArrayList<>();
+    private List<String> warnings = new ArrayList<>();
+
+    public SapInventorySyncResultDTO() {
+    }
+
+    public int getTotalDocumentItems() { return totalDocumentItems; }
+    public void setTotalDocumentItems(int totalDocumentItems) { this.totalDocumentItems = totalDocumentItems; }
+    public int getMatchedItems() { return matchedItems; }
+    public void setMatchedItems(int matchedItems) { this.matchedItems = matchedItems; }
+    public int getUnmatchedItems() { return unmatchedItems; }
+    public void setUnmatchedItems(int unmatchedItems) { this.unmatchedItems = unmatchedItems; }
+    public String getSyncFromDate() { return syncFromDate; }
+    public void setSyncFromDate(String syncFromDate) { this.syncFromDate = syncFromDate; }
+    public String getSyncToDate() { return syncToDate; }
+    public void setSyncToDate(String syncToDate) { this.syncToDate = syncToDate; }
+    public String getLastSyncTimestamp() { return lastSyncTimestamp; }
+    public void setLastSyncTimestamp(String lastSyncTimestamp) { this.lastSyncTimestamp = lastSyncTimestamp; }
+    public List<String> getUnmatchedMaterials() { return unmatchedMaterials; }
+    public void setUnmatchedMaterials(List<String> unmatchedMaterials) { this.unmatchedMaterials = unmatchedMaterials; }
+    public List<String> getWarnings() { return warnings; }
+    public void setWarnings(List<String> warnings) { this.warnings = warnings; }
+    public void addWarning(String warning) { this.warnings.add(warning); }
+    public void addUnmatched(String material) { this.unmatchedMaterials.add(material); }
+}

--- a/src/main/java/com/divudi/core/data/dto/sap/SapMaterialDocumentDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/sap/SapMaterialDocumentDTO.java
@@ -1,0 +1,45 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.sap;
+
+/**
+ * One item line from the SAP MM material document OData response.
+ * Maps to A_MaterialDocItem entity from API_MATERIAL_DOCUMENT_SRV.
+ */
+public class SapMaterialDocumentDTO {
+
+    private String MaterialDocument;
+    private String MaterialDocumentItem;
+    private String Material;
+    private String Plant;
+    private String StorageLocation;
+    private String Quantity;
+    private String BaseUnit;
+    private String PostingDate;
+    private String MaterialDocumentYear;
+
+    public SapMaterialDocumentDTO() {
+    }
+
+    public String getMaterialDocument() { return MaterialDocument; }
+    public void setMaterialDocument(String materialDocument) { MaterialDocument = materialDocument; }
+    public String getMaterialDocumentItem() { return MaterialDocumentItem; }
+    public void setMaterialDocumentItem(String materialDocumentItem) { MaterialDocumentItem = materialDocumentItem; }
+    public String getMaterial() { return Material; }
+    public void setMaterial(String material) { Material = material; }
+    public String getPlant() { return Plant; }
+    public void setPlant(String plant) { Plant = plant; }
+    public String getStorageLocation() { return StorageLocation; }
+    public void setStorageLocation(String storageLocation) { StorageLocation = storageLocation; }
+    public String getQuantity() { return Quantity; }
+    public void setQuantity(String quantity) { Quantity = quantity; }
+    public String getBaseUnit() { return BaseUnit; }
+    public void setBaseUnit(String baseUnit) { BaseUnit = baseUnit; }
+    public String getPostingDate() { return PostingDate; }
+    public void setPostingDate(String postingDate) { PostingDate = postingDate; }
+    public String getMaterialDocumentYear() { return MaterialDocumentYear; }
+    public void setMaterialDocumentYear(String materialDocumentYear) { MaterialDocumentYear = materialDocumentYear; }
+}

--- a/src/main/java/com/divudi/service/sap/SapInventorySyncService.java
+++ b/src/main/java/com/divudi/service/sap/SapInventorySyncService.java
@@ -1,0 +1,280 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.sap;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.dto.sap.SapInventorySyncResultDTO;
+import com.divudi.core.data.dto.sap.SapMaterialDocumentDTO;
+import com.divudi.core.entity.Item;
+import com.divudi.core.facade.ItemFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+/**
+ * Fetches SAP MM goods-receipt material document items and matches them to
+ * HMIS pharmacy items by code, logging the sync results.
+ *
+ * <p>This service performs a read-only audit sync — it records what SAP has received
+ * against HMIS item master data. Actual stock updates (GRN creation) require
+ * additional pricing/department context and are handled by pharmacy workflows.
+ *
+ * <p>Config keys:
+ * <ul>
+ *   <li>{@code SAP Integration - Material Code Field} — Item field to match against SAP material number (default: {@code code})</li>
+ *   <li>{@code SAP Integration - Inventory Last Sync} — ISO timestamp of last successful sync</li>
+ *   <li>{@code SAP Integration - Inventory Sync From Days} — fallback look-back days when no prior sync exists (default: 7)</li>
+ * </ul>
+ */
+@Stateless
+public class SapInventorySyncService implements Serializable {
+
+    private static final Logger LOG = Logger.getLogger(SapInventorySyncService.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private static final String SAP_MATERIAL_DOC_PATH =
+            "/sap/opu/odata/sap/API_MATERIAL_DOCUMENT_SRV/A_MaterialDocItem";
+    private static final String SELECT_FIELDS =
+            "MaterialDocument,MaterialDocumentItem,Material,Plant,StorageLocation,Quantity,BaseUnit,PostingDate,MaterialDocumentYear";
+
+    private static final Gson GSON = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    @Inject
+    private ConfigOptionApplicationController configController;
+
+    @Inject
+    private SapTokenService tokenService;
+
+    @EJB
+    private ItemFacade itemFacade;
+
+    /**
+     * Runs the inventory sync for the given date range.
+     * If {@code fromDate} is null, uses the stored last-sync timestamp or falls back
+     * to {@code SAP Integration - Inventory Sync From Days} days ago.
+     *
+     * @param fromDate optional override start date (yyyy-MM-dd); null = use stored timestamp
+     * @param toDate   optional override end date (yyyy-MM-dd); null = today
+     * @return sync result summary
+     * @throws SapIntegrationException on token failure or SAP API error
+     */
+    public SapInventorySyncResultDTO sync(String fromDate, String toDate) throws SapIntegrationException {
+        if (!tokenService.isEnabled()) {
+            SapInventorySyncResultDTO skipped = new SapInventorySyncResultDTO();
+            skipped.addWarning("SAP integration is disabled");
+            return skipped;
+        }
+
+        String resolvedFrom = resolveFromDate(fromDate);
+        String resolvedTo   = toDate != null && !toDate.isBlank() ? toDate : todayString();
+
+        String token   = tokenService.getBearerToken();
+        String baseUrl = tokenService.getBaseUrl();
+
+        List<SapMaterialDocumentDTO> docs = fetchMaterialDocItems(baseUrl, token, resolvedFrom, resolvedTo);
+
+        if (docs == null) {
+            throw new SapIntegrationException("Failed to fetch material documents from SAP");
+        }
+
+        String materialCodeField = configController.getShortTextValueByKey(
+                "SAP Integration - Material Code Field", "code");
+
+        SapInventorySyncResultDTO result = new SapInventorySyncResultDTO();
+        result.setTotalDocumentItems(docs.size());
+        result.setSyncFromDate(resolvedFrom);
+        result.setSyncToDate(resolvedTo);
+
+        int matched = 0;
+        int unmatched = 0;
+
+        for (SapMaterialDocumentDTO doc : docs) {
+            String materialNumber = doc.getMaterial();
+            if (materialNumber == null || materialNumber.isBlank()) {
+                result.addWarning("Document " + doc.getMaterialDocument() + " item "
+                        + doc.getMaterialDocumentItem() + " has no material number — skipped");
+                unmatched++;
+                continue;
+            }
+
+            Item item = findItemByField(materialCodeField, materialNumber);
+            if (item == null) {
+                result.addUnmatched(materialNumber);
+                LOG.log(Level.WARNING, "SAP material {0} not found in HMIS Item master (field: {1})",
+                        new Object[]{materialNumber, materialCodeField});
+                unmatched++;
+            } else {
+                matched++;
+                LOG.log(Level.FINE, "SAP material {0} matched to HMIS item {1} (id={2})",
+                        new Object[]{materialNumber, item.getName(), item.getId()});
+            }
+        }
+
+        result.setMatchedItems(matched);
+        result.setUnmatchedItems(unmatched);
+
+        // Record sync timestamp
+        String syncTimestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+        result.setLastSyncTimestamp(syncTimestamp);
+        configController.saveShortTextOption("SAP Integration - Inventory Last Sync", syncTimestamp);
+
+        return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private List<SapMaterialDocumentDTO> fetchMaterialDocItems(String baseUrl, String token,
+            String fromDate, String toDate) throws SapIntegrationException {
+        try {
+            // SAP OData datetime filter format: PostingDate ge datetime'2024-01-01T00:00:00'
+            String filter = "PostingDate ge datetime'" + fromDate + "T00:00:00'"
+                    + " and PostingDate le datetime'" + toDate + "T23:59:59'";
+            String url = baseUrl + SAP_MATERIAL_DOC_PATH
+                    + "?$filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8)
+                    + "&$select=" + URLEncoder.encode(SELECT_FIELDS, StandardCharsets.UTF_8)
+                    + "&$format=json";
+
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(30))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Accept", "application/json")
+                    .header("Authorization", "Bearer " + token)
+                    .GET()
+                    .timeout(Duration.ofSeconds(60))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 401) {
+                tokenService.invalidate();
+                token = tokenService.getBearerToken();
+                request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .header("Accept", "application/json")
+                        .header("Authorization", "Bearer " + token)
+                        .GET()
+                        .timeout(Duration.ofSeconds(60))
+                        .build();
+                response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            }
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new SapIntegrationException(
+                        "SAP material document API returned HTTP " + response.statusCode()
+                        + ": " + response.body());
+            }
+
+            return parseMaterialDocItems(response.body());
+
+        } catch (SapIntegrationException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to fetch SAP material documents", e);
+            throw new SapIntegrationException("Failed to fetch SAP material documents: " + e.getMessage(), e);
+        }
+    }
+
+    private List<SapMaterialDocumentDTO> parseMaterialDocItems(String body) throws SapIntegrationException {
+        try {
+            // SAP OData v2 JSON: {"d":{"results":[...]}}
+            JsonObject root = JsonParser.parseString(body).getAsJsonObject();
+            JsonArray results;
+            if (root.has("d") && root.getAsJsonObject("d").has("results")) {
+                results = root.getAsJsonObject("d").getAsJsonArray("results");
+            } else if (root.has("value")) {
+                results = root.getAsJsonArray("value");
+            } else {
+                throw new SapIntegrationException("Unexpected SAP response structure: " + body.substring(0, Math.min(300, body.length())));
+            }
+
+            List<SapMaterialDocumentDTO> items = new ArrayList<>();
+            for (JsonElement el : results) {
+                items.add(GSON.fromJson(el, SapMaterialDocumentDTO.class));
+            }
+            return items;
+        } catch (SapIntegrationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SapIntegrationException("Could not parse SAP material document response: " + e.getMessage(), e);
+        }
+    }
+
+    private Item findItemByField(String fieldName, String value) {
+        String jpql;
+        switch (fieldName) {
+            case "barcode":
+                jpql = "SELECT i FROM Item i WHERE i.barcode = :val AND i.retired = false";
+                break;
+            case "code":
+            default:
+                jpql = "SELECT i FROM Item i WHERE i.code = :val AND i.retired = false";
+                break;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("val", value);
+        return itemFacade.findFirstByJpql(jpql, params);
+    }
+
+    private String resolveFromDate(String fromDate) {
+        if (fromDate != null && !fromDate.isBlank()) {
+            return fromDate;
+        }
+        String stored = configController.getShortTextValueByKey(
+                "SAP Integration - Inventory Last Sync", "");
+        if (stored != null && !stored.isBlank()) {
+            // stored is "yyyy-MM-dd HH:mm:ss" — extract date part
+            return stored.substring(0, 10);
+        }
+        // Fall back to N days ago
+        int days = 7;
+        try {
+            String daysStr = configController.getShortTextValueByKey(
+                    "SAP Integration - Inventory Sync From Days", "7");
+            if (daysStr != null && !daysStr.isBlank()) {
+                days = Integer.parseInt(daysStr.trim());
+            }
+        } catch (NumberFormatException e) {
+            LOG.warning("SAP Integration - Inventory Sync From Days is not a valid integer, using 7");
+        }
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_YEAR, -days);
+        return new SimpleDateFormat("yyyy-MM-dd").format(cal.getTime());
+    }
+
+    private static String todayString() {
+        return new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+    }
+}

--- a/src/main/java/com/divudi/service/sap/SapInventorySyncService.java
+++ b/src/main/java/com/divudi/service/sap/SapInventorySyncService.java
@@ -93,6 +93,9 @@ public class SapInventorySyncService implements Serializable {
             return skipped;
         }
 
+        // isForwardSync: true when caller did not supply an explicit fromDate (normal incremental run)
+        boolean isForwardSync = (fromDate == null || fromDate.isBlank());
+
         String resolvedFrom = resolveFromDate(fromDate);
         String resolvedTo   = toDate != null && !toDate.isBlank() ? toDate : todayString();
 
@@ -125,7 +128,7 @@ public class SapInventorySyncService implements Serializable {
                 continue;
             }
 
-            Item item = findItemByField(materialCodeField, materialNumber);
+            Item item = findItemByField(materialCodeField, materialNumber, result);
             if (item == null) {
                 result.addUnmatched(materialNumber);
                 LOG.log(Level.WARNING, "SAP material {0} not found in HMIS Item master (field: {1})",
@@ -141,10 +144,16 @@ public class SapInventorySyncService implements Serializable {
         result.setMatchedItems(matched);
         result.setUnmatchedItems(unmatched);
 
-        // Record sync timestamp
-        String syncTimestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
-        result.setLastSyncTimestamp(syncTimestamp);
-        configController.saveShortTextOption("SAP Integration - Inventory Last Sync", syncTimestamp);
+        // Only advance the watermark for normal forward syncs, not for explicit backfill ranges.
+        // Store the effective SAP upper bound (resolvedTo end-of-day) for full timestamp precision.
+        if (isForwardSync) {
+            String watermark = resolvedTo + "T23:59:59";
+            result.setLastSyncTimestamp(watermark);
+            configController.saveShortTextOption("SAP Integration - Inventory Last Sync", watermark);
+        } else {
+            result.setLastSyncTimestamp(null);
+            result.addWarning("Watermark not updated — explicit date range supplied (backfill mode)");
+        }
 
         return result;
     }
@@ -159,7 +168,7 @@ public class SapInventorySyncService implements Serializable {
             // SAP OData datetime filter format: PostingDate ge datetime'2024-01-01T00:00:00'
             String filter = "PostingDate ge datetime'" + fromDate + "T00:00:00'"
                     + " and PostingDate le datetime'" + toDate + "T23:59:59'";
-            String url = baseUrl + SAP_MATERIAL_DOC_PATH
+            String firstUrl = baseUrl + SAP_MATERIAL_DOC_PATH
                     + "?$filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8)
                     + "&$select=" + URLEncoder.encode(SELECT_FIELDS, StandardCharsets.UTF_8)
                     + "&$format=json";
@@ -168,36 +177,41 @@ public class SapInventorySyncService implements Serializable {
                     .connectTimeout(Duration.ofSeconds(30))
                     .build();
 
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("Accept", "application/json")
-                    .header("Authorization", "Bearer " + token)
-                    .GET()
-                    .timeout(Duration.ofSeconds(60))
-                    .build();
+            List<SapMaterialDocumentDTO> allItems = new ArrayList<>();
+            String nextUrl = firstUrl;
+            boolean retried = false;
 
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 401) {
-                tokenService.invalidate();
-                token = tokenService.getBearerToken();
-                request = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
+            // Follow SAP OData server-driven paging via d.__next links
+            while (nextUrl != null) {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(nextUrl))
                         .header("Accept", "application/json")
                         .header("Authorization", "Bearer " + token)
                         .GET()
                         .timeout(Duration.ofSeconds(60))
                         .build();
-                response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() == 401 && !retried) {
+                    retried = true;
+                    tokenService.invalidate();
+                    token = tokenService.getBearerToken();
+                    continue;
+                }
+
+                if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                    throw new SapIntegrationException(
+                            "SAP material document API returned HTTP " + response.statusCode()
+                            + ": " + response.body());
+                }
+
+                PageResult page = parsePage(response.body());
+                allItems.addAll(page.items);
+                nextUrl = page.nextLink;
             }
 
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new SapIntegrationException(
-                        "SAP material document API returned HTTP " + response.statusCode()
-                        + ": " + response.body());
-            }
-
-            return parseMaterialDocItems(response.body());
+            return allItems;
 
         } catch (SapIntegrationException e) {
             throw e;
@@ -207,24 +221,43 @@ public class SapInventorySyncService implements Serializable {
         }
     }
 
-    private List<SapMaterialDocumentDTO> parseMaterialDocItems(String body) throws SapIntegrationException {
+    private static class PageResult {
+        final List<SapMaterialDocumentDTO> items;
+        final String nextLink;
+        PageResult(List<SapMaterialDocumentDTO> items, String nextLink) {
+            this.items = items;
+            this.nextLink = nextLink;
+        }
+    }
+
+    private PageResult parsePage(String body) throws SapIntegrationException {
         try {
-            // SAP OData v2 JSON: {"d":{"results":[...]}}
+            // SAP OData v2 JSON: {"d":{"results":[...], "__next":"..."}}
             JsonObject root = JsonParser.parseString(body).getAsJsonObject();
             JsonArray results;
-            if (root.has("d") && root.getAsJsonObject("d").has("results")) {
-                results = root.getAsJsonObject("d").getAsJsonArray("results");
+            String nextLink = null;
+
+            if (root.has("d")) {
+                JsonObject d = root.getAsJsonObject("d");
+                results = d.has("results") ? d.getAsJsonArray("results") : new JsonArray();
+                if (d.has("__next") && !d.get("__next").isJsonNull()) {
+                    nextLink = d.get("__next").getAsString();
+                }
             } else if (root.has("value")) {
                 results = root.getAsJsonArray("value");
+                if (root.has("@odata.nextLink") && !root.get("@odata.nextLink").isJsonNull()) {
+                    nextLink = root.get("@odata.nextLink").getAsString();
+                }
             } else {
-                throw new SapIntegrationException("Unexpected SAP response structure: " + body.substring(0, Math.min(300, body.length())));
+                throw new SapIntegrationException("Unexpected SAP response structure: "
+                        + body.substring(0, Math.min(300, body.length())));
             }
 
             List<SapMaterialDocumentDTO> items = new ArrayList<>();
             for (JsonElement el : results) {
                 items.add(GSON.fromJson(el, SapMaterialDocumentDTO.class));
             }
-            return items;
+            return new PageResult(items, nextLink);
         } catch (SapIntegrationException e) {
             throw e;
         } catch (Exception e) {
@@ -232,14 +265,20 @@ public class SapInventorySyncService implements Serializable {
         }
     }
 
-    private Item findItemByField(String fieldName, String value) {
+    private Item findItemByField(String fieldName, String value, SapInventorySyncResultDTO result) {
         String jpql;
         switch (fieldName) {
             case "barcode":
                 jpql = "SELECT i FROM Item i WHERE i.barcode = :val AND i.retired = false";
                 break;
             case "code":
+                jpql = "SELECT i FROM Item i WHERE i.code = :val AND i.retired = false";
+                break;
             default:
+                result.addWarning("Unsupported SAP Integration - Material Code Field value: '"
+                        + fieldName + "'. Supported values: code, barcode. Falling back to 'code'.");
+                LOG.log(Level.WARNING,
+                        "Unsupported materialCodeField ''{0}'' — falling back to ''code''", fieldName);
                 jpql = "SELECT i FROM Item i WHERE i.code = :val AND i.retired = false";
                 break;
         }
@@ -255,7 +294,7 @@ public class SapInventorySyncService implements Serializable {
         String stored = configController.getShortTextValueByKey(
                 "SAP Integration - Inventory Last Sync", "");
         if (stored != null && !stored.isBlank()) {
-            // stored is "yyyy-MM-dd HH:mm:ss" — extract date part
+            // stored is "yyyy-MM-ddT23:59:59" — extract date part for OData date filter
             return stored.substring(0, 10);
         }
         // Fall back to N days ago

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -81,6 +81,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.pharmacy.StockHistoryApi.class);
         resources.add(com.divudi.ws.pricing.CollectingCentreFeesApi.class);
         resources.add(com.divudi.ws.sap.SapBillingApi.class);
+        resources.add(com.divudi.ws.sap.SapInventoryApi.class);
         resources.add(com.divudi.ws.service.ServiceApi.class);
     }
     

--- a/src/main/java/com/divudi/ws/sap/SapInventoryApi.java
+++ b/src/main/java/com/divudi/ws/sap/SapInventoryApi.java
@@ -16,6 +16,8 @@ import com.google.gson.GsonBuilder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -46,6 +48,8 @@ import javax.ws.rs.core.Response;
 @Path("sap/inventory")
 @RequestScoped
 public class SapInventoryApi {
+
+    private static final Logger LOG = Logger.getLogger(SapInventoryApi.class.getName());
 
     @Context
     private HttpServletRequest requestContext;
@@ -82,9 +86,11 @@ public class SapInventoryApi {
             SapInventorySyncResultDTO result = sapInventorySyncService.sync(fromDate, toDate);
             return successResponse(result);
         } catch (SapIntegrationException e) {
-            return errorResponse(e.getMessage(), 502);
+            LOG.log(Level.SEVERE, "SAP inventory sync failed", e);
+            return errorResponse("SAP sync failed", 502);
         } catch (Exception e) {
-            return errorResponse("Unexpected error: " + e.getMessage(), 500);
+            LOG.log(Level.SEVERE, "Unexpected error during SAP inventory sync", e);
+            return errorResponse("Internal server error", 500);
         }
     }
 

--- a/src/main/java/com/divudi/ws/sap/SapInventoryApi.java
+++ b/src/main/java/com/divudi/ws/sap/SapInventoryApi.java
@@ -1,0 +1,120 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.sap;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.sap.SapInventorySyncResultDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.sap.SapIntegrationException;
+import com.divudi.service.sap.SapInventorySyncService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * REST API for SAP S/4HANA Cloud inventory sync.
+ *
+ * <p>Endpoints:
+ * <ul>
+ *   <li>{@code GET /api/sap/inventory/sync} — manually trigger a SAP MM goods-receipt sync</li>
+ * </ul>
+ *
+ * <p>Query parameters (all optional):
+ * <ul>
+ *   <li>{@code fromDate} — start date yyyy-MM-dd (default: last sync timestamp or N days ago)</li>
+ *   <li>{@code toDate}   — end date yyyy-MM-dd (default: today)</li>
+ * </ul>
+ *
+ * <p>Auth: {@code Finance} header with a valid HMIS API key.
+ */
+@Path("sap/inventory")
+@RequestScoped
+public class SapInventoryApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private SapInventorySyncService sapInventorySyncService;
+
+    private static final Gson GSON = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * Manually trigger a SAP → HMIS inventory sync for a date range.
+     * Fetches SAP MM goods-receipt material documents and matches them to HMIS items.
+     *
+     * @param fromDate optional start date (yyyy-MM-dd)
+     * @param toDate   optional end date (yyyy-MM-dd)
+     */
+    @GET
+    @Path("/sync")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response sync(
+            @QueryParam("fromDate") String fromDate,
+            @QueryParam("toDate") String toDate) {
+
+        WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+        if (user == null) {
+            return errorResponse("Not a valid key", 401);
+        }
+        try {
+            SapInventorySyncResultDTO result = sapInventorySyncService.sync(fromDate, toDate);
+            return successResponse(result);
+        } catch (SapIntegrationException e) {
+            return errorResponse(e.getMessage(), 502);
+        } catch (Exception e) {
+            return errorResponse("Unexpected error: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", "error");
+        body.put("code", code);
+        body.put("message", message);
+        return Response.status(code).entity(GSON.toJson(body)).build();
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", "success");
+        body.put("code", 200);
+        body.put("data", data);
+        return Response.status(200).entity(GSON.toJson(body)).build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/sap/inventory/sync?fromDate=&toDate=` endpoint to manually trigger a SAP MM → HMIS inventory sync
- Fetches `A_MaterialDocItem` from SAP OData for the given date range (defaults to last sync timestamp or N days ago)
- Matches each SAP material number to an HMIS `Item` by configurable field (default: `Item.code`, via `SAP Integration - Material Code Field` config key)
- Unmatched materials logged as warnings — sync continues, never aborts on a single mismatch
- Updates `SAP Integration - Inventory Last Sync` timestamp after each successful run
- Integration silently skipped when `SAP Integration - Enabled = false`
- New config key: `SAP Integration - Inventory Sync From Days` (default `7`) — look-back window when no prior sync timestamp exists

## Design Note

This is a **read-only audit sync** — it records what SAP has received and matches it to HMIS item master. Actual GRN/stock creation requires pricing, batch, and department context not present in the SAP OData payload; that is handled by the HMIS pharmacy GRN workflow.

## Files Changed

| File | Change |
|---|---|
| `dto/sap/SapMaterialDocumentDTO.java` | NEW — SAP A_MaterialDocItem OData fields |
| `dto/sap/SapInventorySyncResultDTO.java` | NEW — sync summary (total/matched/unmatched/warnings) |
| `service/sap/SapInventorySyncService.java` | NEW — fetches, parses, matches SAP docs |
| `ws/sap/SapInventoryApi.java` | NEW — GET /api/sap/inventory/sync endpoint |
| `ws/common/ApplicationConfig.java` | Register SapInventoryApi |
| `bean/common/ConfigOptionApplicationController.java` | Add Inventory Sync From Days default |

## Depends On
Part of #21092. Requires #21093 (token service).

## Test plan
- [ ] SAP disabled: returns 200 with `warnings=["SAP integration is disabled"]`
- [ ] Invalid API key: 401
- [ ] `fromDate` / `toDate` params override date range
- [ ] No params: uses last sync timestamp; if none, uses 7-day fallback
- [ ] After sync: `SAP Integration - Inventory Last Sync` ConfigOption updated
- [ ] SAP returns 401: token invalidated and retried once
- [ ] Unknown material number: counted in `unmatchedItems`, added to `unmatchedMaterials` list
- [ ] Known material (Item.code match): counted in `matchedItems`

Closes #21096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual SAP inventory sync with optional from/to date range
  * Sync result reporting with matched/unmatched counts, warnings, and timestamps
  * Default 7-day look-back window for incremental syncs
  * Secure REST endpoint requiring API key validation for sync requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->