### PR TITLE
feat(patient): core merge entities, facades, and DB migration (#21209)

### DIFF
--- a/src/main/java/com/divudi/core/data/PatientMergeStatus.java
+++ b/src/main/java/com/divudi/core/data/PatientMergeStatus.java
@@ -1,0 +1,5 @@
+package com.divudi.core.data;
+
+public enum PatientMergeStatus {
+    ACTIVE, REVERSED
+}

--- a/src/main/java/com/divudi/core/data/PatientMergeType.java
+++ b/src/main/java/com/divudi/core/data/PatientMergeType.java
@@ -1,0 +1,5 @@
+package com.divudi.core.data;
+
+public enum PatientMergeType {
+    DETERMINISTIC, PROBABILISTIC, MANUAL
+}

--- a/src/main/java/com/divudi/core/entity/PatientMergeAffectedRecord.java
+++ b/src/main/java/com/divudi/core/entity/PatientMergeAffectedRecord.java
@@ -1,0 +1,79 @@
+package com.divudi.core.entity;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "patientmergeaffectedrecord")
+public class PatientMergeAffectedRecord implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private PatientMergeRecord mergeRecord;
+
+    private String entityClass;
+
+    private Long entityId;
+
+    private Long oldPatientId;
+
+    private Long newPatientId;
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public PatientMergeRecord getMergeRecord() {
+        return mergeRecord;
+    }
+
+    public void setMergeRecord(PatientMergeRecord mergeRecord) {
+        this.mergeRecord = mergeRecord;
+    }
+
+    public String getEntityClass() {
+        return entityClass;
+    }
+
+    public void setEntityClass(String entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    public Long getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(Long entityId) {
+        this.entityId = entityId;
+    }
+
+    public Long getOldPatientId() {
+        return oldPatientId;
+    }
+
+    public void setOldPatientId(Long oldPatientId) {
+        this.oldPatientId = oldPatientId;
+    }
+
+    public Long getNewPatientId() {
+        return newPatientId;
+    }
+
+    public void setNewPatientId(Long newPatientId) {
+        this.newPatientId = newPatientId;
+    }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/core/entity/PatientMergeRecord.java
+++ b/src/main/java/com/divudi/core/entity/PatientMergeRecord.java
@@ -1,0 +1,172 @@
+package com.divudi.core.entity;
+
+import com.divudi.core.data.PatientMergeStatus;
+import com.divudi.core.data.PatientMergeType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+@Table(name = "patientmergerecord")
+public class PatientMergeRecord implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date mergeDate;
+
+    @ManyToOne
+    private WebUser mergedBy;
+
+    @ManyToOne
+    private Patient primaryPatient;
+
+    @ManyToOne
+    private Patient secondaryPatient;
+
+    @Lob
+    private String primarySnapshotJson;
+
+    @Lob
+    private String secondarySnapshotJson;
+
+    private String mergeReason;
+
+    @Enumerated(EnumType.STRING)
+    private PatientMergeType mergeType;
+
+    @Enumerated(EnumType.STRING)
+    private PatientMergeStatus status;
+
+    @ManyToOne
+    private WebUser reversedBy;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date reversedAt;
+
+    @OneToMany(mappedBy = "mergeRecord", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<PatientMergeAffectedRecord> affectedRecords = new ArrayList<>();
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Date getMergeDate() {
+        return mergeDate;
+    }
+
+    public void setMergeDate(Date mergeDate) {
+        this.mergeDate = mergeDate;
+    }
+
+    public WebUser getMergedBy() {
+        return mergedBy;
+    }
+
+    public void setMergedBy(WebUser mergedBy) {
+        this.mergedBy = mergedBy;
+    }
+
+    public Patient getPrimaryPatient() {
+        return primaryPatient;
+    }
+
+    public void setPrimaryPatient(Patient primaryPatient) {
+        this.primaryPatient = primaryPatient;
+    }
+
+    public Patient getSecondaryPatient() {
+        return secondaryPatient;
+    }
+
+    public void setSecondaryPatient(Patient secondaryPatient) {
+        this.secondaryPatient = secondaryPatient;
+    }
+
+    public String getPrimarySnapshotJson() {
+        return primarySnapshotJson;
+    }
+
+    public void setPrimarySnapshotJson(String primarySnapshotJson) {
+        this.primarySnapshotJson = primarySnapshotJson;
+    }
+
+    public String getSecondarySnapshotJson() {
+        return secondarySnapshotJson;
+    }
+
+    public void setSecondarySnapshotJson(String secondarySnapshotJson) {
+        this.secondarySnapshotJson = secondarySnapshotJson;
+    }
+
+    public String getMergeReason() {
+        return mergeReason;
+    }
+
+    public void setMergeReason(String mergeReason) {
+        this.mergeReason = mergeReason;
+    }
+
+    public PatientMergeType getMergeType() {
+        return mergeType;
+    }
+
+    public void setMergeType(PatientMergeType mergeType) {
+        this.mergeType = mergeType;
+    }
+
+    public PatientMergeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PatientMergeStatus status) {
+        this.status = status;
+    }
+
+    public WebUser getReversedBy() {
+        return reversedBy;
+    }
+
+    public void setReversedBy(WebUser reversedBy) {
+        this.reversedBy = reversedBy;
+    }
+
+    public Date getReversedAt() {
+        return reversedAt;
+    }
+
+    public void setReversedAt(Date reversedAt) {
+        this.reversedAt = reversedAt;
+    }
+
+    public List<PatientMergeAffectedRecord> getAffectedRecords() {
+        return affectedRecords;
+    }
+
+    public void setAffectedRecords(List<PatientMergeAffectedRecord> affectedRecords) {
+        this.affectedRecords = affectedRecords;
+    }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/core/facade/PatientMergeAffectedRecordFacade.java
+++ b/src/main/java/com/divudi/core/facade/PatientMergeAffectedRecordFacade.java
@@ -1,0 +1,24 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.PatientMergeAffectedRecord;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class PatientMergeAffectedRecordFacade extends AbstractFacade<PatientMergeAffectedRecord> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if (em == null) {
+        }
+        return em;
+    }
+
+    public PatientMergeAffectedRecordFacade() {
+        super(PatientMergeAffectedRecord.class);
+    }
+}

