### PR TITLE
feat(inward): inpatient form fill, list, edit and delete page with dashboard button

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -214,6 +214,7 @@ public class UserPrivilageController implements Serializable {
 
         TreeNode inwardFormsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Forms"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormTemplateAdmin, "Form Template Admin"), inwardFormsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormFill, "Fill / Edit Forms"), inwardFormsNode);
 
         TreeNode inwardClinicalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -1,0 +1,291 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.web.ComponentPresentationType;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.web.CaptureComponent;
+import com.divudi.core.entity.web.DesignComponent;
+import com.divudi.core.entity.inward.PatientFormEntry;
+import com.divudi.core.facade.PatientFormEntryFacade;
+import com.divudi.core.facade.web.CaptureComponentFacade;
+import com.divudi.core.facade.web.DesignComponentFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Lets inpatient staff list, fill, edit and delete the dynamic forms
+ * ({@link PatientFormEntry}) of an admission.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Named
+@SessionScoped
+public class InwardFormController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private PatientFormEntryFacade patientFormEntryFacade;
+    @EJB
+    private CaptureComponentFacade captureComponentFacade;
+    @EJB
+    private DesignComponentFacade designComponentFacade;
+
+    @Inject
+    private SessionController sessionController;
+
+    private PatientEncounter patientEncounter;
+    private List<PatientFormEntry> formEntries;
+    private PatientFormEntry currentEntry;
+    private List<CaptureComponent> currentCaptureComponents;
+    private List<DesignComponent> availableTemplates;
+    private DesignComponent selectedTemplate;
+
+    public String navigateToInwardFormsFromAdmissionProfile(PatientEncounter pe) {
+        if (pe == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return "";
+        }
+        patientEncounter = pe;
+        loadFormEntries();
+        loadAvailableTemplates();
+        currentEntry = null;
+        currentCaptureComponents = null;
+        selectedTemplate = null;
+        return "/inward/admission_forms?faces-redirect=true";
+    }
+
+    public void loadFormEntries() {
+        if (patientEncounter == null) {
+            formEntries = new ArrayList<>();
+            return;
+        }
+        String jpql = "select pfe "
+                + " from PatientFormEntry pfe "
+                + " where pfe.patientEncounter=:pe "
+                + " and pfe.retired=:ret "
+                + " order by pfe.createdAt";
+        Map<String, Object> m = new HashMap<>();
+        m.put("pe", patientEncounter);
+        m.put("ret", false);
+        formEntries = patientFormEntryFacade.findByJpql(jpql, m);
+    }
+
+    public void loadAvailableTemplates() {
+        String jpql = "select d "
+                + " from DesignComponent d "
+                + " where d.componentPresentationType=:pt "
+                + " and d.retired=:ret "
+                + " order by d.name";
+        Map<String, Object> m = new HashMap<>();
+        m.put("pt", ComponentPresentationType.DataEntryForm);
+        m.put("ret", false);
+        availableTemplates = designComponentFacade.findByJpql(jpql, m);
+    }
+
+    private List<DesignComponent> listTemplateFields(DesignComponent template) {
+        String jpql = "select d "
+                + " from DesignComponent d "
+                + " where d.dataEntryForm=:def "
+                + " and d.retired=:ret "
+                + " order by d.orderNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("def", template);
+        m.put("ret", false);
+        return designComponentFacade.findByJpql(jpql, m);
+    }
+
+    public void startNewForm() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return;
+        }
+        if (selectedTemplate == null) {
+            JsfUtil.addErrorMessage("Please select a form to fill");
+            return;
+        }
+        currentEntry = new PatientFormEntry();
+        currentEntry.setPatientEncounter(patientEncounter);
+        currentEntry.setDesignComponent(selectedTemplate);
+
+        currentCaptureComponents = new ArrayList<>();
+        for (DesignComponent field : listTemplateFields(selectedTemplate)) {
+            CaptureComponent cc = new CaptureComponent();
+            cc.setName(field.getName());
+            cc.setDesignComponent(field);
+            cc.setComponentPresentationType(field.getComponentPresentationType());
+            cc.setComponentDataType(field.getComponentDataType());
+            currentCaptureComponents.add(cc);
+        }
+    }
+
+    public void saveForm() {
+        if (currentEntry == null) {
+            JsfUtil.addErrorMessage("Nothing to save");
+            return;
+        }
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return;
+        }
+        currentEntry.setPatientEncounter(patientEncounter);
+
+        if (currentEntry.getId() == null) {
+            currentEntry.setCreater(sessionController.getLoggedUser());
+            currentEntry.setCreatedAt(new Date());
+            patientFormEntryFacade.create(currentEntry);
+        } else {
+            currentEntry.setEditor(sessionController.getLoggedUser());
+            currentEntry.setEditedAt(new Date());
+            patientFormEntryFacade.edit(currentEntry);
+        }
+
+        if (currentCaptureComponents != null) {
+            for (CaptureComponent cc : currentCaptureComponents) {
+                cc.setPatientFormEntry(currentEntry);
+                if (cc.getId() == null) {
+                    cc.setCreater(sessionController.getLoggedUser());
+                    cc.setCreatedAt(new Date());
+                    captureComponentFacade.create(cc);
+                } else {
+                    captureComponentFacade.edit(cc);
+                }
+            }
+        }
+
+        JsfUtil.addSuccessMessage("Form Saved");
+        loadFormEntries();
+        currentEntry = null;
+        currentCaptureComponents = null;
+        selectedTemplate = null;
+    }
+
+    public void editForm(PatientFormEntry entry) {
+        if (entry == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        currentEntry = entry;
+        selectedTemplate = entry.getDesignComponent();
+        String jpql = "select cc "
+                + " from CaptureComponent cc "
+                + " where cc.patientFormEntry=:pfe "
+                + " and cc.retired=:ret "
+                + " order by cc.designComponent.orderNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("pfe", entry);
+        m.put("ret", false);
+        currentCaptureComponents = captureComponentFacade.findByJpql(jpql, m);
+    }
+
+    public void deleteForm(PatientFormEntry entry) {
+        if (entry == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        entry.setRetired(true);
+        entry.setRetirer(sessionController.getLoggedUser());
+        entry.setRetiredAt(new Date());
+        patientFormEntryFacade.edit(entry);
+
+        String jpql = "select cc "
+                + " from CaptureComponent cc "
+                + " where cc.patientFormEntry=:pfe "
+                + " and cc.retired=:ret ";
+        Map<String, Object> m = new HashMap<>();
+        m.put("pfe", entry);
+        m.put("ret", false);
+        List<CaptureComponent> children = captureComponentFacade.findByJpql(jpql, m);
+        for (CaptureComponent cc : children) {
+            cc.setRetired(true);
+            cc.setRetirer(sessionController.getLoggedUser());
+            cc.setRetiredAt(new Date());
+            captureComponentFacade.edit(cc);
+        }
+
+        if (currentEntry != null && currentEntry.equals(entry)) {
+            currentEntry = null;
+            currentCaptureComponents = null;
+        }
+        JsfUtil.addSuccessMessage("Form Deleted");
+        loadFormEntries();
+    }
+
+    public void cancelForm() {
+        currentEntry = null;
+        currentCaptureComponents = null;
+        selectedTemplate = null;
+    }
+
+    public String navigateBackToAdmissionProfile() {
+        return "/inward/admission_profile?faces-redirect=true";
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public List<PatientFormEntry> getFormEntries() {
+        if (formEntries == null) {
+            formEntries = new ArrayList<>();
+        }
+        return formEntries;
+    }
+
+    public void setFormEntries(List<PatientFormEntry> formEntries) {
+        this.formEntries = formEntries;
+    }
+
+    public PatientFormEntry getCurrentEntry() {
+        return currentEntry;
+    }
+
+    public void setCurrentEntry(PatientFormEntry currentEntry) {
+        this.currentEntry = currentEntry;
+    }
+
+    public List<CaptureComponent> getCurrentCaptureComponents() {
+        return currentCaptureComponents;
+    }
+
+    public void setCurrentCaptureComponents(List<CaptureComponent> currentCaptureComponents) {
+        this.currentCaptureComponents = currentCaptureComponents;
+    }
+
+    public List<DesignComponent> getAvailableTemplates() {
+        if (availableTemplates == null) {
+            loadAvailableTemplates();
+        }
+        return availableTemplates;
+    }
+
+    public void setAvailableTemplates(List<DesignComponent> availableTemplates) {
+        this.availableTemplates = availableTemplates;
+    }
+
+    public DesignComponent getSelectedTemplate() {
+        return selectedTemplate;
+    }
+
+    public void setSelectedTemplate(DesignComponent selectedTemplate) {
+        this.selectedTemplate = selectedTemplate;
+    }
+}

--- a/src/main/java/com/divudi/bean/web/CaptureComponentController.java
+++ b/src/main/java/com/divudi/bean/web/CaptureComponentController.java
@@ -99,6 +99,11 @@ public class CaptureComponentController implements Serializable {
         // Reset or initialize the list of dynamic form components
         formComponents = new ArrayList<>();
 
+        if (selectedDataEntryForm == null || selectedDataEntryForm.getEditHtml() == null) {
+            JsfUtil.addErrorMessage("This form has no edit-mode HTML template configured");
+            return "";
+        }
+
         // Retrieve the HTML template with placeholders
         String htmlTemplateWithPlaceholders = selectedDataEntryForm.getEditHtml();
 

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -100,6 +100,7 @@ public enum Privileges {
     InwardFinalBillReportEdit("Inward Final Bill Report Edit"),
     InwardAdministration("Inward Administration"),
     InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
     InwardAdditionalPrivilages("Inward Additional Privileges"),
     InwardBillSearch("Inward Bill Search"),
     InwardBillItemSearch("Inward Bill Item Search"),
@@ -1062,6 +1063,7 @@ public enum Privileges {
             case InpatientClinicalDischarge:
             case InwardDocumentUpload:
             case InwardFormTemplateAdmin:
+            case InwardFormFill:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                template="/resources/template/template.xhtml">
+
+    <ui:define name="content">
+        <h:form id="formInwardForms">
+            <p:growl id="growl" showDetail="true" />
+
+            <p:panel header="Inpatient Forms">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h:outputText styleClass="fw-bold"
+                                  value="#{inwardFormController.patientEncounter.patient.person.nameWithTitle}" />
+                    <p:commandButton value="Back to Dashboard" icon="fa fa-arrow-left" ajax="false"
+                                     styleClass="ui-button-flat"
+                                     action="#{inwardFormController.navigateBackToAdmissionProfile()}" />
+                </div>
+
+                <p:dataTable id="entriesTable"
+                             value="#{inwardFormController.formEntries}" var="entry"
+                             emptyMessage="No forms filled yet">
+                    <p:column headerText="Form">
+                        <h:outputText value="#{entry.designComponent.name}" />
+                    </p:column>
+                    <p:column headerText="Filled At">
+                        <h:outputText value="#{entry.createdAt}">
+                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:outputText>
+                    </p:column>
+                    <p:column headerText="Filled By">
+                        <h:outputText value="#{entry.creater.webUserPerson.name}" />
+                    </p:column>
+                    <p:column headerText="Comments">
+                        <h:outputText value="#{entry.comments}" />
+                    </p:column>
+                    <p:column headerText="Actions" style="width:12rem;text-align:center">
+                        <p:commandButton value="Edit" icon="fa fa-pen" class="me-1"
+                                         process="@this" update="@form"
+                                         action="#{inwardFormController.editForm(entry)}" />
+                        <p:commandButton value="Delete" icon="fa fa-trash"
+                                         styleClass="ui-button-danger"
+                                         process="@this" update="@form"
+                                         action="#{inwardFormController.deleteForm(entry)}">
+                            <p:confirm header="Confirm" message="Delete this form?"
+                                       icon="pi pi-exclamation-triangle" />
+                        </p:commandButton>
+                    </p:column>
+                </p:dataTable>
+            </p:panel>
+
+            <p:panel header="Fill a Form" class="mt-2">
+                <div class="d-flex gap-2 align-items-end mb-3">
+                    <div>
+                        <p:outputLabel value="Select Form" class="form-label d-block" />
+                        <p:selectOneMenu value="#{inwardFormController.selectedTemplate}"
+                                         filter="true" filterMatchMode="contains" style="min-width:18rem">
+                            <f:selectItem itemLabel="-- Select Form --" itemValue="#{null}" noSelectionOption="true" />
+                            <f:selectItems value="#{inwardFormController.availableTemplates}"
+                                           var="tpl" itemLabel="#{tpl.name}" itemValue="#{tpl}" />
+                        </p:selectOneMenu>
+                    </div>
+                    <p:commandButton value="Load Form" icon="fa fa-download"
+                                     process="@this @parent" update="@form"
+                                     action="#{inwardFormController.startNewForm()}" />
+                </div>
+
+                <h:panelGroup layout="block" styleClass="row"
+                              rendered="#{inwardFormController.currentCaptureComponents != null}">
+                    <ui:repeat value="#{inwardFormController.currentCaptureComponents}" var="cc">
+                        <h:panelGroup layout="block" styleClass="col-12 col-md-6 mb-2">
+                            <p:outputLabel value="#{cc.name}" styleClass="form-label d-block" />
+                            <p:inputText value="#{cc.shortTextValue}" styleClass="w-100"
+                                         rendered="#{cc.componentPresentationType eq 'Input_text'}" />
+                            <p:inputTextarea value="#{cc.longTextValue}" rows="2" styleClass="w-100"
+                                             rendered="#{cc.componentPresentationType eq 'Input_text_Area'}" />
+                            <p:inputNumber value="#{cc.doubleValue}" styleClass="w-100"
+                                           rendered="#{cc.componentPresentationType eq 'Input_Number'}" />
+                            <p:selectBooleanCheckbox value="#{cc.booleanValue}"
+                                                     rendered="#{cc.componentPresentationType eq 'SelectBooleanCheckBox'}" />
+                            <p:calendar value="#{cc.dateValue}" pattern="dd MMM yyyy" showButtonPanel="true"
+                                        rendered="#{cc.componentPresentationType eq 'Calendar'}" />
+                            <h:outputText styleClass="text-muted" value="Unsupported field type"
+                                          rendered="#{cc.componentPresentationType ne 'Input_text'
+                                                      and cc.componentPresentationType ne 'Input_text_Area'
+                                                      and cc.componentPresentationType ne 'Input_Number'
+                                                      and cc.componentPresentationType ne 'SelectBooleanCheckBox'
+                                                      and cc.componentPresentationType ne 'Calendar'}" />
+                        </h:panelGroup>
+                    </ui:repeat>
+                </h:panelGroup>
+
+                <h:panelGroup layout="block" styleClass="mt-2"
+                              rendered="#{inwardFormController.currentEntry != null}">
+                    <p:outputLabel value="Comments" styleClass="form-label d-block" />
+                    <p:inputTextarea value="#{inwardFormController.currentEntry.comments}"
+                                     rows="2" styleClass="w-100" />
+                    <div class="d-flex gap-2 mt-2">
+                        <p:commandButton value="Save" icon="fa fa-save"
+                                         process="@form" update="@form"
+                                         action="#{inwardFormController.saveForm()}" />
+                        <p:commandButton value="Cancel" icon="fa fa-times"
+                                         styleClass="ui-button-flat"
+                                         process="@this" update="@form"
+                                         action="#{inwardFormController.cancelForm()}" />
+                    </div>
+                </h:panelGroup>
+            </p:panel>
+
+            <p:confirmDialog global="true">
+                <p:commandButton value="Yes" type="button"
+                                 styleClass="ui-confirmdialog-yes ui-button-danger" icon="pi pi-check" />
+                <p:commandButton value="No" type="button"
+                                 styleClass="ui-confirmdialog-no ui-button-flat" icon="pi pi-times" />
+            </p:confirmDialog>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -619,6 +619,16 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
+                                        value="Forms"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardFormFill')}"
+                                        action="#{inwardFormController.navigateToInwardFormsFromAdmissionProfile(admissionController.current)}"
+                                        icon="fa fa-wpforms"
+                                        class="w-100">
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
                                         value="Diagnosis Card"
                                         ajax="false"
                                         action="#{admissionController.navigateToInpatientDiagnosisCard()}"


### PR DESCRIPTION
## Summary

Final child of the dynamic inpatient form-management epic (#21219). Adds an inpatient-facing page to list, fill, edit and soft-delete the dynamic forms of an admission, with a "Forms" button on the inpatient dashboard.

## Changes

### Controller
- **New** `com.divudi.bean.inward.InwardFormController` (`@SessionScoped`):
  - `navigateToInwardFormsFromAdmissionProfile(PatientEncounter)` — load entries + templates for the admission.
  - `startNewForm()` — instantiate blank `CaptureComponent` list from the selected template's fields.
  - `saveForm()` — persist the `PatientFormEntry` + child values with creater/createdAt (or editor/editedAt) audit and the `patientFormEntry` FK.
  - `editForm(entry)` — reload child `CaptureComponent` values for editing.
  - `deleteForm(entry)` — soft-delete: retire the entry and each child component.

### Page
- **New** `src/main/webapp/inward/admission_forms.xhtml`: filled-forms `p:dataTable` (form name / filled at / filled by / comments) with Edit + Delete (confirm); template picker → Load → dynamic widget per `ComponentPresentationType` (`Input_text`→inputText, `Input_text_Area`→inputTextarea, `Input_Number`→inputNumber, `SelectBooleanCheckBox`→checkbox, `Calendar`→calendar); comments + Save/Cancel.

### Dashboard
- `inward/admission_profile.xhtml` — "Forms" button in the Clinical Data panel, gated by `InwardFormFill`.

### Privilege (all 3 steps)
- New `InwardFormFill`: enum + `getCategory()` → "Inward" + `UserPrivilageController` node under **Inward → Forms → Fill / Edit Forms**.

### Follow-up fix (from #21221 review)
- Null-guard `CaptureComponentController.navigateToStartDataEntry` so the legacy data-entry flow no longer NPEs when a form has no edit-mode HTML.

## Notes / decisions
- Reused the existing `DesignComponentConverter` (registered `forClass`) for the template dropdown — no new converter.
- `PatientEncounter` lives in `com.divudi.core.entity`; `Admission extends PatientEncounter`, so the dashboard button passes `admissionController.current` directly.

## Testing
- `mvn compile` → BUILD SUCCESS.
- New page validated as well-formed XML.

Part of #21219
Closes #21222

🤖 Generated with [Claude Code](https://claude.com/claude-code)