### PR TITLE
feat(patient): probabilistic duplicate scan with Jaro-Winkler scoring (#21213)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.12.0</version>
+        </dependency>
 
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
+++ b/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
@@ -210,35 +210,41 @@ public class PatientMergeController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Probabilistic Scan">
     public void runProbabilisticScan() {
         int cap = Math.min(Math.max(probMaxPairs, 1), 1000);
-        // Blocking: same birth year + same first letter of name
+        // Blocking: (same birth year + same first name letter) OR (shared phone/mobile tail)
         String jpql = "select p1, p2 from Patient p1, Patient p2 "
                 + "where p1.id < p2.id "
                 + "and p1.retired = false and p2.retired = false "
-                + "and p1.person.dob is not null and p2.person.dob is not null "
-                + "and year(p1.person.dob) = year(p2.person.dob) "
-                + "and p1.person.name is not null and p2.person.name is not null "
-                + "and substring(upper(p1.person.name),1,1) = substring(upper(p2.person.name),1,1)";
+                + "and ("
+                + "  (p1.person.dob is not null and p2.person.dob is not null "
+                + "   and year(p1.person.dob) = year(p2.person.dob) "
+                + "   and p1.person.name is not null and p2.person.name is not null "
+                + "   and substring(upper(p1.person.name),1,1) = substring(upper(p2.person.name),1,1))"
+                + "  or (p1.person.phone is not null and p2.person.phone is not null "
+                + "   and length(p1.person.phone) >= 7 and length(p2.person.phone) >= 7 "
+                + "   and substring(p1.person.phone, length(p1.person.phone)-6) = substring(p2.person.phone, length(p2.person.phone)-6))"
+                + "  or (p1.person.mobile is not null and p2.person.mobile is not null "
+                + "   and length(p1.person.mobile) >= 7 and length(p2.person.mobile) >= 7 "
+                + "   and substring(p1.person.mobile, length(p1.person.mobile)-6) = substring(p2.person.mobile, length(p2.person.mobile)-6))"
+                + ")";
         List<Object[]> rows = patientFacade.findObjectsArrayByJpql(jpql, new HashMap<>(), javax.persistence.TemporalType.DATE);
 
         // Collect already-merged pair IDs to exclude
         java.util.Set<String> alreadyMerged = loadAlreadyMergedPairKeys();
 
+        // Score all candidates, then cap after sorting so top matches always surface
         List<ScoredPatientPair> results = new ArrayList<>();
-        int checked = 0;
         for (Object[] row : rows) {
-            if (checked >= cap) break;
             Patient a = (Patient) row[0];
             Patient b = (Patient) row[1];
             String key = Math.min(a.getId(), b.getId()) + "_" + Math.max(a.getId(), b.getId());
             if (alreadyMerged.contains(key)) continue;
-            checked++;
             ScoredPatientPair scored = score(a, b);
             if (scored != null) {
                 results.add(scored);
             }
         }
         results.sort((x, y) -> Double.compare(y.getCompositeScore(), x.getCompositeScore()));
-        probabilisticResults = results;
+        probabilisticResults = results.size() > cap ? results.subList(0, cap) : results;
     }
 
     private java.util.Set<String> loadAlreadyMergedPairKeys() {
@@ -280,20 +286,28 @@ public class PatientMergeController implements Serializable {
     }
 
     private double scorePhone(Patient a, Patient b) {
-        String pA = bestPhone(a);
-        String pB = bestPhone(b);
-        if (pA.isEmpty() || pB.isEmpty()) return 0.0;
-        int len = Math.min(pA.length(), 9);
-        String tailA = pA.substring(Math.max(0, pA.length() - len));
-        String tailB = pB.substring(Math.max(0, pB.length() - len));
-        return tailA.equals(tailB) ? 1.0 : 0.0;
+        List<String> numbersA = allPhones(a);
+        List<String> numbersB = allPhones(b);
+        for (String pA : numbersA) {
+            for (String pB : numbersB) {
+                int len = Math.min(Math.min(pA.length(), pB.length()), 9);
+                if (len < 7) continue;
+                String tailA = pA.substring(pA.length() - len);
+                String tailB = pB.substring(pB.length() - len);
+                if (tailA.equals(tailB)) return 1.0;
+            }
+        }
+        return 0.0;
     }
 
-    private String bestPhone(Patient p) {
-        if (p.getPerson() == null) return "";
+    private List<String> allPhones(Patient p) {
+        List<String> numbers = new ArrayList<>();
+        if (p.getPerson() == null) return numbers;
         String phone = p.getPerson().getPhone() != null ? p.getPerson().getPhone().replaceAll("[^0-9]", "") : "";
         String mobile = p.getPerson().getMobile() != null ? p.getPerson().getMobile().replaceAll("[^0-9]", "") : "";
-        return phone.length() >= mobile.length() ? phone : mobile;
+        if (!phone.isEmpty()) numbers.add(phone);
+        if (!mobile.isEmpty() && !mobile.equals(phone)) numbers.add(mobile);
+        return numbers;
     }
 
     public void mergeProbabilisticPair(ScoredPatientPair pair) {

--- a/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
+++ b/src/main/java/com/divudi/bean/dataAdmin/PatientMergeController.java
@@ -20,6 +20,7 @@ import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.commons.text.similarity.JaroWinklerSimilarity;
 
 @Named
 @SessionScoped
@@ -48,6 +49,13 @@ public class PatientMergeController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Deterministic scan state">
     private int detMaxResults = 50;
     private List<PatientPair> deterministicResults = new ArrayList<>();
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Probabilistic scan state">
+    private int probMaxPairs = 100;
+    private double probNameThreshold = 0.92;
+    private List<ScoredPatientPair> probabilisticResults = new ArrayList<>();
+    private static final JaroWinklerSimilarity JARO_WINKLER = new JaroWinklerSimilarity();
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="History state">
@@ -199,6 +207,123 @@ public class PatientMergeController implements Serializable {
     }
     // </editor-fold>
 
+    // <editor-fold defaultstate="collapsed" desc="Probabilistic Scan">
+    public void runProbabilisticScan() {
+        int cap = Math.min(Math.max(probMaxPairs, 1), 1000);
+        // Blocking: same birth year + same first letter of name
+        String jpql = "select p1, p2 from Patient p1, Patient p2 "
+                + "where p1.id < p2.id "
+                + "and p1.retired = false and p2.retired = false "
+                + "and p1.person.dob is not null and p2.person.dob is not null "
+                + "and year(p1.person.dob) = year(p2.person.dob) "
+                + "and p1.person.name is not null and p2.person.name is not null "
+                + "and substring(upper(p1.person.name),1,1) = substring(upper(p2.person.name),1,1)";
+        List<Object[]> rows = patientFacade.findObjectsArrayByJpql(jpql, new HashMap<>(), javax.persistence.TemporalType.DATE);
+
+        // Collect already-merged pair IDs to exclude
+        java.util.Set<String> alreadyMerged = loadAlreadyMergedPairKeys();
+
+        List<ScoredPatientPair> results = new ArrayList<>();
+        int checked = 0;
+        for (Object[] row : rows) {
+            if (checked >= cap) break;
+            Patient a = (Patient) row[0];
+            Patient b = (Patient) row[1];
+            String key = Math.min(a.getId(), b.getId()) + "_" + Math.max(a.getId(), b.getId());
+            if (alreadyMerged.contains(key)) continue;
+            checked++;
+            ScoredPatientPair scored = score(a, b);
+            if (scored != null) {
+                results.add(scored);
+            }
+        }
+        results.sort((x, y) -> Double.compare(y.getCompositeScore(), x.getCompositeScore()));
+        probabilisticResults = results;
+    }
+
+    private java.util.Set<String> loadAlreadyMergedPairKeys() {
+        String jpql = "select mr.primaryPatient.id, mr.secondaryPatient.id from PatientMergeRecord mr";
+        List<Object[]> rows = patientMergeRecordFacade.findObjectsArrayByJpql(jpql, new HashMap<>(), javax.persistence.TemporalType.DATE);
+        java.util.Set<String> keys = new java.util.HashSet<>();
+        for (Object[] row : rows) {
+            Long idA = (Long) row[0];
+            Long idB = (Long) row[1];
+            keys.add(Math.min(idA, idB) + "_" + Math.max(idA, idB));
+        }
+        return keys;
+    }
+
+    private ScoredPatientPair score(Patient a, Patient b) {
+        String nameA = a.getPerson() != null && a.getPerson().getName() != null ? a.getPerson().getName().toLowerCase() : "";
+        String nameB = b.getPerson() != null && b.getPerson().getName() != null ? b.getPerson().getName().toLowerCase() : "";
+        double nameSim = nameA.isEmpty() || nameB.isEmpty() ? 0.0 : JARO_WINKLER.apply(nameA, nameB);
+        if (nameSim < probNameThreshold) return null;
+
+        double dobScore = scoreDob(a, b);
+        double phoneScore = scorePhone(a, b);
+        double composite = nameSim * 0.40 + dobScore * 0.35 + phoneScore * 0.25;
+        if (composite < 0.80) return null;
+
+        return new ScoredPatientPair(a, b, nameSim, dobScore, phoneScore, composite);
+    }
+
+    private double scoreDob(Patient a, Patient b) {
+        if (a.getPerson() == null || b.getPerson() == null) return 0.0;
+        Date da = a.getPerson().getDob();
+        Date db = b.getPerson().getDob();
+        if (da == null || db == null) return 0.0;
+        long diffDays = Math.abs(da.getTime() - db.getTime()) / (1000L * 60 * 60 * 24);
+        if (diffDays == 0) return 1.0;
+        if (diffDays <= 1) return 0.8;
+        if (diffDays <= 3) return 0.5;
+        return 0.0;
+    }
+
+    private double scorePhone(Patient a, Patient b) {
+        String pA = bestPhone(a);
+        String pB = bestPhone(b);
+        if (pA.isEmpty() || pB.isEmpty()) return 0.0;
+        int len = Math.min(pA.length(), 9);
+        String tailA = pA.substring(Math.max(0, pA.length() - len));
+        String tailB = pB.substring(Math.max(0, pB.length() - len));
+        return tailA.equals(tailB) ? 1.0 : 0.0;
+    }
+
+    private String bestPhone(Patient p) {
+        if (p.getPerson() == null) return "";
+        String phone = p.getPerson().getPhone() != null ? p.getPerson().getPhone().replaceAll("[^0-9]", "") : "";
+        String mobile = p.getPerson().getMobile() != null ? p.getPerson().getMobile().replaceAll("[^0-9]", "") : "";
+        return phone.length() >= mobile.length() ? phone : mobile;
+    }
+
+    public void mergeProbabilisticPair(ScoredPatientPair pair) {
+        if (pair.getSelectedPrimary() == null) {
+            JsfUtil.addErrorMessage("Please select the primary patient.");
+            return;
+        }
+        Patient pri = pair.getSelectedPrimary();
+        Patient sec = pri.getId().equals(pair.getPatientA().getId())
+                ? pair.getPatientB() : pair.getPatientA();
+        try {
+            patientMergeService.merge(pri, sec, PatientMergeType.PROBABILISTIC,
+                    String.format("Probabilistic scan — score %.0f%% (name %.0f%%, DOB %.0f%%, phone %.0f%%)",
+                            pair.getCompositeScore() * 100,
+                            pair.getNameScore() * 100,
+                            pair.getDobScore() * 100,
+                            pair.getPhoneScore() * 100),
+                    sessionController.getLoggedUser());
+            probabilisticResults.remove(pair);
+            JsfUtil.addSuccessMessage("Patients merged.");
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Merge failed: " + e.getMessage());
+        }
+    }
+
+    public void dismissProbabilisticPair(ScoredPatientPair pair) {
+        probabilisticResults.remove(pair);
+    }
+    // </editor-fold>
+
     // <editor-fold defaultstate="collapsed" desc="History & Unmerge">
     public void searchHistory() {
         String jpql = "select mr from PatientMergeRecord mr where mr.mergeDate >= :from and mr.mergeDate <= :to";
@@ -251,6 +376,38 @@ public class PatientMergeController implements Serializable {
         Map<String, Object> p = new HashMap<>();
         p.put("mr", mr);
         return (int) patientMergeRecordFacade.findLongByJpql(jpql, p);
+    }
+    // </editor-fold>
+
+    // <editor-fold defaultstate="collapsed" desc="Inner class — ScoredPatientPair">
+    public static class ScoredPatientPair implements Serializable {
+        private Patient patientA;
+        private Patient patientB;
+        private double nameScore;
+        private double dobScore;
+        private double phoneScore;
+        private double compositeScore;
+        private Patient selectedPrimary;
+
+        public ScoredPatientPair(Patient a, Patient b, double nameScore, double dobScore,
+                double phoneScore, double compositeScore) {
+            this.patientA = a;
+            this.patientB = b;
+            this.nameScore = nameScore;
+            this.dobScore = dobScore;
+            this.phoneScore = phoneScore;
+            this.compositeScore = compositeScore;
+            this.selectedPrimary = a;
+        }
+
+        public Patient getPatientA() { return patientA; }
+        public Patient getPatientB() { return patientB; }
+        public double getNameScore() { return nameScore; }
+        public double getDobScore() { return dobScore; }
+        public double getPhoneScore() { return phoneScore; }
+        public double getCompositeScore() { return compositeScore; }
+        public Patient getSelectedPrimary() { return selectedPrimary; }
+        public void setSelectedPrimary(Patient selectedPrimary) { this.selectedPrimary = selectedPrimary; }
     }
     // </editor-fold>
 
@@ -309,5 +466,13 @@ public class PatientMergeController implements Serializable {
     public void setSelectedMergeRecord(PatientMergeRecord selectedMergeRecord) { this.selectedMergeRecord = selectedMergeRecord; }
 
     public PatientMergeStatus[] getMergeStatusValues() { return PatientMergeStatus.values(); }
+
+    public int getProbMaxPairs() { return probMaxPairs; }
+    public void setProbMaxPairs(int probMaxPairs) { this.probMaxPairs = probMaxPairs; }
+
+    public double getProbNameThreshold() { return probNameThreshold; }
+    public void setProbNameThreshold(double probNameThreshold) { this.probNameThreshold = probNameThreshold; }
+
+    public List<ScoredPatientPair> getProbabilisticResults() { return probabilisticResults; }
     // </editor-fold>
 }

--- a/src/main/java/com/divudi/service/patient/PatientMergeService.java
+++ b/src/main/java/com/divudi/service/patient/PatientMergeService.java
@@ -248,13 +248,16 @@ public class PatientMergeService {
 
     private void restorePatientReference(PatientMergeAffectedRecord ar) {
         Patient old = patientFacade.find(ar.getOldPatientId());
-        if (old == null) {
+        Patient current = patientFacade.find(ar.getNewPatientId());
+        if (old == null || current == null) {
             return;
         }
         Map<String, Object> params = new HashMap<>();
         params.put("old", old);
+        params.put("current", current);
         params.put("id", ar.getEntityId());
-        String jpql = "update " + ar.getEntityClass() + " e set e.patient = :old where e.id = :id";
+        // Guard by current patient to avoid overwriting a later reassignment
+        String jpql = "update " + ar.getEntityClass() + " e set e.patient = :old where e.id = :id and e.patient = :current";
         switch (ar.getEntityClass()) {
             case "Bill":
                 billFacade.updateByJpql(jpql, params);

--- a/src/main/webapp/dataAdmin/patient_data_management.xhtml
+++ b/src/main/webapp/dataAdmin/patient_data_management.xhtml
@@ -204,7 +204,95 @@
                             </p:panel>
                         </p:tab>
 
-                        <!-- ===== TAB 3: MERGE HISTORY ===== -->
+                        <!-- ===== TAB 3: PROBABILISTIC SCAN ===== -->
+                        <p:tab title="Probabilistic Scan"
+                               rendered="#{webUserController.hasPrivilege('MergePatients')}">
+                            <p:panel header="Fuzzy Duplicate Scan (Name, DOB, Phone)" class="m-1">
+                                <div class="row g-2 align-items-end mb-3">
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="txtProbMax" value="Max pairs (1–1000)" />
+                                        <p:inputText id="txtProbMax"
+                                                     value="#{patientMergeController.probMaxPairs}"
+                                                     class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel for="txtProbThresh" value="Name threshold (0–1)" />
+                                        <p:inputText id="txtProbThresh"
+                                                     value="#{patientMergeController.probNameThreshold}"
+                                                     class="w-100" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:commandButton value="Run Scan" icon="fa fa-search"
+                                                         class="w-100 ui-button-info"
+                                                         process="txtProbMax txtProbThresh"
+                                                         update="tblProbResults pdmGrowl"
+                                                         action="#{patientMergeController.runProbabilisticScan()}" />
+                                    </div>
+                                </div>
+
+                                <p:dataTable id="tblProbResults"
+                                             value="#{patientMergeController.probabilisticResults}"
+                                             var="pair"
+                                             emptyMessage="No suggestions found."
+                                             paginator="true"
+                                             rows="10"
+                                             paginatorAlwaysVisible="false"
+                                             class="w-100">
+                                    <p:column headerText="Score" width="70">
+                                        <h:outputText value="#{pair.compositeScore}">
+                                            <f:convertNumber pattern="##0%" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Patient A">
+                                        <h:outputText value="#{pair.patientA.person.name}" /><br />
+                                        <small><h:outputText value="PHN: #{pair.patientA.phn}  DOB: " />
+                                            <h:outputText value="#{pair.patientA.person.dob}"><f:convertDateTime pattern="yyyy-MM-dd" /></h:outputText>
+                                        </small>
+                                    </p:column>
+                                    <p:column headerText="Patient B">
+                                        <h:outputText value="#{pair.patientB.person.name}" /><br />
+                                        <small><h:outputText value="PHN: #{pair.patientB.phn}  DOB: " />
+                                            <h:outputText value="#{pair.patientB.person.dob}"><f:convertDateTime pattern="yyyy-MM-dd" /></h:outputText>
+                                        </small>
+                                    </p:column>
+                                    <p:column headerText="Breakdown" width="160">
+                                        <small>
+                                            Name: <h:outputText value="#{pair.nameScore}"><f:convertNumber pattern="##0%" /></h:outputText><br />
+                                            DOB: <h:outputText value="#{pair.dobScore}"><f:convertNumber pattern="##0%" /></h:outputText><br />
+                                            Phone: <h:outputText value="#{pair.phoneScore}"><f:convertNumber pattern="##0%" /></h:outputText>
+                                        </small>
+                                    </p:column>
+                                    <p:column headerText="Primary" width="200">
+                                        <p:selectOneMenu value="#{pair.selectedPrimary}" class="w-100">
+                                            <f:selectItem itemLabel="#{pair.patientA.person.name} (A)" itemValue="#{pair.patientA}" />
+                                            <f:selectItem itemLabel="#{pair.patientB.person.name} (B)" itemValue="#{pair.patientB}" />
+                                        </p:selectOneMenu>
+                                    </p:column>
+                                    <p:column headerText="Actions" width="120">
+                                        <p:commandButton
+                                            value="Merge"
+                                            icon="fa fa-compress-arrows-alt"
+                                            class="ui-button-warning me-1"
+                                            process="tblProbResults"
+                                            update="tblProbResults pdmGrowl"
+                                            action="#{patientMergeController.mergeProbabilisticPair(pair)}">
+                                            <p:confirm header="Confirm Merge"
+                                                       message="Merge these two patients?"
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            value="Dismiss"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            process="@this"
+                                            update="tblProbResults"
+                                            action="#{patientMergeController.dismissProbabilisticPair(pair)}" />
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </p:tab>
+
+                        <!-- ===== TAB 4: MERGE HISTORY ===== -->
                         <p:tab title="Merge History"
                                rendered="#{webUserController.hasPrivilege('MergePatients')}">
                             <p:panel header="Merge History" class="m-1">
@@ -309,7 +397,7 @@
                             </p:panel>
                         </p:tab>
 
-                        <!-- ===== TAB 4: INACTIVE PATIENTS ===== -->
+                        <!-- ===== TAB 5: INACTIVE PATIENTS ===== -->
                         <p:tab title="Inactive Patients">
                             <p:panel header="Inactive Patients" class="m-1">
                                 <p:commandButton


### PR DESCRIPTION
## Summary

Adds the probabilistic duplicate scan tab to the Patient Data Management panel.

- **`commons-text` 1.12.0** added to `pom.xml` for `JaroWinklerSimilarity`
- `runProbabilisticScan()`: blocking strategy (same birth year + same first letter of name) limits comparison space; scores each candidate pair using name (40% Jaro-Winkler), DOB (35%), phone last-9-digits (25%); surfaces pairs where name similarity ≥ threshold AND composite ≥ 0.80; already-merged pairs (any direction/status) excluded
- `ScoredPatientPair` inner class carries score breakdown for display
- `mergeProbabilisticPair()` / `dismissProbabilisticPair()` actions
- **Probabilistic Scan** tab in `patient_data_management.xhtml`: max-pairs + threshold inputs, results table with score breakdown, Merge + Dismiss per row

## Test plan

- [ ] Probabilistic Scan tab visible to `MergePatients` users
- [ ] Patients with similar names + same birth year appear as candidates
- [ ] Score breakdown shows correct name/DOB/phone percentages
- [ ] Already-merged pairs do not appear in results
- [ ] Merge button calls merge with `PROBABILISTIC` type; row removed from list
- [ ] Dismiss removes pair from session without DB write
- [ ] Max pairs and threshold inputs limit/filter results correctly

**Depends on**: #21227 and #21228 merged first (or deploy all together).

Closes #21213
Part of #21208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added probabilistic patient merge scanning with configurable similarity thresholds and pair limits
  * Enabled users to review scored patient pairs based on name, date of birth, and phone matching before merging

* **Bug Fixes**
  * Improved safety of patient reference restoration during unmerge operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->