### PR TITLE
feat(inward): add On Admission Death flag to PatientEncounter/Admission

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -49,6 +49,7 @@ import com.divudi.core.facade.PatientFacade;
 import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.core.facade.PatientTransferRequestFacade;
 import com.divudi.core.entity.inward.PatientTransferRequest;
+import com.divudi.core.data.inward.EncounterRegistrationFlag;
 import com.divudi.core.data.inward.TransferRequestStatus;
 import com.divudi.core.facade.PersonFacade;
 import com.divudi.core.facade.RoomFacade;
@@ -1570,8 +1571,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             // Stamp the registration source once, on the brand-new patient being
             // admitted. A baby admission has already set NEWBORN; everything else
             // registered at admission time is an inward admission. (Issue #21181)
+            //
+            // Dual-write rule: when the admission is flagged On Admission Death and
+            // the patient record is being created now, the patient's registration
+            // channel is the posthumous admission itself. For patients that already
+            // existed (getId() != null, handled in the else branch below) we never
+            // touch registrationSource — their original channel is preserved.
+            // (Issue #21182)
             if (getPatient().getRegistrationSource() == null) {
-                getPatient().setRegistrationSource(PatientRegistrationSource.INWARD_ADMISSION);
+                if (getCurrent() != null
+                        && getCurrent().getEncounterRegistrationFlag() == EncounterRegistrationFlag.ON_ADMISSION_DEATH) {
+                    getPatient().setRegistrationSource(PatientRegistrationSource.ON_ADMISSION_DEATH);
+                } else {
+                    getPatient().setRegistrationSource(PatientRegistrationSource.INWARD_ADMISSION);
+                }
             }
             getPatientFacade().createAndFlush(getPatient());  // Immediate flush
         } else {
@@ -2020,6 +2033,26 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
      * the normal save.
      */
     public void checkBeforeAdmit() {
+        // Standard admission flow — explicitly stamp STANDARD so a prior click on
+        // the "On Admission Death" button on the same form does not leak its flag
+        // into a subsequent normal admit. (Issue #21182)
+        getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.STANDARD);
+        proceedWithAdmissionCheck();
+    }
+
+    /**
+     * Entry point for the secondary "On Admission Death" button. Flags the
+     * encounter as {@link EncounterRegistrationFlag#ON_ADMISSION_DEATH} before
+     * running the same pre-admission checks and save flow. The dual-write of
+     * {@code patient.registrationSource} for brand-new patients happens in
+     * {@link #savePatient()}. (Issue #21182)
+     */
+    public void checkBeforeAdmitOnAdmissionDeath() {
+        getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.ON_ADMISSION_DEATH);
+        proceedWithAdmissionCheck();
+    }
+
+    private void proceedWithAdmissionCheck() {
         if (getCurrent().getPatient() != null && isPatientAlreadyAdmitted()) {
             PrimeFaces.current().executeScript("PF('dlgActiveAdmission').show();");
         } else {

--- a/src/main/java/com/divudi/core/data/inward/EncounterRegistrationFlag.java
+++ b/src/main/java/com/divudi/core/data/inward/EncounterRegistrationFlag.java
@@ -1,0 +1,31 @@
+package com.divudi.core.data.inward;
+
+/**
+ * Operational / clinical flag applied to a {@code PatientEncounter} (and by
+ * inheritance an {@code Admission}) at the time of registration.
+ *
+ * <p>The default for every encounter is {@link #STANDARD}, which represents a
+ * normal admission and is shown without any badge in the UI. Non-standard
+ * values mark encounters that need special handling for legal, statistical,
+ * or billing purposes.</p>
+ *
+ * Issue: hmislk/hmis#21182
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public enum EncounterRegistrationFlag {
+
+    STANDARD("Standard"),                       // normal admission — default value, no badge shown
+    ON_ADMISSION_DEATH("On Admission Death"),   // patient arrived dead or died before registration was completed
+    RAPID_TEMP_AE("Rapid / Temp A&E");          // quick/temporary A&E registration — demographics may be incomplete (see separate issue)
+
+    private final String label;
+
+    EncounterRegistrationFlag(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -7,6 +7,7 @@ package com.divudi.core.entity;
 import com.divudi.core.data.EncounterType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.SymanticType;
+import com.divudi.core.data.inward.EncounterRegistrationFlag;
 import com.divudi.core.data.inward.PatientEncounterType;
 import com.divudi.core.entity.clinical.ClinicalEntity;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
@@ -122,6 +123,15 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     private double creditPaidAmount;
     @Enumerated(EnumType.STRING)
     PatientEncounterType patientEncounterType;
+
+    /**
+     * Operational / clinical flag for this encounter, set at registration time.
+     * Defaults to {@link EncounterRegistrationFlag#STANDARD} so existing and
+     * normal admissions need no badge. Used to mark special scenarios such as
+     * On Admission Death. (Issue #21182)
+     */
+    @Enumerated(EnumType.STRING)
+    private EncounterRegistrationFlag encounterRegistrationFlag = EncounterRegistrationFlag.STANDARD;
     @OneToMany(mappedBy = "parentEncounter")
     List<PatientEncounter> childEncounters;
     @OneToMany(mappedBy = "encounter", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -499,6 +509,14 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setPatientEncounterType(PatientEncounterType patientEncounterType) {
         this.patientEncounterType = patientEncounterType;
+    }
+
+    public EncounterRegistrationFlag getEncounterRegistrationFlag() {
+        return encounterRegistrationFlag;
+    }
+
+    public void setEncounterRegistrationFlag(EncounterRegistrationFlag encounterRegistrationFlag) {
+        this.encounterRegistrationFlag = encounterRegistrationFlag;
     }
 
     public Institution getCreditCompany() {

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -30,6 +30,8 @@ import javax.persistence.Inheritance;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Temporal;
 import javax.persistence.Transient;
 
@@ -512,11 +514,31 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     }
 
     public EncounterRegistrationFlag getEncounterRegistrationFlag() {
-        return encounterRegistrationFlag;
+        // Legacy rows created before this feature load with a NULL column. There is
+        // no meaningful "unknown" flag state — such an encounter simply was a
+        // standard admission — so normalise NULL to STANDARD on read. (Issue #21182)
+        return encounterRegistrationFlag == null
+                ? EncounterRegistrationFlag.STANDARD
+                : encounterRegistrationFlag;
     }
 
     public void setEncounterRegistrationFlag(EncounterRegistrationFlag encounterRegistrationFlag) {
         this.encounterRegistrationFlag = encounterRegistrationFlag;
+    }
+
+    /**
+     * Guarantees the encounter flag is never persisted as NULL. New entities
+     * already carry the STANDARD field default; this hook additionally back-fills
+     * STANDARD on the next write of any legacy row whose column is still NULL, so
+     * persisted rows progressively converge on a non-null value alongside the
+     * one-time DB migration (v2.1.20). (Issue #21182)
+     */
+    @PrePersist
+    @PreUpdate
+    private void defaultEncounterRegistrationFlag() {
+        if (encounterRegistrationFlag == null) {
+            encounterRegistrationFlag = EncounterRegistrationFlag.STANDARD;
+        }
     }
 
     public Institution getCreditCompany() {

--- a/src/main/resources/db/migrations/v2.1.20/migration-info.json
+++ b/src/main/resources/db/migrations/v2.1.20/migration-info.json
@@ -1,0 +1,36 @@
+{
+    "version": "v2.1.20",
+    "description": "Add ENCOUNTERREGISTRATIONFLAG column to PATIENTENCOUNTER and back-fill legacy rows to STANDARD",
+    "author": "Dr M H B Ariyaratne",
+    "estimatedDurationMinutes": 1,
+    "requiresDowntime": false,
+    "affectedTables": ["patientencounter"],
+    "affectedModules": ["Inward"],
+    "preRequisites": [
+        "Database backup completed",
+        "PATIENTENCOUNTER table must exist"
+    ],
+    "migrationSteps": [
+        {
+            "description": "Detect actual table name case for PATIENTENCOUNTER"
+        },
+        {
+            "description": "Add ENCOUNTERREGISTRATIONFLAG VARCHAR(255) DEFAULT 'STANDARD' column (STRING enum) if it does not exist"
+        },
+        {
+            "description": "Back-fill ENCOUNTERREGISTRATIONFLAG = 'STANDARD' for every row where it IS NULL"
+        },
+        {
+            "description": "Verify column presence and report distribution of encounter flags"
+        }
+    ],
+    "expectedOutcome": {
+        "primaryFix": "PATIENTENCOUNTER.ENCOUNTERREGISTRATIONFLAG available to flag encounters (STANDARD, ON_ADMISSION_DEATH, RAPID_TEMP_AE); covers Admission and all PatientEncounter subclasses via single-table inheritance.",
+        "impact": "Adds one column defaulting to 'STANDARD'. All existing encounters are normalised to STANDARD so no legacy row loads as NULL.",
+        "columnsAdded": 1
+    },
+    "rollbackNotes": [
+        "Rollback DROPs the ENCOUNTERREGISTRATIONFLAG column. Any flag data (e.g. On Admission Death markers) captured after the feature shipped will be lost."
+    ],
+    "relatedIssue": "#21182 - Add On Admission Death flag to PatientEncounter/Admission"
+}

--- a/src/main/resources/db/migrations/v2.1.20/migration.sql
+++ b/src/main/resources/db/migrations/v2.1.20/migration.sql
@@ -1,0 +1,107 @@
+-- Migration v2.1.20: Add ENCOUNTERREGISTRATIONFLAG column to PATIENTENCOUNTER and back-fill legacy rows
+-- Issue: #21182 - Add On Admission Death flag to PatientEncounter/Admission
+-- Author: Dr M H B Ariyaratne
+-- Date: 2026-06-03
+-- Database: main HMIS database (hmisPU)
+--
+-- Purpose:
+--   1. Add a STRING enum column ENCOUNTERREGISTRATIONFLAG to the PATIENTENCOUNTER
+--      table that records an operational/clinical flag for each encounter at
+--      registration time (STANDARD, ON_ADMISSION_DEATH, RAPID_TEMP_AE).
+--   2. Back-fill all existing rows (NULL flag) with 'STANDARD'. Unlike the
+--      registration source, an encounter has no meaningful "unknown" flag state:
+--      every legacy admission was a standard admission, so NULL normalises to
+--      STANDARD both here and in the entity (getter + @PrePersist/@PreUpdate).
+--
+-- PATIENTENCOUNTER is a SINGLE_TABLE inheritance root, so this single column also
+-- covers Admission and every other PatientEncounter subclass.
+--
+-- UNIVERSAL: Detects actual table name case (PATIENTENCOUNTER vs patientencounter)
+-- so this script works on both case-sensitive (Linux, lower_case_table_names=0)
+-- and case-insensitive (Windows) MySQL instances. All DDL is built with prepared
+-- statements against the real table name from INFORMATION_SCHEMA.
+--
+-- IDEMPOTENT: All statements check for existence first, so this migration can be
+-- safely re-run without error.
+
+SELECT 'Migration v2.1.20 - Add ENCOUNTERREGISTRATIONFLAG to PATIENTENCOUNTER' AS status;
+
+-- ==========================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ==========================================
+
+SET @pe_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTENCOUNTER'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected encounter table as: ', IFNULL(@pe_table, '(not found)')) AS info;
+
+SELECT IF(@pe_table IS NULL,
+          'PATIENTENCOUNTER table not found. Migration aborted.',
+          'PATIENTENCOUNTER table found; proceeding') AS applicability;
+
+-- ==========================================
+-- STEP 1: ADD ENCOUNTERREGISTRATIONFLAG COLUMN
+-- ==========================================
+-- DEFAULT 'STANDARD' so any direct insert that omits the column lands on the
+-- default. Column is left nullable to avoid blocking legacy raw inserts; the
+-- entity lifecycle hooks and STEP 2 keep values non-null in practice.
+
+SET @has_flag = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @pe_table
+      AND UPPER(COLUMN_NAME) = 'ENCOUNTERREGISTRATIONFLAG'
+);
+
+SET @sql = IF(@pe_table IS NOT NULL AND @has_flag = 0,
+              CONCAT('ALTER TABLE ', @pe_table,
+                     ' ADD COLUMN ENCOUNTERREGISTRATIONFLAG VARCHAR(255) DEFAULT ''STANDARD'''),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 2: BACK-FILL LEGACY NULL ROWS
+-- ==========================================
+-- Every existing encounter with a NULL flag was a standard admission.
+
+SET @sql = IF(@pe_table IS NOT NULL,
+              CONCAT('UPDATE ', @pe_table,
+                     ' SET ENCOUNTERREGISTRATIONFLAG = ''STANDARD''',
+                     ' WHERE ENCOUNTERREGISTRATIONFLAG IS NULL'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 3: POST-MIGRATION VERIFICATION
+-- ==========================================
+
+SELECT 'ENCOUNTERREGISTRATIONFLAG column' AS status;
+
+SELECT
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    IS_NULLABLE,
+    COLUMN_DEFAULT
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = @pe_table
+  AND UPPER(COLUMN_NAME) = 'ENCOUNTERREGISTRATIONFLAG';
+
+SET @sql = IF(@pe_table IS NOT NULL,
+              CONCAT('SELECT ENCOUNTERREGISTRATIONFLAG AS encounter_flag, COUNT(*) AS encounters FROM ',
+                     @pe_table, ' GROUP BY ENCOUNTERREGISTRATIONFLAG'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.1.20 completed - ENCOUNTERREGISTRATIONFLAG ready' AS final_status;

--- a/src/main/resources/db/migrations/v2.1.20/rollback.sql
+++ b/src/main/resources/db/migrations/v2.1.20/rollback.sql
@@ -1,0 +1,37 @@
+-- Rollback v2.1.20: Drop ENCOUNTERREGISTRATIONFLAG column from PATIENTENCOUNTER
+-- Issue: #21182
+--
+-- WARNING: This is destructive. Dropping the column discards every recorded
+-- encounter flag (e.g. On Admission Death markers captured after the feature
+-- shipped).
+--
+-- UNIVERSAL: handles both case-sensitive and case-insensitive MySQL.
+
+SELECT 'Rollback v2.1.20 - Drop ENCOUNTERREGISTRATIONFLAG column from PATIENTENCOUNTER' AS status;
+
+SET @pe_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTENCOUNTER'
+    LIMIT 1
+);
+
+SELECT CONCAT('Detected encounter table as: ', IFNULL(@pe_table, '(not found - nothing to drop)')) AS info;
+
+SET @has_flag = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @pe_table
+      AND UPPER(COLUMN_NAME) = 'ENCOUNTERREGISTRATIONFLAG'
+);
+
+SET @sql = IF(@pe_table IS NOT NULL AND @has_flag > 0,
+              CONCAT('ALTER TABLE ', @pe_table, ' DROP COLUMN ENCOUNTERREGISTRATIONFLAG'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.1.20 completed' AS final_status;

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -19,6 +19,15 @@
                         <div>
                             <h:outputText styleClass="fa fa-id-card"/>
                             <p:outputLabel value="Inpatient Dashboard" class="mt-2 mx-3"/>
+                            <!-- Encounter flag badge — hidden for the STANDARD default to keep
+                                 the dashboard clean for the vast majority of records. (Issue #21182) -->
+                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag ne null
+                                                     and admissionController.current.encounterRegistrationFlag ne 'STANDARD'}">
+                                <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
+                                       icon="fas fa-cross"
+                                       styleClass="mx-2"
+                                       style="background-color:#455a64; color:#ffffff;"/>
+                            </ui:fragment>
                         </div>
                         <div><div class="d-flex gap-2">
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -195,6 +195,13 @@
                                         </p:column>
                                         <p:column headerText="Patient Name"  >
                                             <h:outputText value="#{a.patient.person.nameWithTitle}" ></h:outputText>
+                                            <!-- Encounter flag badge — hidden for the STANDARD default. (Issue #21182) -->
+                                            <ui:fragment rendered="#{a.encounterRegistrationFlag ne null and a.encounterRegistrationFlag ne 'STANDARD'}">
+                                                <br/>
+                                                <p:tag value="#{a.encounterRegistrationFlag.label}"
+                                                       icon="fas fa-cross"
+                                                       style="background-color:#455a64; color:#ffffff;"/>
+                                            </ui:fragment>
                                         </p:column>
                                         <p:column headerText="Phone/Mobile" >
                                             <h:outputText value="#{a.patient.person.phone}" ></h:outputText>

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -61,6 +61,17 @@
                                         styleClass="ui-button-secondary ms-5">
                                     </p:commandButton>
                                 </h:panelGroup>
+
+                                <!-- Secondary, non-prominent action positioned away from the primary
+                                     "Admit" button. Opens a confirmation dialog before flagging the
+                                     admission as On Admission Death. (Issue #21182) -->
+                                <p:commandButton
+                                    type="button"
+                                    value="On Admission Death"
+                                    icon="fas fa-cross"
+                                    title="Record this admission as an On Admission Death (patient arrived dead, or died before registration was completed)"
+                                    styleClass="ui-button-secondary ms-5"
+                                    onclick="PF('dlgOnAdmissionDeath').show();"/>
                             </div>
                         </div>
                     </f:facet>
@@ -587,6 +598,41 @@
                             action="#{admissionController.saveSelected}"
                             update="@form"
                             onclick="PF('dlgActiveAdmission').hide();"/>
+                    </div>
+                </div>
+            </p:dialog>
+
+            <!-- On Admission Death confirmation dialog (Issue #21182) -->
+            <p:dialog id="dlgOnAdmissionDeath"
+                      widgetVar="dlgOnAdmissionDeath"
+                      header="Confirm On Admission Death"
+                      modal="true"
+                      resizable="false"
+                      closable="true"
+                      style="width:500px">
+                <div style="padding:12px">
+                    <p style="font-weight:bold; font-size:1.05em;">
+                        Record this admission as an <strong>On Admission Death</strong>?
+                    </p>
+                    <p>
+                        Use this only when the patient arrived dead, or died before
+                        registration was completed. The admission will be saved with the
+                        <strong>On Admission Death</strong> flag.
+                    </p>
+                    <div class="d-flex justify-content-end gap-2 mt-3">
+                        <p:commandButton
+                            value="Cancel"
+                            icon="fa fa-times"
+                            type="button"
+                            class="ui-button-secondary"
+                            onclick="PF('dlgOnAdmissionDeath').hide(); return false;"/>
+                        <p:commandButton
+                            value="Confirm — Save as On Admission Death"
+                            icon="fas fa-cross"
+                            class="ui-button-secondary"
+                            action="#{admissionController.checkBeforeAdmitOnAdmissionDeath}"
+                            update="@form"
+                            onclick="PF('dlgOnAdmissionDeath').hide();"/>
                     </div>
                 </div>
             </p:dialog>


### PR DESCRIPTION
## Summary

Adds an `EncounterRegistrationFlag` to `PatientEncounter` (and by inheritance `Admission`) to mark encounters with operational/clinical flags at registration time. The first use-case is **On Admission Death (OAD)** — a patient who arrives dead or dies before registration is completed.

Closes #21182

## Changes

### Enum + entity
- **New `EncounterRegistrationFlag`** (`com.divudi.core.data.inward`) with `STANDARD`, `ON_ADMISSION_DEATH`, `RAPID_TEMP_AE`, each carrying a display label.
- **`PatientEncounter.encounterRegistrationFlag`** — `@Enumerated(EnumType.STRING)`, defaults to `STANDARD` so existing and normal admissions need no badge.

### Admission flow (`AdmissionController`)
- New `checkBeforeAdmitOnAdmissionDeath()` entry point flags the encounter `ON_ADMISSION_DEATH`, then runs the same pre-admission checks/save via a shared `proceedWithAdmissionCheck()`.
- The standard Admit path now explicitly stamps `STANDARD`, so a prior OAD click cannot leak its flag into a later normal admit on the same form.
- **Dual-write rule** in `savePatient()`: when the flagged patient is *created during this admission*, set `patient.registrationSource = ON_ADMISSION_DEATH`; for patients that **already existed**, only the encounter flag is set and the original registration channel is preserved. (The baby-admission path that pre-sets `NEWBORN` is unaffected.)

### UI
- **`inward_admission.xhtml`** — muted `ui-button-secondary` "On Admission Death" button placed at the far end of the header, away from the primary green Admit button. `type="button"` opens a confirmation dialog before saving, guarding against accidental clicks.
- **`admission_profile.xhtml`** — dark-grey `p:tag` badge in the dashboard header, rendered only for non-`STANDARD` flags.
- **`inpatient_search.xhtml`** — same badge under the patient name in admissions search results, hidden for `STANDARD`.

## Acceptance Criteria

- [x] `EncounterRegistrationFlag` enum with `STANDARD`, `ON_ADMISSION_DEATH`, `RAPID_TEMP_AE`
- [x] `PatientEncounter.encounterRegistrationFlag` persisted, default `STANDARD`
- [x] "On Admission Death" secondary button on admission form
- [x] Clicking it saves the admission with `ON_ADMISSION_DEATH`
- [x] Dual-write: sets `patient.registrationSource = ON_ADMISSION_DEATH` only if patient is new
- [x] Badge shown on admission profile page for flagged encounters
- [x] Normal Admit flow is not affected

## Related

- Companion: `PatientRegistrationSource` on `Patient` (#21181)
- Companion: Rapid/Temp A&E Admission Flag (reuses the same enum — separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “On Admission Death” admission flow with a dedicated action button and confirmation dialog.
  * Show encounter flag badges in the inpatient dashboard and patient search to highlight special admission circumstances.

* **Bug Fixes**
  * Patient registration source is now set correctly when recording on-admission deaths (avoids incorrect admission classification).

* **Chores**
  * Database migration to add and back-fill an encounter registration flag column for existing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->