--- a/src/main/java/com/divudi/core/facade/PatientMergeRecordFacade.java
+++ b/src/main/java/com/divudi/core/facade/PatientMergeRecordFacade.java
@@ -1,0 +1,24 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.PatientMergeRecord;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class PatientMergeRecordFacade extends AbstractFacade<PatientMergeRecord> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if (em == null) {
+        }
+        return em;
+    }
+
+    public PatientMergeRecordFacade() {
+        super(PatientMergeRecord.class);
+    }
+}

--- a/src/main/resources/db/migrations/v2.11.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.11.0/migration.sql
@@ -1,0 +1,80 @@
+-- Migration v2.11.0: Create patient merge audit tables
+-- Issue: hmislk/hmis#21209
+--
+-- Background:
+--   Introduces the two tables that back the patient duplicate merge/unmerge
+--   system: patientmergerecord (one row per merge event) and
+--   patientmergeaffectedrecord (one row per entity re-pointed during a merge).
+--   These tables are the foundation for #21210–#21214.
+--
+-- UNIVERSAL: Detects actual table name case via INFORMATION_SCHEMA so this
+--   script works on both case-sensitive (Linux) and case-insensitive (Windows)
+--   MySQL instances.
+--
+-- IDEMPOTENT: Both CREATE TABLE statements are gated on INFORMATION_SCHEMA
+--   existence checks so the script can be safely re-run.
+
+SELECT 'Migration v2.11.0 - Create patient merge audit tables' AS status;
+
+-- ==========================================
+-- STEP 1: CREATE patientmergerecord
+-- ==========================================
+
+SET @pmr_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTMERGERECORD'
+);
+
+SET @sql_pmr = IF(@pmr_exists = 0,
+    'CREATE TABLE patientmergerecord (
+        ID BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        MERGEDATE DATETIME,
+        MERGEDBY_ID BIGINT,
+        PRIMARYPATIENT_ID BIGINT,
+        SECONDARYPATIENT_ID BIGINT,
+        PRIMARYSNAPSHOTJSON LONGTEXT,
+        SECONDARYSNAPSHOTJSON LONGTEXT,
+        MERGEREASON VARCHAR(500),
+        MERGETYPE VARCHAR(30),
+        STATUS VARCHAR(20),
+        REVERSEDBY_ID BIGINT,
+        REVERSEDAT DATETIME
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+    'SELECT ''patientmergerecord already exists — skipping'' AS info'
+);
+
+PREPARE stmt_pmr FROM @sql_pmr;
+EXECUTE stmt_pmr;
+DEALLOCATE PREPARE stmt_pmr;
+
+-- ==========================================
+-- STEP 2: CREATE patientmergeaffectedrecord
+-- ==========================================
+
+SET @pmar_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTMERGEAFFECTEDRECORD'
+);
+
+SET @sql_pmar = IF(@pmar_exists = 0,
+    'CREATE TABLE patientmergeaffectedrecord (
+        ID BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        MERGERECORD_ID BIGINT NOT NULL,
+        ENTITYCLASS VARCHAR(100),
+        ENTITYID BIGINT,
+        OLDPATIENTID BIGINT,
+        NEWPATIENTID BIGINT,
+        FOREIGN KEY (MERGERECORD_ID) REFERENCES patientmergerecord(ID)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+    'SELECT ''patientmergeaffectedrecord already exists — skipping'' AS info'
+);
+
+PREPARE stmt_pmar FROM @sql_pmar;
+EXECUTE stmt_pmar;
+DEALLOCATE PREPARE stmt_pmar;
+
+SELECT 'Migration v2.11.0 complete' AS status;


### PR DESCRIPTION
## Summary

Foundation for the patient duplicate merge/unmerge system (#21208). No behaviour change — pure additions.

- `PatientMergeType` enum: `DETERMINISTIC`, `PROBABILISTIC`, `MANUAL`
- `PatientMergeStatus` enum: `ACTIVE`, `REVERSED`
- `PatientMergeRecord` entity: one row per merge event; holds JSON snapshots of both patients before merge, merge/reversal metadata, and `@OneToMany` to affected records
- `PatientMergeAffectedRecord` entity: one row per DB row re-pointed during a merge (`entityClass`, `entityId`, `oldPatientId`, `newPatientId`) — exact record set used for unmerge replay
- `PatientMergeRecordFacade` and `PatientMergeAffectedRecordFacade`
- Migration `v2.11.0`: idempotent `CREATE TABLE` for both tables with `INFORMATION_SCHEMA` existence checks (case-safe for Linux/Windows MySQL)

## Test plan

- [ ] Application deploys without error
- [ ] Both tables created in DB after migration runs
- [ ] No existing functionality broken

Closes #21209
Part of #21208

🤖 Generated with [Claude Code](https://claude.com/claude-code)