### PR TITLE
feat(patient): merge engine, history, unmerge, deterministic scan, and admin panel

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -517,6 +517,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPrices, "Manage Fees/Prices/Packages"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPatientRelationships, "Manage Patient Relationships"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminInactivePatients, "Manage Inactive Patients"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.MergePatients, "Merge Patients"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ManageCreditCompany, "Manage Credit Companies"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminFilterWithoutDepartment, "Filter Without Department"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchAll, "Search All"), adminNode);

--- a/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
+++ b/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
@@ -1,0 +1,307 @@
+package com.divudi.bean.dataAdmin;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.PatientMergeStatus;
+import com.divudi.core.data.PatientMergeType;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PatientMergeRecord;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.facade.PatientMergeRecordFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.patient.PatientMergeService;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class PatientMergeController implements Serializable {
+
+    // <editor-fold defaultstate="collapsed" desc="EJBs">
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private PatientMergeRecordFacade patientMergeRecordFacade;
+    @EJB
+    private PatientMergeService patientMergeService;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Controllers">
+    @Inject
+    private SessionController sessionController;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Manual merge state">
+    private Patient primaryPatient;
+    private Patient secondaryPatient;
+    private String mergeReason;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Deterministic scan state">
+    private int detMaxResults = 50;
+    private List<PatientPair> deterministicResults = new ArrayList<>();
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="History state">
+    private Date historyFromDate;
+    private Date historyToDate;
+    private PatientMergeStatus historyStatus;
+    private List<PatientMergeRecord> historyResults = new ArrayList<>();
+    private PatientMergeRecord selectedMergeRecord;
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Navigation">
+    public String navigateToPatientDataManagement() {
+        initHistoryDates();
+        primaryPatient = null;
+        secondaryPatient = null;
+        mergeReason = null;
+        deterministicResults = new ArrayList<>();
+        historyResults = new ArrayList<>();
+        return "/dataAdmin/patient_data_management?faces-redirect=true";
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Manual Merge">
+    public void executeMerge() {
+        if (primaryPatient == null || secondaryPatient == null) {
+            JsfUtil.addErrorMessage("Please select both a primary and a secondary patient.");
+            return;
+        }
+        if (primaryPatient.getId().equals(secondaryPatient.getId())) {
+            JsfUtil.addErrorMessage("Primary and secondary patients must be different.");
+            return;
+        }
+        try {
+            patientMergeService.merge(primaryPatient, secondaryPatient,
+                    PatientMergeType.MANUAL, mergeReason, sessionController.getLoggedUser());
+            JsfUtil.addSuccessMessage("Patients merged successfully.");
+            primaryPatient = null;
+            secondaryPatient = null;
+            mergeReason = null;
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Merge failed: " + e.getMessage());
+        }
+    }
+
+    public List<Patient> completePrimaryPatient(String query) {
+        return searchPatients(query);
+    }
+
+    public List<Patient> completeSecondaryPatient(String query) {
+        return searchPatients(query);
+    }
+
+    private List<Patient> searchPatients(String query) {
+        if (query == null || query.trim().length() < 2) {
+            return new ArrayList<>();
+        }
+        String jpql = "select p from Patient p where p.retired = false "
+                + "and (lower(p.person.name) like :q or p.phn like :q or p.person.nic like :q or p.code like :q) "
+                + "order by p.person.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("q", "%" + query.toLowerCase() + "%");
+        return patientFacade.findByJpql(jpql, params, javax.persistence.TemporalType.DATE, 20);
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Deterministic Scan">
+    public void scanByNic() {
+        deterministicResults = runDeterministicScan("nic", "NIC");
+    }
+
+    public void scanByPhn() {
+        deterministicResults = runDeterministicScan("phn", "PHN");
+    }
+
+    public void scanByMrn() {
+        deterministicResults = runDeterministicScan("code", "MRN");
+    }
+
+    public void scanAll() {
+        List<PatientPair> all = new ArrayList<>();
+        all.addAll(runDeterministicScan("nic", "NIC"));
+        all.addAll(runDeterministicScan("phn", "PHN"));
+        all.addAll(runDeterministicScan("code", "MRN"));
+        // De-duplicate by patient ID pair
+        List<PatientPair> deduped = new ArrayList<>();
+        for (PatientPair np : all) {
+            boolean found = false;
+            for (PatientPair ex : deduped) {
+                if (ex.getPatientA().getId().equals(np.getPatientA().getId())
+                        && ex.getPatientB().getId().equals(np.getPatientB().getId())) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                deduped.add(np);
+            }
+        }
+        deterministicResults = deduped;
+    }
+
+    private List<PatientPair> runDeterministicScan(String field, String matchReason) {
+        int cap = Math.min(Math.max(detMaxResults, 1), 500);
+        String jpql;
+        if ("phn".equals(field) || "code".equals(field)) {
+            jpql = "select p1, p2 from Patient p1, Patient p2 "
+                    + "where p1.id < p2.id "
+                    + "and p1.retired = false and p2.retired = false "
+                    + "and p1." + field + " is not null and p1." + field + " <> '' "
+                    + "and p1." + field + " = p2." + field;
+        } else {
+            jpql = "select p1, p2 from Patient p1, Patient p2 "
+                    + "where p1.id < p2.id "
+                    + "and p1.retired = false and p2.retired = false "
+                    + "and p1.person." + field + " is not null and p1.person." + field + " <> '' "
+                    + "and p1.person." + field + " = p2.person." + field;
+        }
+        List<Object[]> allRows = patientFacade.findObjectsArrayByJpql(jpql, new HashMap<>(), javax.persistence.TemporalType.DATE);
+        List<PatientPair> pairs = new ArrayList<>();
+        int limit = Math.min(allRows.size(), cap);
+        List<Object[]> rows = allRows.subList(0, limit);
+        for (Object[] row : rows) {
+            PatientPair pair = new PatientPair((Patient) row[0], (Patient) row[1], matchReason);
+            pairs.add(pair);
+        }
+        return pairs;
+    }
+
+    public void mergeDeterministicPair(PatientPair pair) {
+        if (pair.getSelectedPrimary() == null) {
+            JsfUtil.addErrorMessage("Please select the primary patient.");
+            return;
+        }
+        Patient pri = pair.getSelectedPrimary();
+        Patient sec = pri.getId().equals(pair.getPatientA().getId())
+                ? pair.getPatientB() : pair.getPatientA();
+        try {
+            patientMergeService.merge(pri, sec, PatientMergeType.DETERMINISTIC,
+                    "Deterministic scan — matched on " + pair.getMatchReason(),
+                    sessionController.getLoggedUser());
+            deterministicResults.remove(pair);
+            JsfUtil.addSuccessMessage("Patients merged.");
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Merge failed: " + e.getMessage());
+        }
+    }
+
+    public void dismissDeterministicPair(PatientPair pair) {
+        deterministicResults.remove(pair);
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="History & Unmerge">
+    public void searchHistory() {
+        String jpql = "select mr from PatientMergeRecord mr where mr.mergeDate >= :from and mr.mergeDate <= :to";
+        Map<String, Object> params = new HashMap<>();
+        params.put("from", historyFromDate != null ? historyFromDate : defaultFrom());
+        params.put("to", historyToDate != null ? historyToDate : new Date());
+        if (historyStatus != null) {
+            jpql += " and mr.status = :status";
+            params.put("status", historyStatus);
+        }
+        jpql += " order by mr.mergeDate desc";
+        historyResults = patientMergeRecordFacade.findByJpql(jpql, params);
+    }
+
+    public void executeUnmerge() {
+        if (selectedMergeRecord == null) {
+            JsfUtil.addErrorMessage("No merge record selected.");
+            return;
+        }
+        try {
+            patientMergeService.unmerge(selectedMergeRecord, sessionController.getLoggedUser());
+            JsfUtil.addSuccessMessage("Merge reversed successfully.");
+            searchHistory();
+        } catch (IllegalStateException e) {
+            JsfUtil.addErrorMessage(e.getMessage());
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Unmerge failed: " + e.getMessage());
+        }
+    }
+
+    private void initHistoryDates() {
+        historyToDate = new Date();
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_YEAR, -30);
+        historyFromDate = cal.getTime();
+    }
+
+    private Date defaultFrom() {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_YEAR, -30);
+        return cal.getTime();
+    }
+
+    public int getAffectedRecordCount(PatientMergeRecord mr) {
+        String jpql = "select count(ar) from PatientMergeAffectedRecord ar where ar.mergeRecord = :mr";
+        Map<String, Object> p = new HashMap<>();
+        p.put("mr", mr);
+        return (int) patientMergeRecordFacade.findLongByJpql(jpql, p);
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Inner class — PatientPair">
+    public static class PatientPair implements Serializable {
+        private Patient patientA;
+        private Patient patientB;
+        private String matchReason;
+        private Patient selectedPrimary;
+
+        public PatientPair(Patient a, Patient b, String matchReason) {
+            this.patientA = a;
+            this.patientB = b;
+            this.matchReason = matchReason;
+            this.selectedPrimary = a; // default: earlier-registered (lower id) is primary
+        }
+
+        public Patient getPatientA() { return patientA; }
+        public Patient getPatientB() { return patientB; }
+        public String getMatchReason() { return matchReason; }
+        public Patient getSelectedPrimary() { return selectedPrimary; }
+        public void setSelectedPrimary(Patient selectedPrimary) { this.selectedPrimary = selectedPrimary; }
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public Patient getPrimaryPatient() { return primaryPatient; }
+    public void setPrimaryPatient(Patient primaryPatient) { this.primaryPatient = primaryPatient; }
+
+    public Patient getSecondaryPatient() { return secondaryPatient; }
+    public void setSecondaryPatient(Patient secondaryPatient) { this.secondaryPatient = secondaryPatient; }
+
+    public String getMergeReason() { return mergeReason; }
+    public void setMergeReason(String mergeReason) { this.mergeReason = mergeReason; }
+
+    public int getDetMaxResults() { return detMaxResults; }
+    public void setDetMaxResults(int detMaxResults) { this.detMaxResults = detMaxResults; }
+
+    public List<PatientPair> getDeterministicResults() { return deterministicResults; }
+
+    public Date getHistoryFromDate() { return historyFromDate; }
+    public void setHistoryFromDate(Date historyFromDate) { this.historyFromDate = historyFromDate; }
+
+    public Date getHistoryToDate() { return historyToDate; }
+    public void setHistoryToDate(Date historyToDate) { this.historyToDate = historyToDate; }
+
+    public PatientMergeStatus getHistoryStatus() { return historyStatus; }
+    public void setHistoryStatus(PatientMergeStatus historyStatus) { this.historyStatus = historyStatus; }
+
+    public List<PatientMergeRecord> getHistoryResults() { return historyResults; }
+
+    public PatientMergeRecord getSelectedMergeRecord() { return selectedMergeRecord; }
+    public void setSelectedMergeRecord(PatientMergeRecord selectedMergeRecord) { this.selectedMergeRecord = selectedMergeRecord; }
+
+    public PatientMergeStatus[] getMergeStatusValues() { return PatientMergeStatus.values(); }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
+++ b/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
@@ -165,10 +165,8 @@ public class PatientMergeController implements Serializable {
                     + "and p1.person." + field + " is not null and p1.person." + field + " <> '' "
                     + "and p1.person." + field + " = p2.person." + field;
         }
-        List<Object[]> allRows = patientFacade.findObjectsArrayByJpql(jpql, new HashMap<>(), javax.persistence.TemporalType.DATE);
+        List<Object[]> rows = patientFacade.findPatientPairsByJpql(jpql, new HashMap<>(), cap);
         List<PatientPair> pairs = new ArrayList<>();
-        int limit = Math.min(allRows.size(), cap);
-        List<Object[]> rows = allRows.subList(0, limit);
         for (Object[] row : rows) {
             PatientPair pair = new PatientPair((Patient) row[0], (Patient) row[1], matchReason);
             pairs.add(pair);

--- a/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
+++ b/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
@@ -54,6 +54,7 @@ public class PatientMergeController implements Serializable {
     private Date historyFromDate;
     private Date historyToDate;
     private PatientMergeStatus historyStatus;
+    private String historyMergedByUsername;
     private List<PatientMergeRecord> historyResults = new ArrayList<>();
     private PatientMergeRecord selectedMergeRecord;
     // </editor-fold>
@@ -208,6 +209,10 @@ public class PatientMergeController implements Serializable {
             jpql += " and mr.status = :status";
             params.put("status", historyStatus);
         }
+        if (historyMergedByUsername != null && !historyMergedByUsername.trim().isEmpty()) {
+            jpql += " and lower(mr.mergedBy.username) like :mergedBy";
+            params.put("mergedBy", "%" + historyMergedByUsername.trim().toLowerCase() + "%");
+        }
         jpql += " order by mr.mergeDate desc";
         historyResults = patientMergeRecordFacade.findByJpql(jpql, params);
     }
@@ -294,6 +299,9 @@ public class PatientMergeController implements Serializable {
 
     public PatientMergeStatus getHistoryStatus() { return historyStatus; }
     public void setHistoryStatus(PatientMergeStatus historyStatus) { this.historyStatus = historyStatus; }
+
+    public String getHistoryMergedByUsername() { return historyMergedByUsername; }
+    public void setHistoryMergedByUsername(String historyMergedByUsername) { this.historyMergedByUsername = historyMergedByUsername; }
 
     public List<PatientMergeRecord> getHistoryResults() { return historyResults; }
 

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -697,6 +697,7 @@ public enum Privileges {
     AdminPrices("Admin Prices"),
     AdminPatientRelationships("Manage Patient Relationships"),
     AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
     ManageCreditCompany("Manage Credit Company"),
     AdminFilterWithoutDepartment("Admin Filter Without Department"),
     //</editor-fold>
@@ -1062,6 +1063,7 @@ public enum Privileges {
                 return "Inward";
 
             case AdminInactivePatients:
+            case MergePatients:
                 return "Admin";
 
             default:

--- a/src/main/java/com/divudi/core/facade/PatientFacade.java
+++ b/src/main/java/com/divudi/core/facade/PatientFacade.java
@@ -5,9 +5,12 @@
 package com.divudi.core.facade;
 
 import com.divudi.core.entity.Patient;
+import java.util.List;
+import java.util.Map;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
 
 /**
  *
@@ -25,6 +28,17 @@ public class PatientFacade extends AbstractFacade<Patient> {
 
     public PatientFacade() {
         super(Patient.class);
+    }
+
+    public List<Object[]> findPatientPairsByJpql(String jpql, Map<String, Object> parameters, int maxResults) {
+        Query query = getEntityManager().createQuery(jpql);
+        if (parameters != null) {
+            for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+                query.setParameter(entry.getKey(), entry.getValue());
+            }
+        }
+        query.setMaxResults(maxResults);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/com/divudi/service/patient/PatientMergeService.java
+++ b/src/main/java/com/divudi/service/patient/PatientMergeService.java
@@ -109,12 +109,20 @@ public class PatientMergeService {
             throw new IllegalStateException("Merge #" + mergeRecord.getId() + " is already reversed.");
         }
 
+        Patient primary = mergeRecord.getPrimaryPatient();
         Patient secondary = mergeRecord.getSecondaryPatient();
 
         // Restore affected records
         List<PatientMergeAffectedRecord> affected = loadAffectedRecords(mergeRecord);
         for (PatientMergeAffectedRecord ar : affected) {
             restorePatientReference(ar);
+        }
+
+        // Restore primary demographics from snapshot (undo any null-fill that was applied)
+        restorePatientFromSnapshot(primary, mergeRecord.getPrimarySnapshotJson());
+        patientFacade.edit(primary);
+        if (primary.getPerson() != null) {
+            personFacade.edit(primary.getPerson());
         }
 
         // Restore secondary demographics from snapshot
@@ -161,7 +169,7 @@ public class PatientMergeService {
             params.put("pri", primary);
             params.put("sec", secondary);
             patientEncounterFacade.updateByJpql(
-                    "update PatientEncounter pe set pe.patient = :pri where pe.patient = :sec", params);
+                    "update PatientEncounter pe set pe.patient = :pri where pe.patient = :sec and pe.retired = false", params);
         }
         return buildAffectedRows("PatientEncounter", ids, secondary.getId(), primary.getId());
     }
@@ -178,7 +186,7 @@ public class PatientMergeService {
             params.put("pri", primary);
             params.put("sec", secondary);
             patientInvestigationFacade.updateByJpql(
-                    "update PatientInvestigation pi set pi.patient = :pri where pi.patient = :sec", params);
+                    "update PatientInvestigation pi set pi.patient = :pri where pi.patient = :sec and pi.retired = false", params);
         }
         return buildAffectedRows("PatientInvestigation", ids, secondary.getId(), primary.getId());
     }
@@ -195,7 +203,7 @@ public class PatientMergeService {
             params.put("pri", primary);
             params.put("sec", secondary);
             patientReportFacade.updateByJpql(
-                    "update PatientReport pr set pr.patient = :pri where pr.patient = :sec", params);
+                    "update PatientReport pr set pr.patient = :pri where pr.patient = :sec and pr.retired = false", params);
         }
         return buildAffectedRows("PatientReport", ids, secondary.getId(), primary.getId());
     }
@@ -216,7 +224,7 @@ public class PatientMergeService {
         Map<String, Object> params = new HashMap<>();
         params.put("pri", primary);
         params.put("sec", secondary);
-        String jpql = "update " + entityName + " e set e.patient = :pri where e.patient = :sec";
+        String jpql = "update " + entityName + " e set e.patient = :pri where e.patient = :sec and e.retired = false";
         switch (entityName) {
             case "Bill":
                 billFacade.updateByJpql(jpql, params);

--- a/src/main/java/com/divudi/service/patient/PatientMergeService.java
+++ b/src/main/java/com/divudi/service/patient/PatientMergeService.java
@@ -1,0 +1,351 @@
+package com.divudi.service.patient;
+
+import com.divudi.core.data.PatientMergeStatus;
+import com.divudi.core.data.PatientMergeType;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.PatientMergeAffectedRecord;
+import com.divudi.core.entity.PatientMergeRecord;
+import com.divudi.core.entity.Person;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.PatientInvestigation;
+import com.divudi.core.entity.lab.PatientReport;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.facade.PatientInvestigationFacade;
+import com.divudi.core.facade.PatientMergeAffectedRecordFacade;
+import com.divudi.core.facade.PatientMergeRecordFacade;
+import com.divudi.core.facade.PatientReportFacade;
+import com.divudi.core.facade.PersonFacade;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+@Stateless
+public class PatientMergeService {
+
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private PersonFacade personFacade;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+    @EJB
+    private PatientInvestigationFacade patientInvestigationFacade;
+    @EJB
+    private PatientReportFacade patientReportFacade;
+    @EJB
+    private PatientMergeRecordFacade patientMergeRecordFacade;
+    @EJB
+    private PatientMergeAffectedRecordFacade patientMergeAffectedRecordFacade;
+
+    /**
+     * Merges secondary into primary. Steps:
+     * 1. Snapshot both patients to JSON
+     * 2. Fill null primary demographics from secondary
+     * 3. Collect affected IDs, bulk-re-point all 4 entity types
+     * 4. Retire secondary
+     * 5. Persist PatientMergeRecord with all affected rows
+     */
+    public PatientMergeRecord merge(Patient primary, Patient secondary,
+            PatientMergeType mergeType, String reason, WebUser mergedBy) {
+
+        Date now = new Date();
+
+        // 1. Snapshot
+        PatientMergeRecord mergeRecord = new PatientMergeRecord();
+        mergeRecord.setPrimaryPatient(primary);
+        mergeRecord.setSecondaryPatient(secondary);
+        mergeRecord.setMergeDate(now);
+        mergeRecord.setMergedBy(mergedBy);
+        mergeRecord.setMergeType(mergeType);
+        mergeRecord.setMergeReason(reason);
+        mergeRecord.setStatus(PatientMergeStatus.ACTIVE);
+        mergeRecord.setPrimarySnapshotJson(snapshotPatient(primary));
+        mergeRecord.setSecondarySnapshotJson(snapshotPatient(secondary));
+
+        // 2. Fill null primary fields from secondary
+        fillNullDemographics(primary, secondary);
+        patientFacade.edit(primary);
+        if (primary.getPerson() != null) {
+            personFacade.edit(primary.getPerson());
+        }
+
+        // 3. Collect IDs then bulk-update each entity type
+        List<PatientMergeAffectedRecord> affected = new ArrayList<>();
+        affected.addAll(collectAndRepoint("Bill", primary, secondary));
+        affected.addAll(collectAndRepointEncounters(primary, secondary));
+        affected.addAll(collectAndRepointInvestigations(primary, secondary));
+        affected.addAll(collectAndRepointReports(primary, secondary));
+
+        // 4. Retire secondary
+        secondary.setRetired(true);
+        secondary.setRetireComments("Merged into patient #" + primary.getId() + " on " + now);
+        patientFacade.edit(secondary);
+
+        // 5. Persist
+        patientMergeRecordFacade.create(mergeRecord);
+        for (PatientMergeAffectedRecord ar : affected) {
+            ar.setMergeRecord(mergeRecord);
+            patientMergeAffectedRecordFacade.create(ar);
+        }
+        mergeRecord.setAffectedRecords(affected);
+
+        return mergeRecord;
+    }
+
+    /**
+     * Reverses a previously completed merge.
+     */
+    public void unmerge(PatientMergeRecord mergeRecord, WebUser reversedBy) {
+        if (mergeRecord.getStatus() != PatientMergeStatus.ACTIVE) {
+            throw new IllegalStateException("Merge #" + mergeRecord.getId() + " is already reversed.");
+        }
+
+        Patient secondary = mergeRecord.getSecondaryPatient();
+
+        // Restore affected records
+        List<PatientMergeAffectedRecord> affected = loadAffectedRecords(mergeRecord);
+        for (PatientMergeAffectedRecord ar : affected) {
+            restorePatientReference(ar);
+        }
+
+        // Restore secondary demographics from snapshot
+        restorePatientFromSnapshot(secondary, mergeRecord.getSecondarySnapshotJson());
+
+        // Un-retire secondary
+        secondary.setRetired(false);
+        secondary.setRetireComments(null);
+        patientFacade.edit(secondary);
+        if (secondary.getPerson() != null) {
+            personFacade.edit(secondary.getPerson());
+        }
+
+        // Mark merge reversed
+        mergeRecord.setStatus(PatientMergeStatus.REVERSED);
+        mergeRecord.setReversedBy(reversedBy);
+        mergeRecord.setReversedAt(new Date());
+        patientMergeRecordFacade.edit(mergeRecord);
+    }
+
+    // ------------------------------------------------------------------
+    // Private helpers
+    // ------------------------------------------------------------------
+
+    private List<PatientMergeAffectedRecord> collectAndRepoint(
+            String entityName, Patient primary, Patient secondary) {
+
+        List<Long> ids = collectIds(entityName, secondary);
+        if (!ids.isEmpty()) {
+            bulkUpdate(entityName, primary, secondary);
+        }
+        return buildAffectedRows(entityName, ids, secondary.getId(), primary.getId());
+    }
+
+    private List<PatientMergeAffectedRecord> collectAndRepointEncounters(
+            Patient primary, Patient secondary) {
+
+        String jpql = "select pe.id from PatientEncounter pe where pe.patient = :sec and pe.retired = false";
+        Map<String, Object> p = new HashMap<>();
+        p.put("sec", secondary);
+        List<Long> ids = patientEncounterFacade.findLongValuesByJpql(jpql, p);
+        if (!ids.isEmpty()) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("pri", primary);
+            params.put("sec", secondary);
+            patientEncounterFacade.updateByJpql(
+                    "update PatientEncounter pe set pe.patient = :pri where pe.patient = :sec", params);
+        }
+        return buildAffectedRows("PatientEncounter", ids, secondary.getId(), primary.getId());
+    }
+
+    private List<PatientMergeAffectedRecord> collectAndRepointInvestigations(
+            Patient primary, Patient secondary) {
+
+        String jpql = "select pi.id from PatientInvestigation pi where pi.patient = :sec and pi.retired = false";
+        Map<String, Object> p = new HashMap<>();
+        p.put("sec", secondary);
+        List<Long> ids = patientInvestigationFacade.findLongValuesByJpql(jpql, p);
+        if (!ids.isEmpty()) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("pri", primary);
+            params.put("sec", secondary);
+            patientInvestigationFacade.updateByJpql(
+                    "update PatientInvestigation pi set pi.patient = :pri where pi.patient = :sec", params);
+        }
+        return buildAffectedRows("PatientInvestigation", ids, secondary.getId(), primary.getId());
+    }
+
+    private List<PatientMergeAffectedRecord> collectAndRepointReports(
+            Patient primary, Patient secondary) {
+
+        String jpql = "select pr.id from PatientReport pr where pr.patient = :sec and pr.retired = false";
+        Map<String, Object> p = new HashMap<>();
+        p.put("sec", secondary);
+        List<Long> ids = patientReportFacade.findLongValuesByJpql(jpql, p);
+        if (!ids.isEmpty()) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("pri", primary);
+            params.put("sec", secondary);
+            patientReportFacade.updateByJpql(
+                    "update PatientReport pr set pr.patient = :pri where pr.patient = :sec", params);
+        }
+        return buildAffectedRows("PatientReport", ids, secondary.getId(), primary.getId());
+    }
+
+    private List<Long> collectIds(String entityName, Patient secondary) {
+        String jpql = "select e.id from " + entityName + " e where e.patient = :sec and e.retired = false";
+        Map<String, Object> p = new HashMap<>();
+        p.put("sec", secondary);
+        switch (entityName) {
+            case "Bill":
+                return billFacade.findLongValuesByJpql(jpql, p);
+            default:
+                return new ArrayList<>();
+        }
+    }
+
+    private void bulkUpdate(String entityName, Patient primary, Patient secondary) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("pri", primary);
+        params.put("sec", secondary);
+        String jpql = "update " + entityName + " e set e.patient = :pri where e.patient = :sec";
+        switch (entityName) {
+            case "Bill":
+                billFacade.updateByJpql(jpql, params);
+                break;
+        }
+    }
+
+    private List<PatientMergeAffectedRecord> buildAffectedRows(
+            String entityClass, List<Long> ids, Long oldId, Long newId) {
+        List<PatientMergeAffectedRecord> rows = new ArrayList<>();
+        for (Long id : ids) {
+            PatientMergeAffectedRecord ar = new PatientMergeAffectedRecord();
+            ar.setEntityClass(entityClass);
+            ar.setEntityId(id);
+            ar.setOldPatientId(oldId);
+            ar.setNewPatientId(newId);
+            rows.add(ar);
+        }
+        return rows;
+    }
+
+    private void restorePatientReference(PatientMergeAffectedRecord ar) {
+        Patient old = patientFacade.find(ar.getOldPatientId());
+        if (old == null) {
+            return;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("old", old);
+        params.put("id", ar.getEntityId());
+        String jpql = "update " + ar.getEntityClass() + " e set e.patient = :old where e.id = :id";
+        switch (ar.getEntityClass()) {
+            case "Bill":
+                billFacade.updateByJpql(jpql, params);
+                break;
+            case "PatientEncounter":
+                patientEncounterFacade.updateByJpql(jpql, params);
+                break;
+            case "PatientInvestigation":
+                patientInvestigationFacade.updateByJpql(jpql, params);
+                break;
+            case "PatientReport":
+                patientReportFacade.updateByJpql(jpql, params);
+                break;
+        }
+    }
+
+    private List<PatientMergeAffectedRecord> loadAffectedRecords(PatientMergeRecord mergeRecord) {
+        String jpql = "select ar from PatientMergeAffectedRecord ar where ar.mergeRecord = :mr";
+        Map<String, Object> p = new HashMap<>();
+        p.put("mr", mergeRecord);
+        return patientMergeAffectedRecordFacade.findByJpql(jpql, p);
+    }
+
+    private void fillNullDemographics(Patient primary, Patient secondary) {
+        if (primary.getPerson() == null || secondary.getPerson() == null) {
+            return;
+        }
+        Person pri = primary.getPerson();
+        Person sec = secondary.getPerson();
+
+        if (pri.getName() == null) pri.setName(sec.getName());
+        if (pri.getNic() == null || pri.getNic().isEmpty()) pri.setNic(sec.getNic());
+        if (pri.getPhone() == null || pri.getPhone().isEmpty()) pri.setPhone(sec.getPhone());
+        if (pri.getMobile() == null || pri.getMobile().isEmpty()) pri.setMobile(sec.getMobile());
+        if (pri.getEmail() == null || pri.getEmail().isEmpty()) pri.setEmail(sec.getEmail());
+        if (pri.getAddress() == null || pri.getAddress().isEmpty()) pri.setAddress(sec.getAddress());
+        if (pri.getDob() == null) pri.setDob(sec.getDob());
+        if (pri.getSex() == null) pri.setSex(sec.getSex());
+        if (pri.getTitle() == null) pri.setTitle(sec.getTitle());
+        if (primary.getPhn() == null || primary.getPhn().isEmpty()) primary.setPhn(secondary.getPhn());
+        if (primary.getCode() == null || primary.getCode().isEmpty()) primary.setCode(secondary.getCode());
+    }
+
+    private String snapshotPatient(Patient patient) {
+        try {
+            java.util.LinkedHashMap<String, Object> snap = new java.util.LinkedHashMap<>();
+            snap.put("id", patient.getId());
+            snap.put("phn", patient.getPhn());
+            snap.put("code", patient.getCode());
+            snap.put("retired", patient.isRetired());
+            snap.put("retireComments", patient.getRetireComments());
+            if (patient.getPerson() != null) {
+                Person p = patient.getPerson();
+                java.util.LinkedHashMap<String, Object> personSnap = new java.util.LinkedHashMap<>();
+                personSnap.put("id", p.getId());
+                personSnap.put("name", p.getName());
+                personSnap.put("nic", p.getNic());
+                personSnap.put("phone", p.getPhone());
+                personSnap.put("mobile", p.getMobile());
+                personSnap.put("email", p.getEmail());
+                personSnap.put("address", p.getAddress());
+                personSnap.put("dob", p.getDob() != null ? p.getDob().getTime() : null);
+                personSnap.put("sex", p.getSex() != null ? p.getSex().name() : null);
+                personSnap.put("title", p.getTitle() != null ? p.getTitle().name() : null);
+                snap.put("person", personSnap);
+            }
+            return new com.google.gson.Gson().toJson(snap);
+        } catch (Exception e) {
+            return "{}";
+        }
+    }
+
+    private void restorePatientFromSnapshot(Patient patient, String json) {
+        if (json == null || json.isEmpty()) {
+            return;
+        }
+        try {
+            com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+            if (root.has("phn") && !root.get("phn").isJsonNull()) {
+                patient.setPhn(root.get("phn").getAsString());
+            }
+            if (root.has("code") && !root.get("code").isJsonNull()) {
+                patient.setCode(root.get("code").getAsString());
+            }
+            if (root.has("person") && !root.get("person").isJsonNull()) {
+                com.google.gson.JsonObject ps = root.getAsJsonObject("person");
+                Person p = patient.getPerson();
+                if (p != null) {
+                    if (ps.has("name") && !ps.get("name").isJsonNull()) p.setName(ps.get("name").getAsString());
+                    if (ps.has("nic") && !ps.get("nic").isJsonNull()) p.setNic(ps.get("nic").getAsString());
+                    if (ps.has("phone") && !ps.get("phone").isJsonNull()) p.setPhone(ps.get("phone").getAsString());
+                    if (ps.has("mobile") && !ps.get("mobile").isJsonNull()) p.setMobile(ps.get("mobile").getAsString());
+                    if (ps.has("email") && !ps.get("email").isJsonNull()) p.setEmail(ps.get("email").getAsString());
+                    if (ps.has("address") && !ps.get("address").isJsonNull()) p.setAddress(ps.get("address").getAsString());
+                    if (ps.has("dob") && !ps.get("dob").isJsonNull()) p.setDob(new Date(ps.get("dob").getAsLong()));
+                }
+            }
+        } catch (Exception e) {
+            // snapshot parse failure — leave patient as-is
+        }
+    }
+}

--- a/src/main/resources/db/migrations/v2.11.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.11.0/migration.sql
@@ -9,7 +9,7 @@
 --
 -- UNIVERSAL: Detects actual table name case via INFORMATION_SCHEMA so this
 --   script works on both case-sensitive (Linux) and case-insensitive (Windows)
---   MySQL instances.
+--   MySQL instances. The resolved real name is used in all DDL strings.
 --
 -- IDEMPOTENT: Both CREATE TABLE statements are gated on INFORMATION_SCHEMA
 --   existence checks so the script can be safely re-run.
@@ -20,14 +20,16 @@ SELECT 'Migration v2.11.0 - Create patient merge audit tables' AS status;
 -- STEP 1: CREATE patientmergerecord
 -- ==========================================
 
-SET @pmr_exists = (
-    SELECT COUNT(*)
+-- Resolve actual table name (preserves case on case-sensitive hosts)
+SET @pmr_real_name = (
+    SELECT TABLE_NAME
     FROM INFORMATION_SCHEMA.TABLES
     WHERE TABLE_SCHEMA = DATABASE()
       AND UPPER(TABLE_NAME) = 'PATIENTMERGERECORD'
+    LIMIT 1
 );
 
-SET @sql_pmr = IF(@pmr_exists = 0,
+SET @sql_pmr = IF(@pmr_real_name IS NULL,
     'CREATE TABLE patientmergerecord (
         ID BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
         MERGEDATE DATETIME,
@@ -49,27 +51,42 @@ PREPARE stmt_pmr FROM @sql_pmr;
 EXECUTE stmt_pmr;
 DEALLOCATE PREPARE stmt_pmr;
 
+-- Re-resolve after creation (name is now guaranteed to exist)
+SET @pmr_real_name = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTMERGERECORD'
+    LIMIT 1
+);
+
+SELECT CONCAT('patientmergerecord resolved as: ', IFNULL(@pmr_real_name, '(not found)')) AS info;
+
 -- ==========================================
 -- STEP 2: CREATE patientmergeaffectedrecord
 -- ==========================================
 
-SET @pmar_exists = (
-    SELECT COUNT(*)
+SET @pmar_real_name = (
+    SELECT TABLE_NAME
     FROM INFORMATION_SCHEMA.TABLES
     WHERE TABLE_SCHEMA = DATABASE()
       AND UPPER(TABLE_NAME) = 'PATIENTMERGEAFFECTEDRECORD'
+    LIMIT 1
 );
 
-SET @sql_pmar = IF(@pmar_exists = 0,
-    'CREATE TABLE patientmergeaffectedrecord (
-        ID BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-        MERGERECORD_ID BIGINT NOT NULL,
-        ENTITYCLASS VARCHAR(100),
-        ENTITYID BIGINT,
-        OLDPATIENTID BIGINT,
-        NEWPATIENTID BIGINT,
-        FOREIGN KEY (MERGERECORD_ID) REFERENCES patientmergerecord(ID)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+-- Build the FK REFERENCES clause using the resolved parent table name
+SET @sql_pmar = IF(@pmar_real_name IS NULL,
+    CONCAT(
+        'CREATE TABLE patientmergeaffectedrecord (
+            ID BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            MERGERECORD_ID BIGINT NOT NULL,
+            ENTITYCLASS VARCHAR(100),
+            ENTITYID BIGINT,
+            OLDPATIENTID BIGINT,
+            NEWPATIENTID BIGINT,
+            FOREIGN KEY (MERGERECORD_ID) REFERENCES ', @pmr_real_name, '(ID)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    ),
     'SELECT ''patientmergeaffectedrecord already exists — skipping'' AS info'
 );
 

--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -325,6 +325,26 @@
                                     </p:tab>
 
 
+                                    <p:tab title="Patient Data Management"
+                                           rendered="#{webUserController.hasPrivilege('MergePatients') or webUserController.hasPrivilege('AdminInactivePatients')}">
+                                        <div class="d-grid gap-2">
+                                            <p:commandButton
+                                                class="w-100"
+                                                ajax="false"
+                                                value="Patient Data Management"
+                                                action="#{patientMergeController.navigateToPatientDataManagement()}"
+                                                icon="fa fa-users-cog"
+                                                rendered="#{webUserController.hasPrivilege('MergePatients')}" />
+                                            <p:commandButton
+                                                class="w-100"
+                                                ajax="false"
+                                                value="Inactive Patients"
+                                                action="#{patientController.navigateToInactivePatients()}"
+                                                icon="fa fa-user-slash"
+                                                rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}" />
+                                        </div>
+                                    </p:tab>
+
                                 </p:accordionPanel>
 
                             </h:form>

--- a/src/main/webapp/dataAdmin/patient_data_management.xhtml
+++ b/src/main/webapp/dataAdmin/patient_data_management.xhtml
@@ -234,9 +234,16 @@
                                         </p:selectOneMenu>
                                     </div>
                                     <div class="col-md-2">
+                                        <p:outputLabel for="txtMergedBy" value="Merged By" />
+                                        <p:inputText id="txtMergedBy"
+                                                     value="#{patientMergeController.historyMergedByUsername}"
+                                                     placeholder="username"
+                                                     class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
                                         <p:commandButton value="Search" icon="fa fa-search"
                                                          class="w-100"
-                                                         process="dtHistFrom dtHistTo cmbHistStatus"
+                                                         process="dtHistFrom dtHistTo cmbHistStatus txtMergedBy"
                                                          update="tblHistory pdmGrowl"
                                                          action="#{patientMergeController.searchHistory()}" />
                                     </div>

--- a/src/main/webapp/dataAdmin/patient_data_management.xhtml
+++ b/src/main/webapp/dataAdmin/patient_data_management.xhtml
@@ -1,0 +1,333 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/dataAdmin/admin_data_administration.xhtml">
+            <ui:define name="subcontent">
+                <h:form id="formPdm">
+                    <p:growl id="pdmGrowl" showDetail="true" />
+
+                    <p:tabView id="pdmTabs">
+
+                        <!-- ===== TAB 1: MANUAL MERGE ===== -->
+                        <p:tab title="Manual Merge"
+                               rendered="#{webUserController.hasPrivilege('MergePatients')}">
+                            <p:panel header="Merge Two Patients" class="m-1">
+                                <div class="row g-2">
+                                    <div class="col-md-6">
+                                        <p:outputLabel for="acPrimary" value="Primary Patient (survives)" />
+                                        <p:autoComplete id="acPrimary"
+                                                        value="#{patientMergeController.primaryPatient}"
+                                                        completeMethod="#{patientMergeController.completePrimaryPatient}"
+                                                        var="pt"
+                                                        itemLabel="#{pt.person.name} | #{pt.phn} | #{pt.person.nic}"
+                                                        itemValue="#{pt}"
+                                                        forceSelection="true"
+                                                        minQueryLength="2"
+                                                        class="w-100"
+                                                        inputStyleClass="w-100"
+                                                        dropdown="true">
+                                            <p:ajax event="itemSelect"
+                                                    process="acPrimary"
+                                                    update="panelPreview" />
+                                        </p:autoComplete>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <p:outputLabel for="acSecondary" value="Secondary Patient (will be deactivated)" />
+                                        <p:autoComplete id="acSecondary"
+                                                        value="#{patientMergeController.secondaryPatient}"
+                                                        completeMethod="#{patientMergeController.completeSecondaryPatient}"
+                                                        var="pt"
+                                                        itemLabel="#{pt.person.name} | #{pt.phn} | #{pt.person.nic}"
+                                                        itemValue="#{pt}"
+                                                        forceSelection="true"
+                                                        minQueryLength="2"
+                                                        class="w-100"
+                                                        inputStyleClass="w-100"
+                                                        dropdown="true">
+                                            <p:ajax event="itemSelect"
+                                                    process="acSecondary"
+                                                    update="panelPreview" />
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <!-- Side-by-side preview -->
+                                <h:panelGroup id="panelPreview" layout="block" styleClass="mt-3">
+                                    <p:panel header="Demographics Preview" class="m-1"
+                                             rendered="#{patientMergeController.primaryPatient ne null or patientMergeController.secondaryPatient ne null}">
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <h4>Primary</h4>
+                                                <p:panelGrid columns="2" styleClass="table table-sm" rendered="#{patientMergeController.primaryPatient ne null}">
+                                                    <h:outputText value="Name" /><h:outputText value="#{patientMergeController.primaryPatient.person.name}" />
+                                                    <h:outputText value="PHN" /><h:outputText value="#{patientMergeController.primaryPatient.phn}" />
+                                                    <h:outputText value="MRN" /><h:outputText value="#{patientMergeController.primaryPatient.code}" />
+                                                    <h:outputText value="NIC" /><h:outputText value="#{patientMergeController.primaryPatient.person.nic}" />
+                                                    <h:outputText value="DOB" /><h:outputText value="#{patientMergeController.primaryPatient.person.dob}"><f:convertDateTime pattern="yyyy-MM-dd" /></h:outputText>
+                                                    <h:outputText value="Phone" /><h:outputText value="#{patientMergeController.primaryPatient.person.phone}" />
+                                                </p:panelGrid>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <h4>Secondary</h4>
+                                                <p:panelGrid columns="2" styleClass="table table-sm" rendered="#{patientMergeController.secondaryPatient ne null}">
+                                                    <h:outputText value="Name" /><h:outputText value="#{patientMergeController.secondaryPatient.person.name}" />
+                                                    <h:outputText value="PHN" /><h:outputText value="#{patientMergeController.secondaryPatient.phn}" />
+                                                    <h:outputText value="MRN" /><h:outputText value="#{patientMergeController.secondaryPatient.code}" />
+                                                    <h:outputText value="NIC" /><h:outputText value="#{patientMergeController.secondaryPatient.person.nic}" />
+                                                    <h:outputText value="DOB" /><h:outputText value="#{patientMergeController.secondaryPatient.person.dob}"><f:convertDateTime pattern="yyyy-MM-dd" /></h:outputText>
+                                                    <h:outputText value="Phone" /><h:outputText value="#{patientMergeController.secondaryPatient.person.phone}" />
+                                                </p:panelGrid>
+                                            </div>
+                                        </div>
+                                    </p:panel>
+                                </h:panelGroup>
+
+                                <div class="row g-2 mt-2">
+                                    <div class="col-md-8">
+                                        <p:outputLabel for="txtMergeReason" value="Merge Reason (optional)" />
+                                        <p:inputTextarea id="txtMergeReason"
+                                                         value="#{patientMergeController.mergeReason}"
+                                                         rows="2"
+                                                         class="w-100"
+                                                         autoResize="true" />
+                                    </div>
+                                    <div class="col-md-4 d-flex align-items-end">
+                                        <p:commandButton
+                                            id="btnMerge"
+                                            value="Merge"
+                                            icon="fa fa-compress-arrows-alt"
+                                            class="w-100 ui-button-warning"
+                                            process="acPrimary acSecondary txtMergeReason btnMerge"
+                                            update="pdmGrowl panelPreview acPrimary acSecondary txtMergeReason"
+                                            action="#{patientMergeController.executeMerge()}">
+                                            <p:confirm header="Confirm Merge"
+                                                       message="This will permanently merge the secondary patient into the primary and deactivate the secondary. Continue?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </p:tab>
+
+                        <!-- ===== TAB 2: DETERMINISTIC SCAN ===== -->
+                        <p:tab title="Deterministic Scan"
+                               rendered="#{webUserController.hasPrivilege('MergePatients')}">
+                            <p:panel header="Scan by Exact NIC / PHN / MRN Match" class="m-1">
+                                <div class="row g-2 align-items-end mb-3">
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="txtDetMax" value="Max results (1–500)" />
+                                        <p:inputText id="txtDetMax"
+                                                     value="#{patientMergeController.detMaxResults}"
+                                                     class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Scan by NIC" icon="fa fa-id-card"
+                                                         class="w-100"
+                                                         process="txtDetMax"
+                                                         update="tblDetResults pdmGrowl"
+                                                         action="#{patientMergeController.scanByNic()}" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Scan by PHN" icon="fa fa-id-badge"
+                                                         class="w-100"
+                                                         process="txtDetMax"
+                                                         update="tblDetResults pdmGrowl"
+                                                         action="#{patientMergeController.scanByPhn()}" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Scan by MRN" icon="fa fa-barcode"
+                                                         class="w-100"
+                                                         process="txtDetMax"
+                                                         update="tblDetResults pdmGrowl"
+                                                         action="#{patientMergeController.scanByMrn()}" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Scan All" icon="fa fa-search"
+                                                         class="w-100 ui-button-info"
+                                                         process="txtDetMax"
+                                                         update="tblDetResults pdmGrowl"
+                                                         action="#{patientMergeController.scanAll()}" />
+                                    </div>
+                                </div>
+
+                                <p:dataTable id="tblDetResults"
+                                             value="#{patientMergeController.deterministicResults}"
+                                             var="pair"
+                                             emptyMessage="No duplicates found."
+                                             paginator="true"
+                                             rows="10"
+                                             paginatorAlwaysVisible="false"
+                                             class="w-100">
+                                    <p:column headerText="Match On" width="80">
+                                        <h:outputText value="#{pair.matchReason}" />
+                                    </p:column>
+                                    <p:column headerText="Patient A">
+                                        <h:outputText value="#{pair.patientA.person.name}" /><br />
+                                        <small><h:outputText value="PHN: #{pair.patientA.phn}  NIC: #{pair.patientA.person.nic}  MRN: #{pair.patientA.code}" /></small>
+                                    </p:column>
+                                    <p:column headerText="Patient B">
+                                        <h:outputText value="#{pair.patientB.person.name}" /><br />
+                                        <small><h:outputText value="PHN: #{pair.patientB.phn}  NIC: #{pair.patientB.person.nic}  MRN: #{pair.patientB.code}" /></small>
+                                    </p:column>
+                                    <p:column headerText="Primary" width="200">
+                                        <p:selectOneMenu value="#{pair.selectedPrimary}" class="w-100">
+                                            <f:selectItem itemLabel="#{pair.patientA.person.name} (A)" itemValue="#{pair.patientA}" />
+                                            <f:selectItem itemLabel="#{pair.patientB.person.name} (B)" itemValue="#{pair.patientB}" />
+                                        </p:selectOneMenu>
+                                    </p:column>
+                                    <p:column headerText="Actions" width="120">
+                                        <p:commandButton
+                                            value="Merge"
+                                            icon="fa fa-compress-arrows-alt"
+                                            class="ui-button-warning me-1"
+                                            process="tblDetResults"
+                                            update="tblDetResults pdmGrowl"
+                                            action="#{patientMergeController.mergeDeterministicPair(pair)}">
+                                            <p:confirm header="Confirm Merge"
+                                                       message="Merge these two patients?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            value="Dismiss"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            process="@this"
+                                            update="tblDetResults"
+                                            action="#{patientMergeController.dismissDeterministicPair(pair)}" />
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </p:tab>
+
+                        <!-- ===== TAB 3: MERGE HISTORY ===== -->
+                        <p:tab title="Merge History"
+                               rendered="#{webUserController.hasPrivilege('MergePatients')}">
+                            <p:panel header="Merge History" class="m-1">
+                                <div class="row g-2 align-items-end mb-3">
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="dtHistFrom" value="From" />
+                                        <p:datePicker id="dtHistFrom"
+                                                      value="#{patientMergeController.historyFromDate}"
+                                                      pattern="dd/MM/yyyy"
+                                                      class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="dtHistTo" value="To" />
+                                        <p:datePicker id="dtHistTo"
+                                                      value="#{patientMergeController.historyToDate}"
+                                                      pattern="dd/MM/yyyy"
+                                                      class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="cmbHistStatus" value="Status" />
+                                        <p:selectOneMenu id="cmbHistStatus"
+                                                         value="#{patientMergeController.historyStatus}"
+                                                         class="w-100">
+                                            <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                            <f:selectItems value="#{patientMergeController.mergeStatusValues}"
+                                                           var="s" itemLabel="#{s}" itemValue="#{s}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Search" icon="fa fa-search"
+                                                         class="w-100"
+                                                         process="dtHistFrom dtHistTo cmbHistStatus"
+                                                         update="tblHistory pdmGrowl"
+                                                         action="#{patientMergeController.searchHistory()}" />
+                                    </div>
+                                </div>
+
+                                <p:dataTable id="tblHistory"
+                                             value="#{patientMergeController.historyResults}"
+                                             var="mr"
+                                             emptyMessage="No merge records found."
+                                             paginator="true"
+                                             rows="10"
+                                             paginatorAlwaysVisible="false"
+                                             class="w-100">
+                                    <p:column headerText="Merge Date" width="140">
+                                        <h:outputText value="#{mr.mergeDate}">
+                                            <f:convertDateTime pattern="dd/MM/yyyy HH:mm" timeZone="Asia/Colombo" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Merged By" width="120">
+                                        <h:outputText value="#{mr.mergedBy.username}" />
+                                    </p:column>
+                                    <p:column headerText="Primary Patient">
+                                        <h:outputText value="#{mr.primaryPatient.person.name}" /><br />
+                                        <small><h:outputText value="#{mr.primaryPatient.phn}" /></small>
+                                    </p:column>
+                                    <p:column headerText="Secondary Patient">
+                                        <h:outputText value="#{mr.secondaryPatient.person.name}" /><br />
+                                        <small><h:outputText value="#{mr.secondaryPatient.phn}" /></small>
+                                    </p:column>
+                                    <p:column headerText="Type" width="110">
+                                        <h:outputText value="#{mr.mergeType}" />
+                                    </p:column>
+                                    <p:column headerText="Reason">
+                                        <h:outputText value="#{mr.mergeReason}" />
+                                    </p:column>
+                                    <p:column headerText="Records" width="70">
+                                        <h:outputText value="#{patientMergeController.getAffectedRecordCount(mr)}" />
+                                    </p:column>
+                                    <p:column headerText="Status" width="90">
+                                        <p:tag value="ACTIVE" severity="success"
+                                               rendered="#{mr.status.name() eq 'ACTIVE'}" />
+                                        <p:tag value="REVERSED" severity="secondary"
+                                               rendered="#{mr.status.name() eq 'REVERSED'}" />
+                                    </p:column>
+                                    <p:column headerText="Actions" width="100">
+                                        <p:commandButton
+                                            value="Unmerge"
+                                            icon="fa fa-undo"
+                                            class="ui-button-danger"
+                                            rendered="#{mr.status.name() eq 'ACTIVE'}"
+                                            process="@this"
+                                            update="tblHistory pdmGrowl"
+                                            action="#{patientMergeController.executeUnmerge()}">
+                                            <f:setPropertyActionListener
+                                                value="#{mr}"
+                                                target="#{patientMergeController.selectedMergeRecord}" />
+                                            <p:confirm header="Confirm Unmerge"
+                                                       message="Reverse this merge? Affected records will be re-pointed back to the secondary patient."
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </p:tab>
+
+                        <!-- ===== TAB 4: INACTIVE PATIENTS ===== -->
+                        <p:tab title="Inactive Patients">
+                            <p:panel header="Inactive Patients" class="m-1">
+                                <p:commandButton
+                                    value="View Inactive Patients"
+                                    ajax="false"
+                                    icon="fa fa-user-slash"
+                                    class="ui-button-secondary"
+                                    rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}"
+                                    action="#{patientController.navigateToInactivePatients()}" />
+                            </p:panel>
+                        </p:tab>
+
+                    </p:tabView>
+
+                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
+                        <p:commandButton value="Yes" type="button"
+                                         styleClass="ui-confirmdialog-yes ui-button-danger"
+                                         icon="pi pi-check" />
+                        <p:commandButton value="No" type="button"
+                                         styleClass="ui-confirmdialog-no ui-button-secondary"
+                                         icon="pi pi-times" />
+                    </p:confirmDialog>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -2113,13 +2113,6 @@
                         icon="fa fa-database"
                         rendered="#{webUserController.hasPrivilege('AdminItems')}" >
                     </p:menuitem>
-                    <p:menuitem
-                        ajax="false"
-                        action="#{patientController.navigateToInactivePatients()}"
-                        value="Inactive Patients"
-                        icon="fa fa-user-slash"
-                        rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}" >
-                    </p:menuitem>
 
                 </p:submenu>
 


### PR DESCRIPTION
## Summary

Implements the complete patient merge/unmerge system on top of the core entities from #21227 (merged first). Covers issues #21210, #21211, #21212, and #21214 in a single PR since they share the same `PatientMergeController` and `PatientMergeService`.

### PatientMergeService
- `merge()`: snapshot both patients to JSON → fill null primary demographics from secondary → SELECT affected IDs then bulk JPQL UPDATE for Bill / PatientEncounter / PatientInvestigation / PatientReport → persist `PatientMergeAffectedRecord` per row → retire secondary → save `PatientMergeRecord ACTIVE`
- `unmerge()`: validate ACTIVE → restore each affected row via per-entity `updateByJpql` → restore Person from JSON snapshot → un-retire secondary → mark `REVERSED`

### PatientMergeController (SessionScoped)
- Manual merge: patient autocomplete, side-by-side preview, merge + confirm
- Deterministic scan: NIC / PHN / MRN exact-match JPQL queries, configurable cap (1–500), merge/dismiss per pair
- Merge history: date-range + status filter, affected record count, unmerge button for ACTIVE rows
- Inactive Patients tab (delegates to existing `patientController.navigateToInactivePatients()`)

### UI changes
- `patient_data_management.xhtml`: new page with 4 tabs (Manual Merge, Deterministic Scan, Merge History, Inactive Patients)
- `admin_data_administration.xhtml`: new "Patient Data Management" accordion tab
- `menu.xhtml`: Inactive Patients removed from main nav (now in Patient Data Management panel)

### Privilege
- `MergePatients` added to `Privileges` enum + `getCategory()` + `UserPrivilageController` tree node under Administration

## Test plan

- [ ] Assign `MergePatients` to test user; Patient Data Management tab appears in admin panel
- [ ] Manual merge: select two patients, preview shows correct demographics, merge executes and secondary is retired
- [ ] Null-fill: primary null field filled from secondary after merge
- [ ] Deterministic scan: patients with shared NIC appear in results; merge removes from list
- [ ] Merge History: merged pair appears; Unmerge button visible for ACTIVE merges
- [ ] Unmerge: secondary patient re-activated, bills/encounters re-pointed back
- [ ] Attempting to unmerge already-REVERSED record shows error
- [ ] Inactive Patients button in tab navigates correctly
- [ ] Inactive Patients menu item no longer appears in main nav

**Depends on**: #21227 (core entities) must be merged to `development` first, or deploy with both PRs together.

Closes #21210
Closes #21211
Closes #21212
Closes #21214
Part of #21208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added patient merge functionality with manual selection and automatic duplicate-detection scanning
  * Added ability to reverse (unmerge) previously merged patient records
  * Added merge history tracking with date range and status filtering
  * New "Patient Data Management" section in administration panel for managing duplicate patient accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->