### PR TITLE
feat(patient): add PatientRegistrationSource to Patient entity (#21181)

### DIFF
--- a/src/main/java/com/divudi/bean/channel/PatientPortalController.java
+++ b/src/main/java/com/divudi/bean/channel/PatientPortalController.java
@@ -8,6 +8,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.hr.StaffController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.MessageType;
+import com.divudi.core.data.PatientRegistrationSource;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
@@ -234,6 +235,7 @@ public class PatientPortalController implements Serializable {
         patient.getPerson().setPhone(patientphoneNumber);
         patient.getPerson().setMobile(patientphoneNumber);
         patient.setSelfRegistered(true);
+        patient.setRegistrationSource(PatientRegistrationSource.ONLINE_SELF);
         patientController.save(patient);
         addNewPatient = false;
         patientSelected = true;

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -17,6 +17,7 @@ import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.PatientInsuranceController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.PatientRegistrationSource;
 import com.divudi.core.data.admin.ConfigOptionInfo;
 import com.divudi.core.data.admin.PageMetadata;
 
@@ -764,6 +765,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         patient = null;
         yearMonthDay = null;
         getPatient();
+        // A baby registered from the mother's admission profile is a newborn. The
+        // source is stamped here on the freshly created patient so the later
+        // savePatient() does not overwrite it with INWARD_ADMISSION. (Issue #21181)
+        getPatient().setRegistrationSource(PatientRegistrationSource.NEWBORN);
         copyGuardianFromParentAdmission();
         setPrintPreview(false);
         return "/inward/inward_admission_child?faces-redirect=true";
@@ -1562,6 +1567,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         getPatient().setCreater(getSessionController().getLoggedUser());
 
         if (getPatient().getId() == null) {
+            // Stamp the registration source once, on the brand-new patient being
+            // admitted. A baby admission has already set NEWBORN; everything else
+            // registered at admission time is an inward admission. (Issue #21181)
+            if (getPatient().getRegistrationSource() == null) {
+                getPatient().setRegistrationSource(PatientRegistrationSource.INWARD_ADMISSION);
+            }
             getPatientFacade().createAndFlush(getPatient());  // Immediate flush
         } else {
             getPatientFacade().editAndFlush(getPatient());    // Immediate flush
@@ -1942,6 +1953,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         Patient pt = new Patient();
         patientDetailsEditable = true;
         pt.setPerson(p);
+        pt.setRegistrationSource(PatientRegistrationSource.INWARD_ADMISSION);
         getPatientFacade().create(pt);
         getCurrent().setPatient(pt);
         getFacade().edit(current);

--- a/src/main/java/com/divudi/core/data/PatientRegistrationSource.java
+++ b/src/main/java/com/divudi/core/data/PatientRegistrationSource.java
@@ -1,0 +1,38 @@
+package com.divudi.core.data;
+
+/**
+ * Records how a Patient record was first entered into the system.
+ *
+ * <p>This is the identity-trust anchor for a patient: walk-in registrations are
+ * identity-verified by staff in person, whereas kiosk/online registrations are
+ * unverified. The value is set <b>once</b> at the moment the Patient record is
+ * created and is never changed afterwards.</p>
+ *
+ * <p>Existing patients created before this feature carry a {@code null} value,
+ * which is interpreted as "unrecorded / pre-feature".</p>
+ *
+ * Issue: hmislk/hmis#21181
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public enum PatientRegistrationSource {
+
+    WALK_IN("Walk-in"),                       // registered by counter/cashier staff during OPD or pharmacy visit
+    INWARD_ADMISSION("Inward Admission"),     // new patient registered at time of inpatient admission
+    NEWBORN("Newborn"),                       // baby registered via Baby Admission from mother's admission profile
+    CALL_CENTRE("Call Centre"),               // registered by staff over the phone
+    KIOSK("Kiosk"),                           // patient self-registered at a physical kiosk terminal
+    ONLINE_SELF("Online / Self"),             // patient portal / mobile app (deprecated — legacy data migration only)
+    THIRD_PARTY_AGENT("Third Party Agent"),   // external referral agent / partner submitted registration
+    ON_ADMISSION_DEATH("On Admission Death"); // patient found dead, registered posthumously at time of admission
+
+    private final String label;
+
+    PatientRegistrationSource(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/data/PatientRegistrationSource.java
+++ b/src/main/java/com/divudi/core/data/PatientRegistrationSource.java
@@ -22,7 +22,7 @@ public enum PatientRegistrationSource {
     NEWBORN("Newborn"),                       // baby registered via Baby Admission from mother's admission profile
     CALL_CENTRE("Call Centre"),               // registered by staff over the phone
     KIOSK("Kiosk"),                           // patient self-registered at a physical kiosk terminal
-    ONLINE_SELF("Online / Self"),             // patient portal / mobile app (deprecated — legacy data migration only)
+    ONLINE_SELF("Online / Self"),             // patient portal / mobile app self-registration; also back-filled from legacy selfRegistered=true
     THIRD_PARTY_AGENT("Third Party Agent"),   // external referral agent / partner submitted registration
     ON_ADMISSION_DEATH("On Admission Death"); // patient found dead, registered posthumously at time of admission
 

--- a/src/main/java/com/divudi/core/entity/Patient.java
+++ b/src/main/java/com/divudi/core/entity/Patient.java
@@ -4,6 +4,7 @@
  */
 package com.divudi.core.entity;
 
+import com.divudi.core.data.PatientRegistrationSource;
 import com.divudi.core.data.SpecificPatientStatus;
 import com.divudi.core.util.CommonFunctions;
 import java.io.Serializable;
@@ -23,6 +24,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
@@ -144,7 +146,22 @@ public class Patient implements Serializable, RetirableEntity {
     private SpecificPatientStatus specificStatus = SpecificPatientStatus.NORMAL;
     private String specificStatusComment;
     
+    /**
+     * @deprecated Superseded by {@link #registrationSource}. Kept for backward
+     * compatibility and existing portal logic. New code should read/write
+     * {@code registrationSource} instead; {@code selfRegistered == true} maps to
+     * {@link PatientRegistrationSource#ONLINE_SELF}. Physical removal is deferred
+     * until the data migration has run on all deployments. (Issue #21181)
+     */
+    @Deprecated
     private Boolean selfRegistered = false;
+
+    /**
+     * How this patient was first registered. Set once at creation and never
+     * changed. Null for patients created before this feature. (Issue #21181)
+     */
+    @Enumerated(EnumType.STRING)
+    private PatientRegistrationSource registrationSource;
 
     @Temporal(javax.persistence.TemporalType.DATE)
     private Date cardIssuedDate;
@@ -211,6 +228,21 @@ public class Patient implements Serializable, RetirableEntity {
     @Deprecated
     private void onLoad() {
         calAgeFromDob();
+    }
+
+    /**
+     * Records how this patient was first registered. The value is set once, at
+     * creation. Entry points that know their context set it explicitly before
+     * persist (e.g. inward admission, newborn, online self-registration). Any
+     * other brand-new patient — i.e. one registered at an OPD or pharmacy
+     * counter, or in the EMR — falls through to {@code WALK_IN} here. Existing
+     * patients are never touched, because this fires only on insert. (Issue #21181)
+     */
+    @PrePersist
+    private void defaultRegistrationSourceOnCreate() {
+        if (registrationSource == null) {
+            registrationSource = PatientRegistrationSource.WALK_IN;
+        }
     }
 
     @Deprecated
@@ -779,6 +811,10 @@ public class Patient implements Serializable, RetirableEntity {
         this.specificStatusComment = specificStatusComment;
     }
 
+    /**
+     * @deprecated Use {@link #getRegistrationSource()} instead. (Issue #21181)
+     */
+    @Deprecated
     public Boolean getSelfRegistered() {
         if(selfRegistered == null){
             return false;
@@ -786,7 +822,19 @@ public class Patient implements Serializable, RetirableEntity {
         return selfRegistered;
     }
 
+    /**
+     * @deprecated Use {@link #setRegistrationSource(PatientRegistrationSource)} instead. (Issue #21181)
+     */
+    @Deprecated
     public void setSelfRegistered(Boolean selfRegistered) {
         this.selfRegistered = selfRegistered;
+    }
+
+    public PatientRegistrationSource getRegistrationSource() {
+        return registrationSource;
+    }
+
+    public void setRegistrationSource(PatientRegistrationSource registrationSource) {
+        this.registrationSource = registrationSource;
     }
 }

--- a/src/main/java/com/divudi/core/entity/Patient.java
+++ b/src/main/java/com/divudi/core/entity/Patient.java
@@ -159,7 +159,13 @@ public class Patient implements Serializable, RetirableEntity {
     /**
      * How this patient was first registered. Set once at creation and never
      * changed. Null for patients created before this feature. (Issue #21181)
+     *
+     * <p>{@code updatable = false} keeps the value out of UPDATE statements, so
+     * once it is written on INSERT (by an explicit entry point or the
+     * {@code @PrePersist} default) no later edit flow can change it in the
+     * database — enforcing the "set once" identity anchor.</p>
      */
+    @Column(updatable = false)
     @Enumerated(EnumType.STRING)
     private PatientRegistrationSource registrationSource;
 
@@ -835,6 +841,11 @@ public class Patient implements Serializable, RetirableEntity {
     }
 
     public void setRegistrationSource(PatientRegistrationSource registrationSource) {
+        // Set once: refuse to overwrite an already-assigned source so the
+        // identity anchor cannot be silently changed by a later edit. (Issue #21181)
+        if (this.registrationSource != null && this.registrationSource != registrationSource) {
+            throw new IllegalStateException("registrationSource cannot be changed once set");
+        }
         this.registrationSource = registrationSource;
     }
 }

--- a/src/main/resources/db/migrations/v2.1.19/migration-info.json
+++ b/src/main/resources/db/migrations/v2.1.19/migration-info.json
@@ -1,0 +1,37 @@
+{
+    "version": "v2.1.19",
+    "description": "Add REGISTRATIONSOURCE column to PATIENT and back-fill legacy self-registrations",
+    "author": "Dr M H B Ariyaratne",
+    "estimatedDurationMinutes": 1,
+    "requiresDowntime": false,
+    "affectedTables": ["patient"],
+    "affectedModules": ["OPD", "Pharmacy", "Inward", "Patient Portal"],
+    "preRequisites": [
+        "Database backup completed",
+        "PATIENT table must exist"
+    ],
+    "migrationSteps": [
+        {
+            "description": "Detect actual table name case for PATIENT"
+        },
+        {
+            "description": "Add REGISTRATIONSOURCE VARCHAR(255) NULL column (STRING enum) if it does not exist"
+        },
+        {
+            "description": "Back-fill REGISTRATIONSOURCE = 'ONLINE_SELF' for rows where legacy SELFREGISTERED = 1 and REGISTRATIONSOURCE IS NULL"
+        },
+        {
+            "description": "Verify column presence and report distribution of registration sources"
+        }
+    ],
+    "expectedOutcome": {
+        "primaryFix": "PATIENT.REGISTRATIONSOURCE available to record how each patient was first registered (walk-in, inward admission, newborn, online self, etc.)",
+        "impact": "Adds one nullable column. Existing portal self-registrations are tagged ONLINE_SELF; all other existing patients remain NULL (unrecorded / pre-feature).",
+        "columnsAdded": 1
+    },
+    "rollbackNotes": [
+        "Rollback DROPs the REGISTRATIONSOURCE column. Source data captured after the feature shipped will be lost.",
+        "Legacy SELFREGISTERED is left intact and is NOT removed by this migration."
+    ],
+    "relatedIssue": "#21181 - Add PatientRegistrationSource field to Patient entity"
+}

--- a/src/main/resources/db/migrations/v2.1.19/migration.sql
+++ b/src/main/resources/db/migrations/v2.1.19/migration.sql
@@ -1,0 +1,113 @@
+-- Migration v2.1.19: Add REGISTRATIONSOURCE column to PATIENT and migrate legacy SELFREGISTERED
+-- Issue: #21181 - Add PatientRegistrationSource field to Patient entity
+-- Author: Dr M H B Ariyaratne
+-- Date: 2026-06-03
+-- Database: main HMIS database (hmisPU)
+--
+-- Purpose:
+--   1. Add a STRING enum column REGISTRATIONSOURCE to the PATIENT table that
+--      permanently records how a patient was first entered into the system.
+--   2. Back-fill existing rows where the legacy boolean SELFREGISTERED = 1 with
+--      the value 'ONLINE_SELF' (patient-portal self registrations).
+--
+-- Existing patients with SELFREGISTERED = 0 / NULL are intentionally left with a
+-- NULL REGISTRATIONSOURCE — null means "unrecorded / pre-feature" and renders no
+-- badge in the UI.
+--
+-- The legacy SELFREGISTERED column is NOT dropped here. It is deprecated in code
+-- and its physical removal is deferred to a later migration once every deployment
+-- has back-filled REGISTRATIONSOURCE.
+--
+-- UNIVERSAL: Detects actual table name case (PATIENT vs patient) so this script
+-- works on both case-sensitive (Linux, lower_case_table_names=0) and
+-- case-insensitive (Windows) MySQL instances. All DDL is built with prepared
+-- statements against the real table name from INFORMATION_SCHEMA.
+--
+-- IDEMPOTENT: All statements check for existence first, so this migration can be
+-- safely re-run without error.
+
+SELECT 'Migration v2.1.19 - Add REGISTRATIONSOURCE to PATIENT' AS status;
+
+-- ==========================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ==========================================
+
+SET @patient_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENT'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected patient table as: ', IFNULL(@patient_table, '(not found)')) AS info;
+
+SELECT IF(@patient_table IS NULL,
+          'PATIENT table not found. Migration aborted.',
+          'PATIENT table found; proceeding') AS applicability;
+
+-- ==========================================
+-- STEP 1: ADD REGISTRATIONSOURCE COLUMN
+-- ==========================================
+
+SET @has_reg_source = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @patient_table
+      AND UPPER(COLUMN_NAME) = 'REGISTRATIONSOURCE'
+);
+
+SET @sql = IF(@patient_table IS NOT NULL AND @has_reg_source = 0,
+              CONCAT('ALTER TABLE ', @patient_table, ' ADD COLUMN REGISTRATIONSOURCE VARCHAR(255) NULL'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 2: BACK-FILL FROM LEGACY SELFREGISTERED
+-- ==========================================
+-- Only patients flagged as self-registered (portal) get ONLINE_SELF. Run only
+-- when the legacy column still exists, and never overwrite a value already set.
+
+SET @has_self_reg = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @patient_table
+      AND UPPER(COLUMN_NAME) = 'SELFREGISTERED'
+);
+
+SET @sql = IF(@patient_table IS NOT NULL AND @has_self_reg > 0,
+              CONCAT('UPDATE ', @patient_table,
+                     ' SET REGISTRATIONSOURCE = ''ONLINE_SELF''',
+                     ' WHERE SELFREGISTERED = 1 AND REGISTRATIONSOURCE IS NULL'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 3: POST-MIGRATION VERIFICATION
+-- ==========================================
+
+SELECT 'REGISTRATIONSOURCE column' AS status;
+
+SELECT
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    IS_NULLABLE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @patient_table
+  AND UPPER(COLUMN_NAME) = 'REGISTRATIONSOURCE';
+
+SET @sql = IF(@patient_table IS NOT NULL,
+              CONCAT('SELECT REGISTRATIONSOURCE AS registration_source, COUNT(*) AS patients FROM ',
+                     @patient_table, ' GROUP BY REGISTRATIONSOURCE'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.1.19 completed - REGISTRATIONSOURCE ready' AS final_status;

--- a/src/main/resources/db/migrations/v2.1.19/rollback.sql
+++ b/src/main/resources/db/migrations/v2.1.19/rollback.sql
@@ -1,0 +1,38 @@
+-- Rollback v2.1.19: Drop REGISTRATIONSOURCE column from PATIENT
+-- Issue: #21181
+--
+-- WARNING: This is destructive. Dropping the column discards all recorded
+-- registration sources. The legacy SELFREGISTERED column is untouched, so
+-- portal self-registrations remain recoverable, but walk-in / inward / newborn
+-- source data captured after the feature shipped will be lost.
+--
+-- UNIVERSAL: handles both case-sensitive and case-insensitive MySQL.
+
+SELECT 'Rollback v2.1.19 - Drop REGISTRATIONSOURCE column from PATIENT' AS status;
+
+SET @patient_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENT'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected patient table as: ', IFNULL(@patient_table, '(not found - nothing to drop)')) AS info;
+
+SET @has_reg_source = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @patient_table
+      AND UPPER(COLUMN_NAME) = 'REGISTRATIONSOURCE'
+);
+
+SET @sql = IF(@patient_table IS NOT NULL AND @has_reg_source > 0,
+              CONCAT('ALTER TABLE ', @patient_table, ' DROP COLUMN REGISTRATIONSOURCE'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.1.19 completed' AS final_status;

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -77,6 +77,12 @@
                                     <div class="col-md-5"><p:outputLabel value="NIC" /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
                                     <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+
+                                    <ui:fragment rendered="#{not empty admissionController.current.patient.registrationSource}">
+                                        <div class="col-md-5"><p:outputLabel value="Registration Source" /></div>
+                                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                        <div class="col-md-6"><p:badge value="#{admissionController.current.patient.registrationSource.label}" severity="info" /></div>
+                                    </ui:fragment>
                                 </div>
                             </p:panel>
                         </div>

--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -260,11 +260,19 @@
                                                 <div class="col-md-4">
                                                     <div class="mb-3">
                                                         <strong class="text-muted">Registered Type</strong><br/>
-                                                        <p:badge 
+                                                        <p:badge
                                                             value="#{patientController.current.selfRegistered eq true ? 'Self Registered' : 'System Registered'}"
                                                             severity="#{patientController.current.selfRegistered eq true ? 'warning' : 'success'}">
                                                         </p:badge>
                                                     </div>
+
+                                                    <h:panelGroup layout="block" styleClass="mb-3" rendered="#{not empty patientController.current.registrationSource}">
+                                                        <strong class="text-muted">Registration Source</strong><br/>
+                                                        <p:badge
+                                                            value="#{patientController.current.registrationSource.label}"
+                                                            severity="info">
+                                                        </p:badge>
+                                                    </h:panelGroup>
 
                                                 </div>
                                             </div>

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -23,6 +23,11 @@
                                         <div class="m-2  align-items-center">
                                             <i class="fa fa-pencil m-2" aria-hidden="true"/>
                                             <p:outputLabel value="Edit Patient Demographic Details" />
+                                            <p:badge
+                                                rendered="#{not empty patientController.current.registrationSource}"
+                                                styleClass="m-2"
+                                                value="#{patientController.current.registrationSource.label}"
+                                                severity="info" />
                                         </div>
 
                                         <div class="">


### PR DESCRIPTION
## Summary

Adds a `PatientRegistrationSource` enum and a `Patient.registrationSource` STRING-enum column that **permanently records how a patient record was first entered into the system**. This is the identity-trust anchor: walk-in / inward / newborn registrations are staff-verified in person, whereas kiosk / online registrations are unverified. The value is set **once** at creation and never changed.

Closes #21181

## What changed

### New enum — `com.divudi.core.data.PatientRegistrationSource`
`WALK_IN`, `INWARD_ADMISSION`, `NEWBORN`, `CALL_CENTRE`, `KIOSK`, `ONLINE_SELF`, `THIRD_PARTY_AGENT`, `ON_ADMISSION_DEATH` — each with a human-readable label for badges.

### `Patient` entity
- New `@Enumerated(EnumType.STRING) PatientRegistrationSource registrationSource` field + getter/setter.
- `@PrePersist defaultRegistrationSourceOnCreate()` stamps `WALK_IN` when no source was set. This guarantees **every** counter-created patient (OPD billing, the many pharmacy sale controllers, EMR) is tagged without having to edit each billing controller. Entry points that know their context set their value *before* persist, so they always win. Fires only on insert — existing patients are untouched.
- Legacy `selfRegistered` boolean and its accessors are marked `@Deprecated` (kept for backward compatibility / portal logic; physical removal deferred until the migration has run everywhere).

### Registration entry points
| Entry point | Value |
|---|---|
| OPD / pharmacy / EMR counter new patient | `WALK_IN` (via `@PrePersist` default) |
| `AdmissionController.savePatient()` / `addPatient()` | `INWARD_ADMISSION` |
| `AdmissionController.navigateToAddBabyAdmission()` | `NEWBORN` |
| Patient portal self-registration | `ONLINE_SELF` (set alongside the legacy flag) |

`ON_ADMISSION_DEATH`, `KIOSK`, `CALL_CENTRE`, `THIRD_PARTY_AGENT` are defined for the companion/future entry points listed in the issue and are not wired yet.

### UI — read-only badge
"Registration Source" badge added to `opd/patient.xhtml`, `opd/patient_edit.xhtml`, and `inward/admission_profile.xhtml`. Rendered **only when a value is present**, so existing patients (null = unrecorded / pre-feature) show no badge.

### Migration — `db/migrations/v2.1.19`
- Adds the `REGISTRATIONSOURCE VARCHAR(255) NULL` column to `PATIENT`.
- Back-fills `ONLINE_SELF` where the legacy `SELFREGISTERED = 1`.
- Idempotent and table-name-case-detecting (works on case-sensitive Linux and case-insensitive Windows MySQL), with a matching `rollback.sql` and `migration-info.json`.

## Notes / deviations from the issue
- **`selfRegistered` is deprecated, not physically dropped.** It is still referenced by the patient portal and three XHTML pages, and dropping the column safely requires the back-fill migration to have run on every deployment first. Removal is left to a follow-up once all deployments are migrated.
- The `WALK_IN` default is applied centrally via `@PrePersist` rather than editing each of the ~10+ OPD/pharmacy patient-creation sites, which keeps the change small and guarantees no counter registration path is missed.

## Testing
- `mvn compile` passes.
- Logic verified by reading each entry point: explicit sources are set before persist so the `@PrePersist` default never overrides them; portal sets `ONLINE_SELF`; baby path sets `NEWBORN` before `savePatient()` would set `INWARD_ADMISSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track a patient’s registration source (write-once) and show it as a badge on patient profiles, admission pages, and edit screens; supports online self, walk-in, inward, newborn, etc.
* **Chores**
  * Database migration adds a nullable registration-source column and backfills online self-registrations where applicable.
* **Deprecated**
  * Legacy self-registered flag marked deprecated in favor of the new registration source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->