### PR TITLE
fix(pharmacy): Bin Card shows ISSUE_MEDICINE_ON_REQUEST_INWARD qty in wrong column

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1524,7 +1524,7 @@ public class PharmacySaleBhtController implements Serializable {
                 JsfUtil.addErrorMessage("Item Qty is Zero " + tbi.getItem().getName());
                 return;
             }
-            if (tbi.getPharmaceuticalBillItem().getQty() > tbi.getPharmaceuticalBillItem().getStock().getStock()) {
+            if (Math.abs(tbi.getPharmaceuticalBillItem().getQty()) > tbi.getPharmaceuticalBillItem().getStock().getStock()) {
                 JsfUtil.addErrorMessage("Not Enough Stock " + tbi.getItem().getName());
                 return;
             }
@@ -2261,8 +2261,8 @@ public class PharmacySaleBhtController implements Serializable {
                     }
                     billItem = new BillItem();
                     billItem.setPharmaceuticalBillItem(new PharmaceuticalBillItem());
-                    billItem.getPharmaceuticalBillItem().setQtyInUnit(sq.getQty());
-//                billItem.getPharmaceuticalBillItem().setQtyInUnit((double) (0 - sq.getQty()));
+                    billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - sq.getQty());
+                    billItem.getPharmaceuticalBillItem().setQty(0 - sq.getQty());
                     billItem.getPharmaceuticalBillItem().setStock(sq.getStock());
                     billItem.getPharmaceuticalBillItem().setItemBatch(sq.getStock().getItemBatch());
 
@@ -2273,11 +2273,6 @@ public class PharmacySaleBhtController implements Serializable {
                     billItem.getPharmaceuticalBillItem().setDoe(sq.getStock().getItemBatch().getDateOfExpire());
                     billItem.getPharmaceuticalBillItem().setFreeQty(0.0f);
                     billItem.getPharmaceuticalBillItem().setItemBatch(sq.getStock().getItemBatch());
-                    billItem.getPharmaceuticalBillItem().setQtyInUnit(sq.getQty());
-//                billItem.getPharmaceuticalBillItem().setQtyInUnit((double) (0 - sq.getQty()));
-//                billItem.getPharmaceuticalBillItem().setQtyInUnit((double) (0 - sq.getQty()));
-//                billItem.getPharmaceuticalBillItem().setQtyInUnit((double) (0 - sq.getQty()));
-//                billItem.getPharmaceuticalBillItem().setQtyInUnit((double) (0 - sq.getQty()));
                     billItem.setGrossValue(sq.getStock().getItemBatch().getRetailsaleRate() * sq.getQty());
                     billItem.setNetValue(sq.getQty() * sq.getStock().getItemBatch().getRetailsaleRate());
 
@@ -2293,7 +2288,8 @@ public class PharmacySaleBhtController implements Serializable {
             } else {
                 billItem = new BillItem();
                 billItem.setPharmaceuticalBillItem(new PharmaceuticalBillItem());
-                billItem.getPharmaceuticalBillItem().setQtyInUnit(issuableQty);
+                billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - issuableQty);
+                billItem.getPharmaceuticalBillItem().setQty(0 - issuableQty);
                 billItem.getPharmaceuticalBillItem().setStock(null);
                 billItem.getPharmaceuticalBillItem().setItemBatch(null);
                 billItem.setItem(i.getItem());


### PR DESCRIPTION
## Summary

- `ISSUE_MEDICINE_ON_REQUEST_INWARD` bills were storing a **positive** `qty` on `PharmaceuticalBillItem` — the bin card uses the sign of this field to decide Qty In (positive) vs Qty Out (negative)
- Fixed by negating `PharmaceuticalBillItem.qty` and `qtyInUnit` (`0 - sq.getQty()`) when building bill items in the request settlement workflow, matching the convention already used by `DIRECT_ISSUE_INWARD_MEDICINE`
- Updated the pre-save stock availability check to use `Math.abs()` so it works correctly with the now-negative value

## Root cause

In `PharmacySaleBhtController.populateBillItemsFromRequest()`, the negation of `PharmaceuticalBillItem.qty` had been commented out (4 commented lines visible in the diff). The `DIRECT_ISSUE_INWARD_MEDICINE` workflow (line ~1724) correctly uses `0 - Math.abs(qty)` — the request workflow never did.

## Impact

- Bin Card: `ISSUE_MEDICINE_ON_REQUEST_INWARD` transactions will now appear in **Qty Out** column (was: Qty In)
- Running balance was already correct — only the column display was wrong
- No data correction needed for historical records; fix applies to new bills only

## Test plan

- [ ] Issue medicines on request for an inward patient via the BHT request workflow
- [ ] Open the Bin Card for that item — verify the issued qty appears in **Qty Out**, not Qty In
- [ ] Verify the running balance is still correct after the issue
- [ ] Verify direct issue (`DIRECT_ISSUE_INWARD_MEDICINE`) is unaffected — still shows in Qty Out
- [ ] Confirm the "Not Enough Stock" validation still fires correctly when stock is insufficient

Closes #21144

🤖 Generated with [Claude Code](https://claude.com/claude-code)