### PR TITLE
feat(forms): support all ComponentPresentationType values in inpatient form capture

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -10,9 +10,11 @@ import com.divudi.core.data.web.ComponentPresentationType;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.web.CaptureComponent;
 import com.divudi.core.entity.web.DesignComponent;
+import com.divudi.core.entity.web.DesignComponentChoice;
 import com.divudi.core.entity.inward.PatientFormEntry;
 import com.divudi.core.facade.PatientFormEntryFacade;
 import com.divudi.core.facade.web.CaptureComponentFacade;
+import com.divudi.core.facade.web.DesignComponentChoiceFacade;
 import com.divudi.core.facade.web.DesignComponentFacade;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
@@ -44,6 +46,8 @@ public class InwardFormController implements Serializable {
     private CaptureComponentFacade captureComponentFacade;
     @EJB
     private DesignComponentFacade designComponentFacade;
+    @EJB
+    private DesignComponentChoiceFacade designComponentChoiceFacade;
 
     @Inject
     private SessionController sessionController;
@@ -129,6 +133,13 @@ public class InwardFormController implements Serializable {
             cc.setDesignComponent(field);
             cc.setComponentPresentationType(field.getComponentPresentationType());
             cc.setComponentDataType(field.getComponentDataType());
+            cc.setPlaceholder(field.getPlaceholder());
+            cc.setMinValue(field.getMinValue());
+            cc.setMaxValue(field.getMaxValue());
+            cc.setStepSize(field.getStepSize());
+            cc.setMaxRating(field.getMaxRating());
+            cc.setOnLabel(field.getOnLabel());
+            cc.setOffLabel(field.getOffLabel());
             currentCaptureComponents.add(cc);
         }
     }
@@ -230,6 +241,21 @@ public class InwardFormController implements Serializable {
         currentCaptureComponents = null;
         selectedTemplate = null;
     }
