### PR TITLE
feat(inward): inpatient document upload and management

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -215,6 +215,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode inwardClinicalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalDischarge, "Clinical Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDocumentUpload, "Document Upload"), inwardClinicalNode);
 
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -114,6 +114,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     @Inject
     InpatientClinicalDataController inpatientClinicalDataController;
     @Inject
+    InwardDocumentUploadController inwardDocumentUploadController;
+    @Inject
     PharmacyRequestForBhtController pharmacyRequestForBhtController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
@@ -423,6 +425,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     public String navigateToInpatientImages() {
         inpatientClinicalDataController.setCurrent(current);
         return inpatientClinicalDataController.navigateToImages();
+    }
+
+    public String navigateToInpatientDocuments() {
+        return inwardDocumentUploadController.navigateToDocumentsFromAdmissionProfile(current);
     }
 
     public String navigateToInpatientDiagnosisCard() {

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -102,12 +102,18 @@ public class InwardDocumentUploadController implements Serializable {
             InputStream in = file.getInputStream();
             byte[] fileContent = IOUtils.toByteArray(in);
 
+            String detectedContentType = detectContentType(fileContent, fileName);
+            if (detectedContentType == null) {
+                JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
+                return;
+            }
+
             Upload upload = new Upload();
             upload.setUploadType(selectedUploadType);
             upload.setPatientEncounter(currentEncounter);
             upload.setBaImage(fileContent);
             upload.setFileName(fileName);
-            upload.setFileType(file.getContentType());
+            upload.setFileType(detectedContentType);
             upload.setComments(comments);
             upload.setCreatedAt(new Date());
             upload.setCreater(sessionController.getLoggedUser());
@@ -137,15 +143,38 @@ public class InwardDocumentUploadController implements Serializable {
     }
 
     public StreamedContent getDownloadStream(Upload u) {
-        if (u == null || u.getBaImage() == null) {
+        if (u == null || u.getId() == null) {
             return null;
         }
-        byte[] data = u.getBaImage();
+        Upload persisted = uploadFacade.find(u.getId());
+        if (persisted == null || persisted.isRetired() || persisted.getBaImage() == null) {
+            return null;
+        }
+        byte[] data = persisted.getBaImage();
         return DefaultStreamedContent.builder()
-                .name(u.getFileName())
-                .contentType(u.getFileType())
+                .name(persisted.getFileName())
+                .contentType(persisted.getFileType())
                 .stream(() -> new ByteArrayInputStream(data))
                 .build();
+    }
+
+    private String detectContentType(byte[] bytes, String fileName) {
+        if (bytes == null || bytes.length < 4) {
+            return null;
+        }
+        // PDF: %PDF
+        if (bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46) {
+            return "application/pdf";
+        }
+        // JPEG: FF D8 FF
+        if ((bytes[0] & 0xFF) == 0xFF && (bytes[1] & 0xFF) == 0xD8 && (bytes[2] & 0xFF) == 0xFF) {
+            return "image/jpeg";
+        }
+        // PNG: 89 50 4E 47
+        if ((bytes[0] & 0xFF) == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47) {
+            return "image/png";
+        }
+        return null;
     }
 
     public List<UploadType> getInwardUploadTypes() {

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -20,9 +20,9 @@ import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
-import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
+import org.primefaces.model.file.UploadedFile;
 
 @Named
 @SessionScoped
@@ -43,6 +43,7 @@ public class InwardDocumentUploadController implements Serializable {
     private List<Upload> documents;
     private UploadType selectedUploadType;
     private String comments;
+    private UploadedFile file;
 
     private static final long SIZE_LIMIT = 10240000;
     private static final String ALLOWED_FILE_TYPES_REGEX = "(?i)\\.(pdf|jpeg|jpg|png)$";
@@ -54,6 +55,7 @@ public class InwardDocumentUploadController implements Serializable {
         loadDocuments();
         selectedUploadType = null;
         comments = null;
+        file = null;
         return "/inward/admission_documents?faces-redirect=true";
     }
     // </editor-fold>
@@ -74,16 +76,16 @@ public class InwardDocumentUploadController implements Serializable {
         documents = uploadFacade.findByJpql(jpql, params);
     }
 
-    public void handleFileUpload(FileUploadEvent event) {
-        if (event == null || event.getFile() == null || event.getFile().getSize() == 0) {
+    public void uploadDocument() {
+        if (file == null || file.getSize() == 0) {
             JsfUtil.addErrorMessage("Please select a file.");
             return;
         }
-        if (event.getFile().getSize() > SIZE_LIMIT) {
+        if (file.getSize() > SIZE_LIMIT) {
             JsfUtil.addErrorMessage("File size exceeds the maximum limit of 10 MB.");
             return;
         }
-        String fileName = event.getFile().getFileName();
+        String fileName = file.getFileName();
         if (!fileName.matches(".*" + ALLOWED_FILE_TYPES_REGEX)) {
             JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
             return;
@@ -97,7 +99,7 @@ public class InwardDocumentUploadController implements Serializable {
             return;
         }
         try {
-            InputStream in = event.getFile().getInputStream();
+            InputStream in = file.getInputStream();
             byte[] fileContent = IOUtils.toByteArray(in);
 
             Upload upload = new Upload();
@@ -105,7 +107,7 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setPatientEncounter(currentEncounter);
             upload.setBaImage(fileContent);
             upload.setFileName(fileName);
-            upload.setFileType(event.getFile().getContentType());
+            upload.setFileType(file.getContentType());
             upload.setComments(comments);
             upload.setCreatedAt(new Date());
             upload.setCreater(sessionController.getLoggedUser());
@@ -113,6 +115,7 @@ public class InwardDocumentUploadController implements Serializable {
             uploadFacade.create(upload);
 
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
+            file = null;
             selectedUploadType = null;
             comments = null;
             loadDocuments();
@@ -186,6 +189,14 @@ public class InwardDocumentUploadController implements Serializable {
 
     public void setComments(String comments) {
         this.comments = comments;
+    }
+
+    public UploadedFile getFile() {
+        return file;
+    }
+
+    public void setFile(UploadedFile file) {
+        this.file = file;
     }
     // </editor-fold>
 }

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -1,0 +1,191 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.core.data.UploadType;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.Upload;
+import com.divudi.core.facade.UploadFacade;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import javax.inject.Inject;
+import org.apache.commons.io.IOUtils;
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.DefaultStreamedContent;
+import org.primefaces.model.StreamedContent;
+
+@Named
+@SessionScoped
+public class InwardDocumentUploadController implements Serializable {
+
+    // <editor-fold defaultstate="collapsed" desc="EJBs">
+    @EJB
+    private UploadFacade uploadFacade;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Controllers">
+    @Inject
+    private SessionController sessionController;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Variables">
+    private PatientEncounter currentEncounter;
+    private List<Upload> documents;
+    private UploadType selectedUploadType;
+    private String comments;
+
+    private static final long SIZE_LIMIT = 10240000;
+    private static final String ALLOWED_FILE_TYPES_REGEX = "(?i)\\.(pdf|jpeg|jpg|png)$";
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Navigation">
+    public String navigateToDocumentsFromAdmissionProfile(PatientEncounter pe) {
+        currentEncounter = pe;
+        loadDocuments();
+        selectedUploadType = null;
+        comments = null;
+        return "/inward/admission_documents?faces-redirect=true";
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Functional Methods">
+    public void loadDocuments() {
+        if (currentEncounter == null) {
+            documents = new ArrayList<>();
+            return;
+        }
+        String jpql = "select u from Upload u "
+                + "where u.retired = :ret "
+                + "and u.patientEncounter = :pe "
+                + "order by u.createdAt desc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("pe", currentEncounter);
+        documents = uploadFacade.findByJpql(jpql, params);
+    }
+
+    public void handleFileUpload(FileUploadEvent event) {
+        if (event == null || event.getFile() == null || event.getFile().getSize() == 0) {
+            JsfUtil.addErrorMessage("Please select a file.");
+            return;
+        }
+        if (event.getFile().getSize() > SIZE_LIMIT) {
+            JsfUtil.addErrorMessage("File size exceeds the maximum limit of 10 MB.");
+            return;
+        }
+        String fileName = event.getFile().getFileName();
+        if (!fileName.matches(".*" + ALLOWED_FILE_TYPES_REGEX)) {
+            JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
+            return;
+        }
+        if (selectedUploadType == null) {
+            JsfUtil.addErrorMessage("Please select a document type.");
+            return;
+        }
+        if (currentEncounter == null) {
+            JsfUtil.addErrorMessage("No admission selected.");
+            return;
+        }
+        try {
+            InputStream in = event.getFile().getInputStream();
+            byte[] fileContent = IOUtils.toByteArray(in);
+
+            Upload upload = new Upload();
+            upload.setUploadType(selectedUploadType);
+            upload.setPatientEncounter(currentEncounter);
+            upload.setBaImage(fileContent);
+            upload.setFileName(fileName);
+            upload.setFileType(event.getFile().getContentType());
+            upload.setComments(comments);
+            upload.setCreatedAt(new Date());
+            upload.setCreater(sessionController.getLoggedUser());
+            upload.setRetired(false);
+            uploadFacade.create(upload);
+
+            JsfUtil.addSuccessMessage("Document uploaded successfully.");
+            selectedUploadType = null;
+            comments = null;
+            loadDocuments();
+        } catch (IOException e) {
+            JsfUtil.addErrorMessage("Error uploading file: " + e.getMessage());
+        }
+    }
+
+    public void removeDocument(Upload u) {
+        if (u == null) {
+            return;
+        }
+        u.setRetired(true);
+        u.setRetirer(sessionController.getLoggedUser());
+        u.setRetiredAt(new Date());
+        uploadFacade.edit(u);
+        loadDocuments();
+        JsfUtil.addSuccessMessage("Document removed.");
+    }
+
+    public StreamedContent getDownloadStream(Upload u) {
+        if (u == null || u.getBaImage() == null) {
+            return null;
+        }
+        byte[] data = u.getBaImage();
+        return DefaultStreamedContent.builder()
+                .name(u.getFileName())
+                .contentType(u.getFileType())
+                .stream(() -> new ByteArrayInputStream(data))
+                .build();
+    }
+
+    public List<UploadType> getInwardUploadTypes() {
+        List<UploadType> types = new ArrayList<>();
+        types.add(UploadType.Inward_Consent_Form);
+        types.add(UploadType.Inward_Insurance_Document);
+        types.add(UploadType.Inward_Referral_Letter);
+        types.add(UploadType.Inward_Other);
+        return types;
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public PatientEncounter getCurrentEncounter() {
+        return currentEncounter;
+    }
+
+    public void setCurrentEncounter(PatientEncounter currentEncounter) {
+        this.currentEncounter = currentEncounter;
+    }
+
+    public List<Upload> getDocuments() {
+        return documents;
+    }
+
+    public void setDocuments(List<Upload> documents) {
+        this.documents = documents;
+    }
+
+    public UploadType getSelectedUploadType() {
+        return selectedUploadType;
+    }
+
+    public void setSelectedUploadType(UploadType selectedUploadType) {
+        this.selectedUploadType = selectedUploadType;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -120,6 +120,7 @@ public enum Privileges {
     TheaterIssueBHT("Theater Issue BHT"),
     InpatientClinicalAssessment("Inpatient Clinical Assessment"),
     InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    InwardDocumentUpload("Inward Document Upload"),
     //</editor-fold>
     
     //<editor-fold defaultstate="collapsed" desc="Nurse">
@@ -1057,6 +1058,7 @@ public enum Privileges {
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
             case InpatientClinicalDischarge:
+            case InwardDocumentUpload:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/java/com/divudi/core/data/UploadType.java
+++ b/src/main/java/com/divudi/core/data/UploadType.java
@@ -34,7 +34,11 @@ public enum UploadType {
     Web_Image("Web Image"),
     Report_background_image("Report Background Image"),
     Background_Image("Background Image"),
-    Diagnosis_Card_Template("Diagnosis Card Template");
+    Diagnosis_Card_Template("Diagnosis Card Template"),
+    Inward_Consent_Form("Consent Form"),
+    Inward_Insurance_Document("Insurance Document"),
+    Inward_Referral_Letter("Referral Letter"),
+    Inward_Other("Other Document");
 
     private final String label;
 

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -48,7 +48,7 @@
                                              value="#{inwardDocumentUploadController.file}"
                                              mode="simple"
                                              skinSimple="true"
-                                             accept="image/*,application/pdf"
+                                             accept=".pdf,.jpeg,.jpg,.png,application/pdf,image/jpeg,image/png"
                                              sizeLimit="10240000"
                                              label="Choose File"
                                              class="w-100" />
@@ -86,7 +86,8 @@
                             </p:column>
                             <p:column headerText="Uploaded At" width="160">
                                 <h:outputText value="#{doc.createdAt}">
-                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                                       timeZone="Asia/Colombo" />
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="Uploaded By" width="160">

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formDocuments" enctype="multipart/form-data">
+
+                    <p:panel header="Admission Documents" class="m-1">
+                        <f:facet name="actions">
+                            <p:commandButton
+                                value="Back"
+                                ajax="false"
+                                action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-secondary" />
+                        </f:facet>
+
+                        <!-- Upload section -->
+                        <div class="row g-2 mb-3">
+                            <div class="col-md-3">
+                                <p:outputLabel for="cmbDocType" value="Document Type" />
+                                <p:selectOneMenu id="cmbDocType"
+                                                value="#{inwardDocumentUploadController.selectedUploadType}"
+                                                class="w-100">
+                                    <f:selectItem itemLabel="-- Select Type --" itemValue="#{null}" />
+                                    <f:selectItems value="#{inwardDocumentUploadController.inwardUploadTypes}"
+                                                   var="t"
+                                                   itemLabel="#{t.label}"
+                                                   itemValue="#{t}" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="col-md-5">
+                                <p:outputLabel for="txtDocComments" value="Comments" />
+                                <p:inputTextarea id="txtDocComments"
+                                                value="#{inwardDocumentUploadController.comments}"
+                                                rows="2"
+                                                class="w-100"
+                                                autoResize="true" />
+                            </div>
+                            <div class="col-md-4 d-flex align-items-end">
+                                <p:fileUpload id="fuDocument"
+                                             mode="simple"
+                                             skinSimple="true"
+                                             accept="image/*,application/pdf"
+                                             sizeLimit="10240000"
+                                             listener="#{inwardDocumentUploadController.handleFileUpload}"
+                                             label="Choose File"
+                                             uploadLabel="Upload"
+                                             class="w-100"
+                                             update="tblDocuments :formDocuments:fuDocument :formDocuments:cmbDocType :formDocuments:txtDocComments" />
+                            </div>
+                        </div>
+
+                        <!-- Documents list -->
+                        <p:dataTable id="tblDocuments"
+                                    value="#{inwardDocumentUploadController.documents}"
+                                    var="doc"
+                                    emptyMessage="No documents uploaded."
+                                    paginator="true"
+                                    rows="10"
+                                    paginatorAlwaysVisible="false"
+                                    paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                    class="w-100">
+                            <p:column headerText="Type" width="160">
+                                <h:outputText value="#{doc.uploadType.label}" />
+                            </p:column>
+                            <p:column headerText="File Name">
+                                <h:outputText value="#{doc.fileName}" />
+                            </p:column>
+                            <p:column headerText="Comments">
+                                <h:outputText value="#{doc.comments}" />
+                            </p:column>
+                            <p:column headerText="Uploaded At" width="160">
+                                <h:outputText value="#{doc.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Uploaded By" width="160">
+                                <h:outputText value="#{doc.creater.person.name}" />
+                            </p:column>
+                            <p:column headerText="Actions" width="110">
+                                <p:commandButton
+                                    icon="fa fa-download"
+                                    title="Download"
+                                    ajax="false"
+                                    class="ui-button-info me-1">
+                                    <p:fileDownload value="#{inwardDocumentUploadController.getDownloadStream(doc)}" />
+                                </p:commandButton>
+                                <p:commandButton
+                                    id="btnRemove"
+                                    icon="fa fa-trash"
+                                    title="Remove"
+                                    class="ui-button-danger"
+                                    process="@this"
+                                    update="tblDocuments"
+                                    action="#{inwardDocumentUploadController.removeDocument(doc)}">
+                                    <p:confirm header="Confirm Remove"
+                                               message="Remove this document?"
+                                               icon="pi pi-exclamation-triangle" />
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </p:panel>
+
+                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
+                        <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-danger" icon="pi pi-check" />
+                        <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
+                    </p:confirmDialog>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -43,17 +43,25 @@
                                                 class="w-100"
                                                 autoResize="true" />
                             </div>
-                            <div class="col-md-4 d-flex align-items-end">
+                            <div class="col-md-3 d-flex align-items-end">
                                 <p:fileUpload id="fuDocument"
+                                             value="#{inwardDocumentUploadController.file}"
                                              mode="simple"
                                              skinSimple="true"
                                              accept="image/*,application/pdf"
                                              sizeLimit="10240000"
-                                             listener="#{inwardDocumentUploadController.handleFileUpload}"
                                              label="Choose File"
-                                             uploadLabel="Upload"
-                                             class="w-100"
-                                             update="tblDocuments :formDocuments:fuDocument :formDocuments:cmbDocType :formDocuments:txtDocComments" />
+                                             class="w-100" />
+                            </div>
+                            <div class="col-md-1 d-flex align-items-end">
+                                <p:commandButton
+                                    id="btnUpload"
+                                    value="Upload"
+                                    icon="fa fa-upload"
+                                    action="#{inwardDocumentUploadController.uploadDocument()}"
+                                    process="fuDocument cmbDocType txtDocComments btnUpload"
+                                    update="tblDocuments fuDocument cmbDocType txtDocComments"
+                                    class="w-100" />
                             </div>
                         </div>
 

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -626,6 +626,16 @@
                                         class="w-100">
                                     </p:commandButton>
                                 </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        value="Documents"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardDocumentUpload')}"
+                                        action="#{admissionController.navigateToInpatientDocuments()}"
+                                        icon="fa fa-file-alt"
+                                        class="w-100">
+                                    </p:commandButton>
+                                </div>
                             </div>
                         </p:panel>
                     </div>


### PR DESCRIPTION
## Summary

- Adds 4 new `UploadType` enum values for inward document categories (Consent Form, Insurance Document, Referral Letter, Other)
- Adds `InwardDocumentUpload` privilege with all 3 required steps: enum value, `getCategory()` case, and `UserPrivilageController` tree node under the Clinical sub-tree
- New `InwardDocumentUploadController` (`@SessionScoped`): navigate/load/upload/remove/download, modelled on `PatientReportUploadController`
- New `inward/admission_documents.xhtml`: upload form (type dropdown + comments + `p:fileUpload mode="simple"`) and datatable with download + soft-delete per row
- `AdmissionController`: `@Inject InwardDocumentUploadController` + `navigateToInpatientDocuments()` delegation method
- `admission_profile.xhtml`: Documents button added to the Clinical Data panel, gated by `InwardDocumentUpload` privilege

## Test plan

- [ ] Assign `InwardDocumentUpload` privilege to a test user and confirm Documents button appears in Clinical Data panel
- [ ] Confirm button is hidden for users without the privilege
- [ ] Upload a PDF ≤ 10 MB — should appear in the list immediately
- [ ] Upload a JPEG/PNG — should appear in the list immediately
- [ ] Attempt to upload a file > 10 MB — should show error growl
- [ ] Attempt to upload a disallowed type (e.g. `.docx`) — should show error growl
- [ ] Upload without selecting a document type — should show error growl
- [ ] Download a document — file should open/download in browser
- [ ] Remove a document — should disappear from list (soft-deleted, `retired=true`)
- [ ] Back button returns to the inpatient dashboard

Closes #21217
Closes #21218
Closes #21216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document management for inpatient admissions: upload, download, and remove documents.
  * New inward document types: Consent Form, Insurance Document, Referral Letter, Other.
  * Documents button added to admission profile (privileged access) for quick access.
  * Supports PDF and common image formats, up to 10MB per file; comments and uploader metadata shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->