### PR TITLE
Show before/after edit values on inward bills (Closes #21105)

### DIFF
--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -36,48 +36,58 @@
                                 <h:outputLabel value="Inward Final Bill" class="mx-2"/>
                             </div>
                             <div>
-                                <p:commandButton update="dList tot @all settle saveProvisional" 
-                                                 value="Process"
-                                                 actionListener="#{bhtSummeryController.updateTotal()}"
-                                                 process="@this"
-                                                 class="ui-button-warning mx-1" 
-                                                 icon="fas fa-cog"
-                                                 style="width: 150px; padding: 1px; margin: auto;"
-                                                 rendered="#{!configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" />
-                                <p:commandButton class="ui-button-warning mx-2"
-                                                 icon="fas fa-cogs"
-                                                 value="Process Bill"
-                                                 process="@this"
-                                                 update="dList tot settle saveProvisional @all printTempBill"
-                                                 action="#{bhtSummeryController.createTempBill()}" 
-                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" />
-                                <p:commandButton class="ui-button-info"
-                                                 icon="fas fa-print"
-                                                 value="Check Final Bill"
-                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
+                                <p:commandButton 
+                                    update="dList tot @all settle saveProvisional" 
+                                    value="Process"
+                                    actionListener="#{bhtSummeryController.updateTotal()}"
+                                    process="@this"
+                                    class="ui-button-warning mx-1" 
+                                    icon="fas fa-cog"
+                                    style="width: 150px; padding: 1px; margin: auto;"
+                                    rendered="#{!configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
+                                </p:commandButton>
+                                
+                                <p:commandButton 
+                                    class="ui-button-warning mx-2"
+                                    icon="fas fa-cogs"
+                                    value="Process Bill"
+                                    process="@this"
+                                    update="dList tot settle saveProvisional @all printTempBill"
+                                    action="#{bhtSummeryController.createTempBill()}" 
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
+                                </p:commandButton>
+                                
+                                <p:commandButton 
+                                    class="ui-button-info"
+                                    icon="fas fa-print"
+                                    value="Check Final Bill"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
                                     <p:printer target="printTempBill" />
                                 </p:commandButton>
-                                <p:commandButton value="Save Provisional Bill" 
-                                                 action="#{bhtSummeryController.saveProvisionalBill()}"
-                                                 id="saveProvisional"
-                                                 ajax="false"
-                                                 disabled="#{bhtSummeryController.changed}"
-                                                 class="ui-button-warning mx-1"
-                                                 icon="fa fa-save"
-                                                 style="width: 200px; padding: 1px; margin: auto;"
-                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false)}">
-
+                                
+                                <p:commandButton 
+                                    value="Save Provisional Bill" 
+                                    action="#{bhtSummeryController.saveProvisionalBill()}"
+                                    id="saveProvisional"
+                                    ajax="false"
+                                    disabled="#{bhtSummeryController.changed}"
+                                    class="ui-button-warning mx-1"
+                                    icon="fa fa-save"
+                                    style="width: 200px; padding: 1px; margin: auto;"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false)}">
                                 </p:commandButton>
-                                <p:commandButton value="Settle"
-                                                 action="#{bhtSummeryController.settle}"
-                                                 id="settle"
-                                                 ajax="false"
-                                                 disabled="#{bhtSummeryController.changed}"
-                                                 class="ui-button-success mx-1"
-                                                 icon="fa fa-check"
-                                                 style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
-
+                                
+                                <p:commandButton 
+                                    value="Settle"
+                                    action="#{bhtSummeryController.settle}"
+                                    id="settle"
+                                    ajax="false"
+                                    disabled="#{bhtSummeryController.changed}"
+                                    class="ui-button-success mx-1"
+                                    icon="fa fa-check"
+                                    style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
                                 </p:commandButton>
+                                
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                     <p:commandButton
                                         ajax="false"

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -283,6 +283,7 @@
                                                 <h:outputLabel value="#{bhtSummeryController.grantTotal}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
+                                                
                                                 <h:outputLabel value="Paid By Patient   " />
                                                 <h:outputLabel value=":" class="mx-2"/>
                                                 <h:outputLabel value="#{bhtSummeryController.paid}">
@@ -291,7 +292,7 @@
 
                                                 <h:outputLabel value="Due" rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit' and bhtSummeryController.due > 0 }" />
                                                 <h:outputLabel value=":" class="mx-2" rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit' and bhtSummeryController.due > 0 }"/>
