### PR TITLE
feat(pharmacy): add DTO-based Consumption Report

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,14 @@
       "C:\\Development\\hmis.wiki"
     ],
     "allow": [
-      "Bash(mysql *)"
+      "Bash(mysql *)",
+      "Bash(curl -s *)",
+      "Bash(curl -sS *)",
+      "Bash(curl -s\"*)",
+      "Bash(ping -c *)",
+      "Bash(ss -tnlp*)",
+      "Bash(/home/buddhika/payara/bin/asadmin list*)",
+      "Bash(/home/buddhika/payara/bin/asadmin ping-connection-pool*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
       "Bash(mysql *)",
       "Bash(curl -s *)",
       "Bash(curl -sS *)",
-      "Bash(curl -s\"*)",
       "Bash(ping -c *)",
       "Bash(ss -tnlp*)",
       "Bash(/home/buddhika/payara/bin/asadmin list*)",

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4023,7 +4023,10 @@ public class PharmacyController implements Serializable {
 
         for (BillTypeAtomic billType : billTypeAtomics) {
             Map<String, Object> parameters = new HashMap<>();
+            // [0]=sourceDept [1]=consumptionDept [2]=category [3]=item
+            // [4]=purchaseVal [5]=costVal [6]=retailVal [7]=netTotal [8]=qty
             String jpql = "SELECT "
+                    + "b.department.name, "
                     + "b.toDepartment.name, "
                     + "bi.item.category.name, "
                     + "bi.item.name, "
@@ -4061,6 +4064,10 @@ public class PharmacyController implements Serializable {
                 jpql += "AND bi.item.category = :category ";
                 parameters.put("category", category);
             }
+            if (dosageForm != null) {
+                jpql += "AND bi.item.dosageForm = :df ";
+                parameters.put("df", dosageForm);
+            }
             if (item != null) {
                 jpql += "AND bi.item = :item ";
                 parameters.put("item", item);
@@ -4074,8 +4081,8 @@ public class PharmacyController implements Serializable {
                 parameters.put("departmentTypes", selectedDepartmentTypes);
             }
 
-            jpql += "GROUP BY b.toDepartment.name, bi.item.category.name, bi.item.name "
-                    + "ORDER BY b.toDepartment.name, bi.item.category.name, bi.item.name";
+            jpql += "GROUP BY b.department.name, b.toDepartment.name, bi.item.category.name, bi.item.name "
+                    + "ORDER BY b.department.name, b.toDepartment.name, bi.item.category.name, bi.item.name";
 
             try {
                 List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
@@ -4083,17 +4090,18 @@ public class PharmacyController implements Serializable {
                 double qtySign = consumptionQtySign(billType);
 
                 for (Object[] row : results) {
-                    String deptName = (String) row[0];
-                    String catName = (String) row[1];
-                    String iName = (String) row[2];
-                    Double purchase = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
-                    Double cost = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
-                    Double retail = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
-                    Double net = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
-                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
+                    String sourceDeptName = (String) row[0];
+                    String deptName = (String) row[1];
+                    String catName = (String) row[2];
+                    String iName = (String) row[3];
+                    Double purchase = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double cost = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
+                    Double retail = row[6] != null ? valueSign * ((Number) row[6]).doubleValue() : 0.0;
+                    Double net = row[7] != null ? ((Number) row[7]).doubleValue() : 0.0;
+                    Double qty = row[8] != null ? qtySign * ((Number) row[8]).doubleValue() : 0.0;
 
                     ConsumptionCategoryItemDto dto = new ConsumptionCategoryItemDto(
-                            deptName, catName, iName, qty, purchase, cost, retail, net);
+                            sourceDeptName, deptName, catName, iName, qty, purchase, cost, retail, net);
                     allItems.add(dto);
                 }
             } catch (Exception e) {
@@ -4101,14 +4109,14 @@ public class PharmacyController implements Serializable {
             }
         }
 
-        // Aggregate by dept + category + item
+        // Aggregate by sourceDept + consumptionDept + category + item
         Map<String, ConsumptionCategoryItemDto> aggregated = new LinkedHashMap<>();
         for (ConsumptionCategoryItemDto dto : allItems) {
-            String key = dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
+            String key = dto.getSourceDepartmentName() + "||" + dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
             ConsumptionCategoryItemDto existing = aggregated.get(key);
             if (existing == null) {
                 aggregated.put(key, new ConsumptionCategoryItemDto(
-                        dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
+                        dto.getSourceDepartmentName(), dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
                         dto.getQty(), dto.getTotalPurchaseValue(), dto.getTotalCostValue(),
                         dto.getTotalRetailValue(), dto.getNetTotal()));
             } else {
@@ -4122,26 +4130,37 @@ public class PharmacyController implements Serializable {
 
         List<ConsumptionCategoryItemDto> aggregatedList = new ArrayList<>(aggregated.values());
 
-        // Build category map for categoryWise view
+        // consumptionCategoryDtoMap: consumptionDept -> category -> items (for categoryWise view)
         Map<String, Map<String, List<ConsumptionCategoryItemDto>>> catMap = new TreeMap<>();
-        // Build department totals (scalar map) for summary view
+        // departmentTotals: sourceDept -> consumptionDept -> [purchase,cost,retail,net] (mirrors legacy summary)
         Map<String, Map<String, Double[]>> deptTotals = new TreeMap<>();
+        // pharmacyTotals: sourceDept -> [purchase,cost,retail,net] (for excel/pdf export)
+        Map<String, Double[]> pharmTotals = new TreeMap<>();
 
         for (ConsumptionCategoryItemDto dto : aggregatedList) {
+            String sourceDeptName = dto.getSourceDepartmentName();
             String deptName = dto.getDepartmentName();
             String catName = dto.getCategoryName();
             if (deptName == null || deptName.trim().isEmpty()) continue;
             if (catName == null || catName.trim().isEmpty()) continue;
             if (dto.getQty() == 0.0) continue;
 
+            // Category map: consumptionDept -> category -> items
             catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
                     .computeIfAbsent(catName, k -> new ArrayList<>())
                     .add(dto);
 
-            deptTotals.computeIfAbsent(deptName, k -> new TreeMap<>())
-                    .merge(catName,
-                            new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
-                            (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+            if (sourceDeptName != null && !sourceDeptName.trim().isEmpty()) {
+                // Summary map: sourceDept -> consumptionDept -> [values]
+                deptTotals.computeIfAbsent(sourceDeptName, k -> new TreeMap<>())
+                        .merge(deptName,
+                                new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                                (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+                // Export totals: sourceDept -> [values]
+                pharmTotals.merge(sourceDeptName,
+                        new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                        (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+            }
 
             totalPurchase += dto.getTotalPurchaseValue();
             totalCostValue += dto.getTotalCostValue();
@@ -4151,6 +4170,7 @@ public class PharmacyController implements Serializable {
 
         consumptionCategoryDtoMap = catMap;
         setDepartmentTotals(deptTotals);
+        setPharmacyTotals(pharmTotals);
     }
 
     private void resetFields() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -30,6 +30,9 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.dataStructure.CategoryWithItem;
 import com.divudi.core.data.dataStructure.PharmacySummery;
 import com.divudi.core.data.dto.AmpDto;
+import com.divudi.core.data.dto.ConsumptionBillDto;
+import com.divudi.core.data.dto.ConsumptionBillItemDto;
+import com.divudi.core.data.dto.ConsumptionCategoryItemDto;
 import com.divudi.core.data.dto.PharmacyGrnItemDTO;
 import com.divudi.core.data.dto.BeforeStockTakingDTO;
 import com.divudi.core.data.dto.PharmacyGrnReturnItemDTO;
@@ -3691,6 +3694,7 @@ public class PharmacyController implements Serializable {
         }
     }
 
+    @Deprecated
     public void createConsumptionReportTable() {
         reportTimerController.trackReportExecution(() -> {
             resetFields();
@@ -3725,6 +3729,428 @@ public class PharmacyController implements Serializable {
                     throw new IllegalArgumentException("Invalid report type: " + reportType);
             }
         }, InventoryReports.CONSUMPTION_REPORT, sessionController.getLoggedUser());
+    }
+
+    public void createConsumptionReportTableDto() {
+        reportTimerController.trackReportExecution(() -> {
+            resetConsumptionDtoFields();
+            List<BillTypeAtomic> disposalBillTypes = new ArrayList<>();
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE);
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED);
+
+            switch (reportType) {
+                case "byBill":
+                    if (item != null) {
+                        JsfUtil.addErrorMessage("You can not use List By Bill when an item is selected");
+                        return;
+                    }
+                    if (category != null) {
+                        JsfUtil.addErrorMessage("You can not use List By Bill when a category is selected");
+                        return;
+                    }
+                    generateConsumptionByBillDto(disposalBillTypes);
+                    break;
+                case "byBillItem":
+                    generateConsumptionByBillItemDto(disposalBillTypes);
+                    break;
+                case "summeryReport":
+                case "categoryWise":
+                    generateConsumptionSummaryAndCategoryDto(disposalBillTypes);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid report type: " + reportType);
+            }
+        }, InventoryReports.CONSUMPTION_REPORT, sessionController.getLoggedUser());
+    }
+
+    private void resetConsumptionDtoFields() {
+        consumptionBillDtos = new ArrayList<>();
+        consumptionBillItemDtos = new ArrayList<>();
+        consumptionCategoryDtoMap = new HashMap<>();
+        totalPurchase = 0.0;
+        totalCostValue = 0.0;
+        totalRetailValue = 0.0;
+        totalSaleValue = 0.0;
+        departmentTotals = new HashMap<>();
+    }
+
+    public void generateConsumptionByBillDto(List<BillTypeAtomic> billTypeAtomics) {
+        try {
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT b.id, b.deptId, b.invoiceNumber, ");
+            jpql.append("toDept.name, ");
+            jpql.append("b.cancelled, b.fullReturned, ");
+            jpql.append("cb.id, cb.deptId, ");
+            jpql.append("rb.id, rb.deptId, ");
+            jpql.append("obb.id, obb.deptId, ");
+            jpql.append("bfd.totalPurchaseValue, bfd.totalCostValue, bfd.totalRetailSaleValue, ");
+            jpql.append("b.createdAt, wu.name, b.comments, b.billTypeAtomic ");
+            jpql.append("FROM Bill b ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN b.cancelledBill cb ");
+            jpql.append("LEFT JOIN b.refundedBill rb ");
+            jpql.append("LEFT JOIN b.billedBill obb ");
+            jpql.append("LEFT JOIN b.billFinanceDetails bfd ");
+            jpql.append("LEFT JOIN b.creater cr ");
+            jpql.append("LEFT JOIN cr.webUserPerson wu ");
+            jpql.append("WHERE (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (dept != null) {
+                jpql.append("AND b.department = :dept ");
+                params.put("dept", dept);
+            }
+            if (dosageForm != null) {
+                jpql.append("AND EXISTS (SELECT bi2 FROM BillItem bi2 WHERE bi2.bill = b AND bi2.item.dosageForm = :df) ");
+                params.put("df", dosageForm);
+            }
+            if (toDepartment != null) {
+                jpql.append("AND b.toDepartment = :toDept2 ");
+                params.put("toDept2", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = getBillFacade().findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            consumptionBillDtos = new ArrayList<>();
+            totalPurchase = 0.0;
+            totalCostValue = 0.0;
+            totalRetailValue = 0.0;
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[18] != null ? (BillTypeAtomic) row[18] : null;
+                double valueSign = consumptionValueSign(bta);
+
+                double rawPurchase = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
+                double rawCost = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
+                double rawRetail = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
+
+                double purchase = valueSign * rawPurchase;
+                double cost = valueSign * rawCost;
+                double retail = valueSign * rawRetail;
+
+                ConsumptionBillDto dto = new ConsumptionBillDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        (String) row[1],
+                        (String) row[2],
+                        (String) row[3],
+                        row[4] != null ? (Boolean) row[4] : false,
+                        row[5] != null ? (Boolean) row[5] : false,
+                        row[6] != null ? ((Number) row[6]).longValue() : null,
+                        (String) row[7],
+                        row[8] != null ? ((Number) row[8]).longValue() : null,
+                        (String) row[9],
+                        row[10] != null ? ((Number) row[10]).longValue() : null,
+                        (String) row[11],
+                        purchase, cost, retail,
+                        (java.util.Date) row[15],
+                        (String) row[16],
+                        (String) row[17]
+                );
+
+                consumptionBillDtos.add(dto);
+                totalPurchase += purchase;
+                totalCostValue += cost;
+                totalRetailValue += retail;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption by bill DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Consumption By Bill report.");
+        }
+    }
+
+    public void generateConsumptionByBillItemDto(List<BillTypeAtomic> billTypeAtomics) {
+        try {
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT bi.id, b.id, b.deptId, b.invoiceNumber, ");
+            jpql.append("toDept.name, ");
+            jpql.append("i.name, cat.name, df.name, ");
+            jpql.append("bi.qty, ");
+            jpql.append("b.cancelled, b.fullReturned, ");
+            jpql.append("cb.id, cb.deptId, ");
+            jpql.append("rb.id, rb.deptId, ");
+            jpql.append("obb.id, obb.deptId, ");
+            jpql.append("bifd.purchaseRate, bifd.valueAtPurchaseRate, ");
+            jpql.append("bifd.retailSaleRate, bifd.valueAtRetailRate, ");
+            jpql.append("bifd.costRate, bifd.valueAtCostRate, ");
+            jpql.append("b.createdAt, wu.name, b.comments, b.billTypeAtomic ");
+            jpql.append("FROM BillItem bi ");
+            jpql.append("JOIN bi.bill b ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN bi.item i ");
+            jpql.append("LEFT JOIN i.category cat ");
+            jpql.append("LEFT JOIN i.dosageForm df ");
+            jpql.append("LEFT JOIN b.cancelledBill cb ");
+            jpql.append("LEFT JOIN b.refundedBill rb ");
+            jpql.append("LEFT JOIN b.billedBill obb ");
+            jpql.append("LEFT JOIN bi.billItemFinanceDetails bifd ");
+            jpql.append("LEFT JOIN b.creater cr ");
+            jpql.append("LEFT JOIN cr.webUserPerson wu ");
+            jpql.append("WHERE (bi.retired = false OR bi.retired IS NULL) ");
+            jpql.append("AND (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (dept != null) {
+                jpql.append("AND b.department = :department ");
+                params.put("department", dept);
+            }
+            if (category != null) {
+                jpql.append("AND i.category = :category ");
+                params.put("category", category);
+            }
+            if (dosageForm != null) {
+                jpql.append("AND i.dosageForm = :df ");
+                params.put("df", dosageForm);
+            }
+            if (item != null) {
+                jpql.append("AND bi.item = :item ");
+                params.put("item", item);
+            }
+            if (toDepartment != null) {
+                jpql.append("AND b.toDepartment = :toDepartment ");
+                params.put("toDepartment", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = getBillItemFacade().findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            consumptionBillItemDtos = new ArrayList<>();
+            totalPurchase = 0.0;
+            totalCostValue = 0.0;
+            totalRetailValue = 0.0;
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[26] != null ? (BillTypeAtomic) row[26] : null;
+                double valueSign = consumptionValueSign(bta);
+                double qtySign = consumptionQtySign(bta);
+
+                double rawPurchaseVal = row[18] != null ? ((Number) row[18]).doubleValue() : 0.0;
+                double rawRetailVal = row[20] != null ? ((Number) row[20]).doubleValue() : 0.0;
+                double rawCostVal = row[22] != null ? ((Number) row[22]).doubleValue() : 0.0;
+                double rawQty = row[8] != null ? ((Number) row[8]).doubleValue() : 0.0;
+
+                double purchaseVal = valueSign * rawPurchaseVal;
+                double retailVal = valueSign * rawRetailVal;
+                double costVal = valueSign * rawCostVal;
+                double qty = qtySign * rawQty;
+
+                ConsumptionBillItemDto dto = new ConsumptionBillItemDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        row[1] != null ? ((Number) row[1]).longValue() : null,
+                        (String) row[2],
+                        (String) row[3],
+                        (String) row[4],
+                        (String) row[5],
+                        (String) row[6],
+                        (String) row[7],
+                        qty,
+                        row[9] != null ? (Boolean) row[9] : false,
+                        row[10] != null ? (Boolean) row[10] : false,
+                        row[11] != null ? ((Number) row[11]).longValue() : null,
+                        (String) row[12],
+                        row[13] != null ? ((Number) row[13]).longValue() : null,
+                        (String) row[14],
+                        row[15] != null ? ((Number) row[15]).longValue() : null,
+                        (String) row[16],
+                        row[17] != null ? ((Number) row[17]).doubleValue() : 0.0,
+                        purchaseVal,
+                        row[19] != null ? ((Number) row[19]).doubleValue() : 0.0,
+                        retailVal,
+                        row[21] != null ? ((Number) row[21]).doubleValue() : 0.0,
+                        costVal,
+                        (java.util.Date) row[23],
+                        (String) row[24],
+                        (String) row[25]
+                );
+
+                consumptionBillItemDtos.add(dto);
+                totalPurchase += purchaseVal;
+                totalCostValue += costVal;
+                totalRetailValue += retailVal;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption by bill item DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Consumption By Bill Item report.");
+        }
+    }
+
+    public void generateConsumptionSummaryAndCategoryDto(List<BillTypeAtomic> billTypeAtomics) {
+        totalSaleValue = 0.0;
+        totalCostValue = 0.0;
+        totalPurchase = 0.0;
+        totalRetailValue = 0.0;
+
+        List<ConsumptionCategoryItemDto> allItems = new ArrayList<>();
+
+        for (BillTypeAtomic billType : billTypeAtomics) {
+            Map<String, Object> parameters = new HashMap<>();
+            String jpql = "SELECT "
+                    + "b.toDepartment.name, "
+                    + "bi.item.category.name, "
+                    + "bi.item.name, "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtPurchaseRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtCostRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtRetailRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.netTotal, 0.0)), "
+                    + "SUM(bi.qty) "
+                    + "FROM BillItem bi "
+                    + "JOIN bi.bill b "
+                    + "WHERE (bi.retired = false OR bi.retired IS NULL) "
+                    + "AND (b.retired = false OR b.retired IS NULL) "
+                    + "AND b.completed = true "
+                    + "AND bi.billItemFinanceDetails IS NOT NULL "
+                    + "AND b.createdAt BETWEEN :fromDate AND :toDate "
+                    + "AND b.billTypeAtomic = :billTypeAtomic ";
+
+            parameters.put("fromDate", fromDate);
+            parameters.put("toDate", toDate);
+            parameters.put("billTypeAtomic", billType);
+
+            if (institution != null) {
+                jpql += "AND b.institution = :institution ";
+                parameters.put("institution", institution);
+            }
+            if (site != null) {
+                jpql += "AND b.department.site = :site ";
+                parameters.put("site", site);
+            }
+            if (dept != null) {
+                jpql += "AND b.department = :department ";
+                parameters.put("department", dept);
+            }
+            if (category != null) {
+                jpql += "AND bi.item.category = :category ";
+                parameters.put("category", category);
+            }
+            if (item != null) {
+                jpql += "AND bi.item = :item ";
+                parameters.put("item", item);
+            }
+            if (toDepartment != null) {
+                jpql += "AND b.toDepartment = :toDepartment ";
+                parameters.put("toDepartment", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql += "AND b.departmentType IN :departmentTypes ";
+                parameters.put("departmentTypes", selectedDepartmentTypes);
+            }
+
+            jpql += "GROUP BY b.toDepartment.name, bi.item.category.name, bi.item.name "
+                    + "ORDER BY b.toDepartment.name, bi.item.category.name, bi.item.name";
+
+            try {
+                List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
+                double valueSign = consumptionValueSign(billType);
+                double qtySign = consumptionQtySign(billType);
+
+                for (Object[] row : results) {
+                    String deptName = (String) row[0];
+                    String catName = (String) row[1];
+                    String iName = (String) row[2];
+                    Double purchase = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
+                    Double cost = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double retail = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
+                    Double net = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
+                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
+
+                    ConsumptionCategoryItemDto dto = new ConsumptionCategoryItemDto(
+                            deptName, catName, iName, qty, purchase, cost, retail, net);
+                    allItems.add(dto);
+                }
+            } catch (Exception e) {
+                Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption summary/category DTO for " + billType, e);
+            }
+        }
+
+        // Aggregate by dept + category + item
+        Map<String, ConsumptionCategoryItemDto> aggregated = new LinkedHashMap<>();
+        for (ConsumptionCategoryItemDto dto : allItems) {
+            String key = dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
+            ConsumptionCategoryItemDto existing = aggregated.get(key);
+            if (existing == null) {
+                aggregated.put(key, new ConsumptionCategoryItemDto(
+                        dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
+                        dto.getQty(), dto.getTotalPurchaseValue(), dto.getTotalCostValue(),
+                        dto.getTotalRetailValue(), dto.getNetTotal()));
+            } else {
+                existing.setQty(existing.getQty() + dto.getQty());
+                existing.setTotalPurchaseValue(existing.getTotalPurchaseValue() + dto.getTotalPurchaseValue());
+                existing.setTotalCostValue(existing.getTotalCostValue() + dto.getTotalCostValue());
+                existing.setTotalRetailValue(existing.getTotalRetailValue() + dto.getTotalRetailValue());
+                existing.setNetTotal(existing.getNetTotal() + dto.getNetTotal());
+            }
+        }
+
+        List<ConsumptionCategoryItemDto> aggregatedList = new ArrayList<>(aggregated.values());
+
+        // Build category map for categoryWise view
+        Map<String, Map<String, List<ConsumptionCategoryItemDto>>> catMap = new TreeMap<>();
+        // Build department totals (scalar map) for summary view
+        Map<String, Map<String, Double[]>> deptTotals = new TreeMap<>();
+
+        for (ConsumptionCategoryItemDto dto : aggregatedList) {
+            String deptName = dto.getDepartmentName();
+            String catName = dto.getCategoryName();
+            if (deptName == null || deptName.trim().isEmpty()) continue;
+            if (catName == null || catName.trim().isEmpty()) continue;
+            if (dto.getQty() == 0.0) continue;
+
+            catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
+                    .computeIfAbsent(catName, k -> new ArrayList<>())
+                    .add(dto);
+
+            deptTotals.computeIfAbsent(deptName, k -> new TreeMap<>())
+                    .merge(catName,
+                            new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                            (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+
+            totalPurchase += dto.getTotalPurchaseValue();
+            totalCostValue += dto.getTotalCostValue();
+            totalRetailValue += dto.getTotalRetailValue();
+            totalSaleValue += dto.getNetTotal();
+        }
+
+        consumptionCategoryDtoMap = catMap;
+        setDepartmentTotals(deptTotals);
     }
 
     private void resetFields() {
@@ -9072,6 +9498,10 @@ public class PharmacyController implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyTransferReceiveByDepartmentDTO> transferReceivesByDepartment;
     private List<com.divudi.core.data.dto.PharmacyDisposeIssueByDepartmentDTO> disposeIssuesByDepartment;
 
+    private List<ConsumptionBillDto> consumptionBillDtos;
+    private List<ConsumptionBillItemDto> consumptionBillItemDtos;
+    private Map<String, Map<String, List<ConsumptionCategoryItemDto>>> consumptionCategoryDtoMap = new HashMap<>();
+
     private List<InstitutionSale> institutionTransferIssue;
     private List<InstitutionSale> institutionIssue;
 
@@ -10947,6 +11377,30 @@ public class PharmacyController implements Serializable {
 
     public void setDisposeIssuesByDepartment(List<com.divudi.core.data.dto.PharmacyDisposeIssueByDepartmentDTO> disposeIssuesByDepartment) {
         this.disposeIssuesByDepartment = disposeIssuesByDepartment;
+    }
+
+    public List<ConsumptionBillDto> getConsumptionBillDtos() {
+        return consumptionBillDtos;
+    }
+
+    public void setConsumptionBillDtos(List<ConsumptionBillDto> consumptionBillDtos) {
+        this.consumptionBillDtos = consumptionBillDtos;
+    }
+
+    public List<ConsumptionBillItemDto> getConsumptionBillItemDtos() {
+        return consumptionBillItemDtos;
+    }
+
+    public void setConsumptionBillItemDtos(List<ConsumptionBillItemDto> consumptionBillItemDtos) {
+        this.consumptionBillItemDtos = consumptionBillItemDtos;
+    }
+
+    public Map<String, Map<String, List<ConsumptionCategoryItemDto>>> getConsumptionCategoryDtoMap() {
+        return consumptionCategoryDtoMap;
+    }
+
+    public void setConsumptionCategoryDtoMap(Map<String, Map<String, List<ConsumptionCategoryItemDto>>> consumptionCategoryDtoMap) {
+        this.consumptionCategoryDtoMap = consumptionCategoryDtoMap;
     }
 
     public Double getTotalDisposeIssuesByDepartmentQuantity() {

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -6362,8 +6362,13 @@ public class ReportController implements Serializable, ControllerWithReportFilte
         return "/reports/inpatientReports/room_change?faces-redirect=true";
     }
 
+    @Deprecated
     public String navigateToconsumption() {
         return "/reports/inventoryReports/consumption?faces-redirect=true";
+    }
+
+    public String navigateToConsumptionDto() {
+        return "/reports/inventoryReports/consumption_dto?faces-redirect=true";
     }
 
     public String navigateToCostOfGoodSoldReports() {

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionBillDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionBillDto.java
@@ -1,0 +1,99 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class ConsumptionBillDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billId;
+    private String deptId;
+    private String invoiceNumber;
+    private String toDepartmentName;
+    private boolean cancelled;
+    private boolean fullReturned;
+
+    private Long cancelledBillId;
+    private String cancelledBillDeptId;
+    private Long refundedBillId;
+    private String refundedBillDeptId;
+    private Long billedBillId;
+    private String billedBillDeptId;
+
+    private double consumptionPurchaseValue;
+    private double consumptionCostValue;
+    private double consumptionRetailValue;
+
+    private Date createdAt;
+    private String creatorName;
+    private String comments;
+
+    public ConsumptionBillDto() {}
+
+    // Full constructor for building from Object[] row
+    public ConsumptionBillDto(
+            Long billId, String deptId, String invoiceNumber,
+            String toDepartmentName, boolean cancelled, boolean fullReturned,
+            Long cancelledBillId, String cancelledBillDeptId,
+            Long refundedBillId, String refundedBillDeptId,
+            Long billedBillId, String billedBillDeptId,
+            double consumptionPurchaseValue, double consumptionCostValue, double consumptionRetailValue,
+            Date createdAt, String creatorName, String comments) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.invoiceNumber = invoiceNumber;
+        this.toDepartmentName = toDepartmentName;
+        this.cancelled = cancelled;
+        this.fullReturned = fullReturned;
+        this.cancelledBillId = cancelledBillId;
+        this.cancelledBillDeptId = cancelledBillDeptId;
+        this.refundedBillId = refundedBillId;
+        this.refundedBillDeptId = refundedBillDeptId;
+        this.billedBillId = billedBillId;
+        this.billedBillDeptId = billedBillDeptId;
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+        this.consumptionCostValue = consumptionCostValue;
+        this.consumptionRetailValue = consumptionRetailValue;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.comments = comments;
+    }
+
+    // Standard getters and setters for all fields
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+    public boolean isFullReturned() { return fullReturned; }
+    public void setFullReturned(boolean fullReturned) { this.fullReturned = fullReturned; }
+    public Long getCancelledBillId() { return cancelledBillId; }
+    public void setCancelledBillId(Long cancelledBillId) { this.cancelledBillId = cancelledBillId; }
+    public String getCancelledBillDeptId() { return cancelledBillDeptId; }
+    public void setCancelledBillDeptId(String cancelledBillDeptId) { this.cancelledBillDeptId = cancelledBillDeptId; }
+    public Long getRefundedBillId() { return refundedBillId; }
+    public void setRefundedBillId(Long refundedBillId) { this.refundedBillId = refundedBillId; }
+    public String getRefundedBillDeptId() { return refundedBillDeptId; }
+    public void setRefundedBillDeptId(String refundedBillDeptId) { this.refundedBillDeptId = refundedBillDeptId; }
+    public Long getBilledBillId() { return billedBillId; }
+    public void setBilledBillId(Long billedBillId) { this.billedBillId = billedBillId; }
+    public String getBilledBillDeptId() { return billedBillDeptId; }
+    public void setBilledBillDeptId(String billedBillDeptId) { this.billedBillDeptId = billedBillDeptId; }
+    public double getConsumptionPurchaseValue() { return consumptionPurchaseValue; }
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) { this.consumptionPurchaseValue = consumptionPurchaseValue; }
+    public double getConsumptionCostValue() { return consumptionCostValue; }
+    public void setConsumptionCostValue(double consumptionCostValue) { this.consumptionCostValue = consumptionCostValue; }
+    public double getConsumptionRetailValue() { return consumptionRetailValue; }
+    public void setConsumptionRetailValue(double consumptionRetailValue) { this.consumptionRetailValue = consumptionRetailValue; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+}

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionBillItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionBillItemDto.java
@@ -1,0 +1,133 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class ConsumptionBillItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long billId;
+    private String billDeptId;
+    private String invoiceNumber;
+    private String toDepartmentName;
+    private String itemName;
+    private String categoryName;
+    private String dosageFormName;
+    private double consumptionQty;
+    private boolean billCancelled;
+    private boolean billFullReturned;
+
+    private Long cancelledBillId;
+    private String cancelledBillDeptId;
+    private Long refundedBillId;
+    private String refundedBillDeptId;
+    private Long billedBillId;
+    private String billedBillDeptId;
+
+    private double purchaseRate;
+    private double consumptionPurchaseValue;
+    private double retailRate;
+    private double consumptionRetailValue;
+    private double costRate;
+    private double consumptionCostValue;
+
+    private Date createdAt;
+    private String creatorName;
+    private String comments;
+
+    public ConsumptionBillItemDto() {}
+
+    public ConsumptionBillItemDto(
+            Long billItemId, Long billId, String billDeptId, String invoiceNumber,
+            String toDepartmentName, String itemName, String categoryName, String dosageFormName,
+            double consumptionQty, boolean billCancelled, boolean billFullReturned,
+            Long cancelledBillId, String cancelledBillDeptId,
+            Long refundedBillId, String refundedBillDeptId,
+            Long billedBillId, String billedBillDeptId,
+            double purchaseRate, double consumptionPurchaseValue,
+            double retailRate, double consumptionRetailValue,
+            double costRate, double consumptionCostValue,
+            Date createdAt, String creatorName, String comments) {
+        this.billItemId = billItemId;
+        this.billId = billId;
+        this.billDeptId = billDeptId;
+        this.invoiceNumber = invoiceNumber;
+        this.toDepartmentName = toDepartmentName;
+        this.itemName = itemName;
+        this.categoryName = categoryName;
+        this.dosageFormName = dosageFormName;
+        this.consumptionQty = consumptionQty;
+        this.billCancelled = billCancelled;
+        this.billFullReturned = billFullReturned;
+        this.cancelledBillId = cancelledBillId;
+        this.cancelledBillDeptId = cancelledBillDeptId;
+        this.refundedBillId = refundedBillId;
+        this.refundedBillDeptId = refundedBillDeptId;
+        this.billedBillId = billedBillId;
+        this.billedBillDeptId = billedBillDeptId;
+        this.purchaseRate = purchaseRate;
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+        this.retailRate = retailRate;
+        this.consumptionRetailValue = consumptionRetailValue;
+        this.costRate = costRate;
+        this.consumptionCostValue = consumptionCostValue;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.comments = comments;
+    }
+
+    // All getters and setters
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getBillDeptId() { return billDeptId; }
+    public void setBillDeptId(String billDeptId) { this.billDeptId = billDeptId; }
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getDosageFormName() { return dosageFormName; }
+    public void setDosageFormName(String dosageFormName) { this.dosageFormName = dosageFormName; }
+    public double getConsumptionQty() { return consumptionQty; }
+    public void setConsumptionQty(double consumptionQty) { this.consumptionQty = consumptionQty; }
+    public boolean isBillCancelled() { return billCancelled; }
+    public void setBillCancelled(boolean billCancelled) { this.billCancelled = billCancelled; }
+    public boolean isBillFullReturned() { return billFullReturned; }
+    public void setBillFullReturned(boolean billFullReturned) { this.billFullReturned = billFullReturned; }
+    public Long getCancelledBillId() { return cancelledBillId; }
+    public void setCancelledBillId(Long cancelledBillId) { this.cancelledBillId = cancelledBillId; }
+    public String getCancelledBillDeptId() { return cancelledBillDeptId; }
+    public void setCancelledBillDeptId(String cancelledBillDeptId) { this.cancelledBillDeptId = cancelledBillDeptId; }
+    public Long getRefundedBillId() { return refundedBillId; }
+    public void setRefundedBillId(Long refundedBillId) { this.refundedBillId = refundedBillId; }
+    public String getRefundedBillDeptId() { return refundedBillDeptId; }
+    public void setRefundedBillDeptId(String refundedBillDeptId) { this.refundedBillDeptId = refundedBillDeptId; }
+    public Long getBilledBillId() { return billedBillId; }
+    public void setBilledBillId(Long billedBillId) { this.billedBillId = billedBillId; }
+    public String getBilledBillDeptId() { return billedBillDeptId; }
+    public void setBilledBillDeptId(String billedBillDeptId) { this.billedBillDeptId = billedBillDeptId; }
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+    public double getConsumptionPurchaseValue() { return consumptionPurchaseValue; }
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) { this.consumptionPurchaseValue = consumptionPurchaseValue; }
+    public double getRetailRate() { return retailRate; }
+    public void setRetailRate(double retailRate) { this.retailRate = retailRate; }
+    public double getConsumptionRetailValue() { return consumptionRetailValue; }
+    public void setConsumptionRetailValue(double consumptionRetailValue) { this.consumptionRetailValue = consumptionRetailValue; }
+    public double getCostRate() { return costRate; }
+    public void setCostRate(double costRate) { this.costRate = costRate; }
+    public double getConsumptionCostValue() { return consumptionCostValue; }
+    public void setConsumptionCostValue(double consumptionCostValue) { this.consumptionCostValue = consumptionCostValue; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+}

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class ConsumptionCategoryItemDto implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private String sourceDepartmentName;
     private String departmentName;
     private String categoryName;
     private String itemName;
@@ -30,6 +31,16 @@ public class ConsumptionCategoryItemDto implements Serializable {
         this.netTotal = netTotal != null ? netTotal : 0.0;
     }
 
+    public ConsumptionCategoryItemDto(
+            String sourceDepartmentName, String departmentName, String categoryName, String itemName,
+            double qty, Double totalPurchaseValue, Double totalCostValue,
+            Double totalRetailValue, Double netTotal) {
+        this(departmentName, categoryName, itemName, qty, totalPurchaseValue, totalCostValue, totalRetailValue, netTotal);
+        this.sourceDepartmentName = sourceDepartmentName;
+    }
+
+    public String getSourceDepartmentName() { return sourceDepartmentName; }
+    public void setSourceDepartmentName(String sourceDepartmentName) { this.sourceDepartmentName = sourceDepartmentName; }
     public String getDepartmentName() { return departmentName; }
     public void setDepartmentName(String departmentName) { this.departmentName = departmentName; }
     public String getCategoryName() { return categoryName; }

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
@@ -1,0 +1,49 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+public class ConsumptionCategoryItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String departmentName;
+    private String categoryName;
+    private String itemName;
+    private double qty;
+    private Double totalPurchaseValue;
+    private Double totalCostValue;
+    private Double totalRetailValue;
+    private Double netTotal;
+
+    public ConsumptionCategoryItemDto() {}
+
+    public ConsumptionCategoryItemDto(
+            String departmentName, String categoryName, String itemName,
+            double qty, Double totalPurchaseValue, Double totalCostValue,
+            Double totalRetailValue, Double netTotal) {
+        this.departmentName = departmentName;
+        this.categoryName = categoryName;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.totalPurchaseValue = totalPurchaseValue != null ? totalPurchaseValue : 0.0;
+        this.totalCostValue = totalCostValue != null ? totalCostValue : 0.0;
+        this.totalRetailValue = totalRetailValue != null ? totalRetailValue : 0.0;
+        this.netTotal = netTotal != null ? netTotal : 0.0;
+    }
+
+    public String getDepartmentName() { return departmentName; }
+    public void setDepartmentName(String departmentName) { this.departmentName = departmentName; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public double getQty() { return qty; }
+    public void setQty(double qty) { this.qty = qty; }
+    public Double getTotalPurchaseValue() { return totalPurchaseValue; }
+    public void setTotalPurchaseValue(Double totalPurchaseValue) { this.totalPurchaseValue = totalPurchaseValue; }
+    public Double getTotalCostValue() { return totalCostValue; }
+    public void setTotalCostValue(Double totalCostValue) { this.totalCostValue = totalCostValue; }
+    public Double getTotalRetailValue() { return totalRetailValue; }
+    public void setTotalRetailValue(Double totalRetailValue) { this.totalRetailValue = totalRetailValue; }
+    public Double getNetTotal() { return netTotal; }
+    public void setNetTotal(Double netTotal) { this.netTotal = netTotal; }
+}

--- a/src/main/webapp/reports/index.xhtml
+++ b/src/main/webapp/reports/index.xhtml
@@ -439,7 +439,8 @@
                                         ajax="false" 
                                         value="1. Closing Stock" 
                                         action="#{reportController.navigateToClosingStockReport()}"/>
-                                    <p:commandButton   class="w-100"  ajax="false" value="2. Consumption" action="#{reportController.navigateToconsumption()}"  />
+                                    <p:commandButton class="w-100 ui-button-secondary" ajax="false" value="2. Consumption (Legacy)" action="#{reportController.navigateToconsumption()}" title="Legacy entity-based report (deprecated)"/>
+                                    <p:commandButton class="w-100 ui-button-success" ajax="false" value="2. Consumption" action="#{reportController.navigateToConsumptionDto()}" icon="fa fa-rocket" title="High-performance DTO-based Consumption report"/>
                                     <p:commandButton   class="w-100"  ajax="false" value="3. Stock Transfers"  action="#{reportController.navigateToStockTransferReport()}" />
                                     <p:commandButton   class="w-100"  ajax="false" value="4. Cost Of Good Sold" action="#{reportController.navigateToCostOfGoodsSold()}" />
                                     <p:commandButton   class="w-100"  ajax="false" value="5. Good in Transit" action="#{reportController.navigateToGoodInTransit()}" />

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -1,0 +1,967 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Consumption">
+                        <h:panelGrid columns="8" class="w-100">
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5"/>
+                                <p:outputLabel value="From Date" for="fromDate" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:calendar
+                                class="w-100"
+                                inputStyleClass="w-100"
+                                id="fromDate"
+                                value="#{pharmacyController.fromDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5"/>
+                                <p:outputLabel value="To Date" for="toDate" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:calendar
+                                class="w-100"
+                                inputStyleClass="w-100"
+                                id="toDate"
+                                value="#{pharmacyController.toDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <p:outputLabel value="Item Department Type" for="departmentTypeFilter" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all.">
+                                    <f:selectItems
+                                        value="#{pharmacyController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all." position="top"/>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university ml-5"/>
+                                <p:outputLabel value="Institution" for="phmIns" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmIns"
+                                class="w-100"
+                                value="#{pharmacyController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions"/>
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}"
+                                               itemValue="#{ins}"/>
+                                <p:ajax process="phmIns" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt ml-5"/>
+                                <p:outputLabel value="Site" for="phmSite" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmSite"
+                                class="w-100"
+                                value="#{pharmacyController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites"/>
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}"
+                                               itemValue="#{site}"/>
+                                <p:ajax process="phmSite" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <p:outputLabel value="Department" for="phmDept" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmDept"
+                                class="w-100"
+                                value="#{pharmacyController.dept}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Departments"/>
+                                <f:selectItems
+                                    value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.institution, pharmacyController.site)}"
+                                    var="dept"
+                                    itemLabel="#{dept.name}"
+                                    itemValue="#{dept}"/>
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-tags ml-5"/>
+                                <p:outputLabel value="Category" for="phmCategory" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmCategory"
+                                value="#{pharmacyController.category}"
+                                filter="true"
+                                class="w-100 ">
+                                <f:selectItem itemLabel="All Categories"/>
+                                <f:selectItems value="#{pharmaceuticalItemCategoryController.items}"
+                                               var="category"
+                                               itemLabel="#{category.name}"
+                                               itemValue="#{category}"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-capsules ml-5"/>
+                                <p:outputLabel value="Dosage Form" for="phmDf" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmDf"
+                                value="#{pharmacyController.dosageForm}"
+                                class="w-100"
+                                filter="true"
+                                filterMatchMode="contains">
+                                <f:selectItem itemLabel="All Dosage Forms"/>
+                                <f:selectItems value="#{dosageFormController.items}" var="df" itemLabel="#{df.name}" itemValue="#{df}"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-box ml-5"/>
+                                <p:outputLabel value="Item" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:autoComplete value="#{pharmacyController.item}"
+                                            inputStyleClass="w-100"
+                                            class="w-100"
+                                            minQueryLength="3" queryDelay="300" completeMethod="#{itemController.completeAmpItemAll}"
+                                            var="item" itemValue="#{item}" itemLabel="#{item.name}"
+                                            forceSelection="true">
+                                <p:column headerText="Item">
+                                    <h:outputLabel value="#{item.name}"/>
+                                </p:column>
+                                <p:column headerText="Code">
+                                    <h:outputLabel value="#{item.code}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-list-alt ml-5"/>
+                                <p:outputLabel value="Report Type" class="mx-3" for="grnReportType">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu class="w-100" id="grnReportType" value="#{pharmacyController.reportType}">
+                                <f:selectItem itemLabel="Summary" itemValue="summeryReport"/>
+                                <f:selectItem itemLabel="By Bill" itemValue="byBill"/>
+                                <f:selectItem itemLabel="By Bill Item" itemValue="byBillItem"/>
+                                <f:selectItem itemLabel="By Category"
+                                              itemValue="categoryWise"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-barcode ml-5"/>
+                                <p:outputLabel value="Consumption Department" for="phmCde" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:autoComplete value="#{pharmacyController.toDepartment}"
+                                            inputStyleClass="w-100"
+                                            id="phmCde"
+                                            class="w-100"
+                                            completeMethod="#{departmentController.completeDept}"
+                                            var="i" itemValue="#{i}" itemLabel="#{i.name}"
+                                            forceSelection="true">
+                                <p:column headerText="Department">
+                                    <h:outputLabel value="#{i.name}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                        </h:panelGrid>
+
+                        <div class="d-flex align-items-center mt-3">
+                            <p:commandButton class="ui-button-warning mx-1"
+                                             icon="fas fa-cogs"
+                                             value="Process"
+                                             widgetVar="wBtnProcess"
+                                             update="@form :growl"
+                                             onstart="PF('wBtnProcess').disable()"
+                                             oncomplete="PF('wBtnProcess').enable()"
+                                             action="#{pharmacyController.createConsumptionReportTableDto()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tbl1" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblListBillsDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'byBillItem'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblListBillItemsDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblCategoryDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <h:outputScript>
+                                function hidePaginatorBeforePrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = 'none');
+                                }
+
+                                function restorePaginatorAfterPrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = '');
+                                }
+
+                                window.onafterprint = function () {
+                                restorePaginatorAfterPrint();
+                                };
+                            </h:outputScript>
+
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             action="#{pharmacyController.exportConsumptionReportSummaryToExcel()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'byBill'}">
+                                <p:dataExporter type="xlsx" target="tblListBillsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                                <p:dataExporter type="xlsx" target="tblListBillItemsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToExcel()}"/>
+
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             action="#{pharmacyController.exportConsumptionReportSummaryToPdf()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
+                                             action="#{pharmacyController.exportConsumptionReportByBillToPdf()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                                <p:dataExporter type="pdf" target="tblListBillItemsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToPdf()}">
+                            </p:commandButton>
+                        </div>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and (pharmacyController.totalPurchase != 0 or pharmacyController.totalCostValue != 0 or pharmacyController.totalRetailValue != 0 or pharmacyController.totalSaleValue != 0)}" id="tbl1">
+                            <h5 class="mt-3">Department Summary</h5>
+                            <h:panelGroup layout="block" styleClass="mb-3 p-2" style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; font-size: 0.9em;">
+                                <h:panelGroup layout="block">
+                                    <strong>From: </strong>
+                                    <h:outputText value="#{pharmacyController.fromDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <strong class="ml-3">To: </strong>
+                                    <h:outputText value="#{pharmacyController.toDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.institution ne null}">
+                                    <strong>Institution: </strong>
+                                    <h:outputText value="#{pharmacyController.institution.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.site ne null}">
+                                    <strong>Site: </strong>
+                                    <h:outputText value="#{pharmacyController.site.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.dept ne null}">
+                                    <strong>Department: </strong>
+                                    <h:outputText value="#{pharmacyController.dept.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.category ne null}">
+                                    <strong>Category: </strong>
+                                    <h:outputText value="#{pharmacyController.category.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.dosageForm ne null}">
+                                    <strong>Dosage Form: </strong>
+                                    <h:outputText value="#{pharmacyController.dosageForm.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.item ne null}">
+                                    <strong>Item: </strong>
+                                    <h:outputText value="#{pharmacyController.item.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.toDepartment ne null}">
+                                    <strong>Consumption Department: </strong>
+                                    <h:outputText value="#{pharmacyController.toDepartment.name}"/>
+                                </h:panelGroup>
+                            </h:panelGroup>
+
+                            <ui:repeat value="#{pharmacyController.departmentTotals.entrySet()}" var="map"
+                                       varStatus="status">
+                                <p:dataTable id="tblSummary" value="#{map.value.entrySet()}" var="entry"
+                                             rowIndexVar="n" rowKey="#{entry.key}"
+                                             paginator="true"
+                                             paginatorPosition="bottom"
+                                             rows="10"
+                                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                             currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                             rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Department" rendered="#{status.first}"/>
+                                    </f:facet>
+
+                                    <p:column headerText="#{map.key}"
+                                              filterBy="#{entry.key}"
+                                              filterMatchMode="contains">
+                                        <h:outputLabel value="#{entry.key}"/>
+                                    </p:column>
+
+                                    <p:column headerText="Purchase Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[0]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Cost Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[1]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Retail Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[2]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Net Total" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[3]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:columnGroup type="footer">
+                                        <p:row rendered="#{status.last}">
+                                            <p:column colspan="1">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="Total" style="font-weight: bold;"/>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                </p:dataTable>
+                            </ui:repeat>
+                        </h:panelGroup>
+
+                        <!-- No data message for Summary report -->
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and pharmacyController.totalPurchase == 0 and pharmacyController.totalCostValue == 0 and pharmacyController.totalRetailValue == 0 and pharmacyController.totalSaleValue == 0}">
+                            <div class="ui-messages ui-widget ui-corner-all ui-messages-info ui-messages-noicon" style="margin-top: 20px;">
+                                <div class="ui-messages-info-summary">No data found for the selected criteria.</div>
+                            </div>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'byBill'}">
+                            <h5 class="mt-3">Department unit issue by Bill No</h5>
+                            <p:dataTable
+                                id="tblListBillsDto"
+                                value="#{pharmacyController.consumptionBillDtos}"
+                                var="b"
+                                rowIndexVar="n"
+                                rowKey="#{b.billId}"
+                                paginator="true"
+                                rows="10"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                <p:column
+                                    headerText="Bill No"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.deptId}"
+                                    filterBy="#{b.deptId}">
+                                    <h:outputText value="#{b.deptId}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Consumption Department"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.toDepartmentName}"
+                                    filterBy="#{b.toDepartmentName}">
+                                    <h:outputText value="#{b.toDepartmentName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Request No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.invoiceNumber}"
+                                    filterBy="#{b.invoiceNumber}">
+                                    <h:outputText value="#{b.invoiceNumber}"/>
+                                </p:column>
+
+                                <p:column headerText="Status/Links" width="10em">
+                                    <!-- Show status if this bill is cancelled or returned -->
+                                    <h:panelGroup rendered="#{b.cancelled}">
+                                        <h:outputText value="CANCELLED" style="color: red; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{b.fullReturned}">
+                                        <h:outputText value="RETURNED" style="color: orange; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been cancelled, show link to cancellation bill -->
+                                    <h:panelGroup rendered="#{b.cancelledBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Cancel: #{b.cancelledBillDeptId}" style="color: red;"/>
+                                        <p:commandButton
+                                            title="View Cancellation Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.cancelledBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been returned, show link to return bill -->
+                                    <h:panelGroup rendered="#{b.refundedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Return: #{b.refundedBillDeptId}" style="color: orange;"/>
+                                        <p:commandButton
+                                            title="View Return Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.refundedBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this is a cancellation/return bill, show link to original bill -->
+                                    <h:panelGroup rendered="#{b.billedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Original: #{b.billedBillDeptId}" style="color: blue;"/>
+                                        <p:commandButton
+                                            title="View Original Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm ui-button-info"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.billedBillId)}" />
+                                    </h:panelGroup>
+                                </p:column>
+
+                                <p:column
+                                    exportable="false"
+                                    headerText="Action" width="5em">
+                                    <p:commandButton
+                                        id="btnViewBill"
+                                        title="View Bill"
+                                        ajax="false"
+                                        styleClass="mx-1 ui-button-sm"
+                                        icon="pi pi-eye"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.billId)}" />
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionPurchaseValue}">
+                                    <h:outputText value="#{b.consumptionPurchaseValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionCostValue}">
+                                    <h:outputText value="#{b.consumptionCostValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionRetailValue}">
+                                    <h:outputText value="#{b.consumptionRetailValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Created Date and Time"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.createdAt}"
+                                    filterBy="#{pharmacyController.formatDate(b.createdAt)}">
+                                    <h:outputText value="#{b.createdAt}">
+                                        <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Document Created By" width="10em">
+                                    <h:outputText value="#{b.creatorName}"/>
+                                </p:column>
+
+                                <p:column headerText="Remarks" width="10em">
+                                    <h:outputText value="#{b.comments}"/>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                            <h5 class="mt-3"> Department unit issue by Bill Item</h5>
+                            <p:dataTable
+                                id="tblListBillItemsDto"
+                                value="#{pharmacyController.consumptionBillItemDtos}"
+                                var="i"
+                                rowIndexVar="n"
+                                rowKey="#{i.billItemId}"
+                                paginator="true"
+                                rows="10"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                <p:column headerText="No" width="2em">
+                                    <p:outputLabel value="#{n+1}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Bill No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.billDeptId}"
+                                    filterBy="#{i.billDeptId}">
+                                    <p:outputLabel value="#{i.billDeptId}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Request No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.invoiceNumber}"
+                                    filterBy="#{i.invoiceNumber}">
+                                    <p:outputLabel value="#{i.invoiceNumber}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Consumption Department"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.toDepartmentName}"
+                                    filterBy="#{i.toDepartmentName}">
+                                    <p:outputLabel value="#{i.toDepartmentName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Item"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.itemName}"
+                                    filterBy="#{i.itemName}">
+                                    <p:outputLabel value="#{i.itemName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Item Category"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.categoryName}"
+                                    filterBy="#{i.categoryName}">
+                                    <p:outputLabel value="#{i.categoryName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Dosage Form"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.dosageFormName}"
+                                    filterBy="#{i.dosageFormName}">
+                                    <p:outputLabel value="#{i.dosageFormName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Quantity"
+                                    width="4em"
+                                    style="text-align: right; padding-right: 20px;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionQty}"
+                                    filterBy="#{i.consumptionQty}">
+                                    <p:outputLabel value="#{i.consumptionQty}"/>
+                                </p:column>
+
+                                <p:column headerText="Status/Links" width="10em" exportable="false">
+                                    <!-- Show status if this bill is cancelled or returned -->
+                                    <h:panelGroup rendered="#{i.billCancelled}">
+                                        <h:outputText value="CANCELLED" style="color: red; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{i.billFullReturned}">
+                                        <h:outputText value="RETURNED" style="color: orange; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been cancelled, show link to cancellation bill -->
+                                    <h:panelGroup rendered="#{i.cancelledBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Cancel: #{i.cancelledBillDeptId}" style="color: red;"/>
+                                        <p:commandButton
+                                            title="View Cancellation Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.cancelledBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been returned, show link to return bill -->
+                                    <h:panelGroup rendered="#{i.refundedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Return: #{i.refundedBillDeptId}" style="color: orange;"/>
+                                        <p:commandButton
+                                            title="View Return Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.refundedBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this is a cancellation/return bill, show link to original bill -->
+                                    <h:panelGroup rendered="#{i.billedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Original: #{i.billedBillDeptId}" style="color: blue;"/>
+                                        <p:commandButton
+                                            title="View Original Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm ui-button-info"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.billedBillId)}" />
+                                    </h:panelGroup>
+                                </p:column>
+
+                                <p:column headerText="Action" width="5em" exportable="false">
+                                    <p:commandButton
+                                        id="btnViewBillItem"
+                                        title="View Bill"
+                                        ajax="false"
+                                        styleClass="mx-1 ui-button-sm"
+                                        icon="pi pi-eye"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillItemId(i.billItemId)}" />
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.purchaseRate}">
+                                    <p:outputLabel value="#{i.purchaseRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionPurchaseValue}">
+                                    <p:outputLabel value="#{i.consumptionPurchaseValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.retailRate}">
+                                    <p:outputLabel value="#{i.retailRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionRetailValue}">
+                                    <p:outputLabel value="#{i.consumptionRetailValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.costRate}">
+                                    <p:outputLabel value="#{i.costRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionCostValue}">
+                                    <p:outputLabel value="#{i.consumptionCostValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Created At"
+                                    width="8em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.createdAt}"
+                                    filterBy="#{pharmacyController.formatDate(i.createdAt)}">
+                                    <p:outputLabel value="#{i.createdAt}">
+                                        <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="User" width="8em">
+                                    <p:outputLabel value="#{i.creatorName}"/>
+                                </p:column>
+
+                                <p:column headerText="Remarks" width="10em">
+                                    <p:outputLabel value="#{i.comments}"/>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                        <h:panelGroup
+                            rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                            id="tblCategoryDto">
+                            <h5 class="mt-3">Category Wise Issue Details by Department</h5>
+                            <ui:repeat value="#{pharmacyController.consumptionCategoryDtoMap.entrySet()}" var="map"
+                                       varStatus="status">
+                                <p:dataTable id="itblCategoryDto"
+                                             value="#{map.value.entrySet()}"
+                                             var="entry"
+                                             rowIndexVar="n"
+                                             rowKey="#{entry.key}"
+                                             paginator="true"
+                                             paginatorPosition="bottom"
+                                             rows="10"
+                                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                             currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                             rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                    <p:columnGroup type="header">
+                                        <p:row style="background: #e5e9ec" rendered="#{status.first}">
+                                            <p:column headerText="Department Unit"
+                                                      style="font-weight: bold; background: #e5e9ec" colspan="7"/>
+                                        </p:row>
+                                        <p:row style="background: #70a4ca">
+                                            <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
+                                                      colspan="3"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentCostTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentRetailTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentNetTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                        </p:row>
+                                        <p:row>
+                                            <p:column headerText="Category" style="font-weight: bold;"/>
+                                            <p:column headerText="Issues" style="font-weight: bold;"/>
+                                            <p:column headerText="" style="font-weight: bold;" colspan="4"/>
+                                        </p:row>
+                                        <p:row>
+                                            <p:column headerText="" style="font-weight: bold;"/>
+                                            <p:column headerText="Qty" style="font-weight: bold;"/>
+                                            <p:column headerText="Purchase Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Cost Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Retail Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Net Total" style="font-weight: bold;"/>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable value="#{entry.value}" var="item">
+                                        <p:columnGroup type="header">
+                                            <p:row>
+                                                <p:column headerText="#{entry.key}" style="font-weight: bold;" colspan="2"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                            </p:row>
+                                        </p:columnGroup>
+                                        <p:column headerText="Item Name">
+                                            <h:outputText value="#{item.itemName}"/>
+                                        </p:column>
+                                        <p:column headerText="Quantity">
+                                            <h:outputText value="#{item.qty}"/>
+                                        </p:column>
+                                        <p:column headerText="Purchase Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalPurchaseValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Cost Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalCostValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Retail Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalRetailValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Net Total" style="text-align: right;">
+                                            <h:outputText value="#{item.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                    </p:subTable>
+                                    <p:columnGroup type="footer" rendered="#{status.last}">
+                                        <p:row>
+                                            <p:column colspan="2">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="Total" style="font-weight: bold;"/>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                </p:dataTable>
+                            </ui:repeat>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -274,9 +274,11 @@
                                              rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
                                              action="#{pharmacyController.exportConsumptionReportSummaryToPdf()}">
                             </p:commandButton>
