### PR TITLE
feat(api): dynamic form management REST API with AI chat integration

### DIFF
--- a/developer_docs/forms/form-api-guide.md
+++ b/developer_docs/forms/form-api-guide.md
@@ -1,0 +1,135 @@
+# Form API Guide
+
+REST API for designing, populating, and querying dynamic clinical forms.
+
+## Authentication
+
+All endpoints use the `Finance` header with an HMIS API key.
+
+## Base Path
+
+`/api/forms`
+
+---
+
+## Registration Checklist (4 steps)
+
+1. `FormApi.java` — `@Path("forms")`, `@RequestScoped` — **done**
+2. `ApplicationConfig.addRestResourceClasses()` — add `FormApi.class` — **done**
+3. `CapabilityStatementResource.buildResources()` — add "Dynamic Forms" resource — **done**
+4. `AnthropicApiService`:
+   - `buildToolsArray()` — add `manage_forms` tool — **done**
+   - `executeToolCall()` — add `case "manage_forms"` — **done**
+   - `buildSystemPrompt()` — add tool description + module listing — **done**
+
+---
+
+## Endpoints
+
+### Form Templates
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/forms/templates` | List all non-retired form templates |
+| GET | `/forms/templates/{id}` | Get one form template |
+| POST | `/forms/templates` | Create a form template |
+| PUT | `/forms/templates/{id}` | Update a form template |
+| DELETE | `/forms/templates/{id}` | Retire (soft-delete) a form template |
+
+**POST body:**
+```json
+{ "name": "Admission Form", "description": "...", "formCssClass": "row row-cols-1 row-cols-md-3 g-3" }
+```
+
+**Response (single template):**
+```json
+{ "status": "success", "code": 200, "data": { "id": 12, "name": "Admission Form", "description": "...", "formCssClass": "...", "fieldCount": 5 } }
+```
+
+### Fields
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/forms/templates/{id}/fields` | List fields for a form (ordered by orderNo) |
+| POST | `/forms/templates/{id}/fields` | Add a field |
+| PUT | `/forms/fields/{id}` | Update a field |
+| DELETE | `/forms/fields/{id}` | Retire a field |
+
+**POST body:**
+```json
+{
+  "name": "Admission Date",
+  "componentPresentationType": "Calendar",
+  "componentDataType": "Date",
+  "orderNo": 1,
+  "required": true,
+  "editHtml": "<div class=\"col-12 col-md-6 mb-3\"><label class=\"form-label fw-semibold\">{{LABEL}}</label>{{INPUT}}</div>",
+  "viewHtml": "<div class=\"col-12 col-md-6 mb-3\"><div class=\"text-muted small\">{{LABEL}}</div><div class=\"fw-semibold\">{{VALUE}}</div></div>"
+}
+```
+
+**Supported `componentPresentationType` values:**
+`Input_text`, `Input_text_Area`, `TextEditor`, `Input_Number`, `Spinner`, `Slider`, `Rating`, `Calendar`,
+`SelectBooleanCheckBox`, `SelectBooleanButton`, `ToggleSwitch`, `TriStateCheckBox`,
+`SelectOneMenu`, `SelectOneRadio`, `SelectOneListBox`, `SelectCheckBoxMenu`, `SelectManyButton`, `MultiSelectListBox`,
+`AutoComplete`, `Signature`
+
+### Choices
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/forms/fields/{id}/choices` | List choices for a choice-type field |
+| POST | `/forms/fields/{id}/choices` | Add a choice |
+| PUT | `/forms/choices/{id}` | Update a choice |
+| DELETE | `/forms/choices/{id}` | Retire a choice |
+
+**POST body:**
+```json
+{ "label": "ICU", "value": "ICU", "orderNo": 3 }
+```
+
+### Entries and Values
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/forms/entries/{admissionId}` | List all filled form entries for an admission (PatientEncounter ID) |
+| GET | `/forms/entries/{entryId}/values` | List all captured field values for a filled form entry |
+
+---
+
+## C3 Layout Token Reference
+
+| Token | Used in | Replaced with |
+|---|---|---|
+| `{{LABEL}}` | `editHtml`, `viewHtml` | Field label text (HTML-escaped) |
+| `{{INPUT}}` | `editHtml` only | The rendered PrimeFaces input widget |
+| `{{VALUE}}` | `viewHtml` only | The formatted stored value |
+
+See `developer_docs/forms/custom-layout-guide.md` for full details and examples.
+
+---
+
+## Example Curl Calls
+
+```bash
+# List all form templates
+curl -H "Finance: <api-key>" https://hmis.example.com/api/forms/templates
+
+# Create a form
+curl -X POST -H "Finance: <api-key>" -H "Content-Type: application/json" \
+  -d '{"name":"Ward Assessment","formCssClass":"row row-cols-1 row-cols-md-2 g-3"}' \
+  https://hmis.example.com/api/forms/templates
+
+# Add a field
+curl -X POST -H "Finance: <api-key>" -H "Content-Type: application/json" \
+  -d '{"name":"Chief Complaint","componentPresentationType":"Input_text_Area","orderNo":1,"required":true}' \
+  https://hmis.example.com/api/forms/templates/12/fields
+
+# Add a choice to a SelectOneMenu field
+curl -X POST -H "Finance: <api-key>" -H "Content-Type: application/json" \
+  -d '{"label":"Medical","value":"Medical","orderNo":1}' \
+  https://hmis.example.com/api/forms/fields/45/choices
+
+# Get filled form entries for admission 1001
+curl -H "Finance: <api-key>" https://hmis.example.com/api/forms/entries/1001
+```

