### PR TITLE
fix(pharmacy): negate PHARMACY_DISPOSAL_ISSUE_CANCELLED qty in stockConsumptionQtySign

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -6356,7 +6356,8 @@ public class PharmacyReportController implements Serializable {
     }
 
     private static double stockConsumptionQtySign(BillTypeAtomic bta) {
-        if (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN) {
+        if (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN
+                || bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED) {
             return -1.0;
         }
         return 1.0;


### PR DESCRIPTION
## Summary

- `stockConsumptionQtySign()` was only negating `PHARMACY_DISPOSAL_ISSUE_RETURN`; `PHARMACY_DISPOSAL_ISSUE_CANCELLED` was left as `+1.0`, causing cancelled disposal issues to appear as additional consumption
- Added `PHARMACY_DISPOSAL_ISSUE_CANCELLED` to the negative-sign condition so cancelled bills correctly reverse consumption quantity

## Test plan

- [ ] Run Stock Consumption DTO report over a date range that includes cancelled disposal bills — confirm cancelled rows show negative qty (reversal), not positive
- [ ] Confirm normal `PHARMACY_DISPOSAL_ISSUE` rows still show positive qty
- [ ] Confirm `PHARMACY_DISPOSAL_ISSUE_RETURN` rows still show negative qty
- [ ] Verify Excel export reflects the same signs

Closes #21224

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stock consumption quantity sign calculation in pharmacy reports to correctly treat both cancelled and returned disposal issues as negative quantities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->