-                                                <h:outputLabel  value="#{bhtSummeryController.due}" rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit' and bhtSummeryController.due > 0 }">
+                                                <h:outputLabel value="#{bhtSummeryController.due}" rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit' and bhtSummeryController.due > 0 }">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </h:panelGrid>

--- a/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
+++ b/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
@@ -82,7 +82,12 @@
                                                     <h:outputLabel value="Bill Details" ></h:outputLabel>
                                                 </div>
                                                 <div>
-                                                    <p:commandButton value="View Charges" type="button" onclick="PF('chargesList').show();" />
+                                                    <p:commandButton 
+                                                        value="View Charges" 
+                                                        icon="fa fa-line-chart"
+                                                        type="button" 
+                                                        onclick="PF('chargesList').show();" >
+                                                    </p:commandButton>
 
                                                     <p:dialog header="Inward Charges List" widgetVar="chargesList" modal="true" height="60vh" width="75vw">
                                                         <in:finalTable bill="#{inwardSearch.bill}"/>
@@ -91,121 +96,121 @@
                                             </div>
 
                                         </f:facet>
-                                        
+
                                         <div  style="font-size: 20px; font-weight: 700;">
                                             <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Bill No" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.deptId}" style="float: right;"></h:outputLabel>
-                                            </div>
-                                        </div> 
-
-                                        <div class="row mt-3">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Total" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.grantTotal}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row mt-3">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Discount" class="mt-2"></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2 mt-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <p:inputText value="#{inwardSearch.bill.discount}" class="text-end" style="float: right;" onfocus="this.select()">
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                    <p:ajax process="@this" update="@all"
-                                                            event="change"
-                                                            listener="#{inwardSearch.updateTotal()}"/>
-                                                </p:inputText>
-                                            </div>
-                                        </div>
-
-                                        <div class="row mt-3">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Net Total" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.netTotal}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row mt-3">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Paid Amount" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row mt-3">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Due " ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.netTotal-(inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany)}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <h:panelGroup rendered="#{inwardSearch.bill.patientEncounter.paymentMethod eq 'Credit'}">
-                                            <div class="row mt-3">
-                                                <div class="col-md-5 mt-2 d-flex gap-2">
-                                                    <h:outputLabel value="Credit Limit" class="mt-2"/>
-                                                    <p:commandButton 
-                                                        ajax="false" 
-                                                        icon="fa fa-pencil"
-                                                        id="edit_credit_limit"
-                                                        class="ui-button-warning"
-                                                        action="#{inwardSearch.edit()}">
-                                                    </p:commandButton>
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Bill No" ></h:outputLabel>
                                                 </div>
-                                                <div class="col-md-1 justify-content-end d-flex mt-2">
-                                                    <p:outputLabel value=":" class="mx-2 mt-2" />
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <p:inputText value="#{inwardSearch.bill.patientEncounter.creditLimit}" style="float: right;"  class="mt-2">
+                                                    <h:outputLabel value="#{inwardSearch.bill.deptId}" style="float: right;"></h:outputLabel>
+                                                </div>
+                                            </div> 
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Total" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.grantTotal}" style="float: right;" >
                                                         <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Discount" class="mt-2"></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2 mt-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <p:inputText value="#{inwardSearch.bill.discount}" class="text-end" style="float: right;" onfocus="this.select()">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                        <p:ajax process="@this" update="@all"
+                                                                event="change"
+                                                                listener="#{inwardSearch.updateTotal()}"/>
                                                     </p:inputText>
                                                 </div>
                                             </div>
 
-                                            <p:tooltip for="edit_credit_limit" value="Edit Credit Limit"  showDelay="0" hideDelay="0"></p:tooltip>
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Net Total" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.netTotal}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
 
-                                        </h:panelGroup>
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Paid Amount" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Due " ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.netTotal-(inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany)}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <h:panelGroup rendered="#{inwardSearch.bill.patientEncounter.paymentMethod eq 'Credit'}">
+                                                <div class="row mt-3">
+                                                    <div class="col-md-5 mt-2 d-flex gap-2">
+                                                        <h:outputLabel value="Credit Limit" class="mt-2"/>
+                                                        <p:commandButton 
+                                                            ajax="false" 
+                                                            icon="fa fa-pencil"
+                                                            id="edit_credit_limit"
+                                                            class="ui-button-warning"
+                                                            action="#{inwardSearch.edit()}">
+                                                        </p:commandButton>
+                                                    </div>
+                                                    <div class="col-md-1 justify-content-end d-flex mt-2">
+                                                        <p:outputLabel value=":" class="mx-2 mt-2" />
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <p:inputText value="#{inwardSearch.bill.patientEncounter.creditLimit}" style="float: right;"  class="mt-2">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+
+                                                <p:tooltip for="edit_credit_limit" value="Edit Credit Limit"  showDelay="0" hideDelay="0"></p:tooltip>
+
+                                            </h:panelGroup>
                                         </div>
 
