### PR TITLE
feat(pharmacy): add DTO-based Stock Consumption report page

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -33,6 +33,7 @@ import com.divudi.core.data.dto.MovementReportDto;
 import com.divudi.core.data.dto.AmpDto;
 import com.divudi.core.data.dto.BillItemDTO;
 import com.divudi.core.data.dto.CostOfGoodSoldBillDTO;
+import com.divudi.core.data.dto.StockConsumptionItemDto;
 import com.divudi.core.data.dto.ExpiryItemListDto;
 import com.divudi.core.data.dto.ExpiryItemStockListDto;
 import com.divudi.core.data.dto.StockLedgerDTO;
@@ -387,6 +388,11 @@ public class PharmacyReportController implements Serializable {
     private double totalPurchaseValue;
     private double totalRetailValue;
     private double totalSaleValue;
+
+    private List<StockConsumptionItemDto> stockConsumptionItemDtos;
+    private double dtoStockConsumptionPurchaseTotal;
+    private double dtoStockConsumptionCostTotal;
+    private double dtoStockConsumptionRetailTotal;
 
     // Maps to store remaining quantities and values for Good In Transit report
     private Map<Long, Double> billItemRemainingQuantities = new HashMap<>();
@@ -6226,6 +6232,131 @@ public class PharmacyReportController implements Serializable {
         btasToGetBillItems.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
         retrieveBillItemsCompleted(btasToGetBillItems, true);
         calculateStockConsumptionTotals(billItems);
+    }
+
+    public void processStockConsumptionDto() {
+        stockConsumptionItemDtos = new ArrayList<>();
+        dtoStockConsumptionPurchaseTotal = 0.0;
+        dtoStockConsumptionCostTotal = 0.0;
+        dtoStockConsumptionRetailTotal = 0.0;
+        try {
+            List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
+
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT bi.id, b.id, b.deptId, ");
+            jpql.append("refBill.id, refBill.deptId, ");
+            jpql.append("b.createdAt, ");
+            jpql.append("i.name, i.code, ");
+            jpql.append("ib.batchNo, ");
+            jpql.append("bi.qty, ");
+            jpql.append("pbi.purchaseRate, bifd.valueAtPurchaseRate, ");
+            jpql.append("ib.costRate, bifd.valueAtCostRate, ");
+            jpql.append("ib.retailsaleRate, bifd.valueAtRetailRate, ");
+            jpql.append("toDept.name, b.comments, mu.name, ");
+            jpql.append("b.billTypeAtomic ");
+            jpql.append("FROM BillItem bi ");
+            jpql.append("JOIN bi.bill b ");
+            jpql.append("LEFT JOIN b.referenceBill refBill ");
+            jpql.append("LEFT JOIN bi.item i ");
+            jpql.append("LEFT JOIN bi.pharmaceuticalBillItem pbi ");
+            jpql.append("LEFT JOIN pbi.itemBatch ib ");
+            jpql.append("LEFT JOIN bi.billItemFinanceDetails bifd ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN i.issueUnit mu ");
+            jpql.append("WHERE (bi.retired = false OR bi.retired IS NULL) ");
+            jpql.append("AND (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (department != null) {
+                jpql.append("AND b.department = :department ");
+                params.put("department", department);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = billItemFacade.findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[19] != null ? (BillTypeAtomic) row[19] : null;
+                double valueSign = stockConsumptionValueSign(bta);
+                double qtySign = stockConsumptionQtySign(bta);
+
+                double rawQty = row[9] != null ? ((Number) row[9]).doubleValue() : 0.0;
+                double rawPurchaseRate = row[10] != null ? ((Number) row[10]).doubleValue() : 0.0;
+                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : 0.0;
+                double rawCostRate = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
+                double rawCostVal = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
+                double rawRetailRate = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
+                double rawRetailVal = row[15] != null ? ((Number) row[15]).doubleValue() : 0.0;
+
+                double qty = qtySign * rawQty;
+                double purchaseVal = valueSign * rawPurchaseVal;
+                double costVal = valueSign * rawCostVal;
+                double retailVal = valueSign * rawRetailVal;
+
+                StockConsumptionItemDto dto = new StockConsumptionItemDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        row[1] != null ? ((Number) row[1]).longValue() : null,
+                        (String) row[2],
+                        row[3] != null ? ((Number) row[3]).longValue() : null,
+                        (String) row[4],
+                        (java.util.Date) row[5],
+                        (String) row[6],
+                        (String) row[7],
+                        (String) row[8],
+                        qty,
+                        rawPurchaseRate,
+                        purchaseVal,
+                        rawCostRate,
+                        costVal,
+                        rawRetailRate,
+                        retailVal,
+                        (String) row[16],
+                        (String) row[17],
+                        (String) row[18]
+                );
+
+                stockConsumptionItemDtos.add(dto);
+                dtoStockConsumptionPurchaseTotal += purchaseVal;
+                dtoStockConsumptionCostTotal += costVal;
+                dtoStockConsumptionRetailTotal += retailVal;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyReportController.class.getName()).log(Level.SEVERE, "Error generating stock consumption DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Stock Consumption DTO report.");
+        }
+    }
+
+    private static double stockConsumptionValueSign(BillTypeAtomic bta) {
+        return -1.0;
+    }
+
+    private static double stockConsumptionQtySign(BillTypeAtomic bta) {
+        if (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN) {
+            return -1.0;
+        }
+        return 1.0;
     }
 
     public void exportStockConsumptionToExcel() {
@@ -18317,5 +18448,25 @@ public class PharmacyReportController implements Serializable {
             filename += "_" + dates;
         }
         return filename;
+    }
+
+    public List<StockConsumptionItemDto> getStockConsumptionItemDtos() {
+        return stockConsumptionItemDtos;
+    }
+
+    public void setStockConsumptionItemDtos(List<StockConsumptionItemDto> stockConsumptionItemDtos) {
+        this.stockConsumptionItemDtos = stockConsumptionItemDtos;
+    }
+
+    public double getDtoStockConsumptionPurchaseTotal() {
+        return dtoStockConsumptionPurchaseTotal;
+    }
+
+    public double getDtoStockConsumptionCostTotal() {
+        return dtoStockConsumptionCostTotal;
+    }
+
+    public double getDtoStockConsumptionRetailTotal() {
+        return dtoStockConsumptionRetailTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -6304,11 +6304,14 @@ public class PharmacyReportController implements Serializable {
 
                 double rawQty = row[9] != null ? ((Number) row[9]).doubleValue() : 0.0;
                 double rawPurchaseRate = row[10] != null ? ((Number) row[10]).doubleValue() : 0.0;
-                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : 0.0;
                 double rawCostRate = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
-                double rawCostVal = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
                 double rawRetailRate = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
-                double rawRetailVal = row[15] != null ? ((Number) row[15]).doubleValue() : 0.0;
+                // RETURN stores bifd values as positive (inflow); ISSUE/CANCELLED as negative (outflow).
+                // When bifd row is absent fall back to qty*rate with matching sign.
+                double bifdSign = (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN) ? 1.0 : -1.0;
+                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : bifdSign * rawQty * rawPurchaseRate;
+                double rawCostVal     = row[13] != null ? ((Number) row[13]).doubleValue() : bifdSign * rawQty * rawCostRate;
+                double rawRetailVal   = row[15] != null ? ((Number) row[15]).doubleValue() : bifdSign * rawQty * rawRetailRate;
 
                 double qty = qtySign * rawQty;
                 double purchaseVal = valueSign * rawPurchaseVal;

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -18462,11 +18462,23 @@ public class PharmacyReportController implements Serializable {
         return dtoStockConsumptionPurchaseTotal;
     }
 
+    public void setDtoStockConsumptionPurchaseTotal(double dtoStockConsumptionPurchaseTotal) {
+        this.dtoStockConsumptionPurchaseTotal = dtoStockConsumptionPurchaseTotal;
+    }
+
     public double getDtoStockConsumptionCostTotal() {
         return dtoStockConsumptionCostTotal;
     }
 
+    public void setDtoStockConsumptionCostTotal(double dtoStockConsumptionCostTotal) {
+        this.dtoStockConsumptionCostTotal = dtoStockConsumptionCostTotal;
+    }
+
     public double getDtoStockConsumptionRetailTotal() {
         return dtoStockConsumptionRetailTotal;
+    }
+
+    public void setDtoStockConsumptionRetailTotal(double dtoStockConsumptionRetailTotal) {
+        this.dtoStockConsumptionRetailTotal = dtoStockConsumptionRetailTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -6391,7 +6391,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             case "Drug Return Op":
                 return "/reports/inventoryReports/op_drug_return?faces-redirect=true";
             case "Stock Consumption":
-                return "/reports/inventoryReports/stock_consumption?faces-redirect=true";
+                return "/reports/inventoryReports/stock_consumption_dto?faces-redirect=true";
             case "Purchase Return":
                 return "/reports/inventoryReports/purchase_return?faces-redirect=true";
             case "Stock Adjustment Receive":

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -6374,6 +6374,10 @@ public class ReportController implements Serializable, ControllerWithReportFilte
     public String navigateToCostOfGoodSoldReports() {
         pharmacyReportController.setBillItems(new ArrayList<>());
         pharmacyReportController.setNetTotal(0.0);
+        pharmacyReportController.setStockConsumptionItemDtos(new ArrayList<>());
+        pharmacyReportController.setDtoStockConsumptionPurchaseTotal(0.0);
+        pharmacyReportController.setDtoStockConsumptionCostTotal(0.0);
+        pharmacyReportController.setDtoStockConsumptionRetailTotal(0.0);
 
         if (reportTemplateFileIndexName == null) {
             return "";

--- a/src/main/java/com/divudi/core/data/dto/StockConsumptionItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/StockConsumptionItemDto.java
@@ -1,0 +1,103 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class StockConsumptionItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long billId;
+    private String deptId;
+    private Long referenceBillId;
+    private String referenceBillDeptId;
+    private Date createdAt;
+    private String itemName;
+    private String itemCode;
+    private String batchNo;
+    private double qty;
+    private double purchaseRate;
+    private double purchaseValue;
+    private double costRate;
+    private double costValue;
+    private double retailRate;
+    private double retailValue;
+    private String toDepartmentName;
+    private String comments;
+    private String measurementUnitName;
+
+    public StockConsumptionItemDto() {}
+
+    public StockConsumptionItemDto(
+            Long billItemId, Long billId, String deptId,
+            Long referenceBillId, String referenceBillDeptId,
+            Date createdAt, String itemName, String itemCode, String batchNo,
+            double qty,
+            double purchaseRate, double purchaseValue,
+            double costRate, double costValue,
+            double retailRate, double retailValue,
+            String toDepartmentName, String comments, String measurementUnitName) {
+        this.billItemId = billItemId;
+        this.billId = billId;
+        this.deptId = deptId;
+        this.referenceBillId = referenceBillId;
+        this.referenceBillDeptId = referenceBillDeptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.batchNo = batchNo;
+        this.qty = qty;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue;
+        this.costRate = costRate;
+        this.costValue = costValue;
+        this.retailRate = retailRate;
+        this.retailValue = retailValue;
+        this.toDepartmentName = toDepartmentName;
+        this.comments = comments;
+        this.measurementUnitName = measurementUnitName;
+    }
+
+    public double getNetTotal() {
+        return purchaseValue;
+    }
+
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+    public Long getReferenceBillId() { return referenceBillId; }
+    public void setReferenceBillId(Long referenceBillId) { this.referenceBillId = referenceBillId; }
+    public String getReferenceBillDeptId() { return referenceBillDeptId; }
+    public void setReferenceBillDeptId(String referenceBillDeptId) { this.referenceBillDeptId = referenceBillDeptId; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public String getItemCode() { return itemCode; }
+    public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+    public String getBatchNo() { return batchNo; }
+    public void setBatchNo(String batchNo) { this.batchNo = batchNo; }
+    public double getQty() { return qty; }
+    public void setQty(double qty) { this.qty = qty; }
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+    public double getPurchaseValue() { return purchaseValue; }
+    public void setPurchaseValue(double purchaseValue) { this.purchaseValue = purchaseValue; }
+    public double getCostRate() { return costRate; }
+    public void setCostRate(double costRate) { this.costRate = costRate; }
+    public double getCostValue() { return costValue; }
+    public void setCostValue(double costValue) { this.costValue = costValue; }
+    public double getRetailRate() { return retailRate; }
+    public void setRetailRate(double retailRate) { this.retailRate = retailRate; }
+    public double getRetailValue() { return retailValue; }
+    public void setRetailValue(double retailValue) { this.retailValue = retailValue; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+    public String getMeasurementUnitName() { return measurementUnitName; }
+    public void setMeasurementUnitName(String measurementUnitName) { this.measurementUnitName = measurementUnitName; }
+}

--- a/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
@@ -1,0 +1,378 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Stock Consumption (DTO)">
+
+                        <h:panelGrid columns="8" class="w-100">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="From Date" for="fromDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="fromDate"
+                                value="#{pharmacyReportController.fromDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="To Date" for="toDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="toDate"
+                                value="#{pharmacyReportController.toDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department Type" for="departmentTypeFilter" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyReportController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all departments.">
+                                    <f:selectItems
+                                        value="#{pharmacyReportController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all departments." position="top"/>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university mr-2"/>
+                                <p:outputLabel value="Institution" for="phmIns" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmIns"
+                                class="w-100"
+                                value="#{pharmacyReportController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions"/>
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}"/>
+                                <p:ajax process="phmIns" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt mr-2"/>
+                                <p:outputLabel value="Site" for="phmSite" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmSite"
+                                class="w-100"
+                                value="#{pharmacyReportController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites"/>
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}"/>
+                                <p:ajax process="phmSite" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department" for="phmDept" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="phmDept">
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution, pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <div class="d-flex align-items-center mt-5">
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-arrow-left"
+                                ajax="false"
+                                value="Back"
+                                action="#{reportController.navigateToCostOfGoodsSold()}"/>
+
+                            <p:commandButton
+                                class="ui-button-warning mx-1"
+                                icon="fas fa-cogs"
+                                ajax="false"
+                                value="Process"
+                                action="#{pharmacyReportController.processStockConsumptionDto()}"/>
+
+                            <p:commandButton
+                                class="ui-button- mx-1"
+                                icon="fas fa-print"
+                                ajax="false"
+                                value="Print"
+                                onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-success mx-1"
+                                icon="fas fa-file-excel"
+                                ajax="false"
+                                value="Download">
+                                <p:dataExporter type="xlsx" target="tblDto"
+                                                fileName="Stock_Consumption_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-danger mx-1"
+                                icon="fas fa-file-pdf"
+                                ajax="false"
+                                value="PDF">
+                                <p:dataExporter type="pdf" target="tblDto"
+                                                fileName="Stock_Consumption_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-exchange-alt"
+                                ajax="false"
+                                value="View Legacy Report"
+                                title="Switch to the entity-based report for cross-checking"
+                                action="stock_consumption?faces-redirect=true"/>
+                        </div>
+
+                        <h:outputScript>
+                            function hidePaginatorBeforePrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = 'none');
+                            }
+                            function restorePaginatorAfterPrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = '');
+                            }
+                            window.onafterprint = function () { restorePaginatorAfterPrint(); };
+                        </h:outputScript>
+
+                        <p:dataTable id="tblDto"
+                                     value="#{pharmacyReportController.stockConsumptionItemDtos}"
+                                     var="f"
+                                     rowIndexVar="n"
+                                     rowKey="#{f.billItemId}"
+                                     paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                     rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                            <p:column headerText="Date" width="5em">
+                                <h:outputText value="#{f.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="Total"/>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Item Name" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.itemName}">
+                                <h:outputText value="#{f.itemName}"/>
+                            </p:column>
+
+                            <p:column headerText="Batch Code" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.batchNo}">
+                                <h:outputText value="#{f.batchNo}"/>
+                            </p:column>
+
+                            <p:column headerText="Doc No" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.deptId}">
+                                <h:outputText value="#{f.deptId}" class="m-1 w-100"/>
+                            </p:column>
+
+                            <p:column headerText="Ref. Doc No" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.referenceBillDeptId}">
+                                <h:outputText value="#{f.referenceBillDeptId}" class="m-1 w-100"/>
+                            </p:column>
+
+                            <p:column headerText="QTY" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.qty}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Code" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.itemCode}">
+                                <h:outputText value="#{f.itemCode}"/>
+                            </p:column>
+
+                            <p:column headerText="Purchase Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Purchase Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionPurchaseTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Cost Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cost Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionCostTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Retail Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.retailRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Retail Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.retailValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionRetailTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Net Total" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionPurchaseTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Consumption Department" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.toDepartmentName}">
+                                <h:outputText value="#{f.toDepartmentName}"/>
+                            </p:column>
+
+                            <p:column headerText="Remarks" width="5em">
+                                <h:outputText value="#{f.comments}"/>
+                            </p:column>
+
+                            <p:column headerText="UOM" width="5em">
+                                <h:outputText value="#{f.measurementUnitName}"/>
+                            </p:column>
+
+                            <p:column
+                                exportable="false"
+                                headerText="Actions"
+                                width="5em">
+                                <p:commandButton
+                                    value="View Bill"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.billId)}"
+                                    ajax="false"/>
+
+                                <p:commandButton
+                                    value="View Ref Bill"
+                                    rendered="#{f.referenceBillId != null}"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.referenceBillId)}"
+                                    ajax="false"/>
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

