### PR TITLE
feat(inward): send confirmation mail to credit company from BHT

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -150,8 +150,8 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     
     Map<String, Object> originalAdmission;
     Map<String, Object> updatedAdmission;
-
     // </editor-fold>
+    
     // <editor-fold defaultstate="collapsed" desc="Functons">
     public void addPatientAllergy() {
         if (currentPatientAllergy == null || currentPatientAllergy.getItemValue() == null) {
@@ -706,9 +706,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         }
         
         if (getCurrentCompany().getContactPerson() == null) {
-        JsfUtil.addErrorMessage("Company Contact Person is Missing");
-        return "";
-    }
+            JsfUtil.addErrorMessage("Company Contact Person is Missing");
+            return "";
+        }
 
         if (getCurrentCompany().getContactPerson().getEmail() == null || getCurrentCompany().getContactPerson().getEmail().trim().equalsIgnoreCase("")) {
             JsfUtil.addErrorMessage("Company Email is Missing");
@@ -766,8 +766,8 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         patientRoom = getPatientRoomFacade().findByJpql(sql, hm);
 
     }
-
     // </editor-fold>
+    
     // <editor-fold defaultstate="collapsed" desc="Getter & Setters">
     public void setSelectedItems(List<Admission> selectedItems) {
         this.selectedItems = selectedItems;
@@ -1027,8 +1027,8 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     public void setCurrecntEncounterCreditCompany(EncounterCreditCompany currecntEncounterCreditCompany) {
         this.currecntEncounterCreditCompany = currecntEncounterCreditCompany;
     }
-
     // </editor-fold>
+    
     @Override
     public Patient getPatient() {
         if (current != null) {

--- a/src/main/webapp/inward/send_confermation_mail_to_company.xhtml
+++ b/src/main/webapp/inward/send_confermation_mail_to_company.xhtml
@@ -163,10 +163,9 @@
 
                                 </p:panel>
 
-                                <common:patient_details_for_addmission 
-                                    controller="#{bhtEditController}" 
-                                    editable="false">
-                                </common:patient_details_for_addmission>
+                                <common:patient_details_view
+                                    patient="#{bhtEditController.patient}">
+                                </common:patient_details_view>
 
                                 <p:panel class="my-2">
                                     <f:facet name="header">
@@ -185,6 +184,7 @@
                                             yearNavigator="true"
                                             monthNavigator="true"
                                             showButtonBar="true"
+                                            readonly="true"
                                             timeInput="true">
                                             <f:ajax event="dateSelect" execute="@this" />
                                         </p:datePicker>
@@ -199,6 +199,7 @@
                                             id="refCon"
                                             completeMethod="#{consultantController.completeConsultant}" 
                                             var="mysp" 
+                                            readonly="true"
                                             itemLabel="#{mysp.person.name}" 
                                             itemValue="#{mysp}"
                                             styleClass="form-control w-100"
@@ -214,6 +215,7 @@
                                             value="#{bhtEditController.current.opdDoctor}" 
                                             completeMethod="#{doctorController.completeDoctor}"
                                             var="mys" 
+                                            readonly="true"
                                             itemLabel="#{mys.person.name}" 
                                             itemValue="#{mys}"
                                             styleClass="form-control w-100"
@@ -228,7 +230,8 @@
                                             completeMethod="#{doctorController.completeDoctor}" 
                                             var="ix"
                                             itemLabel="#{ix.person.name}" 
-                                            itemValue="#{ix}" 
+                                            itemValue="#{ix}"
+                                            readonly="true"
                                             styleClass="form-control w-100"
                                             class="w-100" 
                                             inputStyleClass="w-100">
@@ -242,6 +245,7 @@
                                             var="ix"
                                             class="w-100 form-control" 
                                             styleClass="w-100" 
+                                            readonly="true"
                                             inputStyleClass="w-100"
                                             itemLabel="#{ix.person.name}" 
                                             itemValue="#{ix}">
@@ -255,6 +259,7 @@
                                             var="refi"
                                             itemLabel="#{refi.name}" 
                                             itemValue="#{refi}" 
+                                            readonly="true"
                                             class="w-100 form-control" 
                                             styleClass="w-100" 
                                             inputStyleClass="w-100">
@@ -269,6 +274,7 @@
                                             value="#{bhtEditController.current.workplace}"
                                             completeMethod="#{institutionController.completeIns}" 
                                             var="mysp"
+                                            readonly="true"
                                             itemLabel="#{mysp.name}" 
                                             itemValue="#{mysp}" 
                                             class="w-100 form-control" 
@@ -277,17 +283,19 @@
                                         </p:autoComplete>
 
                                         <p:outputLabel  value="Referral Number"  />
-                                        <p:inputText  class="w-100"  value="#{bhtEditController.current.referralId}" ></p:inputText>
+                                        <p:inputText  class="w-100"  value="#{bhtEditController.current.referralId}" readonly="true" ></p:inputText>
 
                                         <p:outputLabel  value="Local/Foreigner"  />
                                         <p:selectBooleanCheckbox 
                                             value="#{bhtEditController.current.foriegner}" 
+                                            disabled="true"
                                             itemLabel="Foreigner">
                                         </p:selectBooleanCheckbox>
 
                                         <p:outputLabel  class="w-100"  value="Claimable/Non-Claimable"  />
                                         <p:selectBooleanCheckbox 
                                             value="#{bhtEditController.current.claimable}" 
+                                            disabled="true"
                                             itemLabel="Claimable">
                                         </p:selectBooleanCheckbox>
 

--- a/src/main/webapp/resources/inward/creditCompany/creditCompanyListView.xhtml
+++ b/src/main/webapp/resources/inward/creditCompany/creditCompanyListView.xhtml
@@ -40,7 +40,7 @@
                     <p:commandButton 
                         ajax="false"
                         value="To Send Mail"
-                        title="Send confermation mail to Company"
+                        title="Send confirmation mail to Company"
                         action="#{cc.attrs.controller.navigateToSendMailToCompany(ecc)}"
                         icon="fa fa-paper-plane"
                         class="ui-button-secondary" >

--- a/src/main/webapp/resources/inward/creditCompany/creditCompanyListView.xhtml
+++ b/src/main/webapp/resources/inward/creditCompany/creditCompanyListView.xhtml
@@ -28,11 +28,33 @@
                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                 </h:outputText>
             </p:column>
-            <p:column headerText="Policy No">
+            <p:column headerText="Policy No" class="text-center">
                 <h:outputText value="#{ecc.policyNo}" />
             </p:column>
-            <p:column headerText="Reference No">
+            <p:column headerText="Reference No" class="text-center">
                 <h:outputText value="#{ecc.referanceNo}" />
+            </p:column>
+
+            <p:column headerText="Action" width="17em;" class="text-center">
+                <div class="d-flex gap-2">
+                    <p:commandButton 
+                        ajax="false"
+                        value="To Send Mail"
+                        title="Send confermation mail to Company"
+                        action="#{cc.attrs.controller.navigateToSendMailToCompany(ecc)}"
+                        icon="fa fa-paper-plane"
+                        class="ui-button-secondary" >
+                    </p:commandButton>
+                    <p:commandButton  
+                        id="btnRemove"
+                        ajax="false"
+                        value="Remove"
+                        icon="fas fa-trash" 
+                        action="#{cc.attrs.controller.removeCreditCompany(ecc)}"
+                        styleClass="ui-button-danger" >
+                    </p:commandButton>
+                </div>
+
             </p:column>
         </p:dataTable>
     </cc:implementation>


### PR DESCRIPTION
## Summary

Enables sending a confirmation email to a credit company for an inpatient admission, directly from the credit company list of a BHT.

## Changes

### Credit company list (`creditCompanyListView.xhtml`)
- Added an **Action** column with a **To Send Mail** button that navigates to the confirmation mail page for the selected credit company, plus a **Remove** button to remove the credit company entry.
- Center-aligned the Policy No and Reference No columns.

### Confirmation mail page (`send_confermation_mail_to_company.xhtml`)
- Replaced the editable admission/patient details component with a read-only patient details view.
- Marked the admission detail fields (admission date, consultants, referring/credit institution, workplace, referral number, Local/Foreigner and Claimable checkboxes) as read-only so they are shown for reference but cannot be edited on the mail page.

### Controller (`BhtEditController.java`)
- Fixed the indentation of the "Company Contact Person is Missing" validation block in `sendEmailToCompany()` and cleaned up surrounding formatting.

## Testing
- JSF/UI-only behavioral changes plus a Java formatting fix; verified field rendering on the confirmation mail page.

Closes #21106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added action buttons to the credit companies list for sending confirmation emails and removing entries.
  * Added an "Action" column to the credit companies list.

* **UI/UX Improvements**
  * Centered headers for Policy No and Reference No in the credit companies list.
  * Admission form fields are now read-only (admission date/time, consultants, doctors, staff, workplace).
  * Referral fields (referral ID, foreigner/claimable checkboxes) are now read-only/disabled.
  * Patient details display switched to view mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->