+                            <!-- By Bill PDF export uses pharmacyRows (legacy); use dataExporter from DTO table instead -->
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
-                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
-                                             action="#{pharmacyController.exportConsumptionReportByBillToPdf()}">
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}">
+                                <p:dataExporter type="pdf" target="tblListBillsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'byBillItem'}">
@@ -842,11 +844,11 @@
                                     <p:columnGroup type="header">
                                         <p:row style="background: #e5e9ec" rendered="#{status.first}">
                                             <p:column headerText="Department Unit"
-                                                      style="font-weight: bold; background: #e5e9ec" colspan="7"/>
+                                                      style="font-weight: bold; background: #e5e9ec" colspan="6"/>
                                         </p:row>
                                         <p:row style="background: #70a4ca">
                                             <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
-                                                      colspan="3"/>
+                                                      colspan="2"/>
                                             <p:column
                                                 headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>


### PR DESCRIPTION
## Summary

- Add three new DTO classes (`ConsumptionBillDto`, `ConsumptionBillItemDto`, `ConsumptionCategoryItemDto`) with only scalar fields — no entity references
- Add `createConsumptionReportTableDto()` in `PharmacyController` dispatching to three new LEFT JOIN JPQL methods that return `Object[]` rows directly (no lazy loading, no N+1 queries)
- Add `navigateToConsumptionDto()` in `ReportController` → new page `/reports/inventoryReports/consumption_dto.xhtml`
- New XHTML mirrors the existing Consumption report (all four report types) but uses DTO EL expressions (`b.toDepartmentName`, `b.creatorName`, `i.itemName`, etc.) instead of entity navigation
- Mark legacy `navigateToconsumption()` and `createConsumptionReportTable()` `@Deprecated`; no existing code removed or changed
- `reports/index.xhtml`: legacy button demoted to secondary (muted) style; new green success-theme **"2. Consumption"** button added pointing to the DTO report

## Test plan

- [ ] Navigate to Reports → Inventory Reports → click the green **2. Consumption** button
- [ ] Test **By Bill** report type: verify Bill No, Consumption Dept, Request No, values, creator name all display correctly; verify cancelled/returned/original bill links render for bills with those relationships
- [ ] Test **By Bill Item** report type: verify item name, category, dosage form, rates, quantities, status links
- [ ] Test **Summary** report type: verify department totals table matches legacy report output
- [ ] Test **Category Wise** report type: verify category/item breakdown matches legacy report
- [ ] Confirm the legacy **2. Consumption (Legacy)** button still works unchanged
- [ ] Test with Institution / Site / Department / Category / Dosage Form / Item / Consumption Department filters applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new high-performance Consumption report with multiple views (Summary, By Bill, By Bill Item, Category Wise)
  * Introduced advanced filtering options including date ranges, departments, categories, dosage forms, and items
  * Added Export and Print functionality for each report view

* **Chores**
  * Expanded shell command permissions configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->