-                                        
+
 
                                     </p:panel>
                                 </div>

--- a/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
+++ b/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
@@ -64,27 +64,6 @@
                                         </p:commandButton>
                                     </div>
                                 </div>
-
-                                <h:panelGroup rendered="false">
-                                    <div class="d-flex justify-content-between mb-2" style="display: ">
-                                        <div></div>
-                                        <div class="d-flex gap-2">
-                                            <p:commandButton value="Final Bill &amp; Profesional Bill - Single page" ajax="false">
-                                                <p:printer  ></p:printer>
-                                            </p:commandButton>
-                                            <p:commandButton value="Final Bill &amp; Profesional Bill - 3 pages" ajax="false">
-                                                <p:printer  ></p:printer>
-                                            </p:commandButton> 
-                                            <p:commandButton value="Final Bill &amp; Profesional Bill (Duplicate)" ajax="false">
-                                                <p:printer  ></p:printer>
-                                            </p:commandButton>
-                                            <p:commandButton value="Print Credit Company Letter" ajax="false">
-                                                <p:printer  ></p:printer>
-                                            </p:commandButton>
-                                        </div>
-                                    </div>
-                                </h:panelGroup>
-
                             </f:facet>
 
                             <div class="row mt-3">
@@ -261,9 +240,9 @@
                                                     <p:ajax process="@this" update="@all"
                                                             event="change"
                                                             listener="#{inwardSearch.updateTotal()}"/>
-<!--                                                    <p:ajax process="@this" event="keyup"
-                                                            update="@all"
-                                                            listener="#{inwardSearch.changeIsMade()}"/>-->
+                                                    <!--                                                    <p:ajax process="@this" event="keyup"
+                                                                                                                update="@all"
+                                                                                                                listener="#{inwardSearch.changeIsMade()}"/>-->
                                                 </p:inputText>
                                             </p:column>
                                         </p:dataTable>
@@ -288,9 +267,9 @@
                                                             <p:ajax process="@this" update="@all"
                                                                     event="change"
                                                                     listener="#{inwardSearch.updateProTotal(bip)}"/>
-<!--                                                            <p:ajax process="@this" event="keyup"
-                                                                    update="@all"
-                                                                    listener="#{inwardSearch.changeIsMade()}"/>-->
+                                                            <!--                                                            <p:ajax process="@this" event="keyup"
+                                                                                                                                update="@all"
+                                                                                                                                listener="#{inwardSearch.changeIsMade()}"/>-->
                                                         </p:inputText>
                                                     </p:column>
                                                 </p:dataTable>

--- a/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
+++ b/src/main/webapp/inward/inward_provisional_bill_edit.xhtml
@@ -91,8 +91,9 @@
                                             </div>
 
                                         </f:facet>
-
-                                        <div class="row">
+                                        
+                                        <div  style="font-size: 20px; font-weight: 700;">
+                                            <div class="row">
                                             <div class="col-md-5">
                                                 <h:outputLabel value="Bill No" ></h:outputLabel>
                                             </div>
@@ -104,7 +105,7 @@
                                             </div>
                                         </div> 
 
-                                        <div class="row">
+                                        <div class="row mt-3">
                                             <div class="col-md-5">
                                                 <h:outputLabel value="Total" ></h:outputLabel>
                                             </div>
@@ -118,15 +119,16 @@
                                             </div>
                                         </div>
 
-                                        <div class="row">
+                                        <div class="row mt-3">
                                             <div class="col-md-5">
-                                                <h:outputLabel value="Discount" ></h:outputLabel>
+                                                <h:outputLabel value="Discount" class="mt-2"></h:outputLabel>
                                             </div>
                                             <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
+                                                <p:outputLabel value=":" class="mx-2 mt-2"/>
                                             </div>
                                             <div class="col-md-6">
-                                                <p:inputText value="#{inwardSearch.bill.discount}" style="float: right;" >
+                                                <p:inputText value="#{inwardSearch.bill.discount}" class="text-end" style="float: right;" onfocus="this.select()">
+                                                    <f:convertNumber pattern="#,##0.00" />
                                                     <p:ajax process="@this" update="@all"
                                                             event="change"
                                                             listener="#{inwardSearch.updateTotal()}"/>
