### PR TITLE
fix(pharmacy): use BillItem.qty for BHT Issue count to fix sign mismatch

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -8188,7 +8188,7 @@ public class PharmacyController implements Serializable {
         m.put("btas", billTypeAtomics);
         sql = "select i.bill.department,"
                 + " sum(i.netValue),"
-                + " sum(i.pharmaceuticalBillItem.qty) "
+                + " sum(i.qty) "
                 + " from BillItem i "
                 + " where i.bill.department.institution=:ins"
                 + " and i.item=:itm "


### PR DESCRIPTION
## Summary

Follow-up fix for #21143. The previous fix added `ISSUE_MEDICINE_ON_REQUEST_INWARD` to the `billTypeAtomic IN` filter, but the query was aggregating on `sum(i.pharmaceuticalBillItem.qty)` which has **inconsistent signs** across the two bill types:

| Bill Type Atomic | `pbi.qty` sign | Reason |
|---|---|---|
| `DIRECT_ISSUE_INWARD_MEDICINE` | negative (e.g. `-1`) | Negation applied during save |
| `ISSUE_MEDICINE_ON_REQUEST_INWARD` | positive (e.g. `+1`) | Negation was commented out |

This caused the two to partially cancel: `-5 + 9 = 4` instead of `14`.

**Fix**: use `sum(i.qty)` (`BillItem.qty`) which is consistently positive for both issue bill types and is the correct field for counting issued quantity.

## Verified on Southern Lanka production DB

```
dept     | net_value | qty (old pbi) | qty (new bi)
PHARMACY | 8117.93   | 4             | 14  ✓
```

## Test plan

- [ ] Open Single Item Summary → BHT Issue tab for an item issued via both pathways in the same period
- [ ] Verify count is the sum of both `DIRECT_ISSUE_INWARD_MEDICINE` and `ISSUE_MEDICINE_ON_REQUEST_INWARD` quantities
- [ ] Confirm value column is still correct

Closes #21143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quantity calculation in the pharmacy bill item issue report to ensure accurate aggregated totals are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->