### PR TITLE
fix(pharmacy): fix category-wise totals and exports in DTO consumption report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -5280,6 +5280,64 @@ public class PharmacyController implements Serializable {
         return df.format(value);
     }
 
+    // DTO-aware helpers that read directly from consumptionCategoryDtoMap
+    // (outer key = consumptionDept, inner key = category)
+    public String getDtoDeptPurchaseTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalPurchaseValue() != null ? dto.getTotalPurchaseValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptCostTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalCostValue() != null ? dto.getTotalCostValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptRetailTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalRetailValue() != null ? dto.getTotalRetailValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptNetTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getNetTotal() != null ? dto.getNetTotal() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryPurchaseTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalPurchaseValue() != null ? dto.getTotalPurchaseValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryCostTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalCostValue() != null ? dto.getTotalCostValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryRetailTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalRetailValue() != null ? dto.getTotalRetailValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryNetTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getNetTotal() != null ? dto.getNetTotal() : 0.0).sum();
+        return formatNumber(total);
+    }
+
     public void generateConsumptionReportTableAsDepartmentSummary(final List<DepartmentCategoryWiseItems> list) {
         departmentSummaries = new ArrayList<>();
         totalSaleValue = 0.0;

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -266,9 +266,7 @@
                                 <p:dataExporter type="xlsx" target="tblListBillItemsDto"
                                                 fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
-                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
-                                             value="Download" rendered="#{pharmacyController.reportType eq 'categoryWise'}"
-                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToExcel()}"/>
+                            <!-- Category-wise Excel export uses legacy departmentCategoryMap; new DTO export is future work -->
 
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
@@ -285,10 +283,7 @@
                                 <p:dataExporter type="pdf" target="tblListBillItemsDto"
                                                 fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
-                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
-                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
-                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToPdf()}">
-                            </p:commandButton>
+                            <!-- Category-wise PDF export uses legacy departmentCategoryMap; new DTO export is future work -->
                         </div>
 
                         <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and (pharmacyController.totalPurchase != 0 or pharmacyController.totalCostValue != 0 or pharmacyController.totalRetailValue != 0 or pharmacyController.totalSaleValue != 0)}" id="tbl1">
@@ -850,16 +845,16 @@
                                             <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
                                                       colspan="2"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptPurchaseTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentCostTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptCostTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentRetailTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptRetailTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentNetTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptNetTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                         </p:row>
                                         <p:row>
@@ -881,16 +876,16 @@
                                             <p:row>
                                                 <p:column headerText="#{entry.key}" style="font-weight: bold;" colspan="2"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                             </p:row>
                                         </p:columnGroup>


### PR DESCRIPTION
## Summary

Follow-up to #21155 — fixes two bugs discovered during ruhunu hotfix review.

- **Category-wise header totals wrong**: `departmentTotals` is now keyed `sourceDept → consumptionDept` (for the Summary view), but the category-wise header helpers were still reading it with `consumptionDept` as the outer key, returning 0 whenever source ≠ consumption dept. Added 8 new DTO-aware helper methods that compute directly from `consumptionCategoryDtoMap` (keyed `consumptionDept → category → items`):
  - `getDtoDept{Purchase,Cost,Retail,Net}TotalForConsumptionReport(deptName)`
  - `getDtoCategory{Purchase,Cost,Retail,Net}TotalForConsumptionReport(deptName, catName)`
- **Category Excel/PDF export produced empty output**: `exportConsumptionReportCategoryWiseToExcel/ToPdf()` iterates `departmentCategoryMap` (legacy entity-based), which the DTO path never populates. Removed both buttons from the DTO page; DTO-aware exports are planned as future work.

## Test plan

- [ ] Run Category Wise report on the DTO page — verify department and category totals in the blue header rows match the actual item row values
- [ ] Run Summary report — verify it still shows correct `sourceDept → consumptionDept` grouping
- [ ] Confirm By Bill and By Bill Item report types are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)