@@ -134,7 +136,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="row">
+                                        <div class="row mt-3">
                                             <div class="col-md-5">
                                                 <h:outputLabel value="Net Total" ></h:outputLabel>
                                             </div>
@@ -148,7 +150,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="row">
+                                        <div class="row mt-3">
                                             <div class="col-md-5">
                                                 <h:outputLabel value="Paid Amount" ></h:outputLabel>
                                             </div>
@@ -162,7 +164,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="row">
+                                        <div class="row mt-3">
                                             <div class="col-md-5">
                                                 <h:outputLabel value="Due " ></h:outputLabel>
                                             </div>
@@ -177,7 +179,7 @@
                                         </div>
 
                                         <h:panelGroup rendered="#{inwardSearch.bill.patientEncounter.paymentMethod eq 'Credit'}">
-                                            <div class="row">
+                                            <div class="row mt-3">
                                                 <div class="col-md-5 mt-2 d-flex gap-2">
                                                     <h:outputLabel value="Credit Limit" class="mt-2"/>
                                                     <p:commandButton 
@@ -201,6 +203,9 @@
                                             <p:tooltip for="edit_credit_limit" value="Edit Credit Limit"  showDelay="0" hideDelay="0"></p:tooltip>
 
                                         </h:panelGroup>
+                                        </div>
+
+                                        
 
                                     </p:panel>
                                 </div>
@@ -236,13 +241,11 @@
                                                 <f:facet name="header">
                                                     <h:outputLabel value="Charge (Rs.)"/>
                                                 </f:facet>
-                                                <p:inputText value="#{bip.adjustedValue}" disabled="#{bip.inwardChargeType eq 'ProfessionalCharge'}" >
+                                                <p:inputText value="#{bip.adjustedValue}" disabled="#{bip.inwardChargeType eq 'ProfessionalCharge'}" onfocus="this.select()">
+                                                    <f:convertNumber pattern="#,##0.00" />
                                                     <p:ajax process="@this" update="@all"
                                                             event="change"
                                                             listener="#{inwardSearch.updateTotal()}"/>
-                                                    <!--                                                    <p:ajax process="@this" event="keyup"
-                                                                                                                update="@all"
-                                                                                                                listener="#{inwardSearch.changeIsMade()}"/>-->
                                                 </p:inputText>
                                             </p:column>
                                         </p:dataTable>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -24,11 +24,11 @@
                                         <h:outputLabel value="Final Bill" class="mx-4"></h:outputLabel>
                                     </div>
                                     <div class="d-flex gap-2">
-                                         <p:selectBooleanCheckbox value="#{inwardSearch.showOrginalBill}"
-                                                             label="Show Original Bill" itemLabel="Show Original Bill"
-                                                             class="mx-2">
-                                        <p:ajax process="@this" update="@all"/>
-                                    </p:selectBooleanCheckbox>
+                                        <p:selectBooleanCheckbox value="#{inwardSearch.showOrginalBill}"
+                                                                 label="Show Original Bill" itemLabel="Show Original Bill"
+                                                                 class="mx-2">
+                                            <p:ajax process="@this" update="@all"/>
+                                        </p:selectBooleanCheckbox>
                                         <p:commandButton
                                             icon=" fa fa-refresh"
                                             value="Process Bill"
@@ -155,7 +155,12 @@
                                                     <h:outputLabel value="Bill Details" ></h:outputLabel>
                                                 </div>
                                                 <div>
-                                                    <p:commandButton value="View Charges" type="button" onclick="PF('chargesList').show();" />
+                                                    <p:commandButton 
+                                                        value="View Charges" 
+                                                        icon="fa fa-line-chart"
+                                                        type="button" 
+                                                        onclick="PF('chargesList').show();" >
+                                                    </p:commandButton>
 
                                                     <p:dialog header="Inward Charges List" widgetVar="chargesList" modal="true" height="60vh" width="75vw">
                                                         <in:finalTable bill="#{inwardSearch.bill}"/>
