### PR TITLE
Deprecate selfRegistered — migrate portal to PatientRegistrationSource (#21199)

### DIFF
--- a/src/main/java/com/divudi/bean/channel/PatientPortalController.java
+++ b/src/main/java/com/divudi/bean/channel/PatientPortalController.java
@@ -234,7 +234,6 @@ public class PatientPortalController implements Serializable {
         patient.setPatientMobileNumber(phoneAsLong);
         patient.getPerson().setPhone(patientphoneNumber);
         patient.getPerson().setMobile(patientphoneNumber);
-        patient.setSelfRegistered(true);
         patient.setRegistrationSource(PatientRegistrationSource.ONLINE_SELF);
         patientController.save(patient);
         addNewPatient = false;

--- a/src/main/java/com/divudi/core/entity/Patient.java
+++ b/src/main/java/com/divudi/core/entity/Patient.java
@@ -147,16 +147,6 @@ public class Patient implements Serializable, RetirableEntity {
     private String specificStatusComment;
     
     /**
-     * @deprecated Superseded by {@link #registrationSource}. Kept for backward
-     * compatibility and existing portal logic. New code should read/write
-     * {@code registrationSource} instead; {@code selfRegistered == true} maps to
-     * {@link PatientRegistrationSource#ONLINE_SELF}. Physical removal is deferred
-     * until the data migration has run on all deployments. (Issue #21181)
-     */
-    @Deprecated
-    private Boolean selfRegistered = false;
-
-    /**
      * How this patient was first registered. Set once at creation and never
      * changed. Null for patients created before this feature. (Issue #21181)
      *
@@ -815,25 +805,6 @@ public class Patient implements Serializable, RetirableEntity {
 
     public void setSpecificStatusComment(String specificStatusComment) {
         this.specificStatusComment = specificStatusComment;
-    }
-
-    /**
-     * @deprecated Use {@link #getRegistrationSource()} instead. (Issue #21181)
-     */
-    @Deprecated
-    public Boolean getSelfRegistered() {
-        if(selfRegistered == null){
-            return false;
-        }
-        return selfRegistered;
-    }
-
-    /**
-     * @deprecated Use {@link #setRegistrationSource(PatientRegistrationSource)} instead. (Issue #21181)
-     */
-    @Deprecated
-    public void setSelfRegistered(Boolean selfRegistered) {
-        this.selfRegistered = selfRegistered;
     }
 
     public PatientRegistrationSource getRegistrationSource() {

--- a/src/main/resources/db/migrations/v2.10.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.10.0/migration.sql
@@ -1,0 +1,26 @@
+-- Migration v2.10.0: Backfill registrationSource from selfRegistered and drop selfRegistered column
+-- Issue: hmislk/hmis#21199
+--
+-- Background:
+--   Patient.selfRegistered (Boolean) was superseded by Patient.registrationSource
+--   (PatientRegistrationSource enum) introduced in #21181. Patients that were
+--   self-registered via the patient portal had selfRegistered=true; those rows now
+--   need registrationSource='ONLINE_SELF'. Once migrated the column is dropped.
+--
+-- Idempotent: UPDATE only touches rows where registrationSource is not yet set.
+--             DROP COLUMN uses IF EXISTS so re-running after the column is gone is safe.
+
+SELECT 'Migration v2.10.0 - Backfill registrationSource from selfRegistered' AS status;
+
+-- Step 1: backfill ONLINE_SELF for all formerly self-registered patients
+UPDATE patient
+SET registrationSource = 'ONLINE_SELF'
+WHERE selfRegistered = 1
+  AND (registrationSource IS NULL OR registrationSource = '');
+
+SELECT CONCAT('Rows backfilled to ONLINE_SELF: ', ROW_COUNT()) AS backfill_status;
+
+-- Step 2: drop the now-redundant selfRegistered column
+ALTER TABLE patient DROP COLUMN IF EXISTS selfRegistered;
+
+SELECT 'Migration v2.10.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.10.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.10.0/migration.sql
@@ -3,24 +3,83 @@
 --
 -- Background:
 --   Patient.selfRegistered (Boolean) was superseded by Patient.registrationSource
---   (PatientRegistrationSource enum) introduced in #21181. Patients that were
---   self-registered via the patient portal had selfRegistered=true; those rows now
---   need registrationSource='ONLINE_SELF'. Once migrated the column is dropped.
+--   (PatientRegistrationSource enum) introduced in #21181. v2.1.19 back-filled
+--   REGISTRATIONSOURCE = 'ONLINE_SELF' for selfRegistered=1 rows at the time of
+--   that migration. This migration mops up any rows created since then with the
+--   legacy path, then drops the column entirely now that all Java code has been
+--   migrated to use registrationSource.
 --
--- Idempotent: UPDATE only touches rows where registrationSource is not yet set.
---             DROP COLUMN uses IF EXISTS so re-running after the column is gone is safe.
+-- UNIVERSAL: Detects actual table name case (PATIENT vs patient) so this script
+-- works on both case-sensitive (Linux, lower_case_table_names=0) and
+-- case-insensitive (Windows) MySQL instances.
+--
+-- IDEMPOTENT: Both steps gate on INFORMATION_SCHEMA existence checks, so this
+-- migration can be safely re-run after the column has already been dropped.
 
-SELECT 'Migration v2.10.0 - Backfill registrationSource from selfRegistered' AS status;
+SELECT 'Migration v2.10.0 - Backfill registrationSource and drop selfRegistered column' AS status;
 
--- Step 1: backfill ONLINE_SELF for all formerly self-registered patients
-UPDATE patient
-SET registrationSource = 'ONLINE_SELF'
-WHERE selfRegistered = 1
-  AND (registrationSource IS NULL OR registrationSource = '');
+-- ==========================================
+-- STEP 0: DETECT ACTUAL TABLE NAME CASE
+-- ==========================================
 
-SELECT CONCAT('Rows backfilled to ONLINE_SELF: ', ROW_COUNT()) AS backfill_status;
+SET @patient_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENT'
+    LIMIT 1
+);
 
--- Step 2: drop the now-redundant selfRegistered column
-ALTER TABLE patient DROP COLUMN IF EXISTS selfRegistered;
+SELECT CONCAT('Detected patient table as: ', IFNULL(@patient_table, '(not found)')) AS info;
+
+-- ==========================================
+-- STEP 1: BACKFILL REMAINING ONLINE_SELF ROWS
+-- ==========================================
+-- Only runs when the legacy column still exists so this step is safe to skip on
+-- databases where the column was already removed.
+
+SET @has_self_reg = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @patient_table
+      AND UPPER(COLUMN_NAME) = 'SELFREGISTERED'
+);
+
+SET @sql = IF(@patient_table IS NOT NULL AND @has_self_reg > 0,
+              CONCAT('UPDATE ', @patient_table,
+                     ' SET REGISTRATIONSOURCE = ''ONLINE_SELF''',
+                     ' WHERE SELFREGISTERED = 1 AND (REGISTRATIONSOURCE IS NULL OR REGISTRATIONSOURCE = '''')'),
+              'SELECT 1 /* selfRegistered column already absent, skipping backfill */');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT IF(@has_self_reg > 0,
+          CONCAT('Rows backfilled to ONLINE_SELF: ', ROW_COUNT()),
+          'Backfill skipped — selfRegistered column not present') AS backfill_status;
+
+-- ==========================================
+-- STEP 2: DROP THE REDUNDANT COLUMN
+-- ==========================================
+
+SET @sql = IF(@patient_table IS NOT NULL AND @has_self_reg > 0,
+              CONCAT('ALTER TABLE ', @patient_table, ' DROP COLUMN SELFREGISTERED'),
+              'SELECT 1 /* selfRegistered column already absent, skipping drop */');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 3: VERIFY
+-- ==========================================
+
+SET @sql = IF(@patient_table IS NOT NULL,
+              CONCAT('SELECT REGISTRATIONSOURCE AS registration_source, COUNT(*) AS patients FROM ',
+                     @patient_table, ' GROUP BY REGISTRATIONSOURCE'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SELECT 'Migration v2.10.0 completed' AS final_status;

--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -470,12 +470,14 @@
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
 
-                                                    <h:outputLabel value="Registered Type" class="mx-3"/>
-                                                    <h:outputLabel value=" : " class="mx-3"/>
-                                                    <p:badge 
-                                                        value="#{opdBillController.patient.selfRegistered eq true ? 'Self Registered' : 'System Registered'}"
-                                                        severity="#{opdBillController.patient.selfRegistered eq true ? 'warning' : 'success'}">
-                                                    </p:badge>
+                                                    <h:panelGroup rendered="#{not empty opdBillController.patient.registrationSource}">
+                                                        <h:outputLabel value="Registration Source" class="mx-3"/>
+                                                        <h:outputLabel value=" : " class="mx-3"/>
+                                                        <p:badge
+                                                            value="#{opdBillController.patient.registrationSource.label}"
+                                                            severity="info">
+                                                        </p:badge>
+                                                    </h:panelGroup>
 
                                                     <h:outputLabel value="Area " class="mx-3"/>
                                                     <h:outputLabel value=" : " class="mx-3"/>

--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -477,12 +477,14 @@
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputText>
                                                     
-                                                    <h:outputLabel value="Registered Type" class="mx-3"/>
-                                                    <h:outputLabel value=" : " class="mx-3"/>
-                                                    <p:badge 
-                                                        value="#{opdBillController.patient.selfRegistered eq true ? 'Self Registered' : 'System Registered'}"
-                                                        severity="#{opdBillController.patient.selfRegistered eq true ? 'warning' : 'success'}">
-                                                    </p:badge>
+                                                    <h:panelGroup rendered="#{not empty opdBillController.patient.registrationSource}">
+                                                        <h:outputLabel value="Registration Source" class="mx-3"/>
+                                                        <h:outputLabel value=" : " class="mx-3"/>
+                                                        <p:badge
+                                                            value="#{opdBillController.patient.registrationSource.label}"
+                                                            severity="info">
+                                                        </p:badge>
+                                                    </h:panelGroup>
 
                                                     <h:outputLabel value="Area " class="mx-3"/>
                                                     <h:outputLabel value=" : " class="mx-3"/>

--- a/src/main/webapp/opd/patient.xhtml
+++ b/src/main/webapp/opd/patient.xhtml
@@ -258,14 +258,6 @@
                                                 </div>
 
                                                 <div class="col-md-4">
-                                                    <div class="mb-3">
-                                                        <strong class="text-muted">Registered Type</strong><br/>
-                                                        <p:badge
-                                                            value="#{patientController.current.selfRegistered eq true ? 'Self Registered' : 'System Registered'}"
-                                                            severity="#{patientController.current.selfRegistered eq true ? 'warning' : 'success'}">
-                                                        </p:badge>
-                                                    </div>
-
                                                     <h:panelGroup layout="block" styleClass="mb-3" rendered="#{not empty patientController.current.registrationSource}">
                                                         <strong class="text-muted">Registration Source</strong><br/>
                                                         <p:badge

--- a/src/main/webapp/patient_portal/portal_login.xhtml
+++ b/src/main/webapp/patient_portal/portal_login.xhtml
@@ -1875,7 +1875,7 @@
                                             </span>
                                         </div>
                                         
-                                        <h:panelGroup rendered="#{patientPortalController.patient.selfRegistered}" layout="block">
+                                        <h:panelGroup rendered="#{patientPortalController.patient.registrationSource eq 'ONLINE_SELF'}" layout="block">
                                             <span class="badge-self-registered">
                                                 <i class="fas fa-user-pen"/>
                                                 Self Registered


### PR DESCRIPTION
## Summary

- **`Patient.java`**: Removed `selfRegistered` field, getter, and setter (was already `@Deprecated` since #21181)
- **`PatientPortalController.java`**: Removed the now-redundant `patient.setSelfRegistered(true)` call; `setRegistrationSource(ONLINE_SELF)` was already in place
- **`patient.xhtml`**: Removed the old "Registered Type" `selfRegistered` badge — the "Registration Source" badge from #21181 already covers this
- **`opd_bill.xhtml` / `opd_bill_ac.xhtml`**: Replaced `selfRegistered` badge with `registrationSource.label` badge (conditionally rendered when source is set)
- **`portal_login.xhtml`**: Changed `rendered` condition from `patient.selfRegistered` to `patient.registrationSource eq 'ONLINE_SELF'`
- **`db/migrations/v2.10.0/migration.sql`**: Backfills `registrationSource='ONLINE_SELF'` for all rows where `selfRegistered=1` and source is null, then drops the `selfRegistered` column

## Test plan

- [ ] Portal self-registration: new patient gets `registrationSource = ONLINE_SELF`; portal login shows "Self Registered" badge
- [ ] OPD bill / OPD bill AC: patients with a registrationSource show the source label; patients without (pre-feature) show nothing
- [ ] Patient profile (`patient.xhtml`): old "Registered Type" badge gone; "Registration Source" badge still shows for sourced patients
- [ ] Migration v2.10.0: backfills ONLINE_SELF for legacy `selfRegistered=1` rows; drops the column cleanly

Closes #21199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Interface**
  * Replaced 'Registered Type' badge with 'Registration Source' display across all patient profile views for improved clarity and consistency.

* **Database**
  * Automatic data migration preserves existing patient registration information during upgrade to v2.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->