### PR TITLE
fix(pharmacy): include PharmacyIssue bills in BHT Issue count (Single Item Summary)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -8170,7 +8170,7 @@ public class PharmacyController implements Serializable {
 
     }
 
-    public List<Object[]> calDepartmentBhtIssue(Institution institution, BillType billType) {
+    public List<Object[]> calDepartmentBhtIssue(Institution institution, List<BillType> billTypes) {
         Item item;
 
         if (pharmacyItem instanceof Ampp) {
@@ -8185,14 +8185,14 @@ public class PharmacyController implements Serializable {
         m.put("ins", institution);
         m.put("frm", getFromDate());
         m.put("to", getToDate());
-        m.put("btp", billType);
+        m.put("btps", billTypes);
         sql = "select i.bill.department,"
                 + " sum(i.netValue),"
                 + " sum(i.pharmaceuticalBillItem.qty) "
                 + " from BillItem i "
                 + " where i.bill.department.institution=:ins"
                 + " and i.item=:itm "
-                + " and i.bill.billType=:btp "
+                + " and i.bill.billType in :btps "
                 + " and i.createdAt between :frm and :to  "
                 + " group by i.bill.department";
 
@@ -9015,7 +9015,7 @@ public class PharmacyController implements Serializable {
             List<DepartmentSale> list = new ArrayList<>();
             double totalValue = 0;
             double totalQty = 0;
-            List<Object[]> objs = calDepartmentBhtIssue(ins, BillType.PharmacyBhtPre);
+            List<Object[]> objs = calDepartmentBhtIssue(ins, java.util.Arrays.asList(BillType.PharmacyBhtPre, BillType.PharmacyIssue));
 
             for (Object[] obj : objs) {
                 DepartmentSale r = new DepartmentSale();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -8170,7 +8170,7 @@ public class PharmacyController implements Serializable {
 
     }
 
-    public List<Object[]> calDepartmentBhtIssue(Institution institution, List<BillType> billTypes) {
+    public List<Object[]> calDepartmentBhtIssue(Institution institution, List<BillTypeAtomic> billTypeAtomics) {
         Item item;
 
         if (pharmacyItem instanceof Ampp) {
@@ -8185,14 +8185,14 @@ public class PharmacyController implements Serializable {
         m.put("ins", institution);
         m.put("frm", getFromDate());
         m.put("to", getToDate());
-        m.put("btps", billTypes);
+        m.put("btas", billTypeAtomics);
         sql = "select i.bill.department,"
                 + " sum(i.netValue),"
                 + " sum(i.pharmaceuticalBillItem.qty) "
                 + " from BillItem i "
                 + " where i.bill.department.institution=:ins"
                 + " and i.item=:itm "
-                + " and i.bill.billType in :btps "
+                + " and i.bill.billTypeAtomic in :btas "
                 + " and i.createdAt between :frm and :to  "
                 + " group by i.bill.department";
 
@@ -9015,7 +9015,7 @@ public class PharmacyController implements Serializable {
             List<DepartmentSale> list = new ArrayList<>();
             double totalValue = 0;
             double totalQty = 0;
-            List<Object[]> objs = calDepartmentBhtIssue(ins, java.util.Arrays.asList(BillType.PharmacyBhtPre, BillType.PharmacyIssue));
+            List<Object[]> objs = calDepartmentBhtIssue(ins, Arrays.asList(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE, BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD));
 
             for (Object[] obj : objs) {
                 DepartmentSale r = new DepartmentSale();


### PR DESCRIPTION
## Summary

- `calDepartmentBhtIssue` was filtering by `BillType.PharmacyBhtPre` only, which covers `DIRECT_ISSUE_INWARD_MEDICINE` but silently excludes `ISSUE_MEDICINE_ON_REQUEST_INWARD` (which uses `BillType.PharmacyIssue`)
- Changed the method signature to accept `List<BillType>` and use `IN :btps` instead of `= :btp`
- `createInstitutionBhtIssue` now passes `[PharmacyBhtPre, PharmacyIssue]` so both inward issue pathways are counted

## Root cause confirmed on Southern Lanka production DB

For item 7405 (Perfusor set), period 01 Feb – 28 May 2026:
- `DIRECT_ISSUE_INWARD_MEDICINE`: 5 bills, qty 5 (was counted)
- `ISSUE_MEDICINE_ON_REQUEST_INWARD`: 8 bills, qty 9 (was silently excluded)
- Total correct count: **14** (Single Item Summary was showing 4)

## Test plan

- [ ] Open Single Item Summary for an item that has been issued via both `DIRECT_ISSUE_INWARD_MEDICINE` and `ISSUE_MEDICINE_ON_REQUEST_INWARD` in the same period
- [ ] Verify the BHT Issue tab total matches the sum of both bill types
- [ ] Verify the Bin Card balance for the same item and period is consistent with the corrected BHT Issue count
- [ ] Confirm no regression on items that only have `DIRECT_ISSUE_INWARD_MEDICINE` bills

Closes #21143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pharmacy BHT issue calculations now aggregate across multiple bill atomics, so department-level and overall BHT issue reports include both direct-issue and on-request medicine issues for more complete and accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->