@@ -165,113 +170,116 @@
 
                                         </f:facet>
 
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Bill No" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.deptId}" style="float: right;"></h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Total" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.grantTotal}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Discount" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.discount}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Net Total" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.netTotal}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Paid Amount" ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <div class="row">
-                                            <div class="col-md-5">
-                                                <h:outputLabel value="Due " ></h:outputLabel>
-                                            </div>
-                                            <div class="col-md-1 justify-content-end d-flex">
-                                                <p:outputLabel value=":" class="mx-2"/>
-                                            </div>
-                                            <div class="col-md-6">
-                                                <h:outputLabel value="#{inwardSearch.bill.netTotal-(inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany)}" style="float: right;" >
-                                                    <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </div>
-                                        </div>
-
-                                        <h:panelGroup rendered="#{inwardSearch.bill.patientEncounter.paymentMethod eq 'Credit'}">
+                                        <div  style="font-size: 20px; font-weight: 700;">
                                             <div class="row">
-                                                <div class="col-md-5 mt-2 d-flex gap-2">
-                                                    <h:outputLabel value="Credit Limit" class="mt-2"/>
-                                                    <p:commandButton
-                                                        ajax="false"
-                                                        icon="fa fa-pencil"
-                                                        id="edit_credit_limit"
-                                                        class="ui-button-warning"
-                                                        action="#{inwardSearch.edit()}">
-                                                    </p:commandButton>
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Bill No" ></h:outputLabel>
                                                 </div>
-                                                <div class="col-md-1 justify-content-end d-flex mt-2">
-                                                    <p:outputLabel value=":" class="mx-2 mt-2" />
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
                                                 </div>
                                                 <div class="col-md-6">
-                                                    <p:inputText value="#{inwardSearch.bill.patientEncounter.creditLimit}" style="float: right;"  class="mt-2">
-                                                        <f:convertNumber pattern="#,##0.00" />
-                                                    </p:inputText>
+                                                    <h:outputLabel value="#{inwardSearch.bill.deptId}" style="float: right;"></h:outputLabel>
                                                 </div>
                                             </div>
 
-                                            <p:tooltip for="edit_credit_limit" value="Edit Credit Limit"  showDelay="0" hideDelay="0"></p:tooltip>
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Total" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.grantTotal}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
 
-                                        </h:panelGroup>
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Discount" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.discount}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Net Total" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.netTotal}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Paid Amount" ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-3">
+                                                <div class="col-md-5">
+                                                    <h:outputLabel value="Due " ></h:outputLabel>
+                                                </div>
+                                                <div class="col-md-1 justify-content-end d-flex">
+                                                    <p:outputLabel value=":" class="mx-2"/>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <h:outputLabel value="#{inwardSearch.bill.netTotal-(inwardSearch.bill.paidAmount+inwardSearch.bill.patientEncounter.paidByCreditCompany)}" style="float: right;" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+
+                                            <h:panelGroup rendered="#{inwardSearch.bill.patientEncounter.paymentMethod eq 'Credit'}">
+                                                <div class="row mt-3">
+                                                    <div class="col-md-5 mt-2 d-flex gap-2">
+                                                        <h:outputLabel value="Credit Limit" class="mt-2"/>
+                                                        <p:commandButton
+                                                            ajax="false"
+                                                            icon="fa fa-pencil"
+                                                            id="edit_credit_limit"
+                                                            class="ui-button-warning"
+                                                            action="#{inwardSearch.edit()}">
+                                                        </p:commandButton>
+                                                    </div>
+                                                    <div class="col-md-1 justify-content-end d-flex mt-2">
+                                                        <p:outputLabel value=":" class="mx-2 mt-2" />
+                                                    </div>
+                                                    <div class="col-md-6">
+                                                        <p:inputText value="#{inwardSearch.bill.patientEncounter.creditLimit}" style="float: right;"  class="mt-2">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+
+                                                <p:tooltip for="edit_credit_limit" value="Edit Credit Limit"  showDelay="0" hideDelay="0"></p:tooltip>
+
+                                            </h:panelGroup>
+
+                                        </div>
 
                                     </p:panel>
                                 </div>

--- a/src/main/webapp/inward/inward_search_final.xhtml
+++ b/src/main/webapp/inward/inward_search_final.xhtml
@@ -103,9 +103,18 @@
                                         sortBy="#{bb.deptId}" 
                                         filterBy="#{bb.deptId}" 
                                         filterMatchMode="contains"  >
-                                        <h:outputLabel value="#{bb.deptId}" ></h:outputLabel>
+                                        
+                                        <p:commandLink
+                                            ajax="false"
+                                            value="#{bb.deptId}"
+                                            action="inward_reprint_bill_final?faces-redirect=true" 
+                                            actionListener="#{inwardSearch.refreshFinalBillBackwordReferenceBills}">
+                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
+                                            <f:setPropertyActionListener value="#{bb.patientEncounter.patient}" target="#{admissionController.patient}"/>
+                                            <f:setPropertyActionListener value="#{bb.patientEncounter}" target="#{admissionController.current}"/>
+                                        </p:commandLink>
                                     </p:column>
