### PR TITLE
feat(forms): C3 hybrid pattern — AI-generated field layout wrappers

### DIFF
--- a/developer_docs/forms/custom-layout-guide.md
+++ b/developer_docs/forms/custom-layout-guide.md
@@ -1,0 +1,175 @@
+# Custom Form Layout Guide — C3 Hybrid Pattern
+
+## Overview
+
+The dynamic form system (`DesignComponent` / `CaptureComponent`) supports a **C3 hybrid layout pattern** that separates visual presentation from JSF component logic. An AI assistant or a developer can author per-field HTML wrappers while the input widgets remain code-managed PrimeFaces components.
+
+---
+
+## The Three Concerns
+
+| Concern | Owner | Where stored |
+|---|---|---|
+| Field **layout** — column span, label style, decorators, help text | AI-generated HTML wrappers | `editHtml` / `viewHtml` on `DesignComponent` (copied to `CaptureComponent` at form-fill time) |
+| Field **component** — input widget, value binding, conversion, validation | `componentPresentationType` switch in `admission_forms.xhtml` | Code-managed |
+| Form-level **grid wrapper** | CSS class on the containing row div | `formCssClass` on `DesignComponent` (the form, not the field) |
+
+---
+
+## Placeholder Tokens
+
+### Edit mode (`editHtml`)
+
+| Token | Replaced with |
+|---|---|
+| `{{LABEL}}` | The field label (`cc.name`), HTML-escaped |
+| `{{INPUT}}` | The rendered PrimeFaces input component for the field type |
+
+The template is **split at `{{INPUT}}`**: everything before becomes the opening wrapper, everything after becomes the closing wrapper. The JSF component is inserted between them at render time.
+
+**Example:**
+```html
+<div class="col-12 col-md-4 mb-3 border-start border-primary ps-3">
+  <label class="form-label fw-semibold text-primary">{{LABEL}}</label>
+  <div class="text-muted small mb-1">Enter the admission date</div>
+  {{INPUT}}
+</div>
+```
+
+### View mode (`viewHtml`)
+
+| Token | Replaced with |
+|---|---|
+| `{{LABEL}}` | The field label, HTML-escaped |
+| `{{VALUE}}` | The formatted stored value (see Value Formatting below) |
+
+**Example:**
+```html
+<div class="col-12 col-md-4 mb-3 border-start border-secondary ps-3">
+  <div class="text-muted small">{{LABEL}}</div>
+  <div class="fw-semibold fs-5">{{VALUE}}</div>
+</div>
+```
+
+---
+
+## Value Formatting (`resolveViewValue`)
+
+`InwardFormController.resolveViewValue(CaptureComponent)` converts the stored value to a display string:
+
+| Component type(s) | Storage field | Display |
+|---|---|---|
+| Calendar | `dateValue` | `dd MMM yyyy` |
+| SelectBooleanCheckBox, SelectBooleanButton, ToggleSwitch, TriStateCheckBox | `booleanValue` | `Yes` / `No` |
+| SelectCheckBoxMenu, SelectManyButton, MultiSelectListBox | `longTextValue` (pipe-delimited) | Comma-separated choice **labels** (labels resolved from `DesignComponentChoice`) |
+| Input_Number, Spinner, Slider | `doubleValue` / `intValue` | String representation of the number |
+| Rating | `ratingIntValue` | Number |
+| Input_text, SelectOneMenu, SelectOneRadio, SelectOneListBox, AutoComplete | `shortTextValue` | Raw value |
+| Input_text_Area, TextEditor | `longTextValue` | Raw text (may contain HTML for TextEditor) |
+| Signature | `longTextValue` (Base64) | `[Signature captured]` |
+
+---
+
+## Form-Level CSS (`formCssClass`)
+
+Set on the `DesignComponent` that represents the **form** (not the field). Controls the Bootstrap row wrapper class on `admission_forms.xhtml`.
+
+| Value | Effect |
+|---|---|
+| *(blank)* | Default: `row` |
+| `row row-cols-1 row-cols-md-3 g-3` | Three columns on medium+, one on mobile |
+| `row row-cols-1 g-2` | Always single-column |
+
+---
+
+## Fallback Behaviour
+
+- If `editHtml` is null or blank → the default `col-12 col-md-6 mb-2` wrapper with a `form-label` is used.
+- If `viewHtml` is null or blank → a simple label + bold-value div is used.
+- If `formCssClass` is null or blank → `row` is used.
+
+All existing forms created before C3 support continue to work unchanged.
+
+---
+
+## Security
+
+- HTML wrappers are authored by clinical administrators in the form designer, not by patients or external users.
+- Only `{{LABEL}}`, `{{INPUT}}`, and `{{VALUE}}` tokens are substituted — arbitrary EL expressions are not evaluated.
+- `{{LABEL}}` and `{{VALUE}}` are passed through `escapeHtml()` before substitution to prevent stored XSS via field names or stored values.
+- `{{INPUT}}` is JSF-rendered HTML, which is safe by construction.
+- `escape="false"` on `h:outputText` is only used on admin-authored content — not on user-submitted form data.
+
+---
+
+## AI Prompt Template
+
+To ask Claude (or another AI) to generate wrappers for a form:
+
+```
+Generate editHtml and viewHtml wrappers for each of these fields in a Bootstrap 5 + PrimeFaces layout.
+Use {{LABEL}} for the field label, {{INPUT}} for the input widget (editHtml only), and {{VALUE}} for the display value (viewHtml only).
+All wrappers should be col-based (the parent row uses class="row").
+
+Fields:
+- Admission Date (Calendar)
+- Ward (SelectOneMenu, choices: Medical, Surgical, ICU)
+- Diagnosis (Input_text_Area)
+- Attending Doctor (Input_text)
+
+Design goal: clinical card-style, left border accent, compact spacing.
+```
+
+---
+
+## Where to Configure
+
+### Form designer (admin)
+
+- **Form level**: `forms/data_entry_form.xhtml` — "Form CSS Class" field
+- **Field level**: `forms/data_entry_item.xhtml` — "Edit Wrapper HTML" and "View Wrapper HTML" textareas at the bottom of the field editor
+
+### Runtime (patient forms)
+
+- `inward/admission_forms.xhtml` — View/Edit toggle button switches between view and edit mode for the loaded form
+
+---
+
+## Common Layout Examples
+
+### Two columns (default-like)
+```html
+<div class="col-12 col-md-6 mb-2">
+  <label class="form-label d-block">{{LABEL}}</label>
+  {{INPUT}}
+</div>
+```
+
+### Three columns, accent border
+```html
+<div class="col-12 col-md-4 mb-3 border-start border-3 border-primary ps-3">
+  <label class="form-label fw-semibold text-primary small text-uppercase">{{LABEL}}</label>
+  {{INPUT}}
+</div>
+```
+
+### Full-width with help text
+```html
+<div class="col-12 mb-3">
+  <label class="form-label fw-semibold">{{LABEL}}</label>
+  <div class="text-muted small mb-1">Provide a detailed description</div>
+  {{INPUT}}
+</div>
+```
+
+### View — card style
+```html
+<div class="col-12 col-md-4 mb-3">
+  <div class="card h-100">
+    <div class="card-body py-2 px-3">
+      <div class="card-subtitle text-muted small">{{LABEL}}</div>
+      <div class="card-title mb-0 fw-semibold">{{VALUE}}</div>
+    </div>
+  </div>
+</div>
+```

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -18,11 +18,13 @@ import com.divudi.core.facade.web.DesignComponentChoiceFacade;
 import com.divudi.core.facade.web.DesignComponentFacade;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -58,6 +60,7 @@ public class InwardFormController implements Serializable {
     private List<CaptureComponent> currentCaptureComponents;
     private List<DesignComponent> availableTemplates;
     private DesignComponent selectedTemplate;
+    private boolean viewMode = false;
 
     public String navigateToInwardFormsFromAdmissionProfile(PatientEncounter pe) {
         if (pe == null) {
@@ -70,6 +73,7 @@ public class InwardFormController implements Serializable {
         currentEntry = null;
         currentCaptureComponents = null;
         selectedTemplate = null;
+        viewMode = false;
         return "/inward/admission_forms?faces-redirect=true";
     }
 
@@ -140,6 +144,8 @@ public class InwardFormController implements Serializable {
             cc.setMaxRating(field.getMaxRating());
             cc.setOnLabel(field.getOnLabel());
             cc.setOffLabel(field.getOffLabel());
+            cc.setEditHtml(field.getEditHtml());
+            cc.setViewHtml(field.getViewHtml());
             currentCaptureComponents.add(cc);
         }
     }
@@ -183,6 +189,7 @@ public class InwardFormController implements Serializable {
         currentEntry = null;
         currentCaptureComponents = null;
         selectedTemplate = null;
+        viewMode = false;
     }
 
     public void editForm(PatientFormEntry entry) {
@@ -240,6 +247,129 @@ public class InwardFormController implements Serializable {
         currentEntry = null;
         currentCaptureComponents = null;
         selectedTemplate = null;
+        viewMode = false;
+    }
+
+    public void toggleViewMode() {
+        viewMode = !viewMode;
+    }
+
+    /**
+     * Returns a display string for the stored value of a CaptureComponent,
+     * used as the {{VALUE}} substitution in viewHtml wrappers.
+     */
+    public String resolveViewValue(CaptureComponent cc) {
+        if (cc == null || cc.getComponentPresentationType() == null) {
+            return "";
+        }
+        switch (cc.getComponentPresentationType()) {
+            case Calendar:
+                if (cc.getDateValue() == null) return "";
+                return new SimpleDateFormat("dd MMM yyyy").format(cc.getDateValue());
+            case SelectBooleanCheckBox:
+            case SelectBooleanButton:
+            case ToggleSwitch:
+            case TriStateCheckBox:
+                if (cc.getBooleanValue() == null) return "";
+                return Boolean.TRUE.equals(cc.getBooleanValue()) ? "Yes" : "No";
+            case SelectCheckBoxMenu:
+            case SelectManyButton:
+            case MultiSelectListBox: {
+                List<String> vals = cc.getSelectedValues();
+                if (vals == null || vals.isEmpty()) return "";
+                List<DesignComponentChoice> choices = getChoicesFor(cc);
+                return vals.stream()
+                        .map(v -> choices.stream()
+                                .filter(ch -> v.equals(ch.getValue()))
+                                .map(DesignComponentChoice::getLabel)
+                                .findFirst().orElse(v))
+                        .collect(Collectors.joining(", "));
+            }
+            case Input_Number:
+            case Spinner:
+            case Slider:
+                if (cc.getDoubleValue() != null) return String.valueOf(cc.getDoubleValue());
+                if (cc.getIntValue() != null) return String.valueOf(cc.getIntValue());
+                return "";
+            case Rating:
+                return cc.getRatingIntValue() != null ? String.valueOf(cc.getRatingIntValue()) : "";
+            case Input_text:
+            case SelectOneMenu:
+            case SelectOneRadio:
+            case SelectOneListBox:
+            case AutoComplete:
+                return cc.getShortTextValue() != null ? cc.getShortTextValue() : "";
+            case Input_text_Area:
+            case TextEditor:
+                return cc.getLongTextValue() != null ? cc.getLongTextValue() : "";
+            case Signature:
+                return cc.getLongTextValue() != null && !cc.getLongTextValue().isEmpty()
+                        ? "[Signature captured]" : "";
+            default:
+                return "";
+        }
+    }
+
+    /**
+     * Returns the HTML fragment that goes BEFORE the JSF input component in edit mode.
+     * Splits editHtml at the {{INPUT}} marker; if no marker or no editHtml, returns the
+     * default opening div + label.
+     */
+    public String resolveEditWrapperOpen(CaptureComponent cc) {
+        String label = cc.getName() != null ? cc.getName() : "";
+        String html = cc.getEditHtml();
+        if (html == null || html.trim().isEmpty()) {
+            return "<div class=\"col-12 col-md-6 mb-2\">"
+                    + "<label class=\"form-label d-block\">" + escapeHtml(label) + "</label>";
+        }
+        String resolved = html.replace("{{LABEL}}", escapeHtml(label));
+        int idx = resolved.indexOf("{{INPUT}}");
+        if (idx < 0) {
+            return resolved;
+        }
+        return resolved.substring(0, idx);
+    }
+
+    /**
+     * Returns the HTML fragment that goes AFTER the JSF input component in edit mode.
+     * Splits editHtml at the {{INPUT}} marker; if no marker or no editHtml, returns
+     * the default closing div.
+     */
+    public String resolveEditWrapperClose(CaptureComponent cc) {
+        String html = cc.getEditHtml();
+        if (html == null || html.trim().isEmpty()) {
+            return "</div>";
+        }
+        String label = cc.getName() != null ? cc.getName() : "";
+        String resolved = html.replace("{{LABEL}}", escapeHtml(label));
+        int idx = resolved.indexOf("{{INPUT}}");
+        if (idx < 0) {
+            return "";
+        }
+        return resolved.substring(idx + "{{INPUT}}".length());
+    }
+
+    /**
+     * Substitutes {{LABEL}} and {{VALUE}} into viewHtml.
+     * Falls back to a simple label + value display when viewHtml is blank.
+     */
+    public String resolveViewWrapper(CaptureComponent cc) {
+        String label = cc.getName() != null ? cc.getName() : "";
+        String value = resolveViewValue(cc);
+        String html = cc.getViewHtml();
+        if (html == null || html.trim().isEmpty()) {
+            return "<div class=\"col-12 col-md-6 mb-2\">"
+                    + "<div class=\"text-muted small\">" + escapeHtml(label) + "</div>"
+                    + "<div class=\"fw-semibold\">" + escapeHtml(value) + "</div>"
+                    + "</div>";
+        }
+        return html.replace("{{LABEL}}", escapeHtml(label)).replace("{{VALUE}}", escapeHtml(value));
+    }
+
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("\"", "&quot;").replace("'", "&#39;");
     }
 
     public List<DesignComponentChoice> getChoicesFor(CaptureComponent cc) {
@@ -313,5 +443,13 @@ public class InwardFormController implements Serializable {
 
     public void setSelectedTemplate(DesignComponent selectedTemplate) {
         this.selectedTemplate = selectedTemplate;
+    }
+
+    public boolean isViewMode() {
+        return viewMode;
+    }
+
+    public void setViewMode(boolean viewMode) {
+        this.viewMode = viewMode;
     }
 }

--- a/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
@@ -81,6 +81,10 @@ public class CaptureComponent implements Serializable {
     private Integer maxRating;
     private String onLabel;
     private String offLabel;
+    @Lob
+    private String editHtml;
+    @Lob
+    private String viewHtml;
 
     @Transient
     private List<String> selectedValues;
@@ -381,6 +385,22 @@ public class CaptureComponent implements Serializable {
 
     public void setOffLabel(String offLabel) {
         this.offLabel = offLabel;
+    }
+
+    public String getEditHtml() {
+        return editHtml;
+    }
+
+    public void setEditHtml(String editHtml) {
+        this.editHtml = editHtml;
+    }
+
+    public String getViewHtml() {
+        return viewHtml;
+    }
+
+    public void setViewHtml(String viewHtml) {
+        this.viewHtml = viewHtml;
     }
 
     private static final String MULTI_SELECT_DELIMITER = "|";

--- a/src/main/java/com/divudi/core/entity/web/DesignComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponent.java
@@ -66,6 +66,7 @@ public class DesignComponent implements Serializable {
     private Integer maxRating;
     private String onLabel;
     private String offLabel;
+    private String formCssClass;
 
     public Long getId() {
         return id;
@@ -274,6 +275,14 @@ public class DesignComponent implements Serializable {
 
     public void setOffLabel(String offLabel) {
         this.offLabel = offLabel;
+    }
+
+    public String getFormCssClass() {
+        return formCssClass;
+    }
+
+    public void setFormCssClass(String formCssClass) {
+        this.formCssClass = formCssClass;
     }
 
 }

--- a/src/main/webapp/forms/data_entry_form.xhtml
+++ b/src/main/webapp/forms/data_entry_form.xhtml
@@ -24,6 +24,13 @@
                                          value="#{designComponentController.currentDataEntryForm.description}"
                                          class="form-control w-100" rows="1" />
                     </div>
+                    <div class="col-12 col-md-6 mb-2">
+                        <p:outputLabel value="Form CSS Class (optional)" for="txtFormCssClass" class="form-label" />
+                        <p:inputText id="txtFormCssClass"
+                                     value="#{designComponentController.currentDataEntryForm.formCssClass}"
+                                     placeholder="e.g. row row-cols-3 g-3"
+                                     class="form-control w-100" />
+                    </div>
                 </div>
 
                 <div class="d-flex gap-2 mt-2">

--- a/src/main/webapp/forms/data_entry_item.xhtml
+++ b/src/main/webapp/forms/data_entry_item.xhtml
@@ -154,8 +154,34 @@
                     </p:panel>
                 </h:panelGroup>
 
+                <p:panel header="Custom Layout HTML (C3 Pattern)" class="mt-2">
+                    <p class="text-muted small mb-2">
+                        Tokens: <code>{{LABEL}}</code> — field label,
+                        <code>{{INPUT}}</code> — the input widget (edit mode),
+                        <code>{{VALUE}}</code> — the formatted stored value (view mode).
+                        Leave blank to use the default Bootstrap col-md-6 wrapper.
+                    </p>
+                    <div class="row">
+                        <div class="col-12 col-md-6 mb-2">
+                            <p:outputLabel value="Edit Wrapper HTML" for="txtEditHtml" class="form-label" />
+                            <p:inputTextarea id="txtEditHtml"
+                                             value="#{designComponentController.currentDataEntryItem.editHtml}"
+                                             rows="5" class="w-100 font-monospace"
+                                             placeholder="&lt;div class=&quot;col-12 col-md-6 mb-3&quot;&gt;&#10;  &lt;label&gt;{{LABEL}}&lt;/label&gt;&#10;  {{INPUT}}&#10;&lt;/div&gt;" />
+                        </div>
+                        <div class="col-12 col-md-6 mb-2">
+                            <p:outputLabel value="View Wrapper HTML" for="txtViewHtml" class="form-label" />
+                            <p:inputTextarea id="txtViewHtml"
+                                             value="#{designComponentController.currentDataEntryItem.viewHtml}"
+                                             rows="5" class="w-100 font-monospace"
+                                             placeholder="&lt;div class=&quot;col-12 col-md-6 mb-3&quot;&gt;&#10;  &lt;div class=&quot;text-muted small&quot;&gt;{{LABEL}}&lt;/div&gt;&#10;  &lt;div class=&quot;fw-semibold&quot;&gt;{{VALUE}}&lt;/div&gt;&#10;&lt;/div&gt;" />
+                        </div>
+                    </div>
+                </p:panel>
+
                 <div class="d-flex gap-2 mt-2">
                     <p:commandButton ajax="false" value="Save" icon="fa fa-save"
+                                     styleClass="ui-button-success"
                                      action="#{designComponentController.saveDataEntryComponentOfForm()}" />
                     <p:commandButton ajax="false" value="Cancel" icon="fa fa-arrow-left"
                                      styleClass="ui-button-flat"

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -91,7 +91,8 @@
                 </h:panelGroup>
 
                 <!-- EDIT MODE: render PrimeFaces components inside editHtml outer wrapper -->
-                <h:panelGroup layout="block" styleClass="row"
+                <h:panelGroup layout="block"
+                              styleClass="#{inwardFormController.selectedTemplate != null and inwardFormController.selectedTemplate.formCssClass != null and inwardFormController.selectedTemplate.formCssClass != '' ? inwardFormController.selectedTemplate.formCssClass : 'row'}"
                               rendered="#{inwardFormController.currentCaptureComponents != null and not inwardFormController.viewMode}">
                     <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc" varStatus="st">
 

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -69,117 +69,145 @@
                                      action="#{inwardFormController.startNewForm()}" />
                 </div>
 
-                <h:panelGroup layout="block" styleClass="row"
+                <!-- View/Edit toggle — only shown when a form is loaded -->
+                <h:panelGroup layout="block" styleClass="mb-2"
                               rendered="#{inwardFormController.currentCaptureComponents != null}">
+                    <p:commandButton
+                        value="#{inwardFormController.viewMode ? 'Switch to Edit Mode' : 'Switch to View Mode'}"
+                        icon="#{inwardFormController.viewMode ? 'fa fa-pen' : 'fa fa-eye'}"
+                        styleClass="#{inwardFormController.viewMode ? 'ui-button-secondary' : 'ui-button-info'}"
+                        process="@this" update="@form"
+                        action="#{inwardFormController.toggleViewMode()}" />
+                </h:panelGroup>
+
+                <!-- VIEW MODE: render each field's viewHtml wrapper (or default) with resolved value -->
+                <h:panelGroup layout="block"
+                              rendered="#{inwardFormController.currentCaptureComponents != null and inwardFormController.viewMode}">
+                    <div class="#{inwardFormController.selectedTemplate != null and inwardFormController.selectedTemplate.formCssClass != null and inwardFormController.selectedTemplate.formCssClass != '' ? inwardFormController.selectedTemplate.formCssClass : 'row'}">
+                        <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc">
+                            <h:outputText value="#{inwardFormController.resolveViewWrapper(cc)}" escape="false" />
+                        </c:forEach>
+                    </div>
+                </h:panelGroup>
+
+                <!-- EDIT MODE: render PrimeFaces components inside editHtml outer wrapper -->
+                <h:panelGroup layout="block" styleClass="row"
+                              rendered="#{inwardFormController.currentCaptureComponents != null and not inwardFormController.viewMode}">
                     <c:forEach items="#{inwardFormController.currentCaptureComponents}" var="cc" varStatus="st">
-                        <h:panelGroup layout="block" styleClass="col-12 col-md-6 mb-2">
-                            <p:outputLabel value="#{cc.name}" styleClass="form-label d-block" />
 
-                            <p:inputText value="#{cc.shortTextValue}" styleClass="w-100"
+                        <!-- Open the field wrapper: editHtml up to {{INPUT}}, or default col div -->
+                        <h:outputText escape="false"
+                                      value="#{inwardFormController.resolveEditWrapperOpen(cc)}" />
+
+                        <!-- PrimeFaces input component — selected by componentPresentationType -->
+                        <p:inputText value="#{cc.shortTextValue}" styleClass="w-100"
+                                     placeholder="#{cc.placeholder}"
+                                     rendered="#{cc.componentPresentationType eq 'Input_text'}" />
+
+                        <p:inputTextarea value="#{cc.longTextValue}" rows="3" styleClass="w-100"
                                          placeholder="#{cc.placeholder}"
-                                         rendered="#{cc.componentPresentationType eq 'Input_text'}" />
+                                         rendered="#{cc.componentPresentationType eq 'Input_text_Area'}" />
 
-                            <p:inputTextarea value="#{cc.longTextValue}" rows="3" styleClass="w-100"
-                                             placeholder="#{cc.placeholder}"
-                                             rendered="#{cc.componentPresentationType eq 'Input_text_Area'}" />
+                        <p:textEditor value="#{cc.longTextValue}"
+                                      rendered="#{cc.componentPresentationType eq 'TextEditor'}" />
 
-                            <p:textEditor value="#{cc.longTextValue}"
-                                          rendered="#{cc.componentPresentationType eq 'TextEditor'}" />
+                        <p:inputNumber value="#{cc.doubleValue}" styleClass="w-100"
+                                       rendered="#{cc.componentPresentationType eq 'Input_Number'}" />
 
-                            <p:inputNumber value="#{cc.doubleValue}" styleClass="w-100"
-                                           rendered="#{cc.componentPresentationType eq 'Input_Number'}" />
+                        <p:spinner value="#{cc.intValue}" styleClass="w-100"
+                                   min="#{cc.minValue != null ? cc.minValue : 0}"
+                                   max="#{cc.maxValue != null ? cc.maxValue : 999999}"
+                                   stepFactor="#{cc.stepSize != null ? cc.stepSize : 1}"
+                                   rendered="#{cc.componentPresentationType eq 'Spinner'}" />
 
-                            <p:spinner value="#{cc.intValue}" styleClass="w-100"
-                                       min="#{cc.minValue != null ? cc.minValue : 0}"
-                                       max="#{cc.maxValue != null ? cc.maxValue : 999999}"
-                                       stepFactor="#{cc.stepSize != null ? cc.stepSize : 1}"
-                                       rendered="#{cc.componentPresentationType eq 'Spinner'}" />
-
-                            <h:panelGroup rendered="#{cc.componentPresentationType eq 'Slider'}">
-                                <p:inputText id="sliIn#{st.index}" value="#{cc.doubleValue}" styleClass="w-100" />
-                                <p:slider for="sliIn#{st.index}"
-                                          minValue="#{cc.minValue != null ? cc.minValue : 0}"
-                                          maxValue="#{cc.maxValue != null ? cc.maxValue : 100}"
-                                          step="#{cc.stepSize != null ? cc.stepSize : 1}" />
-                            </h:panelGroup>
-
-                            <p:rating value="#{cc.ratingIntValue}"
-                                      stars="#{cc.maxRating != null ? cc.maxRating : 5}"
-                                      rendered="#{cc.componentPresentationType eq 'Rating'}" />
-
-                            <p:calendar value="#{cc.dateValue}"
-                                        pattern="dd MMM yyyy" showButtonPanel="true" styleClass="w-100"
-                                        rendered="#{cc.componentPresentationType eq 'Calendar'}" />
-
-                            <p:selectBooleanCheckbox value="#{cc.booleanValue}"
-                                                     rendered="#{cc.componentPresentationType eq 'SelectBooleanCheckBox'}" />
-
-                            <p:selectBooleanButton value="#{cc.booleanValue}"
-                                                   onLabel="#{cc.onLabel != null and cc.onLabel != '' ? cc.onLabel : 'Yes'}"
-                                                   offLabel="#{cc.offLabel != null and cc.offLabel != '' ? cc.offLabel : 'No'}"
-                                                   rendered="#{cc.componentPresentationType eq 'SelectBooleanButton'}" />
-
-                            <p:toggleSwitch value="#{cc.booleanValue}"
-                                            rendered="#{cc.componentPresentationType eq 'ToggleSwitch'}" />
-
-                            <p:triStateCheckbox value="#{cc.booleanValue}"
-                                                rendered="#{cc.componentPresentationType eq 'TriStateCheckBox'}" />
-
-                            <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
-                                             rendered="#{cc.componentPresentationType eq 'SelectOneMenu'}">
-                                <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectOneMenu>
-
-                            <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
-                                              rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectOneRadio>
-
-                            <p:selectOneListbox value="#{cc.shortTextValue}" styleClass="w-100"
-                                                rendered="#{cc.componentPresentationType eq 'SelectOneListBox'}">
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectOneListbox>
-
-                            <p:selectCheckboxMenu value="#{cc.selectedValues}" styleClass="w-100"
-                                                  label="Select..."
-                                                  rendered="#{cc.componentPresentationType eq 'SelectCheckBoxMenu'}">
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectCheckboxMenu>
-
-                            <p:selectManyButton value="#{cc.selectedValues}"
-                                                rendered="#{cc.componentPresentationType eq 'SelectManyButton'}">
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectManyButton>
-
-                            <p:selectManyMenu value="#{cc.selectedValues}" styleClass="w-100"
-                                              rendered="#{cc.componentPresentationType eq 'MultiSelectListBox'}">
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectManyMenu>
-
-                            <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
-                                             filter="true" filterMatchMode="contains"
-                                             rendered="#{cc.componentPresentationType eq 'AutoComplete'}">
-                                <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
-                                <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
-                                               var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
-                            </p:selectOneMenu>
-
-                            <p:signature value="#{cc.longTextValue}" style="width:100%;height:150px"
-                                         rendered="#{cc.componentPresentationType eq 'Signature'}" />
-
+                        <h:panelGroup rendered="#{cc.componentPresentationType eq 'Slider'}">
+                            <p:inputText id="sliIn#{st.index}" value="#{cc.doubleValue}" styleClass="w-100" />
+                            <p:slider for="sliIn#{st.index}"
+                                      minValue="#{cc.minValue != null ? cc.minValue : 0}"
+                                      maxValue="#{cc.maxValue != null ? cc.maxValue : 100}"
+                                      step="#{cc.stepSize != null ? cc.stepSize : 1}" />
                         </h:panelGroup>
+
+                        <p:rating value="#{cc.ratingIntValue}"
+                                  stars="#{cc.maxRating != null ? cc.maxRating : 5}"
+                                  rendered="#{cc.componentPresentationType eq 'Rating'}" />
+
+                        <p:calendar value="#{cc.dateValue}"
+                                    pattern="dd MMM yyyy" showButtonPanel="true" styleClass="w-100"
+                                    rendered="#{cc.componentPresentationType eq 'Calendar'}" />
+
+                        <p:selectBooleanCheckbox value="#{cc.booleanValue}"
+                                                 rendered="#{cc.componentPresentationType eq 'SelectBooleanCheckBox'}" />
+
+                        <p:selectBooleanButton value="#{cc.booleanValue}"
+                                               onLabel="#{cc.onLabel != null and cc.onLabel != '' ? cc.onLabel : 'Yes'}"
+                                               offLabel="#{cc.offLabel != null and cc.offLabel != '' ? cc.offLabel : 'No'}"
+                                               rendered="#{cc.componentPresentationType eq 'SelectBooleanButton'}" />
+
+                        <p:toggleSwitch value="#{cc.booleanValue}"
+                                        rendered="#{cc.componentPresentationType eq 'ToggleSwitch'}" />
+
+                        <p:triStateCheckbox value="#{cc.booleanValue}"
+                                            rendered="#{cc.componentPresentationType eq 'TriStateCheckBox'}" />
+
+                        <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
+                                         rendered="#{cc.componentPresentationType eq 'SelectOneMenu'}">
+                            <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectOneMenu>
+
+                        <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
+                                          rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectOneRadio>
+
+                        <p:selectOneListbox value="#{cc.shortTextValue}" styleClass="w-100"
+                                            rendered="#{cc.componentPresentationType eq 'SelectOneListBox'}">
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectOneListbox>
+
+                        <p:selectCheckboxMenu value="#{cc.selectedValues}" styleClass="w-100"
+                                              label="Select..."
+                                              rendered="#{cc.componentPresentationType eq 'SelectCheckBoxMenu'}">
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectCheckboxMenu>
+
+                        <p:selectManyButton value="#{cc.selectedValues}"
+                                            rendered="#{cc.componentPresentationType eq 'SelectManyButton'}">
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectManyButton>
+
+                        <p:selectManyMenu value="#{cc.selectedValues}" styleClass="w-100"
+                                          rendered="#{cc.componentPresentationType eq 'MultiSelectListBox'}">
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectManyMenu>
+
+                        <p:selectOneMenu value="#{cc.shortTextValue}" styleClass="w-100"
+                                         filter="true" filterMatchMode="contains"
+                                         rendered="#{cc.componentPresentationType eq 'AutoComplete'}">
+                            <f:selectItem itemLabel="-- Select --" itemValue="" noSelectionOption="true" />
+                            <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
+                                           var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
+                        </p:selectOneMenu>
+
+                        <p:signature value="#{cc.longTextValue}" style="width:100%;height:150px"
+                                     rendered="#{cc.componentPresentationType eq 'Signature'}" />
+
+                        <!-- Close the field wrapper -->
+                        <h:outputText escape="false"
+                                      value="#{inwardFormController.resolveEditWrapperClose(cc)}" />
+
                     </c:forEach>
                 </h:panelGroup>
 
                 <h:panelGroup layout="block" styleClass="mt-2"
-                              rendered="#{inwardFormController.currentEntry != null}">
+                              rendered="#{inwardFormController.currentEntry != null and not inwardFormController.viewMode}">
                     <p:outputLabel value="Comments" styleClass="form-label d-block" />
                     <p:inputTextarea value="#{inwardFormController.currentEntry.comments}"
                                      rows="2" styleClass="w-100" />


### PR DESCRIPTION
## Summary

- Adds per-field AI-authored HTML wrappers (`editHtml` / `viewHtml`) to `DesignComponent` and `CaptureComponent` so field layout can be AI-generated while JSF/PrimeFaces components remain code-managed
- Adds `formCssClass` on the form `DesignComponent` to control the form-level Bootstrap row wrapper class
- Adds a **View/Edit toggle** on `admission_forms.xhtml`: view mode renders each field through its `viewHtml` wrapper with the stored value formatted as plain text; edit mode wraps the PrimeFaces input inside the `editHtml` template split at the `{{INPUT}}` token
- All forms without custom HTML fall back to the existing `col-12 col-md-6 mb-2` default — zero behaviour change for existing forms
- Adds `developer_docs/forms/custom-layout-guide.md` covering the C3 pattern, all tokens, value formatting, security rationale, AI prompt template and common layout examples

## Token reference

| Token | Mode | Substituted with |
|---|---|---|
| `{{LABEL}}` | edit + view | Field label (HTML-escaped) |
| `{{INPUT}}` | edit only | The rendered PrimeFaces component (split point) |
| `{{VALUE}}` | view only | Formatted stored value (dates formatted, booleans as Yes/No, multi-select as comma-separated labels) |

## Test plan

- [ ] Existing forms with no `editHtml`/`viewHtml` render identically to before (default col-md-6 wrapper)
- [ ] View/Edit toggle button appears when a form is loaded and switches mode correctly
- [ ] View mode shows formatted values for Date, Boolean, Multi-select, Text, Number, Signature fields
- [ ] Edit mode with custom `editHtml` shows the PrimeFaces widget wrapped in the AI HTML
- [ ] `formCssClass` set on the form changes the row wrapper class
- [ ] Admin can enter `editHtml`/`viewHtml` in the field designer (`data_entry_item.xhtml`)
- [ ] Admin can enter `formCssClass` in the form designer (`data_entry_form.xhtml`)

Closes #21253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom HTML template support for form field layouts using placeholder tokens for flexible component composition
  * View/edit mode toggle allowing users to switch between form editing and read-only display
  * Configurable CSS classes and custom HTML wrapper support for enhanced form styling

* **Documentation**
  * Added comprehensive guide for implementing custom form layout patterns with Bootstrap examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->