### PR TITLE
Set PatientRegistrationSource on new patients in ChannelBillController (#21200, #21201)

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelBillController.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.BillType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.HistoryType;
 import com.divudi.core.data.MessageType;
+import com.divudi.core.data.PatientRegistrationSource;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.ejb.BillNumberGenerator;
@@ -2219,11 +2220,24 @@ public class ChannelBillController implements Serializable {
                 getNewPatient().setCreatedAt(new Date());
                 getNewPatient().getPerson().setCreater(getSessionController().getLoggedUser());
                 getNewPatient().getPerson().setCreatedAt(new Date());
+                getNewPatient().setRegistrationSource(resolveRegistrationSource());
                 getPersonFacade().create(getNewPatient().getPerson());
                 getPatientFacade().create(getNewPatient());
                 break;
             case "tabSearchPt":
                 break;
+        }
+    }
+
+    private PatientRegistrationSource resolveRegistrationSource() {
+        if (paymentMethod == PaymentMethod.OnCall) {
+            return PatientRegistrationSource.CALL_CENTRE;
+        } else if (paymentMethod == PaymentMethod.Agent || paymentMethod == PaymentMethod.OnlineBookingAgent) {
+            return PatientRegistrationSource.THIRD_PARTY_AGENT;
+        } else if (paymentMethod == PaymentMethod.OnlineSettlement) {
+            return PatientRegistrationSource.ONLINE_SELF;
+        } else {
+            return PatientRegistrationSource.WALK_IN;
         }
     }
 


### PR DESCRIPTION
## Summary

- In `ChannelBillController.savePatient()`, new patients now get their `registrationSource` set based on the booking's payment method via a new `resolveRegistrationSource()` helper
- `PaymentMethod.OnCall` → `CALL_CENTRE` (#21200)
- `PaymentMethod.Agent` / `PaymentMethod.OnlineBookingAgent` → `THIRD_PARTY_AGENT` (#21201)
- `PaymentMethod.OnlineSettlement` → `ONLINE_SELF` (coordinated per issue specs)
- All other payment methods → `WALK_IN` (safe default)
- Existing patients found via search (`tabSearchPt`) are untouched

## Test plan

- [ ] Book a channel via OnCall payment — new patient has `registrationSource = CALL_CENTRE`
- [ ] Book via Agent payment — new patient has `registrationSource = THIRD_PARTY_AGENT`
- [ ] Book via OnlineBookingAgent payment — new patient has `registrationSource = THIRD_PARTY_AGENT`
- [ ] Book via OnlineSettlement — new patient has `registrationSource = ONLINE_SELF`
- [ ] Book via Cash/Card — new patient has `registrationSource = WALK_IN`
- [ ] Search for existing patient during booking — `registrationSource` unchanged

Closes #21200
Closes #21201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient registration source is now automatically captured and tracked when creating new patient records. The system categorizes patient registrations into four distinct channels: call centre, third-party agent, online self-registration, or walk-in, based on payment method information provided during registration. This improves patient data collection and tracking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->