--- a/src/main/java/com/divudi/core/data/dto/forms/FormChoiceDto.java
+++ b/src/main/java/com/divudi/core/data/dto/forms/FormChoiceDto.java
@@ -1,0 +1,26 @@
+package com.divudi.core.data.dto.forms;
+
+public class FormChoiceDto {
+    private Long id;
+    private String label;
+    private String value;
+    private Integer orderNo;
+
+    public FormChoiceDto() {}
+
+    public FormChoiceDto(Long id, String label, String value, Integer orderNo) {
+        this.id = id;
+        this.label = label;
+        this.value = value;
+        this.orderNo = orderNo;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+    public Integer getOrderNo() { return orderNo; }
+    public void setOrderNo(Integer orderNo) { this.orderNo = orderNo; }
+}

--- a/src/main/java/com/divudi/core/data/dto/forms/FormEntryDto.java
+++ b/src/main/java/com/divudi/core/data/dto/forms/FormEntryDto.java
@@ -1,0 +1,27 @@
+package com.divudi.core.data.dto.forms;
+
+import java.util.Date;
+
+public class FormEntryDto {
+    private Long id;
+    private Long formTemplateId;
+    private String formTemplateName;
+    private String comments;
+    private Date createdAt;
+    private String createdBy;
+
+    public FormEntryDto() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getFormTemplateId() { return formTemplateId; }
+    public void setFormTemplateId(Long formTemplateId) { this.formTemplateId = formTemplateId; }
+    public String getFormTemplateName() { return formTemplateName; }
+    public void setFormTemplateName(String formTemplateName) { this.formTemplateName = formTemplateName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getCreatedBy() { return createdBy; }
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+}

--- a/src/main/java/com/divudi/core/data/dto/forms/FormFieldDto.java
+++ b/src/main/java/com/divudi/core/data/dto/forms/FormFieldDto.java
@@ -1,0 +1,58 @@
+package com.divudi.core.data.dto.forms;
+
+public class FormFieldDto {
+    private Long id;
+    private String name;
+    private String code;
+    private String description;
+    private String componentPresentationType;
+    private String componentDataType;
+    private Integer orderNo;
+    private boolean required;
+    private String placeholder;
+    private Double minValue;
+    private Double maxValue;
+    private Double stepSize;
+    private Integer maxRating;
+    private String onLabel;
+    private String offLabel;
+    private String editHtml;
+    private String viewHtml;
+
+    public FormFieldDto() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getComponentPresentationType() { return componentPresentationType; }
+    public void setComponentPresentationType(String componentPresentationType) { this.componentPresentationType = componentPresentationType; }
+    public String getComponentDataType() { return componentDataType; }
+    public void setComponentDataType(String componentDataType) { this.componentDataType = componentDataType; }
+    public Integer getOrderNo() { return orderNo; }
+    public void setOrderNo(Integer orderNo) { this.orderNo = orderNo; }
+    public boolean isRequired() { return required; }
+    public void setRequired(boolean required) { this.required = required; }
+    public String getPlaceholder() { return placeholder; }
+    public void setPlaceholder(String placeholder) { this.placeholder = placeholder; }
+    public Double getMinValue() { return minValue; }
+    public void setMinValue(Double minValue) { this.minValue = minValue; }
+    public Double getMaxValue() { return maxValue; }
+    public void setMaxValue(Double maxValue) { this.maxValue = maxValue; }
+    public Double getStepSize() { return stepSize; }
+    public void setStepSize(Double stepSize) { this.stepSize = stepSize; }
+    public Integer getMaxRating() { return maxRating; }
+    public void setMaxRating(Integer maxRating) { this.maxRating = maxRating; }
+    public String getOnLabel() { return onLabel; }
+    public void setOnLabel(String onLabel) { this.onLabel = onLabel; }
+    public String getOffLabel() { return offLabel; }
+    public void setOffLabel(String offLabel) { this.offLabel = offLabel; }
+    public String getEditHtml() { return editHtml; }
+    public void setEditHtml(String editHtml) { this.editHtml = editHtml; }
+    public String getViewHtml() { return viewHtml; }
+    public void setViewHtml(String viewHtml) { this.viewHtml = viewHtml; }
+}

--- a/src/main/java/com/divudi/core/data/dto/forms/FormTemplateDto.java
+++ b/src/main/java/com/divudi/core/data/dto/forms/FormTemplateDto.java
@@ -1,0 +1,30 @@
+package com.divudi.core.data.dto.forms;
+
+public class FormTemplateDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String formCssClass;
+    private int fieldCount;
+
+    public FormTemplateDto() {}
+
+    public FormTemplateDto(Long id, String name, String description, String formCssClass, int fieldCount) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.formCssClass = formCssClass;
+        this.fieldCount = fieldCount;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getFormCssClass() { return formCssClass; }
+    public void setFormCssClass(String formCssClass) { this.formCssClass = formCssClass; }
+    public int getFieldCount() { return fieldCount; }
+    public void setFieldCount(int fieldCount) { this.fieldCount = fieldCount; }
+}

--- a/src/main/java/com/divudi/core/data/dto/forms/FormValueDto.java
+++ b/src/main/java/com/divudi/core/data/dto/forms/FormValueDto.java
@@ -1,0 +1,46 @@
+package com.divudi.core.data.dto.forms;
+
+import java.util.Date;
+import java.util.List;
+
+public class FormValueDto {
+    private Long id;
+    private Long fieldId;
+    private String fieldName;
+    private String componentPresentationType;
+    private String shortTextValue;
+    private String longTextValue;
+    private Double doubleValue;
+    private Integer intValue;
+    private Boolean booleanValue;
+    private Date dateValue;
+    private Integer ratingIntValue;
+    private List<String> selectedValues;
+
+    public FormValueDto() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getFieldId() { return fieldId; }
+    public void setFieldId(Long fieldId) { this.fieldId = fieldId; }
+    public String getFieldName() { return fieldName; }
+    public void setFieldName(String fieldName) { this.fieldName = fieldName; }
+    public String getComponentPresentationType() { return componentPresentationType; }
+    public void setComponentPresentationType(String componentPresentationType) { this.componentPresentationType = componentPresentationType; }
+    public String getShortTextValue() { return shortTextValue; }
+    public void setShortTextValue(String shortTextValue) { this.shortTextValue = shortTextValue; }
+    public String getLongTextValue() { return longTextValue; }
+    public void setLongTextValue(String longTextValue) { this.longTextValue = longTextValue; }
+    public Double getDoubleValue() { return doubleValue; }
+    public void setDoubleValue(Double doubleValue) { this.doubleValue = doubleValue; }
+    public Integer getIntValue() { return intValue; }
+    public void setIntValue(Integer intValue) { this.intValue = intValue; }
+    public Boolean getBooleanValue() { return booleanValue; }
+    public void setBooleanValue(Boolean booleanValue) { this.booleanValue = booleanValue; }
+    public Date getDateValue() { return dateValue; }
+    public void setDateValue(Date dateValue) { this.dateValue = dateValue; }
+    public Integer getRatingIntValue() { return ratingIntValue; }
+    public void setRatingIntValue(Integer ratingIntValue) { this.ratingIntValue = ratingIntValue; }
+    public List<String> getSelectedValues() { return selectedValues; }
+    public void setSelectedValues(List<String> selectedValues) { this.selectedValues = selectedValues; }
+}

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -2209,6 +2209,13 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    private String requireNumericId(String value, String fieldName) {
+        if (value == null || !value.trim().matches("\\d+")) {
+            throw new IllegalArgumentException("Error: " + fieldName + " must be a numeric id.");
+        }
+        return value.trim();
+    }
+
     private String callFormsApi(
             String resourceType, String method, String id, String formId, String fieldId,
             String admissionId, String entryId, String name, String description, String formCssClass,
@@ -2235,7 +2242,7 @@ public class AnthropicApiService implements Serializable {
                 case "TEMPLATE":
                     switch (method.toUpperCase()) {
                         case "LIST": url = base + "/templates"; httpMethod = "GET"; break;
-                        case "GET":  url = base + "/templates/" + id; httpMethod = "GET"; break;
+                        case "GET":  url = base + "/templates/" + requireNumericId(id, "id"); httpMethod = "GET"; break;
                         case "POST": {
                             url = base + "/templates"; httpMethod = "POST";
                             Map<String, Object> body = new HashMap<>();
@@ -2246,7 +2253,7 @@ public class AnthropicApiService implements Serializable {
                             break;
                         }
                         case "PUT": {
-                            url = base + "/templates/" + id; httpMethod = "PUT";
+                            url = base + "/templates/" + requireNumericId(id, "id"); httpMethod = "PUT";
                             Map<String, Object> body = new HashMap<>();
                             if (name != null) body.put("name", name);
                             if (description != null) body.put("description", description);
@@ -2254,16 +2261,16 @@ public class AnthropicApiService implements Serializable {
                             requestBody = new com.google.gson.Gson().toJson(body);
                             break;
                         }
-                        case "DELETE": url = base + "/templates/" + id; httpMethod = "DELETE"; break;
+                        case "DELETE": url = base + "/templates/" + requireNumericId(id, "id"); httpMethod = "DELETE"; break;
                         default: return "Unknown method: " + method;
                     }
                     break;
 
                 case "FIELD":
                     switch (method.toUpperCase()) {
-                        case "LIST": url = base + "/templates/" + formId + "/fields"; httpMethod = "GET"; break;
+                        case "LIST": url = base + "/templates/" + requireNumericId(formId, "form_id") + "/fields"; httpMethod = "GET"; break;
                         case "POST": {
-                            url = base + "/templates/" + formId + "/fields"; httpMethod = "POST";
+                            url = base + "/templates/" + requireNumericId(formId, "form_id") + "/fields"; httpMethod = "POST";
                             Map<String, Object> body = new HashMap<>();
                             if (name != null)        body.put("name", name);
                             if (description != null) body.put("description", description);
@@ -2284,7 +2291,7 @@ public class AnthropicApiService implements Serializable {
                             break;
                         }
                         case "PUT": {
-                            url = base + "/fields/" + id; httpMethod = "PUT";
+                            url = base + "/fields/" + requireNumericId(id, "id"); httpMethod = "PUT";
                             Map<String, Object> body = new HashMap<>();
                             if (name != null)        body.put("name", name);
                             if (description != null) body.put("description", description);
@@ -2304,16 +2311,16 @@ public class AnthropicApiService implements Serializable {
                             requestBody = new com.google.gson.Gson().toJson(body);
                             break;
                         }
-                        case "DELETE": url = base + "/fields/" + id; httpMethod = "DELETE"; break;
+                        case "DELETE": url = base + "/fields/" + requireNumericId(id, "id"); httpMethod = "DELETE"; break;
                         default: return "Unknown method: " + method;
                     }
                     break;
 
                 case "CHOICE":
                     switch (method.toUpperCase()) {
-                        case "LIST": url = base + "/fields/" + fieldId + "/choices"; httpMethod = "GET"; break;
+                        case "LIST": url = base + "/fields/" + requireNumericId(fieldId, "field_id") + "/choices"; httpMethod = "GET"; break;
                         case "POST": {
-                            url = base + "/fields/" + fieldId + "/choices"; httpMethod = "POST";
+                            url = base + "/fields/" + requireNumericId(fieldId, "field_id") + "/choices"; httpMethod = "POST";
                             Map<String, Object> body = new HashMap<>();
                             if (label != null)   body.put("label", label);
                             if (value != null)   body.put("value", value);
@@ -2322,7 +2329,7 @@ public class AnthropicApiService implements Serializable {
                             break;
                         }
                         case "PUT": {
-                            url = base + "/choices/" + id; httpMethod = "PUT";
+                            url = base + "/choices/" + requireNumericId(id, "id"); httpMethod = "PUT";
                             Map<String, Object> body = new HashMap<>();
                             if (label != null)   body.put("label", label);
                             if (value != null)   body.put("value", value);
@@ -2330,16 +2337,18 @@ public class AnthropicApiService implements Serializable {
                             requestBody = new com.google.gson.Gson().toJson(body);
                             break;
                         }
-                        case "DELETE": url = base + "/choices/" + id; httpMethod = "DELETE"; break;
+                        case "DELETE": url = base + "/choices/" + requireNumericId(id, "id"); httpMethod = "DELETE"; break;
                         default: return "Unknown method: " + method;
                     }
                     break;
 
                 case "ENTRY":
-                    url = base + "/entries/" + admissionId; httpMethod = "GET"; break;
+                    if (!"LIST".equalsIgnoreCase(method)) return "Unknown method: " + method + " for ENTRY";
+                    url = base + "/entries/" + requireNumericId(admissionId, "admission_id"); httpMethod = "GET"; break;
 
                 case "VALUE":
-                    url = base + "/entries/" + entryId + "/values"; httpMethod = "GET"; break;
+                    if (!"LIST".equalsIgnoreCase(method)) return "Unknown method: " + method + " for VALUE";
+                    url = base + "/entries/" + requireNumericId(entryId, "entry_id") + "/values"; httpMethod = "GET"; break;
 
                 default:
                     return "Unknown resource_type: " + resourceType;

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -744,6 +744,108 @@ public class AnthropicApiService implements Serializable {
                                 .add("resource_type").add("method").add("investigation_id")))
                 .build();
 
+        JsonObject manageFormsTool = Json.createObjectBuilder()
+                .add("name", "manage_forms")
+                .add("description",
+                        "Design and manage dynamic clinical form templates (create/update/retire), "
+                        + "fields of all input types (text, number, date, calendar, signature, choice lists, boolean, rating, slider, spinner), "
+                        + "per-field choice options, and AI-generated HTML layout wrappers (editHtml/viewHtml) for custom C3 hybrid layout. "
+                        + "Also query filled form entries and their captured values for a given admission.\n\n"
+                        + "resource_type: TEMPLATE | FIELD | CHOICE | ENTRY | VALUE\n"
+                        + "method: LIST | GET | POST | PUT | DELETE\n\n"
+                        + "TEMPLATE: LIST returns all non-retired forms. GET requires id. POST requires name. PUT requires id. DELETE requires id.\n"
+                        + "FIELD: LIST requires form_id. POST requires form_id + name + componentPresentationType. PUT requires id. DELETE requires id.\n"
+                        + "  componentPresentationType values: Input_text, Input_text_Area, TextEditor, Input_Number, Spinner, Slider, Rating, Calendar,\n"
+                        + "  SelectBooleanCheckBox, SelectBooleanButton, ToggleSwitch, TriStateCheckBox, SelectOneMenu, SelectOneRadio,\n"
+                        + "  SelectOneListBox, SelectCheckBoxMenu, SelectManyButton, MultiSelectListBox, AutoComplete, Signature\n"
+                        + "  editHtml: wrap the {{INPUT}} placeholder with Bootstrap 5 HTML. {{LABEL}} is the field label.\n"
+                        + "  viewHtml: wrap {{LABEL}} and {{VALUE}} for the read-only view.\n"
+                        + "CHOICE: LIST requires field_id. POST requires field_id + label. PUT requires id. DELETE requires id.\n"
+                        + "ENTRY: LIST requires admission_id. Returns PatientFormEntry records for the admission.\n"
+                        + "VALUE: LIST requires entry_id. Returns CaptureComponent values for a filled entry.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("resource_type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("TEMPLATE").add("FIELD").add("CHOICE").add("ENTRY").add("VALUE"))
+                                        .add("description", "Which sub-resource to operate on"))
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("GET").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "CRUD operation"))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Record ID (string) — required for GET/PUT/DELETE on templates, fields, and choices"))
+                                .add("form_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Form template ID — required when listing or adding fields"))
+                                .add("field_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Field ID — required when listing or adding choices"))
+                                .add("admission_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "PatientEncounter ID — required for ENTRY LIST"))
+                                .add("entry_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "PatientFormEntry ID — required for VALUE LIST"))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Display name for a template, field, or choice label"))
+                                .add("description", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Description text (optional)"))
+                                .add("formCssClass", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Bootstrap CSS class for the form row wrapper (e.g. 'row row-cols-1 row-cols-md-3 g-3')"))
+                                .add("componentPresentationType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Input widget type for a field (e.g. Input_text, Calendar, SelectOneMenu, Signature, etc.)"))
+                                .add("componentDataType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Data type for a field (optional)"))
+                                .add("orderNo", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Display order number (integer as string)"))
+                                .add("required", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' or 'false' — whether the field is mandatory"))
+                                .add("placeholder", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Placeholder text for text input fields"))
+                                .add("minValue", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Minimum value for numeric/range fields"))
+                                .add("maxValue", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Maximum value for numeric/range fields"))
+                                .add("stepSize", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Step increment for Slider/Spinner fields"))
+                                .add("maxRating", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Maximum star count for Rating fields"))
+                                .add("onLabel", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Label when SelectBooleanButton is ON"))
+                                .add("offLabel", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Label when SelectBooleanButton is OFF"))
+                                .add("editHtml", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "HTML wrapper for edit mode. Use {{LABEL}} for the field label, {{INPUT}} where the PrimeFaces widget will be rendered. Use Bootstrap 5 col classes."))
+                                .add("viewHtml", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "HTML wrapper for view mode. Use {{LABEL}} and {{VALUE}} tokens."))
+                                .add("label", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Choice label shown to the user"))
+                                .add("value", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Choice value stored (defaults to label if omitted)")))
+                        .add("required", Json.createArrayBuilder().add("resource_type").add("method")))
+                .build();
+
         return Json.createArrayBuilder()
                 .add(searchCodeTool)
                 .add(fetchFileTool)
@@ -754,6 +856,7 @@ public class AnthropicApiService implements Serializable {
                 .add(inwardRoomsTool)
                 .add(manageInvestigationsTool)
                 .add(manageInvestigationFormatTool)
+                .add(manageFormsTool)
                 .build();
     }
 
@@ -931,6 +1034,38 @@ public class AnthropicApiService implements Serializable {
                             moCharge, moAfterCharge, adminCharge, medCareCharge,
                             durationHours, overShoot, durationDays,
                             query, size, retireComments, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_forms": {
+                    String resourceType = toolInput.getString("resource_type", "TEMPLATE");
+                    String method       = toolInput.getString("method", "LIST");
+                    String id           = toolInput.containsKey("id")           ? toolInput.getString("id", "")           : "";
+                    String formId       = toolInput.containsKey("form_id")      ? toolInput.getString("form_id", "")      : "";
+                    String fieldId      = toolInput.containsKey("field_id")     ? toolInput.getString("field_id", "")     : "";
+                    String admissionId  = toolInput.containsKey("admission_id") ? toolInput.getString("admission_id", "") : "";
+                    String entryId      = toolInput.containsKey("entry_id")     ? toolInput.getString("entry_id", "")     : "";
+                    String name         = toolInput.containsKey("name")         ? toolInput.getString("name", null)       : null;
+                    String description  = toolInput.containsKey("description")  ? toolInput.getString("description", null): null;
+                    String formCssClass = toolInput.containsKey("formCssClass") ? toolInput.getString("formCssClass", null): null;
+                    String cpt          = toolInput.containsKey("componentPresentationType") ? toolInput.getString("componentPresentationType", null) : null;
+                    String cdt          = toolInput.containsKey("componentDataType")         ? toolInput.getString("componentDataType", null)         : null;
+                    String orderNo      = toolInput.containsKey("orderNo")      ? toolInput.getString("orderNo", null)    : null;
+                    String required     = toolInput.containsKey("required")     ? toolInput.getString("required", null)   : null;
+                    String placeholder  = toolInput.containsKey("placeholder")  ? toolInput.getString("placeholder", null): null;
+                    String minValue     = toolInput.containsKey("minValue")     ? toolInput.getString("minValue", null)   : null;
+                    String maxValue     = toolInput.containsKey("maxValue")     ? toolInput.getString("maxValue", null)   : null;
+                    String stepSize     = toolInput.containsKey("stepSize")     ? toolInput.getString("stepSize", null)   : null;
+                    String maxRating    = toolInput.containsKey("maxRating")    ? toolInput.getString("maxRating", null)  : null;
+                    String onLabel      = toolInput.containsKey("onLabel")      ? toolInput.getString("onLabel", null)    : null;
+                    String offLabel     = toolInput.containsKey("offLabel")     ? toolInput.getString("offLabel", null)   : null;
+                    String editHtml     = toolInput.containsKey("editHtml")     ? toolInput.getString("editHtml", null)   : null;
+                    String viewHtml     = toolInput.containsKey("viewHtml")     ? toolInput.getString("viewHtml", null)   : null;
+                    String label        = toolInput.containsKey("label")        ? toolInput.getString("label", null)      : null;
+                    String value        = toolInput.containsKey("value")        ? toolInput.getString("value", null)      : null;
+                    return callFormsApi(resourceType, method, id, formId, fieldId, admissionId, entryId,
+                            name, description, formCssClass, cpt, cdt, orderNo, required,
+                            placeholder, minValue, maxValue, stepSize, maxRating,
+                            onLabel, offLabel, editHtml, viewHtml, label, value,
+                            hmisBaseUrl, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -2074,6 +2209,171 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    private String callFormsApi(
+            String resourceType, String method, String id, String formId, String fieldId,
+            String admissionId, String entryId, String name, String description, String formCssClass,
+            String cpt, String cdt, String orderNo, String required, String placeholder,
+            String minValue, String maxValue, String stepSize, String maxRating,
+            String onLabel, String offLabel, String editHtml, String viewHtml,
+            String label, String value,
+            String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key not configured.";
+        }
+        try {
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            String base = hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/forms";
+
+            String url;
+            String httpMethod;
+            String requestBody = null;
+
+            switch (resourceType.toUpperCase()) {
+                case "TEMPLATE":
+                    switch (method.toUpperCase()) {
+                        case "LIST": url = base + "/templates"; httpMethod = "GET"; break;
+                        case "GET":  url = base + "/templates/" + id; httpMethod = "GET"; break;
+                        case "POST": {
+                            url = base + "/templates"; httpMethod = "POST";
+                            Map<String, Object> body = new HashMap<>();
+                            if (name != null) body.put("name", name);
+                            if (description != null) body.put("description", description);
+                            if (formCssClass != null) body.put("formCssClass", formCssClass);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "PUT": {
+                            url = base + "/templates/" + id; httpMethod = "PUT";
+                            Map<String, Object> body = new HashMap<>();
+                            if (name != null) body.put("name", name);
+                            if (description != null) body.put("description", description);
+                            if (formCssClass != null) body.put("formCssClass", formCssClass);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "DELETE": url = base + "/templates/" + id; httpMethod = "DELETE"; break;
+                        default: return "Unknown method: " + method;
+                    }
+                    break;
+
+                case "FIELD":
+                    switch (method.toUpperCase()) {
+                        case "LIST": url = base + "/templates/" + formId + "/fields"; httpMethod = "GET"; break;
+                        case "POST": {
+                            url = base + "/templates/" + formId + "/fields"; httpMethod = "POST";
+                            Map<String, Object> body = new HashMap<>();
+                            if (name != null)        body.put("name", name);
+                            if (description != null) body.put("description", description);
+                            if (cpt != null)         body.put("componentPresentationType", cpt);
+                            if (cdt != null)         body.put("componentDataType", cdt);
+                            if (orderNo != null)     body.put("orderNo", orderNo);
+                            if (required != null)    body.put("required", required);
+                            if (placeholder != null) body.put("placeholder", placeholder);
+                            if (minValue != null)    body.put("minValue", minValue);
+                            if (maxValue != null)    body.put("maxValue", maxValue);
+                            if (stepSize != null)    body.put("stepSize", stepSize);
+                            if (maxRating != null)   body.put("maxRating", maxRating);
+                            if (onLabel != null)     body.put("onLabel", onLabel);
+                            if (offLabel != null)    body.put("offLabel", offLabel);
+                            if (editHtml != null)    body.put("editHtml", editHtml);
+                            if (viewHtml != null)    body.put("viewHtml", viewHtml);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "PUT": {
+                            url = base + "/fields/" + id; httpMethod = "PUT";
+                            Map<String, Object> body = new HashMap<>();
+                            if (name != null)        body.put("name", name);
+                            if (description != null) body.put("description", description);
+                            if (cpt != null)         body.put("componentPresentationType", cpt);
+                            if (cdt != null)         body.put("componentDataType", cdt);
+                            if (orderNo != null)     body.put("orderNo", orderNo);
+                            if (required != null)    body.put("required", required);
+                            if (placeholder != null) body.put("placeholder", placeholder);
+                            if (minValue != null)    body.put("minValue", minValue);
+                            if (maxValue != null)    body.put("maxValue", maxValue);
+                            if (stepSize != null)    body.put("stepSize", stepSize);
+                            if (maxRating != null)   body.put("maxRating", maxRating);
+                            if (onLabel != null)     body.put("onLabel", onLabel);
+                            if (offLabel != null)    body.put("offLabel", offLabel);
+                            if (editHtml != null)    body.put("editHtml", editHtml);
+                            if (viewHtml != null)    body.put("viewHtml", viewHtml);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "DELETE": url = base + "/fields/" + id; httpMethod = "DELETE"; break;
+                        default: return "Unknown method: " + method;
+                    }
+                    break;
+
+                case "CHOICE":
+                    switch (method.toUpperCase()) {
+                        case "LIST": url = base + "/fields/" + fieldId + "/choices"; httpMethod = "GET"; break;
+                        case "POST": {
+                            url = base + "/fields/" + fieldId + "/choices"; httpMethod = "POST";
+                            Map<String, Object> body = new HashMap<>();
+                            if (label != null)   body.put("label", label);
+                            if (value != null)   body.put("value", value);
+                            if (orderNo != null) body.put("orderNo", orderNo);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "PUT": {
+                            url = base + "/choices/" + id; httpMethod = "PUT";
+                            Map<String, Object> body = new HashMap<>();
+                            if (label != null)   body.put("label", label);
+                            if (value != null)   body.put("value", value);
+                            if (orderNo != null) body.put("orderNo", orderNo);
+                            requestBody = new com.google.gson.Gson().toJson(body);
+                            break;
+                        }
+                        case "DELETE": url = base + "/choices/" + id; httpMethod = "DELETE"; break;
+                        default: return "Unknown method: " + method;
+                    }
+                    break;
+
+                case "ENTRY":
+                    url = base + "/entries/" + admissionId; httpMethod = "GET"; break;
+
+                case "VALUE":
+                    url = base + "/entries/" + entryId + "/values"; httpMethod = "GET"; break;
+
+                default:
+                    return "Unknown resource_type: " + resourceType;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey);
+
+            if (requestBody != null) {
+                reqBuilder.header("Content-Type", "application/json");
+                if ("POST".equals(httpMethod)) {
+                    reqBuilder.POST(HttpRequest.BodyPublishers.ofString(requestBody));
+                } else {
+                    reqBuilder.PUT(HttpRequest.BodyPublishers.ofString(requestBody));
+                }
+            } else if ("DELETE".equals(httpMethod)) {
+                reqBuilder.DELETE();
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + ": " + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Forms API call interrupted.";
+        } catch (Exception e) {
+            return "Forms API error: " + e.getMessage();
+        }
+    }
+
     public String buildSystemPrompt(String hmisApiBaseUrl, String userHmisApiKey, String githubBranch) {
         String branch = (githubBranch != null && !githubBranch.trim().isEmpty())
                 ? githubBranch.trim() : "development";
@@ -2102,7 +2402,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have nine tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, and investigation report formats:\n\n");
+        sb.append("You have ten tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, and dynamic clinical form templates:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");
@@ -2157,6 +2457,29 @@ public class AnthropicApiService implements Serializable {
           .append("PUT_CATEGORY / PUT_ROOM / PUT_CHARGE to update. ")
           .append("DELETE_CATEGORY / DELETE_ROOM / DELETE_CHARGE to soft-retire. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live inward room billing.\n\n");
+        sb.append("### manage_forms\n");
+        sb.append("Design and manage dynamic clinical form templates end-to-end. ")
+          .append("resource_type: TEMPLATE | FIELD | CHOICE | ENTRY | VALUE. ")
+          .append("method: LIST | GET | POST | PUT | DELETE. ")
+          .append("Use TEMPLATE LIST to discover existing forms. ")
+          .append("Use TEMPLATE POST to create a form shell (name required, optional formCssClass for Bootstrap row layout). ")
+          .append("Use FIELD POST to add fields: required params are form_id, name, and componentPresentationType. ")
+          .append("Supported types: Input_text, Input_text_Area, TextEditor, Input_Number, Spinner, Slider, Rating, Calendar, ")
+          .append("SelectBooleanCheckBox, SelectBooleanButton, ToggleSwitch, TriStateCheckBox, SelectOneMenu, SelectOneRadio, ")
+          .append("SelectOneListBox, SelectCheckBoxMenu, SelectManyButton, MultiSelectListBox, AutoComplete, Signature. ")
+          .append("Use CHOICE POST (field_id + label required) to add options for SelectOneMenu, SelectOneRadio, and other choice-type fields. ")
+          .append("Use ENTRY LIST (admission_id required) to see filled forms for an inpatient admission. ")
+          .append("Use VALUE LIST (entry_id required) to read all captured field values for a specific form submission.\n\n")
+          .append("C3 Layout Pattern: When generating editHtml for a field, use these tokens:\n")
+          .append("  {{LABEL}} — the field label text\n")
+          .append("  {{INPUT}} — replaced at render time with the JSF PrimeFaces input component\n")
+          .append("Use Bootstrap 5 grid classes (col-12, col-md-6, col-md-4, col-md-3) for layout. Example:\n")
+          .append("  <div class=\"col-12 col-md-6 mb-3\">\n")
+          .append("    <label class=\"form-label fw-semibold\">{{LABEL}}</label>\n")
+          .append("    {{INPUT}}\n")
+          .append("  </div>\n")
+          .append("When generating viewHtml, use {{LABEL}} and {{VALUE}} (the formatted stored value).\n")
+          .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
 
         sb.append("## How to Use the Tools\n");
         sb.append("- When a user describes a problem or asks why something behaves a certain way, search the source code first.\n");
@@ -2614,6 +2937,29 @@ public class AnthropicApiService implements Serializable {
                     {"POST", "/config/setInteger/{key}/{value}",  "Set an integer config option by key name"}
                 });
 
+        appendModule(sb, "Dynamic Forms", "/forms",
+                "Design and manage dynamic clinical form templates (create/update/retire), fields of all input types, "
+                + "per-field choice options, and AI-generated HTML layout wrappers (editHtml/viewHtml) for the C3 hybrid pattern. "
+                + "Query filled form entries and captured values for admissions.",
+                githubUrl(branch, "developer_docs/forms/form-api-guide.md"),
+                new String[][]{
+                    {"GET",    "/forms/templates",                        "List all form templates"},
+                    {"GET",    "/forms/templates/{id}",                   "Get a form template by ID"},
+                    {"POST",   "/forms/templates",                        "Create a form template (name required)"},
+                    {"PUT",    "/forms/templates/{id}",                   "Update a form template"},
+                    {"DELETE", "/forms/templates/{id}",                   "Retire a form template"},
+                    {"GET",    "/forms/templates/{id}/fields",            "List fields for a form"},
+                    {"POST",   "/forms/templates/{id}/fields",            "Add a field to a form"},
+                    {"PUT",    "/forms/fields/{id}",                      "Update a field"},
+                    {"DELETE", "/forms/fields/{id}",                      "Retire a field"},
+                    {"GET",    "/forms/fields/{id}/choices",              "List choices for a choice-type field"},
+                    {"POST",   "/forms/fields/{id}/choices",              "Add a choice to a field"},
+                    {"PUT",    "/forms/choices/{id}",                     "Update a choice"},
+                    {"DELETE", "/forms/choices/{id}",                     "Retire a choice"},
+                    {"GET",    "/forms/entries/{admissionId}",            "List filled form entries for an admission"},
+                    {"GET",    "/forms/entries/{entryId}/values",         "List captured field values for a form entry"}
+                });
+
         sb.append("## Your Capabilities\n");
         sb.append("- Search the live codebase and configuration to answer questions grounded in actual system behaviour\n");
         sb.append("- Query and search HMIS data via REST API calls\n");
@@ -2624,7 +2970,8 @@ public class AnthropicApiService implements Serializable {
         sb.append("- Access inpatient admission records and process payments\n");
         sb.append("- Query login history and audit trails\n");
         sb.append("- Analyse reports and uploaded images/documents, including medicine lists\n");
-        sb.append("- Troubleshoot and explain system behaviour using the actual source code\n\n");
+        sb.append("- Troubleshoot and explain system behaviour using the actual source code\n");
+        sb.append("- Design and manage dynamic clinical form templates, fields, choices, and layout wrappers using the C3 hybrid pattern\n\n");
         sb.append("When making API calls, always explain what you are doing and present results clearly. ");
         sb.append("When answering questions about system behaviour, use the tools to search the actual source code and configuration rather than guessing.\n");
 

--- a/src/main/java/com/divudi/service/forms/FormApiService.java
+++ b/src/main/java/com/divudi/service/forms/FormApiService.java
@@ -60,7 +60,7 @@ public class FormApiService {
 
     public FormTemplateDto getFormTemplateWithFields(Long id) {
         DesignComponent dc = designComponentFacade.find(id);
-        if (dc == null || dc.isRetired()) {
+        if (dc == null || dc.isRetired() || dc.getComponentPresentationType() != ComponentPresentationType.DataEntryForm) {
             throw new IllegalArgumentException("Form template not found: " + id);
         }
         FormTemplateDto dto = toTemplateDto(dc, countFields(dc));
@@ -84,7 +84,7 @@ public class FormApiService {
 
     public FormTemplateDto updateFormTemplate(Long id, String name, String description, String formCssClass, WebUser user) {
         DesignComponent dc = designComponentFacade.find(id);
-        if (dc == null || dc.isRetired()) {
+        if (dc == null || dc.isRetired() || dc.getComponentPresentationType() != ComponentPresentationType.DataEntryForm) {
             throw new IllegalArgumentException("Form template not found: " + id);
         }
         if (name != null && !name.trim().isEmpty()) {
@@ -102,7 +102,7 @@ public class FormApiService {
 
     public void retireFormTemplate(Long id, String retireComments, WebUser user) {
         DesignComponent dc = designComponentFacade.find(id);
-        if (dc == null || dc.isRetired()) {
+        if (dc == null || dc.isRetired() || dc.getComponentPresentationType() != ComponentPresentationType.DataEntryForm) {
             throw new IllegalArgumentException("Form template not found: " + id);
         }
         dc.setRetired(true);
@@ -183,11 +183,15 @@ public class FormApiService {
 
     public FormFieldDto updateFormField(Long fieldId, Map<String, Object> body, WebUser user) {
         DesignComponent field = designComponentFacade.find(fieldId);
-        if (field == null || field.isRetired()) {
+        if (field == null || field.isRetired() || field.getDataEntryForm() == null) {
             throw new IllegalArgumentException("Field not found: " + fieldId);
         }
         if (body.containsKey("name") && body.get("name") != null) {
-            field.setName(body.get("name").toString().trim());
+            String updatedName = body.get("name").toString().trim();
+            if (updatedName.isEmpty()) {
+                throw new IllegalArgumentException("name is required");
+            }
+            field.setName(updatedName);
         }
         if (body.containsKey("code")) {
             field.setCode((String) body.get("code"));
@@ -248,7 +252,7 @@ public class FormApiService {
 
     public void retireFormField(Long fieldId, WebUser user) {
         DesignComponent field = designComponentFacade.find(fieldId);
-        if (field == null || field.isRetired()) {
+        if (field == null || field.isRetired() || field.getDataEntryForm() == null) {
             throw new IllegalArgumentException("Field not found: " + fieldId);
         }
         field.setRetired(true);

--- a/src/main/java/com/divudi/service/forms/FormApiService.java
+++ b/src/main/java/com/divudi/service/forms/FormApiService.java
@@ -78,6 +78,7 @@ public class FormApiService {
         dc.setComponentPresentationType(ComponentPresentationType.DataEntryForm);
         dc.setRetired(false);
         designComponentFacade.create(dc);
+        designComponentFacade.flush();
         return toTemplateDto(dc, 0);
     }
 
@@ -168,6 +169,7 @@ public class FormApiService {
         field.setEditHtml((String) body.get("editHtml"));
         field.setViewHtml((String) body.get("viewHtml"));
         designComponentFacade.create(field);
+        designComponentFacade.flush();
         return toFieldDto(field);
     }
 
@@ -272,6 +274,7 @@ public class FormApiService {
         ch.setOrderNo(orderNo);
         ch.setRetired(false);
         designComponentChoiceFacade.create(ch);
+        designComponentChoiceFacade.flush();
         return new FormChoiceDto(ch.getId(), ch.getLabel(), ch.getValue(), ch.getOrderNo());
     }
 

--- a/src/main/java/com/divudi/service/forms/FormApiService.java
+++ b/src/main/java/com/divudi/service/forms/FormApiService.java
@@ -1,0 +1,435 @@
+package com.divudi.service.forms;
+
+import com.divudi.core.data.dto.forms.FormChoiceDto;
+import com.divudi.core.data.dto.forms.FormEntryDto;
+import com.divudi.core.data.dto.forms.FormFieldDto;
+import com.divudi.core.data.dto.forms.FormTemplateDto;
+import com.divudi.core.data.dto.forms.FormValueDto;
+import com.divudi.core.data.web.ComponentDataType;
+import com.divudi.core.data.web.ComponentPresentationType;
+import com.divudi.core.data.web.TemplateComponentType;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.PatientFormEntry;
+import com.divudi.core.entity.web.CaptureComponent;
+import com.divudi.core.entity.web.DesignComponent;
+import com.divudi.core.entity.web.DesignComponentChoice;
+import com.divudi.core.facade.PatientFormEntryFacade;
+import com.divudi.core.facade.web.CaptureComponentFacade;
+import com.divudi.core.facade.web.DesignComponentChoiceFacade;
+import com.divudi.core.facade.web.DesignComponentFacade;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Stateless
+public class FormApiService {
+
+    @EJB
+    private DesignComponentFacade designComponentFacade;
+
+    @EJB
+    private DesignComponentChoiceFacade designComponentChoiceFacade;
+
+    @EJB
+    private PatientFormEntryFacade patientFormEntryFacade;
+
+    @EJB
+    private CaptureComponentFacade captureComponentFacade;
+
+    // -------------------------------------------------------------------------
+    // Form Templates
+    // -------------------------------------------------------------------------
+
+    public List<FormTemplateDto> listFormTemplates() {
+        String jpql = "SELECT d FROM DesignComponent d WHERE d.retired = false AND d.type = :type ORDER BY d.name";
+        Map<String, Object> params = new HashMap<>();
+        params.put("type", TemplateComponentType.DataEntryForm);
+        List<DesignComponent> forms = designComponentFacade.findByJpql(jpql, params);
+        List<FormTemplateDto> result = new ArrayList<>();
+        for (DesignComponent dc : forms) {
+            int fieldCount = countFields(dc);
+            result.add(toTemplateDto(dc, fieldCount));
+        }
+        return result;
+    }
+
+    public FormTemplateDto getFormTemplateWithFields(Long id) {
+        DesignComponent dc = designComponentFacade.find(id);
+        if (dc == null || dc.isRetired()) {
+            throw new IllegalArgumentException("Form template not found: " + id);
+        }
+        FormTemplateDto dto = toTemplateDto(dc, countFields(dc));
+        return dto;
+    }
+
+    public FormTemplateDto createFormTemplate(String name, String description, String formCssClass, WebUser user) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("name is required");
+        }
+        DesignComponent dc = new DesignComponent();
+        dc.setName(name.trim());
+        dc.setDescription(description);
+        dc.setFormCssClass(formCssClass);
+        dc.setType(TemplateComponentType.DataEntryForm);
+        dc.setRetired(false);
+        designComponentFacade.create(dc);
+        return toTemplateDto(dc, 0);
+    }
+
+    public FormTemplateDto updateFormTemplate(Long id, String name, String description, String formCssClass, WebUser user) {
+        DesignComponent dc = designComponentFacade.find(id);
+        if (dc == null || dc.isRetired()) {
+            throw new IllegalArgumentException("Form template not found: " + id);
+        }
+        if (name != null && !name.trim().isEmpty()) {
+            dc.setName(name.trim());
+        }
+        if (description != null) {
+            dc.setDescription(description);
+        }
+        if (formCssClass != null) {
+            dc.setFormCssClass(formCssClass);
+        }
+        designComponentFacade.edit(dc);
+        return toTemplateDto(dc, countFields(dc));
+    }
+
+    public void retireFormTemplate(Long id, String retireComments, WebUser user) {
+        DesignComponent dc = designComponentFacade.find(id);
+        if (dc == null || dc.isRetired()) {
+            throw new IllegalArgumentException("Form template not found: " + id);
+        }
+        dc.setRetired(true);
+        designComponentFacade.edit(dc);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    public List<FormFieldDto> listFormFields(Long formId) {
+        DesignComponent form = designComponentFacade.find(formId);
+        if (form == null || form.isRetired()) {
+            throw new IllegalArgumentException("Form template not found: " + formId);
+        }
+        String jpql = "SELECT d FROM DesignComponent d WHERE d.retired = false AND d.dataEntryForm = :form ORDER BY d.orderNo";
+        Map<String, Object> params = new HashMap<>();
+        params.put("form", form);
+        List<DesignComponent> fields = designComponentFacade.findByJpql(jpql, params);
+        List<FormFieldDto> result = new ArrayList<>();
+        for (DesignComponent f : fields) {
+            result.add(toFieldDto(f));
+        }
+        return result;
+    }
+
+    public FormFieldDto addFormField(Long formId, Map<String, Object> body, WebUser user) {
+        DesignComponent form = designComponentFacade.find(formId);
+        if (form == null || form.isRetired()) {
+            throw new IllegalArgumentException("Form template not found: " + formId);
+        }
+        String name = (String) body.get("name");
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("name is required");
+        }
+        DesignComponent field = new DesignComponent();
+        field.setName(name.trim());
+        field.setCode((String) body.get("code"));
+        field.setDescription((String) body.get("description"));
+        field.setDataEntryForm(form);
+        field.setType(TemplateComponentType.DataEntryFormField);
+        field.setRetired(false);
+
+        String cpt = (String) body.get("componentPresentationType");
+        if (cpt != null && !cpt.trim().isEmpty()) {
+            field.setComponentPresentationType(ComponentPresentationType.valueOf(cpt.trim()));
+        }
+        String cdt = (String) body.get("componentDataType");
+        if (cdt != null && !cdt.trim().isEmpty()) {
+            field.setComponentDataType(ComponentDataType.valueOf(cdt.trim()));
+        }
+        if (body.get("orderNo") != null) {
+            field.setOrderNo(toInteger(body.get("orderNo")));
+        }
+        if (body.get("required") != null) {
+            field.setRequired(Boolean.parseBoolean(body.get("required").toString()));
+        }
+        field.setPlaceholder((String) body.get("placeholder"));
+        field.setMinValue(toDouble(body.get("minValue")));
+        field.setMaxValue(toDouble(body.get("maxValue")));
+        field.setStepSize(toDouble(body.get("stepSize")));
+        field.setMaxRating(toInteger(body.get("maxRating")));
+        field.setOnLabel((String) body.get("onLabel"));
+        field.setOffLabel((String) body.get("offLabel"));
+        field.setEditHtml((String) body.get("editHtml"));
+        field.setViewHtml((String) body.get("viewHtml"));
+        designComponentFacade.create(field);
+        return toFieldDto(field);
+    }
+
+    public FormFieldDto updateFormField(Long fieldId, Map<String, Object> body, WebUser user) {
+        DesignComponent field = designComponentFacade.find(fieldId);
+        if (field == null || field.isRetired()) {
+            throw new IllegalArgumentException("Field not found: " + fieldId);
+        }
+        if (body.containsKey("name") && body.get("name") != null) {
+            field.setName(body.get("name").toString().trim());
+        }
+        if (body.containsKey("code")) {
+            field.setCode((String) body.get("code"));
+        }
+        if (body.containsKey("description")) {
+            field.setDescription((String) body.get("description"));
+        }
+        if (body.containsKey("componentPresentationType") && body.get("componentPresentationType") != null) {
+            field.setComponentPresentationType(ComponentPresentationType.valueOf(body.get("componentPresentationType").toString().trim()));
+        }
+        if (body.containsKey("componentDataType") && body.get("componentDataType") != null) {
+            field.setComponentDataType(ComponentDataType.valueOf(body.get("componentDataType").toString().trim()));
+        }
+        if (body.containsKey("orderNo")) {
+            field.setOrderNo(toInteger(body.get("orderNo")));
+        }
+        if (body.containsKey("required")) {
+            field.setRequired(Boolean.parseBoolean(body.get("required").toString()));
+        }
+        if (body.containsKey("placeholder")) {
+            field.setPlaceholder((String) body.get("placeholder"));
+        }
+        if (body.containsKey("minValue")) {
+            field.setMinValue(toDouble(body.get("minValue")));
+        }
+        if (body.containsKey("maxValue")) {
+            field.setMaxValue(toDouble(body.get("maxValue")));
+        }
+        if (body.containsKey("stepSize")) {
+            field.setStepSize(toDouble(body.get("stepSize")));
+        }
+        if (body.containsKey("maxRating")) {
+            field.setMaxRating(toInteger(body.get("maxRating")));
+        }
+        if (body.containsKey("onLabel")) {
+            field.setOnLabel((String) body.get("onLabel"));
+        }
+        if (body.containsKey("offLabel")) {
+            field.setOffLabel((String) body.get("offLabel"));
+        }
+        if (body.containsKey("editHtml")) {
+            field.setEditHtml((String) body.get("editHtml"));
+        }
+        if (body.containsKey("viewHtml")) {
+            field.setViewHtml((String) body.get("viewHtml"));
+        }
+        designComponentFacade.edit(field);
+        return toFieldDto(field);
+    }
+
+    public void retireFormField(Long fieldId, WebUser user) {
+        DesignComponent field = designComponentFacade.find(fieldId);
+        if (field == null || field.isRetired()) {
+            throw new IllegalArgumentException("Field not found: " + fieldId);
+        }
+        field.setRetired(true);
+        designComponentFacade.edit(field);
+    }
+
+    // -------------------------------------------------------------------------
+    // Choices
+    // -------------------------------------------------------------------------
+
+    public List<FormChoiceDto> listChoices(Long fieldId) {
+        DesignComponent field = designComponentFacade.find(fieldId);
+        if (field == null || field.isRetired()) {
+            throw new IllegalArgumentException("Field not found: " + fieldId);
+        }
+        String jpql = "SELECT c FROM DesignComponentChoice c WHERE c.retired = false AND c.designComponent = :field ORDER BY c.orderNo";
+        Map<String, Object> params = new HashMap<>();
+        params.put("field", field);
+        List<DesignComponentChoice> choices = designComponentChoiceFacade.findByJpql(jpql, params);
+        List<FormChoiceDto> result = new ArrayList<>();
+        for (DesignComponentChoice ch : choices) {
+            result.add(new FormChoiceDto(ch.getId(), ch.getLabel(), ch.getValue(), ch.getOrderNo()));
+        }
+        return result;
+    }
+
+    public FormChoiceDto addChoice(Long fieldId, String label, String value, Integer orderNo, WebUser user) {
+        DesignComponent field = designComponentFacade.find(fieldId);
+        if (field == null || field.isRetired()) {
+            throw new IllegalArgumentException("Field not found: " + fieldId);
+        }
+        if (label == null || label.trim().isEmpty()) {
+            throw new IllegalArgumentException("label is required");
+        }
+        DesignComponentChoice ch = new DesignComponentChoice();
+        ch.setDesignComponent(field);
+        ch.setLabel(label.trim());
+        ch.setValue(value != null ? value : label.trim());
+        ch.setOrderNo(orderNo);
+        ch.setRetired(false);
+        designComponentChoiceFacade.create(ch);
+        return new FormChoiceDto(ch.getId(), ch.getLabel(), ch.getValue(), ch.getOrderNo());
+    }
+
+    public FormChoiceDto updateChoice(Long choiceId, String label, String value, Integer orderNo, WebUser user) {
+        DesignComponentChoice ch = designComponentChoiceFacade.find(choiceId);
+        if (ch == null || ch.isRetired()) {
+            throw new IllegalArgumentException("Choice not found: " + choiceId);
+        }
+        if (label != null && !label.trim().isEmpty()) {
+            ch.setLabel(label.trim());
+        }
+        if (value != null) {
+            ch.setValue(value);
+        }
+        if (orderNo != null) {
+            ch.setOrderNo(orderNo);
+        }
+        designComponentChoiceFacade.edit(ch);
+        return new FormChoiceDto(ch.getId(), ch.getLabel(), ch.getValue(), ch.getOrderNo());
+    }
+
+    public void retireChoice(Long choiceId, WebUser user) {
+        DesignComponentChoice ch = designComponentChoiceFacade.find(choiceId);
+        if (ch == null || ch.isRetired()) {
+            throw new IllegalArgumentException("Choice not found: " + choiceId);
+        }
+        ch.setRetired(true);
+        designComponentChoiceFacade.edit(ch);
+    }
+
+    // -------------------------------------------------------------------------
+    // Entries and Values
+    // -------------------------------------------------------------------------
+
+    public List<FormEntryDto> listEntriesForAdmission(Long admissionId) {
+        String jpql = "SELECT e FROM PatientFormEntry e WHERE e.retired = false AND e.patientEncounter.id = :admId ORDER BY e.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("admId", admissionId);
+        List<PatientFormEntry> entries = patientFormEntryFacade.findByJpql(jpql, params);
+        List<FormEntryDto> result = new ArrayList<>();
+        for (PatientFormEntry e : entries) {
+            result.add(toEntryDto(e));
+        }
+        return result;
+    }
+
+    public List<FormValueDto> listValuesForEntry(Long entryId) {
+        PatientFormEntry entry = patientFormEntryFacade.find(entryId);
+        if (entry == null || entry.isRetired()) {
+            throw new IllegalArgumentException("Entry not found: " + entryId);
+        }
+        String jpql = "SELECT cc FROM CaptureComponent cc WHERE cc.retired = false AND cc.patientFormEntry = :entry ORDER BY cc.id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("entry", entry);
+        List<CaptureComponent> components = captureComponentFacade.findByJpql(jpql, params);
+        List<FormValueDto> result = new ArrayList<>();
+        for (CaptureComponent cc : components) {
+            result.add(toValueDto(cc));
+        }
+        return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private int countFields(DesignComponent form) {
+        String jpql = "SELECT COUNT(d) FROM DesignComponent d WHERE d.retired = false AND d.dataEntryForm = :form";
+        Map<String, Object> params = new HashMap<>();
+        params.put("form", form);
+        Long count = designComponentFacade.findLongByJpql(jpql, params);
+        return count != null ? count.intValue() : 0;
+    }
+
+    private FormTemplateDto toTemplateDto(DesignComponent dc, int fieldCount) {
+        return new FormTemplateDto(
+                dc.getId(),
+                dc.getName(),
+                dc.getDescription(),
+                dc.getFormCssClass(),
+                fieldCount);
+    }
+
+    private FormFieldDto toFieldDto(DesignComponent dc) {
+        FormFieldDto dto = new FormFieldDto();
+        dto.setId(dc.getId());
+        dto.setName(dc.getName());
+        dto.setCode(dc.getCode());
+        dto.setDescription(dc.getDescription());
+        dto.setComponentPresentationType(dc.getComponentPresentationType() != null ? dc.getComponentPresentationType().name() : null);
+        dto.setComponentDataType(dc.getComponentDataType() != null ? dc.getComponentDataType().name() : null);
+        dto.setOrderNo(dc.getOrderNo());
+        dto.setRequired(dc.isRequired());
+        dto.setPlaceholder(dc.getPlaceholder());
+        dto.setMinValue(dc.getMinValue());
+        dto.setMaxValue(dc.getMaxValue());
+        dto.setStepSize(dc.getStepSize());
+        dto.setMaxRating(dc.getMaxRating());
+        dto.setOnLabel(dc.getOnLabel());
+        dto.setOffLabel(dc.getOffLabel());
+        dto.setEditHtml(dc.getEditHtml());
+        dto.setViewHtml(dc.getViewHtml());
+        return dto;
+    }
+
+    private FormEntryDto toEntryDto(PatientFormEntry e) {
+        FormEntryDto dto = new FormEntryDto();
+        dto.setId(e.getId());
+        if (e.getDesignComponent() != null) {
+            dto.setFormTemplateId(e.getDesignComponent().getId());
+            dto.setFormTemplateName(e.getDesignComponent().getName());
+        }
+        dto.setComments(e.getComments());
+        dto.setCreatedAt(e.getCreatedAt());
+        if (e.getCreater() != null && e.getCreater().getWebUserPerson() != null) {
+            dto.setCreatedBy(e.getCreater().getWebUserPerson().getName());
+        }
+        return dto;
+    }
+
+    private FormValueDto toValueDto(CaptureComponent cc) {
+        FormValueDto dto = new FormValueDto();
+        dto.setId(cc.getId());
+        if (cc.getDesignComponent() != null) {
+            dto.setFieldId(cc.getDesignComponent().getId());
+            dto.setFieldName(cc.getDesignComponent().getName());
+        }
+        dto.setComponentPresentationType(cc.getComponentPresentationType() != null ? cc.getComponentPresentationType().name() : null);
+        dto.setShortTextValue(cc.getShortTextValue());
+        dto.setLongTextValue(cc.getLongTextValue());
+        dto.setDoubleValue(cc.getDoubleValue());
+        dto.setIntValue(cc.getIntValue());
+        dto.setBooleanValue(cc.getBooleanValue());
+        dto.setDateValue(cc.getDateValue());
+        dto.setRatingIntValue(cc.getRatingIntValue());
+        if (cc.getLongTextValue() != null && !cc.getLongTextValue().trim().isEmpty()) {
+            dto.setSelectedValues(Arrays.asList(cc.getLongTextValue().split("\\|")));
+        }
+        return dto;
+    }
+
+    private Double toDouble(Object val) {
+        if (val == null) return null;
+        try {
+            return Double.parseDouble(val.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Integer toInteger(Object val) {
+        if (val == null) return null;
+        try {
+            return (int) Double.parseDouble(val.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/divudi/service/forms/FormApiService.java
+++ b/src/main/java/com/divudi/service/forms/FormApiService.java
@@ -7,7 +7,6 @@ import com.divudi.core.data.dto.forms.FormTemplateDto;
 import com.divudi.core.data.dto.forms.FormValueDto;
 import com.divudi.core.data.web.ComponentDataType;
 import com.divudi.core.data.web.ComponentPresentationType;
-import com.divudi.core.data.web.TemplateComponentType;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.PatientFormEntry;
 import com.divudi.core.entity.web.CaptureComponent;
@@ -47,9 +46,9 @@ public class FormApiService {
     // -------------------------------------------------------------------------
 
     public List<FormTemplateDto> listFormTemplates() {
-        String jpql = "SELECT d FROM DesignComponent d WHERE d.retired = false AND d.type = :type ORDER BY d.name";
+        String jpql = "SELECT d FROM DesignComponent d WHERE d.retired = false AND d.componentPresentationType = :cpt AND d.dataEntryForm IS NULL ORDER BY d.name";
         Map<String, Object> params = new HashMap<>();
-        params.put("type", TemplateComponentType.DataEntryForm);
+        params.put("cpt", ComponentPresentationType.DataEntryForm);
         List<DesignComponent> forms = designComponentFacade.findByJpql(jpql, params);
         List<FormTemplateDto> result = new ArrayList<>();
         for (DesignComponent dc : forms) {
@@ -76,7 +75,7 @@ public class FormApiService {
         dc.setName(name.trim());
         dc.setDescription(description);
         dc.setFormCssClass(formCssClass);
-        dc.setType(TemplateComponentType.DataEntryForm);
+        dc.setComponentPresentationType(ComponentPresentationType.DataEntryForm);
         dc.setRetired(false);
         designComponentFacade.create(dc);
         return toTemplateDto(dc, 0);
@@ -143,7 +142,6 @@ public class FormApiService {
         field.setCode((String) body.get("code"));
         field.setDescription((String) body.get("description"));
         field.setDataEntryForm(form);
-        field.setType(TemplateComponentType.DataEntryFormField);
         field.setRetired(false);
 
         String cpt = (String) body.get("componentPresentationType");

--- a/src/main/java/com/divudi/service/forms/FormApiService.java
+++ b/src/main/java/com/divudi/service/forms/FormApiService.java
@@ -147,11 +147,19 @@ public class FormApiService {
 
         String cpt = (String) body.get("componentPresentationType");
         if (cpt != null && !cpt.trim().isEmpty()) {
-            field.setComponentPresentationType(ComponentPresentationType.valueOf(cpt.trim()));
+            try {
+                field.setComponentPresentationType(ComponentPresentationType.valueOf(cpt.trim()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid componentPresentationType: " + cpt.trim());
+            }
         }
         String cdt = (String) body.get("componentDataType");
         if (cdt != null && !cdt.trim().isEmpty()) {
-            field.setComponentDataType(ComponentDataType.valueOf(cdt.trim()));
+            try {
+                field.setComponentDataType(ComponentDataType.valueOf(cdt.trim()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid componentDataType: " + cdt.trim());
+            }
         }
         if (body.get("orderNo") != null) {
             field.setOrderNo(toInteger(body.get("orderNo")));
@@ -188,10 +196,18 @@ public class FormApiService {
             field.setDescription((String) body.get("description"));
         }
         if (body.containsKey("componentPresentationType") && body.get("componentPresentationType") != null) {
-            field.setComponentPresentationType(ComponentPresentationType.valueOf(body.get("componentPresentationType").toString().trim()));
+            try {
+                field.setComponentPresentationType(ComponentPresentationType.valueOf(body.get("componentPresentationType").toString().trim()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid componentPresentationType: " + body.get("componentPresentationType"));
+            }
         }
         if (body.containsKey("componentDataType") && body.get("componentDataType") != null) {
-            field.setComponentDataType(ComponentDataType.valueOf(body.get("componentDataType").toString().trim()));
+            try {
+                field.setComponentDataType(ComponentDataType.valueOf(body.get("componentDataType").toString().trim()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid componentDataType: " + body.get("componentDataType"));
+            }
         }
         if (body.containsKey("orderNo")) {
             field.setOrderNo(toInteger(body.get("orderNo")));

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -54,6 +54,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.finance.CostingData.class);
         resources.add(com.divudi.ws.finance.Finance.class);
         resources.add(com.divudi.ws.finance.Qb.class);
+        resources.add(com.divudi.ws.forms.FormApi.class);
         resources.add(com.divudi.ws.institution.DepartmentApi.class);
         resources.add(com.divudi.ws.institution.InstitutionApi.class);
         resources.add(com.divudi.ws.institution.SiteApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -288,6 +288,16 @@ public class CapabilityStatementResource {
                         + "Auth: Finance header.",
                         "API Key (Finance header)",
                         "GET", "POST"))
+                .add(resource("Dynamic Forms", "/api/forms",
+                        "Design and manage dynamic clinical form templates and capture filled values. "
+                        + "Templates: GET /forms/templates lists all; GET /forms/templates/{id} returns one with field count; POST creates; PUT updates; DELETE retires. "
+                        + "Fields: GET /forms/templates/{id}/fields; POST adds a field (componentPresentationType, componentDataType, editHtml, viewHtml, choices). "
+                        + "PUT /forms/fields/{id} updates; DELETE /forms/fields/{id} retires. "
+                        + "Choices: GET /forms/fields/{id}/choices; POST adds; PUT /forms/choices/{id} updates; DELETE /forms/choices/{id} retires. "
+                        + "Filled data: GET /forms/entries/{admissionId} lists all PatientFormEntry records for an admission; "
+                        + "GET /forms/entries/{entryId}/values lists all CaptureComponent values for a filled entry.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("SAP Integration - Inventory", "/api/sap/inventory",
                         "SAP S/4HANA Cloud MM inventory sync. "
                         + "GET /sync?fromDate=yyyy-MM-dd&toDate=yyyy-MM-dd fetches SAP goods-receipt material documents "

--- a/src/main/java/com/divudi/ws/forms/FormApi.java
+++ b/src/main/java/com/divudi/ws/forms/FormApi.java
@@ -58,6 +58,11 @@ public class FormApi {
             List<FormTemplateDto> list = formApiService.listFormTemplates();
             return successResponse(list);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -74,6 +79,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -97,6 +107,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -121,6 +136,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -137,6 +157,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -157,6 +182,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -176,6 +206,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -195,6 +230,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -211,6 +251,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -231,6 +276,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -256,6 +306,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -281,6 +336,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -297,6 +357,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -315,6 +380,11 @@ public class FormApi {
             List<FormEntryDto> list = formApiService.listEntriesForAdmission(admissionId);
             return successResponse(list);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -331,6 +401,11 @@ public class FormApi {
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 404);
         } catch (Exception e) {
+            Throwable root = rootCause(e);
+            if (root instanceof IllegalArgumentException) {
+                String msg = root.getMessage() != null ? root.getMessage() : e.getMessage();
+                return errorResponse(msg, msg != null && msg.contains("not found") ? 404 : 400);
+            }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }
     }
@@ -357,6 +432,11 @@ public class FormApi {
         } catch (JsonSyntaxException e) {
             return null;
         }
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        Throwable cause = t.getCause();
+        return (cause != null && cause != t) ? rootCause(cause) : t;
     }
 
     private Response errorResponse(String message, int code) {

--- a/src/main/java/com/divudi/ws/forms/FormApi.java
+++ b/src/main/java/com/divudi/ws/forms/FormApi.java
@@ -99,11 +99,11 @@ public class FormApi {
             Map body = parseBody(requestBody);
             if (body == null) return errorResponse("Request body is required", 400);
             FormTemplateDto dto = formApiService.createFormTemplate(
-                    (String) body.get("name"),
-                    (String) body.get("description"),
-                    (String) body.get("formCssClass"),
+                    safeGetString(body, "name"),
+                    safeGetString(body, "description"),
+                    safeGetString(body, "formCssClass"),
                     user);
-            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+            return createdResponse(dto);
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), 400);
         } catch (Exception e) {
@@ -128,9 +128,9 @@ public class FormApi {
             if (body == null) return errorResponse("Request body is required", 400);
             FormTemplateDto dto = formApiService.updateFormTemplate(
                     id,
-                    (String) body.get("name"),
-                    (String) body.get("description"),
-                    (String) body.get("formCssClass"),
+                    safeGetString(body, "name"),
+                    safeGetString(body, "description"),
+                    safeGetString(body, "formCssClass"),
                     user);
             return successResponse(dto);
         } catch (IllegalArgumentException e) {
@@ -202,7 +202,7 @@ public class FormApi {
             Map body = parseBody(requestBody);
             if (body == null) return errorResponse("Request body is required", 400);
             FormFieldDto dto = formApiService.addFormField(id, body, user);
-            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+            return createdResponse(dto);
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
@@ -298,11 +298,11 @@ public class FormApi {
             Integer orderNo = body.get("orderNo") != null ? (int) Double.parseDouble(body.get("orderNo").toString()) : null;
             FormChoiceDto dto = formApiService.addChoice(
                     id,
-                    (String) body.get("label"),
-                    (String) body.get("value"),
+                    safeGetString(body, "label"),
+                    safeGetString(body, "value"),
                     orderNo,
                     user);
-            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+            return createdResponse(dto);
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
         } catch (Exception e) {
@@ -328,8 +328,8 @@ public class FormApi {
             Integer orderNo = body.get("orderNo") != null ? (int) Double.parseDouble(body.get("orderNo").toString()) : null;
             FormChoiceDto dto = formApiService.updateChoice(
                     id,
-                    (String) body.get("label"),
-                    (String) body.get("value"),
+                    safeGetString(body, "label"),
+                    safeGetString(body, "value"),
                     orderNo,
                     user);
             return successResponse(dto);
@@ -424,6 +424,11 @@ public class FormApi {
         return user;
     }
 
+    private String safeGetString(Map body, String key) {
+        Object val = body.get(key);
+        return val != null ? val.toString() : null;
+    }
+
     @SuppressWarnings("unchecked")
     private Map parseBody(String body) {
         if (body == null || body.trim().isEmpty()) return null;
@@ -448,13 +453,17 @@ public class FormApi {
     }
 
     private Response successResponse(Object data) {
-        return Response.status(200).entity(gson.toJson(successData(data))).build();
+        return Response.status(200).entity(gson.toJson(successData(data, 200))).build();
     }
 
-    private Map<String, Object> successData(Object data) {
+    private Response createdResponse(Object data) {
+        return Response.status(201).entity(gson.toJson(successData(data, 201))).build();
+    }
+
+    private Map<String, Object> successData(Object data, int code) {
         Map<String, Object> response = new HashMap<>();
         response.put("status", "success");
-        response.put("code", 200);
+        response.put("code", code);
         response.put("data", data);
         return response;
     }

--- a/src/main/java/com/divudi/ws/forms/FormApi.java
+++ b/src/main/java/com/divudi/ws/forms/FormApi.java
@@ -1,0 +1,381 @@
+package com.divudi.ws.forms;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.forms.FormChoiceDto;
+import com.divudi.core.data.dto.forms.FormEntryDto;
+import com.divudi.core.data.dto.forms.FormFieldDto;
+import com.divudi.core.data.dto.forms.FormTemplateDto;
+import com.divudi.core.data.dto.forms.FormValueDto;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.forms.FormApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Path("forms")
+@RequestScoped
+public class FormApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private FormApiService formApiService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    public FormApi() {}
+
+    // -------------------------------------------------------------------------
+    // Form Templates
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Path("/templates")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listTemplates() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            List<FormTemplateDto> list = formApiService.listFormTemplates();
+            return successResponse(list);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @GET
+    @Path("/templates/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getTemplate(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            FormTemplateDto dto = formApiService.getFormTemplateWithFields(id);
+            return successResponse(dto);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Path("/templates")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createTemplate(String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            FormTemplateDto dto = formApiService.createFormTemplate(
+                    (String) body.get("name"),
+                    (String) body.get("description"),
+                    (String) body.get("formCssClass"),
+                    user);
+            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/templates/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateTemplate(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            FormTemplateDto dto = formApiService.updateFormTemplate(
+                    id,
+                    (String) body.get("name"),
+                    (String) body.get("description"),
+                    (String) body.get("formCssClass"),
+                    user);
+            return successResponse(dto);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/templates/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireTemplate(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            formApiService.retireFormTemplate(id, null, user);
+            return successResponse("Form template retired");
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Path("/templates/{id}/fields")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listFields(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            List<FormFieldDto> list = formApiService.listFormFields(id);
+            return successResponse(list);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Path("/templates/{id}/fields")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addField(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            FormFieldDto dto = formApiService.addFormField(id, body, user);
+            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/fields/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateField(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            FormFieldDto dto = formApiService.updateFormField(id, body, user);
+            return successResponse(dto);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/fields/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireField(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            formApiService.retireFormField(id, user);
+            return successResponse("Field retired");
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Choices
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Path("/fields/{id}/choices")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listChoices(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            List<FormChoiceDto> list = formApiService.listChoices(id);
+            return successResponse(list);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Path("/fields/{id}/choices")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addChoice(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            Integer orderNo = body.get("orderNo") != null ? (int) Double.parseDouble(body.get("orderNo").toString()) : null;
+            FormChoiceDto dto = formApiService.addChoice(
+                    id,
+                    (String) body.get("label"),
+                    (String) body.get("value"),
+                    orderNo,
+                    user);
+            return Response.status(201).entity(gson.toJson(successData(dto))).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/choices/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateChoice(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            Map body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+            Integer orderNo = body.get("orderNo") != null ? (int) Double.parseDouble(body.get("orderNo").toString()) : null;
+            FormChoiceDto dto = formApiService.updateChoice(
+                    id,
+                    (String) body.get("label"),
+                    (String) body.get("value"),
+                    orderNo,
+                    user);
+            return successResponse(dto);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), e.getMessage().contains("not found") ? 404 : 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/choices/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireChoice(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            formApiService.retireChoice(id, user);
+            return successResponse("Choice retired");
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Entries and Values
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Path("/entries/{admissionId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listEntries(@PathParam("admissionId") Long admissionId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            List<FormEntryDto> list = formApiService.listEntriesForAdmission(admissionId);
+            return successResponse(list);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @GET
+    @Path("/entries/{entryId}/values")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listValues(@PathParam("entryId") Long entryId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            List<FormValueDto> list = formApiService.listValuesForEntry(entryId);
+            return successResponse(list);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 404);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map parseBody(String body) {
+        if (body == null || body.trim().isEmpty()) return null;
+        try {
+            return gson.fromJson(body, Map.class);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
## Summary
- Adds `/api/forms/*` REST API (15 endpoints) for full CRUD of clinical form templates, fields, choices, and read-only access to filled entries/values
- Registers `FormApi` in `ApplicationConfig` and adds "Dynamic Forms" to `CapabilityStatementResource`
- Adds `manage_forms` tool to `AnthropicApiService` (tool definition + `executeToolCall` handler + `callFormsApi` + system prompt update with C3 token guidance)
- 5 DTOs: `FormTemplateDto`, `FormFieldDto`, `FormChoiceDto`, `FormEntryDto`, `FormValueDto`
- Developer doc: `developer_docs/forms/form-api-guide.md`

## Test plan
- [ ] `GET /api/forms/templates` returns list of DataEntryForm DesignComponents
- [ ] `POST /api/forms/templates` creates a new form (name required, 400 without it)
- [ ] `POST /api/forms/templates/{id}/fields` with `componentPresentationType=Calendar` creates a field
- [ ] `POST /api/forms/fields/{id}/choices` adds a choice to a SelectOneMenu field
- [ ] `GET /api/forms/entries/{admissionId}` returns filled PatientFormEntry records
- [ ] `GET /api/capabilities` lists "Dynamic Forms" module
- [ ] AI chat: ask Claude to create a form with 3 fields — it should call manage_forms TEMPLATE POST then FIELD POST × 3

Closes #21254

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic Forms API: create, manage, retire form templates, fields, and choices; list filled entries and captured values. Now advertised in the system capability listing and accessible via /api/forms.

* **Documentation**
  * Published a comprehensive Dynamic Forms API guide with authentication details, endpoint usage, C3 layout tokens, and example curl commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->