### PR TITLE
SAP Integration: Register APIs in CapabilityStatementResource and AnthropicApiService (#21097)

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -2408,6 +2408,29 @@ public class AnthropicApiService implements Serializable {
                     {"GET", "/qb/paymentreturn/{institution_code}/{last_return_payment_id}",    "Payment return / refund records"}
                 });
 
+        // ── SAP Integration ───────────────────────────────────────────────────
+        appendModule(sb, "SAP Integration - Billing", "/sap/billing",
+                "Push HMIS bills to SAP S/4HANA Cloud FI as journal entries, and receive payment confirmations from SAP. "
+                + "Requires SAP integration to be enabled via ConfigOption keys. "
+                + "All endpoints use the Finance header.",
+                null,
+                new String[][]{
+                    {"POST", "/sap/billing/push/{billId}",          "Push an HMIS bill to SAP FI as a journal entry (debit AR, credit revenue per line item)"},
+                    {"GET",  "/sap/billing/status/{billId}",        "Get the SAP push status and SAP document number for a bill"},
+                    {"POST", "/sap/billing/confirm",                "Receive a payment confirmation webhook from SAP (body: sapDocumentNumber, hmsBillReference, amount, currency, postingDate)"},
+                    {"GET",  "/sap/billing/confirm/status/{billId}", "Get the SAP payment confirmation status for a bill"}
+                });
+
+        appendModule(sb, "SAP Integration - Inventory", "/sap/inventory",
+                "Fetch SAP S/4HANA Cloud MM goods-receipt material documents and match them to HMIS pharmacy items. "
+                + "Read-only audit sync — matches SAP materials to HMIS Item master by code or barcode field (configurable). "
+                + "Does not create GRN bills; pharmacy GRN workflows handle actual stock updates. "
+                + "fromDate defaults to last-sync watermark or N-days-ago fallback; watermark advances only on forward syncs.",
+                null,
+                new String[][]{
+                    {"GET", "/sap/inventory/sync", "Trigger SAP MM goods-receipt sync. Query params: fromDate (yyyy-MM-dd, optional), toDate (yyyy-MM-dd, optional)"}
+                });
+
         // ── Clinical ──────────────────────────────────────────────────────────
         appendModule(sb, "Clinical - Metadata", "/clinical/metadata",
                 "Manage EMR clinical master data. Required param: type. "

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -279,6 +279,24 @@ public class CapabilityStatementResource {
                         + "POST /recalculate?institutionId=X recalculates item totals for all items with CC fees.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("SAP Integration - Billing", "/api/sap/billing",
+                        "Bidirectional SAP S/4HANA Cloud FI integration. "
+                        + "POST /push/{billId} pushes an HMIS bill to SAP as a journal entry (debit AR, credit revenue). "
+                        + "GET /status/{billId} returns the push status and SAP document number. "
+                        + "POST /confirm receives a payment confirmation webhook from SAP. "
+                        + "GET /confirm/status/{billId} returns the confirmation status. "
+                        + "Auth: Finance header.",
+                        "API Key (Finance header)",
+                        "GET", "POST"))
+                .add(resource("SAP Integration - Inventory", "/api/sap/inventory",
+                        "SAP S/4HANA Cloud MM inventory sync. "
+                        + "GET /sync?fromDate=yyyy-MM-dd&toDate=yyyy-MM-dd fetches SAP goods-receipt material documents "
+                        + "and matches them to HMIS pharmacy items by code or barcode (configurable). "
+                        + "fromDate defaults to last-sync watermark; toDate defaults to today. "
+                        + "Read-only audit sync — does not create GRN bills. "
+                        + "Auth: Finance header.",
+                        "API Key (Finance header)",
+                        "GET"))
                 .add(resource("FHIR Patient", "/api/fhir/Patient",
                         "FHIR R5 Patient search, read, create, update",
                         "API Key (use FHIR header, not Finance)",


### PR DESCRIPTION
## Summary
- `CapabilityStatementResource`: adds two new capability entries — `SAP Integration - Billing` (`/api/sap/billing`) and `SAP Integration - Inventory` (`/api/sap/inventory`) — so both appear in `GET /api/capabilities` discovery
- `AnthropicApiService.buildSystemPrompt()`: adds SAP module descriptions (Billing + Inventory) so the AI assistant can describe SAP integration operations when asked
- `ApplicationConfig` registration was already done in #21094 (`SapBillingApi`) and #21096 (`SapInventoryApi`)

## Test plan
- [ ] `GET /api/capabilities` response includes `SAP Integration - Billing` and `SAP Integration - Inventory` entries
- [ ] Each entry lists the correct path, operations, and authentication scheme
- [ ] AI assistant chat describes SAP billing push/confirm and inventory sync when asked about SAP integration
- [ ] No regressions to existing capability entries

Part of #21092
Closes #21097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAP Integration - Billing: push bills to SAP, check operation status, and confirm payments
  * Added SAP Integration - Inventory: trigger SAP inventory synchronization
  * Both integrations available via new API endpoints with Finance-header authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->