- Add `StockConsumptionItemDto` DTO class with all fields from the original `stock_consumption.xhtml` report
- Add `processStockConsumptionDto()` in `PharmacyReportController` using Object[] JPQL projection with LEFT JOINs (avoids full entity loading)
- Add `stock_consumption_dto.xhtml` — same filters as original, PrimeFaces dataTable, Print/Excel/PDF export, and a **View Legacy Report** link for accuracy cross-checking
- Update `ReportController` navigation so clicking "Stock Consumption" from the COGS page goes to the new DTO page (old page preserved at original URL)

**Bill types covered:** `PHARMACY_DISPOSAL_ISSUE`, `PHARMACY_DISPOSAL_ISSUE_CANCELLED`, `PHARMACY_DISPOSAL_ISSUE_RETURN`

**Sign convention matches original:**
- Values negated (stored as negative → displayed positive via `valueSign = -1.0`)
- QTY negated only for RETURN; ISSUE and CANCELLED show qty as-is

**Rate sources match original:** `pbi.purchaseRate`, `ib.costRate`, `ib.retailsaleRate` (not `BillItemFinanceDetails` rates which can be null on older records)

**UOM:** joins `i.issueUnit` (non-deprecated) instead of `i.measurementUnit`

## Test plan

- [ ] Navigate to Cost of Goods Sold → click "Stock Consumption" → lands on new DTO page
- [ ] Set date range and click Process → table populates
- [ ] Compare totals with "View Legacy Report" for the same date range — values should match
- [ ] Verify Print, Excel, and PDF export work
- [ ] Verify "View Bill" and "View Ref Bill" action buttons navigate correctly
- [ ] Verify filters (institution, site, department, department types) narrow results as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stock Consumption (DTO) report page with date range, institution/site/department cascading filters, and department-type selection.
  * Report shows item-level consumption rows with purchase/cost/retail rates and values, footer totals, and links to view related bills.
  * Added Print, XLSX, and PDF export actions and updated navigation to the new Stock Consumption DTO view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->