### PR TITLE
feat(inward): add Rapid/Temp A&E registration flag to admission

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2078,7 +2078,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
      */
     public void checkBeforeAdmitRapidTempAe() {
         getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.RAPID_TEMP_AE);
-        applyRapidTempPlaceholders();
+        // Placeholders are applied later in saveSelected(), only after the
+        // non-demographic validations pass, so a failed/aborted admit never
+        // mutates the patient and the placeholders cannot leak into a
+        // subsequent standard admission. (Issue #21183)
         proceedWithAdmissionCheck();
     }
 
@@ -2086,7 +2089,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
      * Fills blank patient name/address with site-configurable placeholders so a
      * Rapid / Temp A&E admission can proceed without demographic verification.
      * NIC, phone and other identifiers are intentionally left untouched (never
-     * faked) — they are completed later. (Issue #21183)
+     * faked) — they are completed later. Called from {@link #saveSelected()}
+     * only after {@link #errorCheck()} has passed. (Issue #21183)
      */
     private void applyRapidTempPlaceholders() {
         if (getCurrent() == null || getCurrent().getPatient() == null) {
@@ -2155,6 +2159,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (errorCheck()) {
             admittingProcessStarted = false;
             return;
+        }
+        // Rapid / Temp A&E: now that all non-demographic validations have
+        // passed and we are committed to saving, backfill the placeholder
+        // demographics. Doing it here (rather than at button-click time) keeps
+        // the patient untouched on a failed admit and prevents the placeholders
+        // from leaking into a standard admission. (Issue #21183)
+        if (isRapidTempAe()) {
+            applyRapidTempPlaceholders();
         }
         savePatient();
         savePatientAllergies();

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1582,6 +1582,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 if (getCurrent() != null
                         && getCurrent().getEncounterRegistrationFlag() == EncounterRegistrationFlag.ON_ADMISSION_DEATH) {
                     getPatient().setRegistrationSource(PatientRegistrationSource.ON_ADMISSION_DEATH);
+                } else if (getCurrent() != null
+                        && getCurrent().getEncounterRegistrationFlag() == EncounterRegistrationFlag.RAPID_TEMP_AE) {
+                    // Rapid / Temp A&E: the patient physically walked in (arrived
+                    // alive) — only their demographics are incomplete. The
+                    // registrationSource records HOW the patient was registered
+                    // (walk-in); the encounter flag records the temporary state.
+                    // (Issue #21183)
+                    getPatient().setRegistrationSource(PatientRegistrationSource.WALK_IN);
                 } else {
                     getPatient().setRegistrationSource(PatientRegistrationSource.INWARD_ADMISSION);
                 }
@@ -1732,7 +1740,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return true;
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Patient Details Required in Patient Admission", false)) {
+        // Rapid / Temp A&E admissions are admitted with incomplete demographics
+        // by design; blank name/address are placeholder-filled and the required
+        // patient-detail checks below are skipped. (Issue #21183)
+        if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Patient Details Required in Patient Admission", false)) {
             if (configOptionApplicationController.getBooleanValueByKey("Patient Title is Required in Patient Admission", false)) {
                 if (getCurrent().getPatient().getPerson().getTitle() == null) {
                     JsfUtil.addErrorMessage("Patient Title is Required");
@@ -1853,7 +1864,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Guardian Details Required in Patient Admission")) {
+        if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Guardian Details Required in Patient Admission")) {
             if (getCurrent().getGuardian() == null) {
                 JsfUtil.addErrorMessage("Guardian is Required");
                 return true;
@@ -2050,6 +2061,74 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     public void checkBeforeAdmitOnAdmissionDeath() {
         getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.ON_ADMISSION_DEATH);
         proceedWithAdmissionCheck();
+    }
+
+    /**
+     * Entry point for the secondary "Rapid / Temp Admit (A&E)" button. Intended
+     * for emergency / A&E admissions where full demographics are not yet
+     * available. Flags the encounter as
+     * {@link EncounterRegistrationFlag#RAPID_TEMP_AE}, fills any blank patient
+     * name/address with configurable placeholders, and bypasses the demographic
+     * validations in {@link #errorCheck()} so the patient can be admitted
+     * immediately. Demographics are completed later from the inpatient
+     * dashboard. The patient's {@code registrationSource} is stamped
+     * {@link PatientRegistrationSource#WALK_IN} in {@link #savePatient()} — the
+     * patient physically arrived; only their details are incomplete.
+     * (Issue #21183)
+     */
+    public void checkBeforeAdmitRapidTempAe() {
+        getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.RAPID_TEMP_AE);
+        applyRapidTempPlaceholders();
+        proceedWithAdmissionCheck();
+    }
+
+    /**
+     * Fills blank patient name/address with site-configurable placeholders so a
+     * Rapid / Temp A&E admission can proceed without demographic verification.
+     * NIC, phone and other identifiers are intentionally left untouched (never
+     * faked) — they are completed later. (Issue #21183)
+     */
+    private void applyRapidTempPlaceholders() {
+        if (getCurrent() == null || getCurrent().getPatient() == null) {
+            return;
+        }
+        Person person = getCurrent().getPatient().getPerson();
+        if (person == null) {
+            return;
+        }
+        if (person.getName() == null || person.getName().trim().isEmpty()) {
+            person.setName(configOptionApplicationController.getShortTextValueByKey(
+                    "Inward Admission - Rapid Temp A&E Placeholder Name", "Unidentified Patient"));
+        }
+        if (person.getAddress() == null || person.getAddress().trim().isEmpty()) {
+            person.setAddress(configOptionApplicationController.getShortTextValueByKey(
+                    "Inward Admission - Rapid Temp A&E Placeholder Address", "Unknown"));
+        }
+    }
+
+    /**
+     * @return {@code true} when the current encounter is being admitted as a
+     * Rapid / Temp A&E registration, for which demographic-required validations
+     * are skipped. (Issue #21183)
+     */
+    private boolean isRapidTempAe() {
+        return getCurrent() != null
+                && getCurrent().getEncounterRegistrationFlag() == EncounterRegistrationFlag.RAPID_TEMP_AE;
+    }
+
+    /**
+     * Clears the {@link EncounterRegistrationFlag#RAPID_TEMP_AE} flag once staff
+     * have completed the patient's demographics, returning the encounter to
+     * {@link EncounterRegistrationFlag#STANDARD}. (Issue #21183)
+     */
+    public void markRapidTempAdmissionComplete() {
+        if (getCurrent() == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return;
+        }
+        getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.STANDARD);
+        getFacade().edit(getCurrent());
+        JsfUtil.addSuccessMessage("Registration marked as complete.");
     }
 
     private void proceedWithAdmissionCheck() {

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -20,13 +20,20 @@
                             <h:outputText styleClass="fa fa-id-card"/>
                             <p:outputLabel value="Inpatient Dashboard" class="mt-2 mx-3"/>
                             <!-- Encounter flag badge — hidden for the STANDARD default to keep
-                                 the dashboard clean for the vast majority of records. (Issue #21182) -->
-                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag ne null
-                                                     and admissionController.current.encounterRegistrationFlag ne 'STANDARD'}">
+                                 the dashboard clean for the vast majority of records. Styling
+                                 is flag-aware: dark for On Admission Death, amber for the
+                                 Rapid / Temp A&E pending-completion state. (Issues #21182, #21183) -->
+                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'ON_ADMISSION_DEATH'}">
                                 <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
                                        icon="fas fa-cross"
                                        styleClass="mx-2"
                                        style="background-color:#455a64; color:#ffffff;"/>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'RAPID_TEMP_AE'}">
+                                <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
+                                       icon="fas fa-truck-medical"
+                                       styleClass="mx-2"
+                                       style="background-color:#f0ad4e; color:#212529;"/>
                             </ui:fragment>
                         </div>
                         <div><div class="d-flex gap-2">
@@ -52,6 +59,43 @@
                         </div>
                     </div>
                 </f:facet>
+
+                <!-- Rapid / Temp A&E warning: demographics may be incomplete. Offers the
+                     follow-up actions (complete details, change patient if duplicate, or
+                     mark complete once verified). Hidden for all other flags. (Issue #21183) -->
+                <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'RAPID_TEMP_AE'}">
+                    <div class="alert alert-warning d-flex justify-content-between align-items-center flex-wrap gap-2 my-2" role="alert">
+                        <div>
+                            <h:outputText styleClass="fas fa-triangle-exclamation me-2"/>
+                            <h:outputText value="Temporary A&amp;E admission — patient demographics may be incomplete. Please complete the patient details, or change to the correct patient if this is a duplicate record."/>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                value="Complete Registration"
+                                ajax="false"
+                                icon="fa fa-user-edit"
+                                class="ui-button-success"
+                                action="#{patientController.navigateToOpdPatientEdit()}">
+                                <f:setPropertyActionListener
+                                    value="#{admissionController.current.patient}"
+                                    target="#{patientController.current}" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Change Patient"
+                                ajax="false"
+                                icon="fa fa-user-friends"
+                                class="ui-button-warning"
+                                action="#{admissionPatientChangeController.navigateToChangeAdmissionPatient()}"/>
+                            <p:commandButton
+                                value="Mark as Complete"
+                                icon="fa fa-check"
+                                class="ui-button-secondary"
+                                process="@this"
+                                update="form"
+                                action="#{admissionController.markRapidTempAdmissionComplete}"/>
+                        </div>
+                    </div>
+                </ui:fragment>
 
                 <div class="row">
                     <!-- Column 1: Patient Info -->

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -72,6 +72,17 @@
                                     title="Record this admission as an On Admission Death (patient arrived dead, or died before registration was completed)"
                                     styleClass="ui-button-secondary ms-5"
                                     onclick="PF('dlgOnAdmissionDeath').show();"/>
+
+                                <!-- Rapid / Temp A&E admission. Opens a confirmation dialog, then admits
+                                     immediately with placeholder demographics that staff complete later.
+                                     (Issue #21183) -->
+                                <p:commandButton
+                                    type="button"
+                                    value="Rapid / Temp Admit (A&amp;E)"
+                                    icon="fas fa-truck-medical"
+                                    title="Quickly admit an A&amp;E patient with incomplete demographics. Blank name/address are filled with placeholders and demographic checks are skipped; complete the details later."
+                                    styleClass="ui-button-warning ms-2"
+                                    onclick="PF('dlgRapidTempAe').show();"/>
                             </div>
                         </div>
                     </f:facet>
@@ -633,6 +644,47 @@
                             action="#{admissionController.checkBeforeAdmitOnAdmissionDeath}"
                             update="@form"
                             onclick="PF('dlgOnAdmissionDeath').hide();"/>
+                    </div>
+                </div>
+            </p:dialog>
+
+            <!-- Rapid / Temp A&E confirmation dialog (Issue #21183) -->
+            <p:dialog id="dlgRapidTempAe"
+                      widgetVar="dlgRapidTempAe"
+                      header="Confirm Rapid / Temp A&amp;E Admission"
+                      modal="true"
+                      resizable="false"
+                      closable="true"
+                      style="width:520px">
+                <div style="padding:12px">
+                    <p style="font-weight:bold; font-size:1.05em;">
+                        Admit this patient as a <strong>Rapid / Temp A&amp;E</strong> registration?
+                    </p>
+                    <p>
+                        Use this for emergency admissions where full demographics are not
+                        yet available. Any blank <strong>Name</strong> or
+                        <strong>Address</strong> will be filled with placeholders, and the
+                        usual demographic checks are skipped so the patient can be admitted
+                        immediately.
+                    </p>
+                    <p class="text-muted">
+                        The admission will be flagged <strong>Rapid / Temp A&amp;E</strong>.
+                        Please complete the patient details later from the Inpatient Dashboard.
+                    </p>
+                    <div class="d-flex justify-content-end gap-2 mt-3">
+                        <p:commandButton
+                            value="Cancel"
+                            icon="fa fa-times"
+                            type="button"
+                            class="ui-button-secondary"
+                            onclick="PF('dlgRapidTempAe').hide(); return false;"/>
+                        <p:commandButton
+                            value="Confirm — Rapid / Temp Admit"
+                            icon="fas fa-truck-medical"
+                            class="ui-button-warning"
+                            action="#{admissionController.checkBeforeAdmitRapidTempAe}"
+                            update="@form"
+                            onclick="PF('dlgRapidTempAe').hide();"/>
                     </div>
                 </div>
             </p:dialog>


### PR DESCRIPTION
## Summary

Adds a **Rapid / Temp Admit (A&E)** path for emergency admissions where full demographics are not yet available. The patient is admitted immediately with placeholder details and the encounter is flagged `RAPID_TEMP_AE` so staff can follow up and complete the record later.

Reuses the `EncounterRegistrationFlag` enum introduced in #21182 (the `RAPID_TEMP_AE` value is already present in `development`).

## Changes

### `AdmissionController.java`
- **`checkBeforeAdmitRapidTempAe()`** — flags the encounter `RAPID_TEMP_AE`, applies placeholder demographics, then runs the normal admit-check/save flow.
- **`applyRapidTempPlaceholders()`** — fills blank **Name**/**Address** with site-configurable placeholders (defaults `Unidentified Patient` / `Unknown`). NIC/phone are intentionally left untouched (never faked).
- **`errorCheck()`** — skips the patient-detail and guardian required-field validation blocks for rapid admits.
- **`savePatient()`** — new patients created this way get `registrationSource = WALK_IN` (they physically arrived; only details are incomplete).
- **`markRapidTempAdmissionComplete()`** — resets the flag to `STANDARD` once demographics are verified.

### `inward_admission.xhtml`
- Amber **"Rapid / Temp Admit (A&E)"** button next to "On Admission Death".
- Confirmation dialog explaining placeholders are applied and details completed later.

### `admission_profile.xhtml` (inpatient dashboard)
- Prominent amber **warning banner** for `RAPID_TEMP_AE` admissions with three actions: **Complete Registration** (→ patient edit), **Change Patient** (→ existing de-dup feature), **Mark as Complete** (→ resets flag).
- Flag badge made **flag-aware**: dark for On Admission Death, amber + ambulance icon for Rapid/Temp A&E.

## Acceptance criteria

- [x] `RAPID_TEMP_AE` present in `EncounterRegistrationFlag` enum (from #21182)
- [x] "Rapid / Temp Admit (A&E)" button saves with `RAPID_TEMP_AE` flag
- [x] `patient.registrationSource` set to `WALK_IN`
- [x] Warning banner shown on admission profile
- [x] "Complete Registration" button navigates to patient edit
- [x] "Mark as Complete" resets flag to `STANDARD`
- [x] Change-Patient (de-duplication) workflow linked from the banner
- [ ] Badge + filter in **admissions search** — deferred (scope narrowed to the admit flow + inpatient dashboard); can be a follow-up

## Notes

- Placeholder config keys (`Inward Admission - Rapid Temp A&E Placeholder Name` / `... Address`) are created lazily on first use, matching the existing inward-admission config convention.
- No DB schema change — uses the existing `encounterRegistrationFlag` column.

Closes #21183

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Rapid / Temp Admit (A&E)" mode for expedited emergency intake.
  * Admit action includes a dedicated Rapid/Temp button and confirmation dialog.
  * Dashboard shows explicit admission flag badges (including Rapid/Temp) and a warning alert with actions: complete registration, change patient, or mark rapid admission complete.
  * Rapid admits allow minimal data entry and auto-fill placeholders, with a flow to finalize demographics later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->