-
+                                    
                                     <p:column 
                                         headerText="BHT No"  
                                         sortBy="#{bb.patientEncounter.bhtNo}" 
@@ -190,18 +199,6 @@
                                         </h:outputLabel>
                                     </p:column> 
 
-                                    <p:column>
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="View Bill" 
-                                            action="inward_reprint_bill_final?faces-redirect=true" 
-                                            actionListener="#{inwardSearch.refreshFinalBillBackwordReferenceBills}" 
-                                            >
-                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
-                                            <f:setPropertyActionListener value="#{bb.patientEncounter.patient}" target="#{admissionController.patient}"/>
-                                            <f:setPropertyActionListener value="#{bb.patientEncounter}" target="#{admissionController.current}"/>
-                                        </p:commandButton>
-                                    </p:column>
                                 </p:dataTable>
                             </div>
                         </div>

--- a/src/main/webapp/inward/inward_search_provisional.xhtml
+++ b/src/main/webapp/inward/inward_search_provisional.xhtml
@@ -48,7 +48,7 @@
                                         action="#{searchController.createInwardProvisionalBills()}" 
                                         value="Search Bills"  />
                                     <p:spacer height="10" width="5" ></p:spacer>
-                                    
+
                                     <p:commandButton 
                                         ajax="false" 
                                         icon="fa fa-search"
@@ -57,7 +57,7 @@
                                         value="Search Cancelled Bills"
                                         rendered="false"/>
                                     <p:spacer height="10" width="5" ></p:spacer>
-                                    
+
                                     <p:commandButton 
                                         ajax="false" 
                                         icon="fa-solid fa-file-excel"
@@ -100,13 +100,20 @@
                                     rowsPerPageTemplate="15,25,50"
                                     >
 
-
                                     <p:column 
                                         headerText="Bill No" 
                                         sortBy="#{bb.deptId}" 
                                         filterBy="#{bb.deptId}" 
                                         filterMatchMode="contains"  >
-                                        <h:outputLabel value="#{bb.deptId}" ></h:outputLabel>
+                                        <p:commandLink
+                                            ajax="false"
+                                            value="#{bb.deptId}"
+                                            action="inward_provisional_bill_edit?faces-redirect=true" 
+                                            actionListener="#{inwardSearch.refreshFinalBillBackwordReferenceBills}">
+                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
+                                            <f:setPropertyActionListener value="#{bb.patientEncounter.patient}" target="#{admissionController.patient}"/>
+                                            <f:setPropertyActionListener value="#{bb.patientEncounter}" target="#{admissionController.current}"/>
+                                        </p:commandLink>
                                     </p:column>
 
                                     <p:column 
@@ -193,18 +200,6 @@
                                         </h:outputLabel>
                                     </p:column> 
 
-                                    <p:column>
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="View Bill" 
-                                            action="inward_provisional_bill_edit?faces-redirect=true" 
-                                            actionListener="#{inwardSearch.refreshFinalBillBackwordReferenceBills}" 
-                                            >
-                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
-                                            <f:setPropertyActionListener value="#{bb.patientEncounter.patient}" target="#{admissionController.patient}"/>
-                                            <f:setPropertyActionListener value="#{bb.patientEncounter}" target="#{admissionController.current}"/>
-                                        </p:commandButton>
-                                    </p:column>
                                 </p:dataTable>
                             </div>
                         </div>

--- a/src/main/webapp/resources/inward/finalTable.xhtml
+++ b/src/main/webapp/resources/inward/finalTable.xhtml
@@ -44,17 +44,18 @@
                     padding: 8px !important;
                 }
             </style>
- 
-            <p:dataTable id="tb1"
-                         styleClass="mt-2 bhtFinalTable"
-                         value="#{cc.attrs.bill.billItems}" 
-                         var="bip"
-                         rowIndexVar="i"
-                         rowStyleClass="#{(bip.adjustedValue ne 0) ? '' : 'noDisplayRow' }"
-                         >
+
+            <p:dataTable 
+                id="tb1"
+                styleClass="mt-2 bhtFinalTable"
+                value="#{cc.attrs.bill.billItems}" 
+                var="bip"
+                rowStyleClass="#{(bip.adjustedValue ne 0) ? '' : 'noDisplayRow' }">
+                
                 <p:column headerText="Inward Charge Type">
                     <h:outputLabel   value="#{bip.inwardChargeType.name}"/>
                 </p:column>