+
+    public List<DesignComponentChoice> getChoicesFor(CaptureComponent cc) {
+        if (cc == null || cc.getDesignComponent() == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "select c from DesignComponentChoice c"
+                + " where c.designComponent=:dc"
+                + " and c.retired=:ret"
+                + " order by c.orderNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("dc", cc.getDesignComponent());
+        m.put("ret", false);
+        return designComponentChoiceFacade.findByJpql(jpql, m);
+    }
+
 
     public String navigateBackToAdmissionProfile() {
         return "/inward/admission_profile?faces-redirect=true";

--- a/src/main/java/com/divudi/bean/web/DesignComponentController.java
+++ b/src/main/java/com/divudi/bean/web/DesignComponentController.java
@@ -3,18 +3,22 @@ package com.divudi.bean.web;
 import com.divudi.core.data.web.ComponentDataType;
 import com.divudi.core.data.web.ComponentPresentationType;
 import com.divudi.core.entity.web.DesignComponent;
+import com.divudi.core.entity.web.DesignComponentChoice;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.web.ComponentMappingType;
+import com.divudi.core.facade.web.DesignComponentChoiceFacade;
 import com.divudi.core.facade.web.DesignComponentFacade;
 import javax.inject.Named;
 import javax.enterprise.context.SessionScoped;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
-import javax.ejb.EJB;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
@@ -30,6 +34,43 @@ public class DesignComponentController implements Serializable {
 
     @EJB
     DesignComponentFacade facade;
+    @EJB
+    DesignComponentChoiceFacade choiceFacade;
+    private static final Set<ComponentPresentationType> SHORT_TEXT_TYPES = EnumSet.of(
+            ComponentPresentationType.Input_text,
+            ComponentPresentationType.SelectOneMenu,
+            ComponentPresentationType.SelectOneRadio,
+            ComponentPresentationType.SelectOneListBox,
+            ComponentPresentationType.AutoComplete
+    );
+    private static final Set<ComponentPresentationType> LONG_TEXT_TYPES = EnumSet.of(
+            ComponentPresentationType.Input_text_Area,
+            ComponentPresentationType.TextEditor,
+            ComponentPresentationType.SelectCheckBoxMenu,
+            ComponentPresentationType.SelectManyButton,
+            ComponentPresentationType.MultiSelectListBox
+    );
+    private static final Set<ComponentPresentationType> NUMERIC_TYPES = EnumSet.of(
+            ComponentPresentationType.Input_Number,
+            ComponentPresentationType.Spinner,
+            ComponentPresentationType.Slider
+    );
+    private static final Set<ComponentPresentationType> BOOLEAN_TYPES = EnumSet.of(
+            ComponentPresentationType.SelectBooleanCheckBox,
+            ComponentPresentationType.SelectBooleanButton,
+            ComponentPresentationType.ToggleSwitch,
+            ComponentPresentationType.TriStateCheckBox
+    );
+    private static final Set<ComponentPresentationType> CHOICE_TYPES = EnumSet.of(
+            ComponentPresentationType.SelectOneMenu,
+            ComponentPresentationType.SelectOneRadio,
+            ComponentPresentationType.SelectOneListBox,
+            ComponentPresentationType.SelectCheckBoxMenu,
+            ComponentPresentationType.SelectManyButton,
+            ComponentPresentationType.MultiSelectListBox,
+            ComponentPresentationType.AutoComplete
+    );
+
     private int manageEmrIndex;
     private DesignComponent current;
     private List<DesignComponent> list;
@@ -37,6 +78,8 @@ public class DesignComponentController implements Serializable {
     private List<DesignComponent> listOfDataEntryForms;
     private DesignComponent currentDataEntryItem;
     private List<DesignComponent> listOfDataEntryItems;
+    private List<DesignComponentChoice> currentItemChoices;
+    private DesignComponentChoice currentChoice;
 
     public List<ComponentPresentationType> getComponentPresentationTypes() {
         return Arrays.asList(ComponentPresentationType.values());
@@ -87,6 +130,8 @@ public class DesignComponentController implements Serializable {
             JsfUtil.addErrorMessage("Nothing selected");
             return "";
         }
+        currentItemChoices = loadChoicesForItem(currentDataEntryItem);
+        currentChoice = new DesignComponentChoice();
         return "/forms/data_entry_item?faces-redirect=true";
     }
 
@@ -123,6 +168,8 @@ public class DesignComponentController implements Serializable {
 
         currentDataEntryItem = new DesignComponent();
         currentDataEntryItem.setDataEntryForm(currentDataEntryForm);
+        currentItemChoices = new ArrayList<>();
+        currentChoice = new DesignComponentChoice();
         return "/forms/data_entry_item?faces-redirect=true";
     }
 
@@ -194,6 +241,10 @@ public class DesignComponentController implements Serializable {
             return null;
         }
 
+        if (!validatePresentationDataTypeCombination(currentDataEntryItem)) {
+            return null;
+        }
+
         if (currentDataEntryItem.getId() == null) {
             facade.create(currentDataEntryItem);
             getListOfDataEntryItems().add(currentDataEntryItem);
@@ -201,7 +252,10 @@ public class DesignComponentController implements Serializable {
             facade.edit(currentDataEntryItem);
         }
 
+        saveCurrentChoices();
         currentDataEntryItem = new DesignComponent();
+        currentItemChoices = new ArrayList<>();
+        currentChoice = new DesignComponentChoice();
         return navigateToListComponentsOfDataEntryForm();
     }
 
@@ -251,6 +305,130 @@ public class DesignComponentController implements Serializable {
             listOfDataEntryItems = listItemsOfDataEntryForm(currentDataEntryForm);
         }
         JsfUtil.addSuccessMessage("Removed");
+    }
+
+    private boolean validatePresentationDataTypeCombination(DesignComponent item) {
+        ComponentPresentationType pt = item.getComponentPresentationType();
+        ComponentDataType dt = item.getComponentDataType();
+        if (pt == null) {
+            JsfUtil.addErrorMessage("Please select an Input Type");
+            return false;
+        }
+        if (dt == null) {
+            JsfUtil.addErrorMessage("Please select a Data Type");
+            return false;
+        }
+        if (SHORT_TEXT_TYPES.contains(pt) && dt != ComponentDataType.Short_Text) {
+            JsfUtil.addErrorMessage(pt + " requires Data Type: Short_Text");
+            return false;
+        }
+        if (LONG_TEXT_TYPES.contains(pt) && dt != ComponentDataType.Long_Text) {
+            JsfUtil.addErrorMessage(pt + " requires Data Type: Long_Text");
+            return false;
+        }
+        if (NUMERIC_TYPES.contains(pt)
+                && dt != ComponentDataType.Double
+                && dt != ComponentDataType.Integer
+                && dt != ComponentDataType.Long
+                && dt != ComponentDataType.Short) {
+            JsfUtil.addErrorMessage(pt + " requires a numeric Data Type (Double, Integer, Long or Short)");
+            return false;
+        }
+        if (BOOLEAN_TYPES.contains(pt) && dt != ComponentDataType.Boolean) {
+            JsfUtil.addErrorMessage(pt + " requires Data Type: Boolean");
+            return false;
+        }
+        if (pt == ComponentPresentationType.Rating && dt != ComponentDataType.Integer) {
+            JsfUtil.addErrorMessage("Rating requires Data Type: Integer");
+            return false;
+        }
+        if (pt == ComponentPresentationType.Calendar && dt != ComponentDataType.Date) {
+            JsfUtil.addErrorMessage("Calendar requires Data Type: Date");
+            return false;
+        }
+        if (pt == ComponentPresentationType.Signature && dt != ComponentDataType.Long_Text) {
+            JsfUtil.addErrorMessage("Signature requires Data Type: Long_Text (stored as Base64 string by PrimeFaces)");
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isChoiceType() {
+        return currentDataEntryItem != null
+                && CHOICE_TYPES.contains(currentDataEntryItem.getComponentPresentationType());
+    }
+
+    public boolean isNumericType() {
+        return currentDataEntryItem != null
+                && NUMERIC_TYPES.contains(currentDataEntryItem.getComponentPresentationType());
+    }
+
+    public boolean isRatingType() {
+        return currentDataEntryItem != null
+                && currentDataEntryItem.getComponentPresentationType() == ComponentPresentationType.Rating;
+    }
+
+    public boolean isBooleanButtonType() {
+        return currentDataEntryItem != null
+                && currentDataEntryItem.getComponentPresentationType() == ComponentPresentationType.SelectBooleanButton;
+    }
+
+    public boolean isTextInputType() {
+        return currentDataEntryItem != null
+                && (currentDataEntryItem.getComponentPresentationType() == ComponentPresentationType.Input_text
+                || currentDataEntryItem.getComponentPresentationType() == ComponentPresentationType.Input_text_Area);
+    }
+
+    public void addChoice() {
+        if (currentDataEntryItem == null) {
+            return;
+        }
+        if (currentChoice == null || currentChoice.getLabel() == null || currentChoice.getLabel().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a label for the choice");
+            return;
+        }
+        if (currentChoice.getValue() == null || currentChoice.getValue().trim().isEmpty()) {
+            currentChoice.setValue(currentChoice.getLabel());
+        }
+        currentChoice.setOrderNo(currentItemChoices.size() + 1);
+        currentItemChoices.add(currentChoice);
+        currentChoice = new DesignComponentChoice();
+    }
+
+    public void removeChoice(DesignComponentChoice choice) {
+        currentItemChoices.remove(choice);
+        if (choice.getId() != null) {
+            choice.setRetired(true);
+            choiceFacade.edit(choice);
+        }
+    }
+
+    private void saveCurrentChoices() {
+        if (currentDataEntryItem == null || currentDataEntryItem.getId() == null) {
+            return;
+        }
+        for (DesignComponentChoice choice : currentItemChoices) {
+            choice.setDesignComponent(currentDataEntryItem);
+            if (choice.getId() == null) {
+                choiceFacade.create(choice);
+            } else {
+                choiceFacade.edit(choice);
+            }
+        }
+    }
+
+    private List<DesignComponentChoice> loadChoicesForItem(DesignComponent item) {
+        if (item == null || item.getId() == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "select c from DesignComponentChoice c"
+                + " where c.designComponent=:dc"
+                + " and c.retired=:ret"
+                + " order by c.orderNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("dc", item);
+        m.put("ret", false);
+        return choiceFacade.findByJpql(jpql, m);
     }
 
     public List<DesignComponent> completeDesignComponents(String query) {
@@ -306,6 +484,28 @@ public class DesignComponentController implements Serializable {
 
     public void setListOfDataEntryItems(List<DesignComponent> listOfDataEntryItems) {
         this.listOfDataEntryItems = listOfDataEntryItems;
+    }
+
+    public List<DesignComponentChoice> getCurrentItemChoices() {
+        if (currentItemChoices == null) {
+            currentItemChoices = new ArrayList<>();
+        }
+        return currentItemChoices;
+    }
+
+    public void setCurrentItemChoices(List<DesignComponentChoice> currentItemChoices) {
+        this.currentItemChoices = currentItemChoices;
+    }
+
+    public DesignComponentChoice getCurrentChoice() {
+        if (currentChoice == null) {
+            currentChoice = new DesignComponentChoice();
+        }
+        return currentChoice;
+    }
+
+    public void setCurrentChoice(DesignComponentChoice currentChoice) {
+        this.currentChoice = currentChoice;
     }
 
     @FacesConverter(forClass = DesignComponent.class)

--- a/src/main/java/com/divudi/bean/web/DesignComponentController.java
+++ b/src/main/java/com/divudi/bean/web/DesignComponentController.java
@@ -79,6 +79,7 @@ public class DesignComponentController implements Serializable {
     private DesignComponent currentDataEntryItem;
     private List<DesignComponent> listOfDataEntryItems;
     private List<DesignComponentChoice> currentItemChoices;
+    private List<DesignComponentChoice> choicesToRetire;
     private DesignComponentChoice currentChoice;
 
     public List<ComponentPresentationType> getComponentPresentationTypes() {
@@ -169,6 +170,7 @@ public class DesignComponentController implements Serializable {
         currentDataEntryItem = new DesignComponent();
         currentDataEntryItem.setDataEntryForm(currentDataEntryForm);
         currentItemChoices = new ArrayList<>();
+        choicesToRetire = new ArrayList<>();
         currentChoice = new DesignComponentChoice();
         return "/forms/data_entry_item?faces-redirect=true";
     }
@@ -255,6 +257,7 @@ public class DesignComponentController implements Serializable {
         saveCurrentChoices();
         currentDataEntryItem = new DesignComponent();
         currentItemChoices = new ArrayList<>();
+        choicesToRetire = new ArrayList<>();
         currentChoice = new DesignComponentChoice();
         return navigateToListComponentsOfDataEntryForm();
     }
@@ -396,10 +399,23 @@ public class DesignComponentController implements Serializable {
     }
 
     public void removeChoice(DesignComponentChoice choice) {
+        if (choice == null) {
+            return;
+        }
         currentItemChoices.remove(choice);
         if (choice.getId() != null) {
             choice.setRetired(true);
-            choiceFacade.edit(choice);
+            if (choicesToRetire == null) {
+                choicesToRetire = new ArrayList<>();
+            }
+            choicesToRetire.add(choice);
+        }
+        resequenceChoiceOrderNos();
+    }
+
+    private void resequenceChoiceOrderNos() {
+        for (int i = 0; i < currentItemChoices.size(); i++) {
+            currentItemChoices.get(i).setOrderNo(i + 1);
         }
     }
 
@@ -407,7 +423,15 @@ public class DesignComponentController implements Serializable {
         if (currentDataEntryItem == null || currentDataEntryItem.getId() == null) {
             return;
         }
-        for (DesignComponentChoice choice : currentItemChoices) {
+        if (choicesToRetire != null) {
+            for (DesignComponentChoice retired : choicesToRetire) {
+                choiceFacade.edit(retired);
+            }
+            choicesToRetire.clear();
+        }
+        for (int i = 0; i < currentItemChoices.size(); i++) {
+            DesignComponentChoice choice = currentItemChoices.get(i);
+            choice.setOrderNo(i + 1);
             choice.setDesignComponent(currentDataEntryItem);
             if (choice.getId() == null) {
                 choiceFacade.create(choice);

--- a/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
@@ -383,10 +383,13 @@ public class CaptureComponent implements Serializable {
         this.offLabel = offLabel;
     }
 
+    private static final String MULTI_SELECT_DELIMITER = "|";
+    private static final String MULTI_SELECT_DELIMITER_REGEX = "\\|";
+
     public List<String> getSelectedValues() {
         if (selectedValues == null) {
             if (longTextValue != null && !longTextValue.trim().isEmpty()) {
-                selectedValues = new ArrayList<>(Arrays.asList(longTextValue.split(",")));
+                selectedValues = new ArrayList<>(Arrays.asList(longTextValue.split(MULTI_SELECT_DELIMITER_REGEX)));
             } else {
                 selectedValues = new ArrayList<>();
             }
@@ -399,7 +402,7 @@ public class CaptureComponent implements Serializable {
         if (selectedValues == null || selectedValues.isEmpty()) {
             this.longTextValue = null;
         } else {
-            this.longTextValue = selectedValues.stream().collect(Collectors.joining(","));
+            this.longTextValue = selectedValues.stream().collect(Collectors.joining(MULTI_SELECT_DELIMITER));
         }
     }
 

--- a/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
@@ -11,7 +11,11 @@ import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.PatientFormEntry;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -21,6 +25,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
+import javax.persistence.Transient;
 
 /**
  *
@@ -66,6 +71,19 @@ public class CaptureComponent implements Serializable {
 
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date dateValue;
+
+    private String placeholder;
+    @javax.persistence.Column(name = "min_value")
+    private Double minValue;
+    @javax.persistence.Column(name = "max_value")
+    private Double maxValue;
+    private Double stepSize;
+    private Integer maxRating;
+    private String onLabel;
+    private String offLabel;
+
+    @Transient
+    private List<String> selectedValues;
 
     @ManyToOne
     private PatientFormEntry patientFormEntry;
@@ -307,6 +325,82 @@ public class CaptureComponent implements Serializable {
 
     public void setRetireComments(String retireComments) {
         this.retireComments = retireComments;
+    }
+
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    public Double getMinValue() {
+        return minValue;
+    }
+
+    public void setMinValue(Double minValue) {
+        this.minValue = minValue;
+    }
+
+    public Double getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMaxValue(Double maxValue) {
+        this.maxValue = maxValue;
+    }
+
+    public Double getStepSize() {
+        return stepSize;
+    }
+
+    public void setStepSize(Double stepSize) {
+        this.stepSize = stepSize;
+    }
+
+    public Integer getMaxRating() {
+        return maxRating;
+    }
+
+    public void setMaxRating(Integer maxRating) {
+        this.maxRating = maxRating;
+    }
+
+    public String getOnLabel() {
+        return onLabel;
+    }
+
+    public void setOnLabel(String onLabel) {
+        this.onLabel = onLabel;
+    }
+
+    public String getOffLabel() {
+        return offLabel;
+    }
+
+    public void setOffLabel(String offLabel) {
+        this.offLabel = offLabel;
+    }
+
+    public List<String> getSelectedValues() {
+        if (selectedValues == null) {
+            if (longTextValue != null && !longTextValue.trim().isEmpty()) {
+                selectedValues = new ArrayList<>(Arrays.asList(longTextValue.split(",")));
+            } else {
+                selectedValues = new ArrayList<>();
+            }
+        }
+        return selectedValues;
+    }
+
+    public void setSelectedValues(List<String> selectedValues) {
+        this.selectedValues = selectedValues;
+        if (selectedValues == null || selectedValues.isEmpty()) {
+            this.longTextValue = null;
+        } else {
+            this.longTextValue = selectedValues.stream().collect(Collectors.joining(","));
+        }
     }
 
 }

--- a/src/main/java/com/divudi/core/entity/web/DesignComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponent.java
@@ -57,6 +57,16 @@ public class DesignComponent implements Serializable {
     private Integer orderNo;
     private boolean required;
 
+    private String placeholder;
+    @javax.persistence.Column(name = "min_value")
+    private Double minValue;
+    @javax.persistence.Column(name = "max_value")
+    private Double maxValue;
+    private Double stepSize;
+    private Integer maxRating;
+    private String onLabel;
+    private String offLabel;
+
     public Long getId() {
         return id;
     }
@@ -208,6 +218,62 @@ public class DesignComponent implements Serializable {
 
     public void setRequired(boolean required) {
         this.required = required;
+    }
+
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    public Double getMinValue() {
+        return minValue;
+    }
+
+    public void setMinValue(Double minValue) {
+        this.minValue = minValue;
+    }
+
+    public Double getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMaxValue(Double maxValue) {
+        this.maxValue = maxValue;
+    }
+
+    public Double getStepSize() {
+        return stepSize;
+    }
+
+    public void setStepSize(Double stepSize) {
+        this.stepSize = stepSize;
+    }
+
+    public Integer getMaxRating() {
+        return maxRating;
+    }
+
+    public void setMaxRating(Integer maxRating) {
+        this.maxRating = maxRating;
+    }
+
+    public String getOnLabel() {
+        return onLabel;
+    }
+
+    public void setOnLabel(String onLabel) {
+        this.onLabel = onLabel;
+    }
+
+    public String getOffLabel() {
+        return offLabel;
+    }
+
+    public void setOffLabel(String offLabel) {
+        this.offLabel = offLabel;
     }
 
 }

--- a/src/main/java/com/divudi/core/entity/web/DesignComponentChoice.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponentChoice.java
@@ -1,0 +1,99 @@
+package com.divudi.core.entity.web;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+/**
+ * One selectable option belonging to a choice-based DesignComponent field
+ * (SelectOneMenu, SelectOneRadio, SelectManyButton, etc.).
+ * label is shown to the user; value is stored in CaptureComponent.shortTextValue
+ * (single-select) or appended to CaptureComponent.longTextValue as CSV (multi-select).
+ */
+@Entity
+public class DesignComponentChoice implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private DesignComponent designComponent;
+
+    private String label;
+    private String value;
+    private Integer orderNo;
+    private boolean retired;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public DesignComponent getDesignComponent() {
+        return designComponent;
+    }
+
+    public void setDesignComponent(DesignComponent designComponent) {
+        this.designComponent = designComponent;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Integer getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(Integer orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    @Override
+    public int hashCode() {
+        return (id != null ? id.hashCode() : 0);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof DesignComponentChoice)) {
+            return false;
+        }
+        DesignComponentChoice other = (DesignComponentChoice) object;
+        return !((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id)));
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/facade/web/DesignComponentChoiceFacade.java
+++ b/src/main/java/com/divudi/core/facade/web/DesignComponentChoiceFacade.java
@@ -1,0 +1,23 @@
+package com.divudi.core.facade.web;
+
+import com.divudi.core.entity.web.DesignComponentChoice;
+import com.divudi.core.facade.AbstractFacade;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class DesignComponentChoiceFacade extends AbstractFacade<DesignComponentChoice> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public DesignComponentChoiceFacade() {
+        super(DesignComponentChoice.class);
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -48,7 +48,6 @@
             <!-- already in the L2 cache. Avoids fetching large blobs on        -->
             <!-- every cache hit.                                               -->
             <property name="eclipselink.jdbc.result-set-access-optimization" value="true"/>
-
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">

--- a/src/main/webapp/forms/data_entry_form.xhtml
+++ b/src/main/webapp/forms/data_entry_form.xhtml
@@ -19,20 +19,22 @@
                                      class="form-control w-100" />
                     </div>
                     <div class="col-12 col-md-6 mb-2">
-                        <p:outputLabel value="Description" class="form-label" />
-                        <p:inputTextarea value="#{designComponentController.currentDataEntryForm.description}"
-                                         class="form-control w-100" rows="2" />
+                        <p:outputLabel value="Description" for="txtDescription" class="form-label" />
+                        <p:inputTextarea id="txtDescription"
+                                         value="#{designComponentController.currentDataEntryForm.description}"
+                                         class="form-control w-100" rows="1" />
                     </div>
                 </div>
 
                 <div class="d-flex gap-2 mt-2">
                     <p:commandButton ajax="false" value="Save" icon="fa fa-save"
+                                     styleClass="ui-button-success"
                                      action="#{designComponentController.saveCurrentDataEntryForm()}" />
                     <p:commandButton ajax="false" value="Add Field" icon="fa fa-plus"
                                      styleClass="ui-button-secondary"
                                      action="#{designComponentController.navigateToAddComponentsToDataEntryForm()}" />
                     <p:commandButton ajax="false" value="Back to Forms" icon="fa fa-arrow-left"
-                                     styleClass="ui-button-flat"
+                                     styleClass="ui-button-info ui-button-outlined"
                                      action="#{designComponentController.navigateToListDataEntryForms()}" />
                 </div>
             </p:panel>
@@ -58,7 +60,8 @@
                         <h:outputText value="#{fld.required ? 'Yes' : 'No'}" />
                     </p:column>
                     <p:column headerText="Actions" style="width:11rem;text-align:center">
-                        <p:commandButton ajax="false" value="Edit" icon="fa fa-pen" class="me-1"
+                        <p:commandButton ajax="false" value="Edit" icon="fa fa-pen"
+                                         styleClass="ui-button-warning me-1"
                                          action="#{designComponentController.navigateToEditDesignComponent()}">
                             <f:setPropertyActionListener value="#{fld}"
                                                          target="#{designComponentController.currentDataEntryItem}" />

--- a/src/main/webapp/forms/data_entry_item.xhtml
+++ b/src/main/webapp/forms/data_entry_item.xhtml
@@ -134,17 +134,20 @@
                         <div class="row mt-2">
                             <div class="col-5">
                                 <p:outputLabel value="Label" class="form-label" />
-                                <p:inputText value="#{designComponentController.currentChoice.label}"
+                                <p:inputText id="txtChoiceLabel"
+                                             value="#{designComponentController.currentChoice.label}"
                                              class="w-100" />
                             </div>
                             <div class="col-5">
                                 <p:outputLabel value="Value (blank = same as label)" class="form-label" />
-                                <p:inputText value="#{designComponentController.currentChoice.value}"
+                                <p:inputText id="txtChoiceValue"
+                                             value="#{designComponentController.currentChoice.value}"
                                              class="w-100" />
                             </div>
                             <div class="col-2 d-flex align-items-end">
                                 <p:commandButton value="Add" icon="fa fa-plus"
-                                                 process="@form" update="panelChoices"
+                                                 process="@this txtChoiceLabel txtChoiceValue"
+                                                 update="panelChoices"
                                                  action="#{designComponentController.addChoice()}" />
                             </div>
                         </div>

--- a/src/main/webapp/forms/data_entry_item.xhtml
+++ b/src/main/webapp/forms/data_entry_item.xhtml
@@ -111,9 +111,9 @@
                     </div>
                 </h:panelGroup>
 
-                <h:panelGroup id="panelChoices" layout="block"
-                              rendered="#{designComponentController.choiceType}">
-                    <p:panel header="Choice Options" class="mt-2">
+                <h:panelGroup id="panelChoices" layout="block">
+                    <p:panel header="Choice Options" class="mt-2"
+                             rendered="#{designComponentController.choiceType}">
                         <p:dataTable value="#{designComponentController.currentItemChoices}" var="ch"
                                      emptyMessage="No choices added yet">
                             <p:column headerText="Order" style="width:5rem">

--- a/src/main/webapp/forms/data_entry_item.xhtml
+++ b/src/main/webapp/forms/data_entry_item.xhtml
@@ -31,9 +31,10 @@
                     </div>
                     <div class="col-12 col-md-4 mb-2">
                         <p:outputLabel value="Input Type" class="form-label" />
-                        <p:selectOneMenu filter="true" filterMatchMode="contains"
+                        <p:selectOneMenu id="selInputType" filter="true" filterMatchMode="contains"
                                          value="#{designComponentController.currentDataEntryItem.componentPresentationType}"
                                          class="w-100">
+                            <p:ajax update="panelMeta panelChoices" />
                             <f:selectItem itemLabel="-- Select --" itemValue="#{null}" noSelectionOption="true" />
                             <f:selectItems value="#{designComponentController.componentPresentationTypes}"
                                            var="pt" itemLabel="#{pt}" itemValue="#{pt}" />
@@ -62,6 +63,93 @@
                         </div>
                     </div>
                 </div>
+
+                <h:panelGroup id="panelMeta" layout="block">
+                    <div class="row">
+                        <div class="col-12 col-md-6 mb-2"
+                             style="#{designComponentController.textInputType ? '' : 'display:none'}">
+                            <p:outputLabel value="Placeholder" class="form-label" />
+                            <p:inputText value="#{designComponentController.currentDataEntryItem.placeholder}"
+                                         class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.numericType ? '' : 'display:none'}">
+                            <p:outputLabel value="Min Value" class="form-label" />
+                            <p:inputNumber value="#{designComponentController.currentDataEntryItem.minValue}"
+                                           class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.numericType ? '' : 'display:none'}">
+                            <p:outputLabel value="Max Value" class="form-label" />
+                            <p:inputNumber value="#{designComponentController.currentDataEntryItem.maxValue}"
+                                           class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.numericType ? '' : 'display:none'}">
+                            <p:outputLabel value="Step Size" class="form-label" />
+                            <p:inputNumber value="#{designComponentController.currentDataEntryItem.stepSize}"
+                                           class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.ratingType ? '' : 'display:none'}">
+                            <p:outputLabel value="Max Stars" class="form-label" />
+                            <p:spinner value="#{designComponentController.currentDataEntryItem.maxRating}"
+                                       min="1" max="10" class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.booleanButtonType ? '' : 'display:none'}">
+                            <p:outputLabel value="On Label" class="form-label" />
+                            <p:inputText value="#{designComponentController.currentDataEntryItem.onLabel}"
+                                         class="w-100" />
+                        </div>
+                        <div class="col-12 col-md-3 mb-2"
+                             style="#{designComponentController.booleanButtonType ? '' : 'display:none'}">
+                            <p:outputLabel value="Off Label" class="form-label" />
+                            <p:inputText value="#{designComponentController.currentDataEntryItem.offLabel}"
+                                         class="w-100" />
+                        </div>
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup id="panelChoices" layout="block"
+                              rendered="#{designComponentController.choiceType}">
+                    <p:panel header="Choice Options" class="mt-2">
+                        <p:dataTable value="#{designComponentController.currentItemChoices}" var="ch"
+                                     emptyMessage="No choices added yet">
+                            <p:column headerText="Order" style="width:5rem">
+                                <h:outputText value="#{ch.orderNo}" />
+                            </p:column>
+                            <p:column headerText="Label">
+                                <h:outputText value="#{ch.label}" />
+                            </p:column>
+                            <p:column headerText="Value">
+                                <h:outputText value="#{ch.value}" />
+                            </p:column>
+                            <p:column headerText="Remove" style="width:6rem;text-align:center">
+                                <p:commandButton icon="fa fa-trash" styleClass="ui-button-danger"
+                                                 process="@this" update="panelChoices"
+                                                 action="#{designComponentController.removeChoice(ch)}" />
+                            </p:column>
+                        </p:dataTable>
+                        <div class="row mt-2">
+                            <div class="col-5">
+                                <p:outputLabel value="Label" class="form-label" />
+                                <p:inputText value="#{designComponentController.currentChoice.label}"
+                                             class="w-100" />
+                            </div>
+                            <div class="col-5">
+                                <p:outputLabel value="Value (blank = same as label)" class="form-label" />
+                                <p:inputText value="#{designComponentController.currentChoice.value}"
+                                             class="w-100" />
+                            </div>
+                            <div class="col-2 d-flex align-items-end">
+                                <p:commandButton value="Add" icon="fa fa-plus"
+                                                 process="@form" update="panelChoices"
+                                                 action="#{designComponentController.addChoice()}" />
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
 
                 <div class="d-flex gap-2 mt-2">
                     <p:commandButton ajax="false" value="Save" icon="fa fa-save"

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -5,6 +5,7 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:c="http://java.sun.com/jsp/jstl/core"
                 template="/resources/template/template.xhtml">
 
     <ui:define name="content">
@@ -70,27 +71,111 @@
 
                 <h:panelGroup layout="block" styleClass="row"
                               rendered="#{inwardFormController.currentCaptureComponents != null}">
-                    <ui:repeat value="#{inwardFormController.currentCaptureComponents}" var="cc">
+                    <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc">
                         <h:panelGroup layout="block" styleClass="col-12 col-md-6 mb-2">
                             <p:outputLabel value="#{cc.name}" styleClass="form-label d-block" />
+
                             <p:inputText value="#{cc.shortTextValue}" styleClass="w-100"
+                                         placeholder="#{cc.placeholder}"
                                          rendered="#{cc.componentPresentationType eq 'Input_text'}" />
-                            <p:inputTextarea value="#{cc.longTextValue}" rows="2" styleClass="w-100"
+
+                            <p:inputTextarea value="#{cc.longTextValue}" rows="3" styleClass="w-100"
+                                             placeholder="#{cc.placeholder}"
                                              rendered="#{cc.componentPresentationType eq 'Input_text_Area'}" />
+
+                            <p:textEditor value="#{cc.longTextValue}"
+                                          rendered="#{cc.componentPresentationType eq 'TextEditor'}" />
+
                             <p:inputNumber value="#{cc.doubleValue}" styleClass="w-100"
                                            rendered="#{cc.componentPresentationType eq 'Input_Number'}" />
+
+                            <p:spinner value="#{cc.intValue}" styleClass="w-100"
+                                       min="#{cc.minValue != null ? cc.minValue : 0}"
+                                       max="#{cc.maxValue != null ? cc.maxValue : 999999}"
+                                       stepFactor="#{cc.stepSize != null ? cc.stepSize : 1}"
+                                       rendered="#{cc.componentPresentationType eq 'Spinner'}" />
+
+                            <h:panelGroup rendered="#{cc.componentPresentationType eq 'Slider'}">
+                                <p:inputText id="sliIn" value="#{cc.doubleValue}" styleClass="w-100" />
+                                <p:slider for="sliIn"
+                                          minValue="#{cc.minValue != null ? cc.minValue : 0}"
+                                          maxValue="#{cc.maxValue != null ? cc.maxValue : 100}"
+                                          step="#{cc.stepSize != null ? cc.stepSize : 1}" />
+                            </h:panelGroup>
+
+                            <p:rating value="#{cc.ratingIntValue}"
+                                      stars="#{cc.maxRating != null ? cc.maxRating : 5}"
+                                      rendered="#{cc.componentPresentationType eq 'Rating'}" />
+
+                            <p:calendar value="#{cc.dateValue}"
+                                        pattern="dd MMM yyyy" showButtonPanel="true" styleClass="w-100"
+                                        rendered="#{cc.componentPresentationType eq 'Calendar'}" />
+
                             <p:selectBooleanCheckbox value="#{cc.booleanValue}"
                                                      rendered="#{cc.componentPresentationType eq 'SelectBooleanCheckBox'}" />
-                            <p:calendar value="#{cc.dateValue}" pattern="dd MMM yyyy" showButtonPanel="true"
-                                        rendered="#{cc.componentPresentationType eq 'Calendar'}" />
-                            <h:outputText styleClass="text-muted" value="Unsupported field type"
-                                          rendered="#{cc.componentPresentationType ne 'Input_text'
-                                                      and cc.componentPresentationType ne 'Input_text_Area'
-                                                      and cc.componentPresentationType ne 'Input_Number'
-                                                      and cc.componentPresentationType ne 'SelectBooleanCheckBox'
-                                                      and cc.componentPresentationType ne 'Calendar'}" />
+
+                            <p:selectBooleanButton value="#{cc.booleanValue}"
+                                                   onLabel="#{cc.onLabel != null and cc.onLabel != '' ? cc.onLabel : 'Yes'}"
+                                                   offLabel="#{cc.offLabel != null and cc.offLabel != '' ? cc.offLabel : 'No'}"
+                                                   rendered="#{cc.componentPresentationType eq 'SelectBooleanButton'}" />
+
+                            <p:toggleSwitch value="#{cc.booleanValue}"
+                                            rendered="#{cc.componentPresentationType eq 'ToggleSwitch'}" />
+
+                            <p:triStateCheckbox value="#{cc.booleanValue}"
+                                                rendered="#{cc.componentPresentationType eq 'TriStateCheckBox'}" />
+
+                            <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
+                                             rendered="#{cc.componentPresentationType eq 'SelectOneMenu'}">
+                                <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectOneMenu>
+
+                            <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
+                                              rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectOneRadio>
+
+                            <p:selectOneListbox value="#{cc.shortTextValue}" styleClass="w-100"
+                                                rendered="#{cc.componentPresentationType eq 'SelectOneListBox'}">
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectOneListbox>
+
+                            <p:selectCheckboxMenu value="#{cc.selectedValues}" styleClass="w-100"
+                                                  label="Select..."
+                                                  rendered="#{cc.componentPresentationType eq 'SelectCheckBoxMenu'}">
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectCheckboxMenu>
+
+                            <p:selectManyButton value="#{cc.selectedValues}"
+                                                rendered="#{cc.componentPresentationType eq 'SelectManyButton'}">
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectManyButton>
+
+                            <p:selectManyMenu value="#{cc.selectedValues}" styleClass="w-100"
+                                              rendered="#{cc.componentPresentationType eq 'MultiSelectListBox'}">
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectManyMenu>
+
+                            <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
+                                             filter="true" filterMatchMode="contains"
+                                             rendered="#{cc.componentPresentationType eq 'AutoComplete'}">
+                                <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
+                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                            </p:selectOneMenu>
+
+                            <p:signature value="#{cc.longTextValue}" style="width:100%;height:150px"
+                                         rendered="#{cc.componentPresentationType eq 'Signature'}" />
+
                         </h:panelGroup>
-                    </ui:repeat>
+                    </c:forEach>
                 </h:panelGroup>
 
                 <h:panelGroup layout="block" styleClass="mt-2"

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -71,7 +71,7 @@
 
                 <h:panelGroup layout="block" styleClass="row"
                               rendered="#{inwardFormController.currentCaptureComponents != null}">
-                    <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc">
+                    <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc" varStatus="st">
                         <h:panelGroup layout="block" styleClass="col-12 col-md-6 mb-2">
                             <p:outputLabel value="#{cc.name}" styleClass="form-label d-block" />
 
@@ -96,8 +96,8 @@
                                        rendered="#{cc.componentPresentationType eq 'Spinner'}" />
 
                             <h:panelGroup rendered="#{cc.componentPresentationType eq 'Slider'}">
-                                <p:inputText id="sliIn" value="#{cc.doubleValue}" styleClass="w-100" />
-                                <p:slider for="sliIn"
+                                <p:inputText id="sliIn#{st.index}" value="#{cc.doubleValue}" styleClass="w-100" />
+                                <p:slider for="sliIn#{st.index}"
                                           minValue="#{cc.minValue != null ? cc.minValue : 0}"
                                           maxValue="#{cc.maxValue != null ? cc.maxValue : 100}"
                                           step="#{cc.stepSize != null ? cc.stepSize : 1}" />


### PR DESCRIPTION
## Summary

- Adds `DesignComponentChoice` entity + facade to store selectable options for choice-based field types (`SelectOneMenu`, `SelectOneRadio`, `SelectManyButton`, etc.)
- Adds 7 metadata fields to both `DesignComponent` and `CaptureComponent`: `placeholder`, `min_value`, `max_value`, `stepSize`, `maxRating`, `onLabel`, `offLabel` (`min_value`/`max_value` use `@Column` rename to avoid MySQL reserved-word clash with `MINVALUE`/`MAXVALUE`)
- Adds `@Transient selectedValues` list on `CaptureComponent` with CSV serialisation to `longTextValue` for multi-select components
- Adds `validatePresentationDataTypeCombination()` in `DesignComponentController` — enforces legal data-type per presentation type at save time with a clear error message
- Adds choice list editor and conditional metadata panels (placeholder, min/max/step, max stars, on/off labels) to `data_entry_item.xhtml`, revealed via AJAX when input type is selected
- Switches `admission_forms.xhtml` from `ui:repeat` to `c:forEach` — `ui:repeat` is a runtime iterator that reuses one component subtree (all fields share the same client ID), causing PrimeFaces JS widgets for the 2nd+ fields to silently fail; `c:forEach` is a build-time tag that creates a separate component subtree per item with unique IDs
- Wires all 19 `ComponentPresentationType` values in `admission_forms.xhtml`; `p:signature` bound to `longTextValue` (PrimeFaces 14 stores Base64 string, not `byte[]`)

## Test plan

- [ ] Open form designer (`/forms/data_entry_forms.xhtml`), create a new form with fields of different types (text, number, calendar, signature, select menu with choices, rating)
- [ ] Verify save is blocked with a clear error when an incompatible data type is selected (e.g. Calendar + Short_Text)
- [ ] Navigate to an inpatient admission, open Forms, select the new form and click Load Form — verify all fields render their correct PrimeFaces widgets
- [ ] Fill in values and click Save — verify `CaptureComponent` rows are persisted with correct field values
- [ ] Edit the saved form — verify values are restored correctly
- [ ] Verify multi-select fields (SelectCheckBoxMenu, SelectManyButton) persist and restore CSV values

Closes #21248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable choice/dropdown options for form fields with ordering and labels.
  * New input metadata: placeholders, numeric constraints (min/max/step), rating limits, and toggle labels.
  * Expanded input types: rich text, sliders, ratings, multi-selects, autosuggest, tri-state and signature capture.
* **UX / Forms**
  * Form editor panels to add/remove choices and edit input-specific settings; enhanced form rendering to surface new input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->