### PR TITLE
fix(inward): clear stale discount on fee recalculation after user edit

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2406,10 +2406,12 @@ public class InwardBeanController implements Serializable {
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
                 || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
-            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            // Fix C: clear stale discount and recompute net so calTotals() sees correct feeValue
             if (billFee != null) {
                 billFee.setFeeDiscount(0.0);
                 billFee.setFeeUnitDiscount(0.0);
+                double gross = billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() : 0.0;
+                billFee.setFeeValue(gross);
             }
             return;
         }
@@ -2433,17 +2435,27 @@ public class InwardBeanController implements Serializable {
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
                 || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
-            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            // Fix C: clear stale discount and recompute net so calTotals() sees correct feeValue
             if (billFee != null) {
                 billFee.setFeeDiscount(0.0);
                 billFee.setFeeUnitDiscount(0.0);
+                double gross = billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() : 0.0;
+                double uQty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
+                        ? billFee.getBillItem().getQty() : 1.0;
+                billFee.setFeeUnitValue(gross / uQty);
+                billFee.setFeeValue(gross);
             }
             return;
         }
         if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {
-            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            // Fix C: clear stale discount and recompute net so calTotals() sees correct feeValue
             billFee.setFeeDiscount(0.0);
             billFee.setFeeUnitDiscount(0.0);
+            double gross = billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() : 0.0;
+            double uQty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
+                    ? billFee.getBillItem().getQty() : 1.0;
+            billFee.setFeeUnitValue(gross / uQty);
+            billFee.setFeeValue(gross);
             return;
         }
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2406,6 +2406,11 @@ public class InwardBeanController implements Serializable {
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
                 || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
+            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            if (billFee != null) {
+                billFee.setFeeDiscount(0.0);
+                billFee.setFeeUnitDiscount(0.0);
+            }
             return;
         }
 
@@ -2414,6 +2419,10 @@ public class InwardBeanController implements Serializable {
             billFee.setFeeMargin(margin);
             billFeeFacade.edit(billFee);
         }
+
+        // Fix A: reset discount before recalculating so stale values don't survive
+        billFee.setFeeDiscount(0.0);
+        billFee.setFeeUnitDiscount(0.0);
 
         double net = (billFee.getFeeGrossValue() + margin) - billFee.getFeeDiscount();
 
@@ -2424,9 +2433,17 @@ public class InwardBeanController implements Serializable {
         if (billFee == null || item.isMarginNotAllowed()
                 || billFee.getFee() == null
                 || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
+            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            if (billFee != null) {
+                billFee.setFeeDiscount(0.0);
+                billFee.setFeeUnitDiscount(0.0);
+            }
             return;
         }
         if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {
+            // Fix C: clear stale discount so early exit doesn't leave old values in place
+            billFee.setFeeDiscount(0.0);
+            billFee.setFeeUnitDiscount(0.0);
             return;
         }
 
@@ -2445,6 +2462,11 @@ public class InwardBeanController implements Serializable {
                 billFeeFacade.edit(billFee);
             }
         }
+
+        // Fix A: reset discount before applyInwardDiscountToBillFee so stale values
+        // don't survive if that method exits early without setting a new discount
+        billFee.setFeeUnitDiscount(0.0);
+        billFee.setFeeDiscount(0.0);
 
         applyInwardDiscountToBillFee(billFee, item, patientEncounter);
 


### PR DESCRIPTION
## Summary

- When a user edits a service fee after adding it to an inward bill, stale `feeDiscount`/`feeUnitDiscount` values from the initial calculation were left in place by early exits in `setBillFeeMargin`, causing the changed gross to be incorrectly reduced by a phantom discount
- Three defensive layers applied in `InwardBeanController`:
  - **Fix C**: Zero out `feeDiscount`/`feeUnitDiscount` on every early-exit path in both `setBillFeeMargin` overloads — stale values never survive a recalculation cycle
  - **Fix A**: Reset discount fields to `0` immediately before calling `applyInwardDiscountToBillFee` — if that method exits early (e.g. `discountAllowed=false`), the previous cycle's values are not carried forward
  - **Fix B**: Confirmed the `item.isDiscountAllowed()` guard already uses `Boolean.TRUE.equals` (null-safe) — `null` is correctly treated as false (discount not allowed)
- Discount and margin on the edited fee are still recalculated from the user-entered gross value, so eligible services continue to behave correctly

## Test plan

- [ ] Add an inward service that is **not** eligible for discount (item `discountAllowed = false`) — edit its fee — verify discount remains 0 and net = gross + service charge
- [ ] Add an inward service that **is** eligible for discount — edit its fee from 100 → 150 — verify discount and service charge recalculate based on 150, not 100
- [ ] Add a service with `marginNotAllowed = true` — edit its fee — verify no discount or margin is applied and net = gross
- [ ] Verify the Fees tab totals update correctly after each edit

Closes #21186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fee margin logic to reset discount fields in all return and computation paths, preventing stale discount values from affecting billing. Discounts are now cleared before margin calculations and before inward-discount application, improving billing accuracy and consistency across encounters and admission types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->