+                
                 <p:column headerText="Total Value" style="text-align: right;">
                     <h:outputLabel  value="#{bip.grossValue}">
                         <f:convertNumber pattern="#,##0.00" />
@@ -64,7 +65,8 @@
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </f:facet>
-                </p:column>                            
+                </p:column>
+                
                 <p:column headerText="Discount Value"  style="text-align: right;">
                     <h:outputLabel  value="#{bip.discount}">
                         <f:convertNumber pattern="#,##0.00" />
@@ -92,7 +94,7 @@
                         <f:convertNumber pattern="#,##0.00" />
                     </h:outputLabel>
                 </p:column>
-                
+
                 <p:column headerText="Difference"  style="text-align: center; width: 12em;" exportable="false">
                     <h:panelGroup style="font-size: 18px; font-weight: 700">
                         <h:panelGroup rendered="#{(bip.adjustedValue - bip.netValue) ge 0.005}" style="color: green;">
@@ -115,13 +117,9 @@
                     </h:panelGroup>
                 </p:column>
 
-
             </p:dataTable>
 
         </p:panel>
-
-
-
 
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/inward/finalTable.xhtml
+++ b/src/main/webapp/resources/inward/finalTable.xhtml
@@ -86,17 +86,25 @@
                     </h:outputLabel>
                 </p:column>
                 
-                <p:column headerText="Difference"  style="text-align: right;">
+                <p:column headerText="Difference"  style="text-align: center; width: 12em;" exportable="false">
                     <h:panelGroup style="font-size: 18px; font-weight: 700">
-                        <h:outputText styleClass="fas fa-arrow-down mx-1"
-                                      style="color: red;"
-                                      rendered="#{(bip.adjustedValue - bip.netValue) lt 0}" />
-                        <h:outputText styleClass="fas fa-arrow-up mx-1"
-                                      style="color: green;"
-                                      rendered="#{(bip.adjustedValue - bip.netValue) gt 0}" />
-                        <h:outputLabel  value="#{bip.adjustedValue - bip.netValue}">
-                            <f:convertNumber pattern="#,##0.00" />
-                        </h:outputLabel>
+                        <h:panelGroup rendered="#{(bip.adjustedValue - bip.netValue) ge 0.005}" style="color: green;">
+                            <h:outputText styleClass="fas fa-arrow-up mx-1" />
+                            <h:outputLabel value="#{bip.adjustedValue - bip.netValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{(bip.adjustedValue - bip.netValue) le -0.005}" style="color: red;">
+                            <h:outputText styleClass="fas fa-arrow-down mx-1" />
+                            <h:outputLabel value="#{bip.adjustedValue - bip.netValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{(bip.adjustedValue - bip.netValue) gt -0.005 and (bip.adjustedValue - bip.netValue) lt 0.005}" style="color: blue;">
+                            <h:outputLabel value="0">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </h:panelGroup>
                     </h:panelGroup>
                 </p:column>
 

--- a/src/main/webapp/resources/inward/finalTable.xhtml
+++ b/src/main/webapp/resources/inward/finalTable.xhtml
@@ -36,10 +36,17 @@
                 .noDisplayRow {
                     display: none;
                 }
+                .bhtFinalTable .ui-datatable-data td,
+                .bhtFinalTable .ui-datatable-data th,
+                .bhtFinalTable thead th,
+                .bhtFinalTable tbody td,
+                .bhtFinalTable tfoot td {
+                    padding: 8px !important;
+                }
             </style>
  
             <p:dataTable id="tb1"
-                         class="mt-2"
+                         styleClass="mt-2 bhtFinalTable"
                          value="#{cc.attrs.bill.billItems}" 
                          var="bip"
                          rowIndexVar="i"

--- a/src/main/webapp/resources/inward/finalTable.xhtml
+++ b/src/main/webapp/resources/inward/finalTable.xhtml
@@ -50,7 +50,7 @@
                 styleClass="mt-2 bhtFinalTable"
                 value="#{cc.attrs.bill.billItems}" 
                 var="bip"
-                rowStyleClass="#{(bip.adjustedValue ne 0) ? '' : 'noDisplayRow' }">
+                rowStyleClass="#{(bip.adjustedValue ne 0 or bip.netValue ne 0) ? '' : 'noDisplayRow' }">
                 
                 <p:column headerText="Inward Charge Type">
                     <h:outputLabel   value="#{bip.inwardChargeType.name}"/>

--- a/src/main/webapp/resources/inward/finalTable.xhtml
+++ b/src/main/webapp/resources/inward/finalTable.xhtml
@@ -42,12 +42,9 @@
                          class="mt-2"
                          value="#{cc.attrs.bill.billItems}" 
                          var="bip"
-                         rowStyleClass="#{(bip.grossValue ne 0) ? '' : 'noDisplayRow' }"
+                         rowIndexVar="i"
+                         rowStyleClass="#{(bip.adjustedValue ne 0) ? '' : 'noDisplayRow' }"
                          >
-                <p:column headerText="searialNo">
-                    #{bip.id}
-                    <h:outputLabel   value="#{bip.searialNo}"/>
-                </p:column>
                 <p:column headerText="Inward Charge Type">
                     <h:outputLabel   value="#{bip.inwardChargeType.name}"/>
                 </p:column>
@@ -88,6 +85,21 @@
                         <f:convertNumber pattern="#,##0.00" />
                     </h:outputLabel>
                 </p:column>
+                
+                <p:column headerText="Difference"  style="text-align: right;">
+                    <h:panelGroup style="font-size: 18px; font-weight: 700">
+                        <h:outputText styleClass="fas fa-arrow-down mx-1"
+                                      style="color: red;"
+                                      rendered="#{(bip.adjustedValue - bip.netValue) lt 0}" />
+                        <h:outputText styleClass="fas fa-arrow-up mx-1"
+                                      style="color: green;"
+                                      rendered="#{(bip.adjustedValue - bip.netValue) gt 0}" />
+                        <h:outputLabel  value="#{bip.adjustedValue - bip.netValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </h:panelGroup>
+                </p:column>
+
 
             </p:dataTable>
 


### PR DESCRIPTION
## Issue

Closes #21105 — *Need To see Before edit Values*

Inward bill editing needed a way to verify all values before and after an edit, so that any change made through the edit process is accurately reflected without hidden discrepancies.

## Changes

**Difference visibility (core fix)**
- Added a **Difference** column to the inward final bill charges table showing `Adjusted Value − Net Value`, making before/after edit differences visible at a glance.
- Coloured the arrow and value by sign — green (increase), red (decrease) — and show a blue `0.00` when the difference rounds to zero at two decimals.
- Difference is excluded from the Excel export and the table cells now use 8px padding for readability.

**Bill summary & inputs**
- Restyled the provisional and final-reprint bill summary panels: larger text, row spacing, and two-decimal number formatting.
- Discount and charge inputs now format to two decimals, right-align, and select-on-focus.
- Added a chart icon to the **View Charges** button and fixed checkbox indentation on the reprint page.

**Navigation**
- The Bill No column is now a direct link to the bill edit / reprint page on both the provisional and final search pages, replacing the separate **View Bill** button column.

**Cleanup**
- Removed an unused hidden print-button panel and tidied command-button markup on the final/interim bill pages.

## Test Plan

**Difference column**
1. Open an inward final bill that has charges and edit an adjusted value so it differs from the net value.
2. Confirm the **Difference** column shows `Adjusted Value − Net Value`:
   - Increase → green value with an up arrow.
   - Decrease → red value with a down arrow.
   - Equal (rounds to zero at 2 decimals) → blue `0.00` with no arrow.
3. Verify rows with a zero adjusted value remain hidden.
4. Click **Download Excel** and confirm the Difference column is **not** exported, while all other columns match the on-screen values.
5. Confirm table cells render with comfortable 8px padding.

**Bill summary & inputs**
6. Open the provisional bill edit and final reprint pages; confirm the summary panel shows larger text, proper spacing, and all amounts formatted to two decimals.
7. Focus a discount/charge input and confirm the value is selected on focus and formats to two decimals.
8. Confirm the **View Charges** button shows the chart icon and the reprint-page checkbox is aligned correctly.

**Navigation**
9. From the provisional search page, click a **Bill No** and confirm it opens the corresponding bill edit page directly.
10. From the final search page, click a **Bill No** and confirm it opens the final reprint page directly.
11. Confirm the standalone **View Bill** button column is gone from both search pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bill No cells now act as direct navigation links to view/edit provisional and final bills.
  * Added a "Difference" column in final table with visual indicators for positive/negative/zero deltas.

* **UI/UX Improvements**
  * Removed redundant "View Bill" buttons for cleaner tables.
  * Consolidated and improved bill-detail layouts, spacing, and table styling across inward screens.
  * Minor whitespace and markup refinements for more consistent rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmislk/hmis/pull/21202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
