### PR TITLE
feat(item): department-prefixed item coding with Generate Code button and duplicate validation (#14854)

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -1873,7 +1873,7 @@ public class ItemController implements Serializable {
         }
         for (Item i : selectedList) {
             Item item = itemFacade.findWithoutCache(i.getId());
-                
+
             item.setAllowedForBillingPriority(true);
             itemFacade.editAndCommit(item);
         }
@@ -1888,7 +1888,7 @@ public class ItemController implements Serializable {
         }
         for (Item i : selectedList) {
             Item item = itemFacade.findWithoutCache(i.getId());
-                
+
             item.setAllowedForBillingPriority(false);
             itemFacade.editAndCommit(item);
         }
@@ -1906,7 +1906,7 @@ public class ItemController implements Serializable {
         for (Item i : selectedList) {
             if (i instanceof Investigation) {
                 Item item = itemFacade.findWithoutCache(i.getId());
-                
+
                 item.setAllowToSendSMS(true);
                 itemFacade.editAndCommit(item);
                 updatedCount++;
@@ -1930,7 +1930,7 @@ public class ItemController implements Serializable {
         for (Item i : selectedList) {
             if (i instanceof Investigation) {
                 Item item = itemFacade.findWithoutCache(i.getId());
-                
+
                 item.setAllowToSendSMS(false);
                 itemFacade.editAndCommit(item);
                 updatedCount++;
@@ -1943,7 +1943,7 @@ public class ItemController implements Serializable {
             JsfUtil.addSuccessMessage(updatedCount + " item(s) unmarked for report SMS.");
         }
     }
-    
+
     public void markSelectedItemsToAllowCalculatedRequerd() {
         if (selectedList == null || selectedList.isEmpty()) {
             JsfUtil.addErrorMessage("Nothing is selected");
@@ -1954,7 +1954,7 @@ public class ItemController implements Serializable {
         for (Item i : selectedList) {
             if (i instanceof Investigation) {
                 Item item = itemFacade.findWithoutCache(i.getId());
-                
+
                 item.setCalculatedRequerd(true);
                 itemFacade.editAndCommit(item);
                 updatedCount++;
@@ -1978,7 +1978,7 @@ public class ItemController implements Serializable {
         for (Item i : selectedList) {
             if (i instanceof Investigation) {
                 Item item = itemFacade.findWithoutCache(i.getId());
-                
+
                 item.setCalculatedRequerd(false);
                 itemFacade.editAndCommit(item);
                 updatedCount++;
@@ -2420,10 +2420,18 @@ public class ItemController implements Serializable {
     public List<Item> completeMedicineByTypeWithFilter(String query, boolean includeVtm, boolean includeAtm, boolean includeVmp, boolean includeAmp) {
         DepartmentType[] dts = new DepartmentType[]{DepartmentType.Pharmacy, null};
         List<Class> classList = new ArrayList<>();
-        if (includeVtm) classList.add(Vtm.class);
-        if (includeAtm) classList.add(Atm.class);
-        if (includeVmp) classList.add(Vmp.class);
-        if (includeAmp) classList.add(Amp.class);
+        if (includeVtm) {
+            classList.add(Vtm.class);
+        }
+        if (includeAtm) {
+            classList.add(Atm.class);
+        }
+        if (includeVmp) {
+            classList.add(Vmp.class);
+        }
+        if (includeAmp) {
+            classList.add(Amp.class);
+        }
         if (classList.isEmpty()) {
             return new ArrayList<>();
         }
@@ -3018,12 +3026,11 @@ public class ItemController implements Serializable {
 
     /**
      * DTO-based autocomplete for transfer request item entry. Runs four
-     * lightweight constructor queries (one per subtype) instead of loading
-     * full Item entities. Returns at most {@code maxResults} entries sorted by
-     * name.
+     * lightweight constructor queries (one per subtype) instead of loading full
+     * Item entities. Returns at most {@code maxResults} entries sorted by name.
      *
-     * @param query      text typed by the user
-     * @param dept       toDepartment used to resolve allowed department types
+     * @param query text typed by the user
+     * @param dept toDepartment used to resolve allowed department types
      * @param typeFilter when non-null, restrict results to this department type
      */
     public List<ItemDTO> completeAmpAmppVmpVmppItemDtosForRequestingDepartment(
@@ -3074,15 +3081,15 @@ public class ItemController implements Serializable {
 
         String dtoClass = "com.divudi.core.data.dto.search.ItemDTO";
 
-        String ampJpql  = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Amp',  i.id)     FROM Amp  i " + where;
+        String ampJpql = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Amp',  i.id)     FROM Amp  i " + where;
         String amppJpql = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Ampp', i.amp.id) FROM Ampp i " + where;
-        String vmpJpql  = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Vmp',  i.id)     FROM Vmp  i " + where;
+        String vmpJpql = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Vmp',  i.id)     FROM Vmp  i " + where;
         String vmppJpql = "SELECT new " + dtoClass + "(i.id, i.name, COALESCE(i.code,''), i.dblValue, 'Vmpp', i.vmp.id) FROM Vmpp i " + where;
 
         List<ItemDTO> results = new ArrayList<>();
-        results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(ampJpql,  params, TemporalType.TIMESTAMP, maxResults));
+        results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(ampJpql, params, TemporalType.TIMESTAMP, maxResults));
         results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(amppJpql, params, TemporalType.TIMESTAMP, maxResults));
-        results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(vmpJpql,  params, TemporalType.TIMESTAMP, maxResults));
+        results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(vmpJpql, params, TemporalType.TIMESTAMP, maxResults));
         results.addAll((List<ItemDTO>) getFacade().findLightsByJpql(vmppJpql, params, TemporalType.TIMESTAMP, maxResults));
 
         results.sort(java.util.Comparator.comparing(dto -> dto.getName() != null ? dto.getName() : ""));
@@ -3955,22 +3962,41 @@ public class ItemController implements Serializable {
         getCurrent();
     }
 
+    public String generateNextItemCode(Institution itemInstitution, Department itemDepartment) {
+
+        if (itemInstitution == null && itemDepartment == null) {
+            return "";
+        }
+        
+        StringBuilder code = new StringBuilder();
+        String symbol = configOptionApplicationController.getShortTextValueByKey("Item Codes Generate - The symbol used between the department number and the item number when automatically generating item codes.", "-");
+
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Use Item Institution Code", false)) {
+            if (itemInstitution != null && itemInstitution.getCode() != null && !itemInstitution.getCode().isEmpty()) {
+                code.append(itemInstitution.getCode());
+                code.append(symbol);
+            }
+        }
+        if (itemDepartment != null && itemDepartment.getCode() != null && !itemDepartment.getCode().isEmpty()) {
+            code.append(itemDepartment.getCode());
+            code.append(symbol);
+        }
+        code.append(String.format("%06d", getItemCountByDepartment(itemDepartment) + 1));
+        return code.toString();
+    }
+
+    public void generateCode() {
+        String code = generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+        getCurrent().setCode(code);
+    }
+
     public void saveSelectedWithItemLight() {
-        if (configOptionApplicationController.getBooleanValueByKey("Automatically create Item Codes by Department.", false)) {
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
             if (getCurrent().getId() == null) {
-                System.out.println("New Item Found --> Start Generate Item Code ");
                 if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
-                    StringBuilder code = new StringBuilder();
-                    if (getCurrent().getDepartment().getCode() != null && !getCurrent().getDepartment().getCode().isEmpty()) {
-                        code.append(getCurrent().getDepartment().getCode());
-                        code.append(configOptionApplicationController.getShortTextValueByKey("The symbol used between the department number and the item number when automatically generating item codes.", "-"));
-                        code.append(getItemCountByDepartment(getCurrent().getDepartment()));
-                    }
-                    System.out.println("Created NEw Iten Code for " + getCurrent().getName() + " = " + code);
-                    getCurrent().setCode(code.toString());
+                    String code = generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                    getCurrent().setCode(code);
                 }
-            }else{
-                System.out.println("Old Item Found --> Skip Generate Item Code ");
             }
         }
 

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -23,8 +23,6 @@ import com.divudi.core.entity.inward.TheatreService;
 import com.divudi.core.entity.lab.Investigation;
 import com.divudi.core.entity.lab.ItemForItem;
 import com.divudi.core.entity.lab.Machine;
-import com.divudi.core.entity.Speciality;
-import com.divudi.core.entity.Staff;
 import com.divudi.core.data.dto.AmpDto;
 import com.divudi.core.data.dto.search.ItemDTO;
 import com.divudi.core.entity.pharmacy.Amp;
@@ -38,7 +36,6 @@ import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.ItemFeeFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.lab.InvestigationController;
-import com.divudi.bean.common.SpecialityController;
 import com.divudi.bean.hr.StaffController;
 import com.divudi.core.data.SessionNumberType;
 import com.divudi.core.data.Sex;
@@ -3967,7 +3964,7 @@ public class ItemController implements Serializable {
         if (itemInstitution == null && itemDepartment == null) {
             return "";
         }
-        
+
         StringBuilder code = new StringBuilder();
         String symbol = configOptionApplicationController.getShortTextValueByKey("Item Codes Generate - The symbol used between the department number and the item number when automatically generating item codes.", "-");
 
@@ -3989,7 +3986,7 @@ public class ItemController implements Serializable {
         String code = generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
         getCurrent().setCode(code);
     }
-    
+
     public void saveSelectedWithItemLight() {
         if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
             if (getCurrent().getId() == null) {
@@ -3999,7 +3996,7 @@ public class ItemController implements Serializable {
                 }
             }
         }
-        
+
         if (isItemCodeDuplicate(getCurrent().getCode(), getCurrent().getId())) {
             JsfUtil.addErrorMessage("This Item Code is Already Used.");
             return;
@@ -4013,8 +4010,8 @@ public class ItemController implements Serializable {
 
     /**
      * Returns true when another (non-retired) item already uses the given code.
-     * Queries the base {@link Item} entity so duplicates are detected across all
-     * item subtypes (Service, Investigation, etc.). A blank code is never
+     * Queries the base {@link Item} entity so duplicates are detected across
+     * all item subtypes (Service, Investigation, etc.). A blank code is never
      * considered a duplicate. When {@code excludeId} is null (a new item) no
      * id-exclusion is applied — using {@code i.id != null} would wrongly filter
      * out every row and make the check always pass.
@@ -4666,11 +4663,13 @@ public class ItemController implements Serializable {
         String jpql = "select count(i) "
                 + "from Item i "
                 + "where i.department=:dept "
-                + "and (TYPE(i)=:ix or TYPE(i)=:sv)";
+                + "and (TYPE(i)=:ix or TYPE(i)=:sv or TYPE(i)=:inw or TYPE(i)=:the)";
         Map<String, Object> m = new HashMap<>();
         m.put("dept", department);
         m.put("ix", Investigation.class);
         m.put("sv", Service.class);
+        m.put("inw", InwardService.class);
+        m.put("the", TheatreService.class);
         return itemFacade.countByJpql(jpql, m);
     }
 

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -3991,6 +3991,11 @@ public class ItemController implements Serializable {
         if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
             if (getCurrent().getId() == null) {
                 if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    if (getCurrent().getDepartment() == null) {
+                        JsfUtil.addErrorMessage("Please select Department before generating code");
+                        return;
+                    }
+
                     String code = generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
                     getCurrent().setCode(code);
                 }

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -3956,6 +3956,24 @@ public class ItemController implements Serializable {
     }
 
     public void saveSelectedWithItemLight() {
+        if (configOptionApplicationController.getBooleanValueByKey("Automatically create Item Codes by Department.", false)) {
+            if (getCurrent().getId() == null) {
+                System.out.println("New Item Found --> Start Generate Item Code ");
+                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    StringBuilder code = new StringBuilder();
+                    if (getCurrent().getDepartment().getCode() != null && !getCurrent().getDepartment().getCode().isEmpty()) {
+                        code.append(getCurrent().getDepartment().getCode());
+                        code.append(configOptionApplicationController.getShortTextValueByKey("The symbol used between the department number and the item number when automatically generating item codes.", "-"));
+                        code.append(getItemCountByDepartment(getCurrent().getDepartment()));
+                    }
+                    System.out.println("Created NEw Iten Code for " + getCurrent().getName() + " = " + code);
+                    getCurrent().setCode(code.toString());
+                }
+            }else{
+                System.out.println("Old Item Found --> Skip Generate Item Code ");
+            }
+        }
+
         saveSelected(getCurrent());
         JsfUtil.addSuccessMessage("Saved");
         recreateModel();
@@ -4584,6 +4602,21 @@ public class ItemController implements Serializable {
 
     public Department getSelectedDepartment() {
         return selectedDepartment;
+    }
+
+    public Long getItemCountByDepartment(Department department) {
+        if (department == null) {
+            return 0L;
+        }
+        String jpql = "select count(i) "
+                + "from Item i "
+                + "where i.department=:dept "
+                + "and (TYPE(i)=:ix or TYPE(i)=:sv)";
+        Map<String, Object> m = new HashMap<>();
+        m.put("dept", department);
+        m.put("ix", Investigation.class);
+        m.put("sv", Service.class);
+        return itemFacade.countByJpql(jpql, m);
     }
 
     public void setSelectedDepartment(Department selectedDepartment) {

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -3989,7 +3989,7 @@ public class ItemController implements Serializable {
         String code = generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
         getCurrent().setCode(code);
     }
-
+    
     public void saveSelectedWithItemLight() {
         if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
             if (getCurrent().getId() == null) {
@@ -3999,11 +3999,40 @@ public class ItemController implements Serializable {
                 }
             }
         }
+        
+        if (isItemCodeDuplicate(getCurrent().getCode(), getCurrent().getId())) {
+            JsfUtil.addErrorMessage("This Item Code is Already Used.");
+            return;
+        }
 
         saveSelected(getCurrent());
         JsfUtil.addSuccessMessage("Saved");
         recreateModel();
         getAllItems();
+    }
+
+    /**
+     * Returns true when another (non-retired) item already uses the given code.
+     * Queries the base {@link Item} entity so duplicates are detected across all
+     * item subtypes (Service, Investigation, etc.). A blank code is never
+     * considered a duplicate. When {@code excludeId} is null (a new item) no
+     * id-exclusion is applied — using {@code i.id != null} would wrongly filter
+     * out every row and make the check always pass.
+     */
+    public boolean isItemCodeDuplicate(String code, Long excludeId) {
+        if (code == null || code.trim().isEmpty()) {
+            return false;
+        }
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select i from Item i where i.retired = false and i.code = :code ");
+        m.put("code", code.trim());
+        if (excludeId != null) {
+            jpql.append("and i.id != :id ");
+            m.put("id", excludeId);
+        }
+        Item existing = getFacade().findFirstByJpql(jpql.toString(), m);
+        return existing != null;
     }
 
     public void saveSelected(Item item) {

--- a/src/main/java/com/divudi/bean/common/ServiceController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceController.java
@@ -66,6 +66,8 @@ public class ServiceController implements Serializable {
     SessionController sessionController;
     @Inject
     private ServiceSubCategoryController serviceSubCategoryController;
+    @Inject
+    private ItemController itemController;
     @EJB
     private ServiceFacade ejbFacade;
     @EJB
@@ -458,7 +460,6 @@ public class ServiceController implements Serializable {
         String depPat = "";
         String chagPat = "";
 
-
         if (ins != null) {
             insPat = ins.substring(0, 3);
         }
@@ -497,103 +498,69 @@ public class ServiceController implements Serializable {
         }
     }
 
-    public Boolean checkServiceCodeDuplicate(String genaratedServiceCode) {
-        Service temp;
-        HashMap hash = new HashMap();
-        String sql = "select c from Service c "
-                + "where c.retired = false "
-                + "and c.code = :sCode "
-                + "and c.id != :id ";
-
-        hash.put("sCode", genaratedServiceCode);
-        hash.put("id", getCurrent().getId());
-        temp = ejbFacade.findFirstByJpql(sql, hash, TemporalType.TIMESTAMP);
-        if (temp != null) {
-            return false;
-        }
-        return true;
-
+    public void generateCode() {
+        String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+        getCurrent().setCode(code);
     }
 
+    /**
+     * Returns true when the code is free to use (no other item already has it),
+     * false when it is a duplicate. Delegates to
+     * {@link ItemController#isItemCodeDuplicate(String, Long)} so the check runs
+     * against the base Item entity and correctly handles new records (null id).
+     */
+    public Boolean checkServiceCodeDuplicate(String genaratedServiceCode) {
+        return !itemController.isItemCodeDuplicate(genaratedServiceCode, getCurrent().getId());
+    }
+
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
+
     public void saveSelected() {
-        if (getCurrent().getDepartment() == null) {
-            JsfUtil.addErrorMessage("Please Select Department");
+        if (getCurrent().getName() == null || getCurrent().getName().isEmpty()) {
+            JsfUtil.addErrorMessage("Please Enter a name");
             return;
         }
+
+        if (getCurrent().getCategory() == null) {
+            JsfUtil.addErrorMessage("Please Select Category");
+            return;
+        }
+
         if (getCurrent().getInwardChargeType() == null) {
             JsfUtil.addErrorMessage("Please Select Inward Charge type");
             return;
         }
-        if (getCurrent().getName() == null || getCurrent().getName().isEmpty()) {
-            JsfUtil.addErrorMessage("Please Enter a name");
-        } else {
-            if (getCurrent().getFullName() == null) {
-                getCurrent().setFullName(getCurrent().getName());
-            }
-            if (getCurrent().getPrintName() == null) {
-                getCurrent().setPrintName(getCurrent().getName());
+
+        if (getCurrent().getDepartment() == null) {
+            JsfUtil.addErrorMessage("Please Select Department");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
+            if (getCurrent().getId() == null) {
+                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                    getCurrent().setCode(code);
+                }
             }
         }
 
-        if (getCurrent().getCode() == null || getCurrent().getCode().isEmpty()) {
-            setServiceCode();
+        if (!checkServiceCodeDuplicate(getCurrent().getCode())) {
+            JsfUtil.addErrorMessage("Service code is alredy used");
+            return;
         }
 
-//        if (errorCheck()) {
-//            return;
-//        }
-//        if (getServiceSubCategoryController().getParentCategory() != null) {
-//            getCurrent().setCategory(getServiceSubCategoryController().getParentCategory());
-//        }
-        ////// // System.out.println("getCurrent().getId() = " + getCurrent());
-        ////// // System.out.println("getCurrent().getId() = " + getCurrent().getId());
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
-            //////// // System.out.println("1");
-            if (billedAs == false) {
-                //////// // System.out.println("2");
-                getCurrent().setBilledAs(getCurrent());
-
-            }
-            if (reportedAs == false) {
-                //////// // System.out.println("3");
-                getCurrent().setReportedAs(getCurrent());
-            }
-
-            if (!checkServiceCodeDuplicate(getCurrent().getCode())) {
-                JsfUtil.addErrorMessage("Service code is alredy used");
-                return;
-            } else {
-                getFacade().edit(getCurrent());
-                JsfUtil.addSuccessMessage("Saved Old Successfully");
-            }
-
+            getFacade().edit(getCurrent());
+            JsfUtil.addSuccessMessage("Update Successfully");
         } else {
-            //////// // System.out.println("4");
             getCurrent().setCreatedAt(new Date());
             getCurrent().setCreater(getSessionController().getLoggedUser());
-
-            if (!checkServiceCodeDuplicate(getCurrent().getCode())) {
-                JsfUtil.addErrorMessage("Service code is alredy used");
-                return;
-            } else {
-                getFacade().create(getCurrent());
-            }
-
-            if (billedAs == false) {
-                //////// // System.out.println("5");
-                getCurrent().setBilledAs(getCurrent());
-            }
-            if (reportedAs == false) {
-                //////// // System.out.println("6");
-                getCurrent().setReportedAs(getCurrent());
-            }
-
-            if (checkServiceCodeDuplicate(genaratedServiceCode)) {
-                getFacade().edit(getCurrent());
-                JsfUtil.addSuccessMessage("Saved Successfully");
-            }
-
+            getFacade().create(getCurrent());
+            JsfUtil.addSuccessMessage("Saved Successfully");
         }
+
         recreateModel();
         getItems();
     }
@@ -853,7 +820,7 @@ public class ServiceController implements Serializable {
         Map<String, Double> resultMap = new HashMap<>();
 
         if (file != null) {
-            try ( InputStream input = file.getInputStream()) {
+            try (InputStream input = file.getInputStream()) {
                 Workbook workbook = new XSSFWorkbook(input);
                 Sheet sheet = workbook.getSheetAt(0);
                 for (Row row : sheet) {

--- a/src/main/java/com/divudi/bean/inward/InwardServiceController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceController.java
@@ -8,6 +8,8 @@
  */
 package com.divudi.bean.inward;
 import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.ServiceSubCategoryController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
@@ -56,6 +58,10 @@ public class InwardServiceController implements Serializable {
     SessionController sessionController;
     @Inject
     private ServiceSubCategoryController serviceSubCategoryController;
+    @Inject
+    private ItemController itemController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     @EJB
     private InwardServiceFacade ejbFacade;
     @EJB
@@ -209,6 +215,11 @@ public class InwardServiceController implements Serializable {
         return false;
     }
 
+    public void generateCode() {
+        String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+        getCurrent().setCode(code);
+    }
+
     public void saveSelected() {
 
         if (getCurrent().getDepartment() == null) {
@@ -217,6 +228,20 @@ public class InwardServiceController implements Serializable {
         }
         if (getCurrent().getInwardChargeType() == null) {
             JsfUtil.addErrorMessage("Please Select Inward Charge type");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
+            if (getCurrent().getId() == null) {
+                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                    getCurrent().setCode(code);
+                }
+            }
+        }
+
+        if (itemController.isItemCodeDuplicate(getCurrent().getCode(), getCurrent().getId())) {
+            JsfUtil.addErrorMessage("Item code is already used");
             return;
         }
 

--- a/src/main/java/com/divudi/bean/inward/TheatreServiceController.java
+++ b/src/main/java/com/divudi/bean/inward/TheatreServiceController.java
@@ -8,7 +8,8 @@
  */
 package com.divudi.bean.inward;
 import com.divudi.bean.common.BillBeanController;
-import com.divudi.bean.common.ServiceController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.ServiceSubCategoryController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
@@ -56,6 +57,10 @@ public class TheatreServiceController implements Serializable {
     SessionController sessionController;
     @Inject
     private ServiceSubCategoryController serviceSubCategoryController;
+    @Inject
+    private ItemController itemController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     @EJB
     TheatreServiceFacade theatreServiceFacade;
     @EJB
@@ -208,6 +213,11 @@ public class TheatreServiceController implements Serializable {
         return false;
     }
 
+    public void generateCode() {
+        String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+        getCurrent().setCode(code);
+    }
+
     public void saveSelected() {
 
         if (getCurrent().getDepartment() == null) {
@@ -216,6 +226,20 @@ public class TheatreServiceController implements Serializable {
         }
         if (getCurrent().getInwardChargeType() == null) {
             JsfUtil.addErrorMessage("Please Select Inward Charge type");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
+            if (getCurrent().getId() == null) {
+                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                    getCurrent().setCode(code);
+                }
+            }
+        }
+
+        if (itemController.isItemCodeDuplicate(getCurrent().getCode(), getCurrent().getId())) {
+            JsfUtil.addErrorMessage("Item code is already used");
             return;
         }
 
@@ -550,9 +574,9 @@ public class TheatreServiceController implements Serializable {
             if (value == null || value.length() == 0) {
                 return null;
             }
-            ServiceController controller = (ServiceController) facesContext.getApplication().getELResolver().
+            TheatreServiceController controller = (TheatreServiceController) facesContext.getApplication().getELResolver().
                     getValue(facesContext.getELContext(), null, "theatreServiceController");
-            return controller.getEjbFacade().find(getKey(value));
+            return controller.getTheatreServiceFacade().find(getKey(value));
         }
 
         java.lang.Long getKey(String value) {

--- a/src/main/java/com/divudi/bean/lab/InvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationController.java
@@ -9,7 +9,9 @@
 package com.divudi.bean.lab;
 
 import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ItemApplicationController;
+import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.ItemFeeManager;
 import com.divudi.bean.common.ItemForItemController;
 import com.divudi.bean.common.SessionController;
@@ -111,6 +113,10 @@ public class InvestigationController implements Serializable {
     ItemForItemController itemForItemController;
     @Inject
     ItemApplicationController itemApplicationController;
+    @Inject
+    private ItemController itemController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     /**
      * EJBs
      */
@@ -1524,6 +1530,11 @@ public class InvestigationController implements Serializable {
         getItems();
     }
 
+    public void generateCode() {
+        String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+        getCurrent().setCode(code);
+    }
+
     public void saveSelected() {
         if (getCurrent() == null){
             JsfUtil.addErrorMessage("Please add investigation");
@@ -1533,8 +1544,20 @@ public class InvestigationController implements Serializable {
             JsfUtil.addErrorMessage("Please enter a Investigation Name before saving");
             return;
         }
+        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
+            if (getCurrent().getId() == null) {
+                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
+                    String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                    getCurrent().setCode(code);
+                }
+            }
+        }
         if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()){
             JsfUtil.addErrorMessage("Please enter a Investigation Code before saving");
+            return;
+        }
+        if (itemController.isItemCodeDuplicate(getCurrent().getCode(), getCurrent().getId())) {
+            JsfUtil.addErrorMessage("Item code is already used");
             return;
         }
         getCurrent().setSymanticType(SymanticType.Laboratory_Procedure);

--- a/src/main/webapp/admin/items/inward_service.xhtml
+++ b/src/main/webapp/admin/items/inward_service.xhtml
@@ -120,8 +120,11 @@
                                         <p:selectBooleanCheckbox   id="chkBilledAs" value="#{inwardServiceController.billedAs}" itemLabel="Billed as a separate investigation"  >
                                             <p:ajax event="change" process="@this" update="billedAsIx" />
                                         </p:selectBooleanCheckbox>
-                                        <p:autoComplete   disabled="#{!inwardServiceController.billedAs}" 
-                                                          widgetVar="aIx1" id="billedAsIx" forceSelection="true" 
+                                        <p:autoComplete   
+                                            disabled="#{!inwardServiceController.billedAs}" 
+                                                          widgetVar="aIx1" 
+                                                          id="billedAsIx" 
+                                                          forceSelection="true" 
                                                           value="#{inwardServiceController.current.billedAs}" completeMethod="#{inwardServiceController.completeItem}" var="ix1" itemLabel="#{ix1.name}" itemValue="#{ix1}" size="30">
                                         </p:autoComplete>
 

--- a/src/main/webapp/admin/items/inward_service.xhtml
+++ b/src/main/webapp/admin/items/inward_service.xhtml
@@ -13,7 +13,7 @@
 
         <h:panelGroup >
             <h:form id="form"  >
-                <p:growl/>
+                <p:growl id="msg" showDetail="true"/>
                 <p:focus id="selectFocus" for="lstSelect" />
                 <p:focus id="detailFocus" for="gpDetail" />
 
@@ -75,9 +75,9 @@
                                         style="float: right"
                                         id="btnSave" 
                                         value="Save"  
-                                        action="#{inwardServiceController.saveSelected()}" 
+                                        action="#{inwardServiceController.saveSelected()}"
                                         class="ui-button-warning"
-                                        update="lstSelect selectFocus"
+                                        update="msg lstSelect selectFocus"
                                         process="btnSave gpDetail">
                                     </p:commandButton>
                                     <p:defaultCommand target="btnSave"/>
@@ -91,7 +91,19 @@
                                         <h:outputText id="lblFullName" value="Full Name" ></h:outputText>
                                         <h:inputText autocomplete="off" id="txtFullName"   value="#{inwardServiceController.current.fullName}" class="form-control" ></h:inputText>
                                         <p:outputLabel value="Item Code"/>
-                                        <p:inputText autocomplete="off" value="#{inwardServiceController.current.code}" class="form-control"/>
+                                        <h:panelGroup class="d-flex gap-2">
+                                            <p:inputText id="ServiceCode" autocomplete="off" value="#{inwardServiceController.current.code}" class="form-control"/>
+                                            <p:commandButton
+                                                class="ui-button-warning"
+                                                update="ServiceCode"
+                                                process="@this btnGenCode cmbIns cmbDep"
+                                                icon="fa fa-cog"
+                                                title="Auto Generate Code"
+                                                disabled="#{inwardServiceController.current.id ne null}"
+                                                id="btnGenCode"
+                                                action="#{inwardServiceController.generateCode()}">
+                                            </p:commandButton>
+                                        </h:panelGroup>
 
                                         <h:outputText value="Service Category/Sub Category" ></h:outputText>
                                         <p:autoComplete 

--- a/src/main/webapp/admin/items/items.xhtml
+++ b/src/main/webapp/admin/items/items.xhtml
@@ -105,7 +105,7 @@
                                                 columns="2" 
                                                 class="w-100" 
                                                 columnClasses="w-25, w-75">
-                                                
+
                                                 <h:outputText id="lblName" value="Name" ></h:outputText>
                                                 <p:inputText 
                                                     autocomplete="off" 
@@ -140,7 +140,20 @@
                                                 </p:autoComplete>
 
                                                 <p:outputLabel for="ServiceCode" value="Item Code"/>
-                                                <p:inputText id="ServiceCode" value="#{itemController.current.code}" class="w-100 m-1"/>
+                                                <h:panelGroup class="d-flex gap-2">
+                                                    <p:inputText id="ServiceCode" value="#{itemController.current.code}" class="w-100 m-1"/>
+                                                    <p:commandButton 
+                                                        class="ui-button-warning m-1"
+                                                        update="ServiceCode selectFocus gpDetail"
+                                                        process="@this btnGenCode cmbIns cmbDep" 
+                                                        icon="fa fa-cog"
+                                                        title="Auto Generate Code"
+                                                        disabled="#{itemController.current.id ne null}"
+                                                        id="btnGenCode"         
+                                                        action="#{itemController.generateCode()}">
+                                                    </p:commandButton>
+                                                </h:panelGroup>
+
 
                                                 <h:outputText value="Financial Category" ></h:outputText>
                                                 <p:autoComplete 
@@ -188,7 +201,7 @@
                                         </p:tab>
                                         <p:tab title="Additional Details" >
                                             <h:panelGrid columns="2" >
-                                                
+
                                                 <h:outputText value="" ></h:outputText>
                                                 <p:selectBooleanCheckbox value="#{itemController.current.inactive}" itemLabel="Service Inactive"/>
                                                 <h:outputText value="" ></h:outputText>
@@ -212,7 +225,7 @@
                                                 <p:selectBooleanCheckbox value="#{itemController.current.printFeesForBills}" itemLabel="Print Separate Fees"/>
                                                 <h:outputText value="" ></h:outputText>
                                                 <p:selectBooleanCheckbox value="#{itemController.current.printSessionNumber}" itemLabel="Print Session Number"/>
-                                                
+
                                             </h:panelGrid>
                                             <hr/>
                                             <h:panelGrid columns="2" columnClasses="w-50, w-50" >
@@ -222,10 +235,10 @@
                                                 <h:outputText value="#{itemController.current.creater.webUserPerson.nameWithTitle}"/>
                                                 <h:outputText value="Created At"/>
                                                 <h:outputText value="#{itemController.current.createdAt}">
-                                                   <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputText>
                                             </h:panelGrid>
-                                            
+
                                         </p:tab>
                                         <p:tab rendered="false" title="Depricated" >
                                             <h:outputText id="lblVatPercentage" value="VAT Percentage" ></h:outputText>

--- a/src/main/webapp/admin/items/items.xhtml
+++ b/src/main/webapp/admin/items/items.xhtml
@@ -144,7 +144,7 @@
                                                     <p:inputText id="ServiceCode" value="#{itemController.current.code}" class="w-100 m-1"/>
                                                     <p:commandButton 
                                                         class="ui-button-warning m-1"
-                                                        update="ServiceCode selectFocus gpDetail"
+                                                        update="ServiceCode"
                                                         process="@this btnGenCode cmbIns cmbDep" 
                                                         icon="fa fa-cog"
                                                         title="Auto Generate Code"

--- a/src/main/webapp/admin/items/opd_service.xhtml
+++ b/src/main/webapp/admin/items/opd_service.xhtml
@@ -145,7 +145,7 @@
                                                     <p:inputText id="ServiceCode" value="#{serviceController.current.code}" class="form-control mx-2"/>
                                                     <p:commandButton
                                                         class="ui-button-warning"
-                                                        update="ServiceCode gpDetail"
+                                                        update="ServiceCode"
                                                         process="@this btnGenCode cmbIns cmbDep"
                                                         icon="fa fa-cog"
                                                         title="Auto Generate Code"

--- a/src/main/webapp/admin/items/opd_service.xhtml
+++ b/src/main/webapp/admin/items/opd_service.xhtml
@@ -140,8 +140,20 @@
                                                     <f:selectItems value="#{enumController.inwardChargeTypes}" var="i" itemLabel="#{i.label}" itemValue="#{i}"/>
                                                 </p:selectOneMenu>
 
-                                                <p:outputLabel value="Item Code"/>
-                                                <p:inputText id="ServiceCode" value="#{serviceController.current.code}" class="form-control mx-2"/>
+                                                <p:outputLabel value="Item Code" />
+                                                <h:panelGroup class="d-flex gap-2">
+                                                    <p:inputText id="ServiceCode" value="#{serviceController.current.code}" class="form-control mx-2"/>
+                                                    <p:commandButton
+                                                        class="ui-button-warning"
+                                                        update="ServiceCode gpDetail"
+                                                        process="@this btnGenCode cmbIns cmbDep"
+                                                        icon="fa fa-cog"
+                                                        title="Auto Generate Code"
+                                                        disabled="#{serviceController.current.id ne null}"
+                                                        id="btnGenCode"
+                                                        action="#{serviceController.generateCode()}">
+                                                    </p:commandButton>
+                                                </h:panelGroup>
                                                 <h:outputText></h:outputText>
                                             </h:panelGrid>
                                         </p:tab>
@@ -221,27 +233,11 @@
                                     </p:tabView>
                                 </h:panelGrid>
 
-                                <div class="d-flex justify-content-end align-items-center">
-                                    <p:commandButton 
-                                        class="ui-button-warning my-2 mx-2"
-                                        id="btnGenarate" 
-                                        icon="fas fa-redo-alt"
-                                        update="gpDetail"
-                                        process="btnGenarate gpDetail" 
-                                        value="Genarate Item Code"          
-                                        action="#{serviceController.setServiceCode}">
-                                    </p:commandButton> 
-                                </div>
                             </p:panel>
                         </div>
                     </div>
                 </p:panel>
-
-                <!--                <p:panel >
-                                    <p:media value="http://www.youtube.com/v/KZnUr8lcqjo" width="420" height="315" player="flash"/>
                 
-                                </p:panel>-->
-
             </h:form>
         </h:panelGroup>
         <h:form>

--- a/src/main/webapp/admin/items/theatre_service.xhtml
+++ b/src/main/webapp/admin/items/theatre_service.xhtml
@@ -12,7 +12,7 @@
 
         <h:panelGroup >
             <h:form id="form"  >
-                <p:growl/>
+                <p:growl id="msg"  showDetail="true"/>
 
                 <p:panel header="Manage Service" >
                     <div class="row">
@@ -21,7 +21,7 @@
                                 id="btnAdd"
                                 value="Add" 
                                 process="btnAdd"
-                                update="gpDetail"
+                                update="gpDetail msg"
                                 class="w-25 ui-button-success"
                                 action="#{theatreServiceController.prepareAdd()}" >
 
@@ -78,9 +78,9 @@
                                         id="btnSave"
                                         value="Save" 
                                         process="btnSave gpDetail"
-                                        update="lstSelect "
+                                        update="msg lstSelect"
                                         class="w-25 ui-button-warning"
-                                        action="#{theatreServiceController.saveSelected()}" 
+                                        action="#{theatreServiceController.saveSelected()}"
                                         >
                                     </p:commandButton>
                                     <p:defaultCommand target="btnSave"/>
@@ -88,8 +88,7 @@
                                 </f:facet>
 
                                 <h:panelGrid id="gpDetail" columns="2">
-                                    <h:outputLabel value="Created At" />
-                                    <p:calendar   value="#{theatreServiceController.current.createdAt}" pattern="#{sessionController.applicationPreference.longTimeFormat}" />
+                                    
                                     <h:outputText id="lblName" value="Name" ></h:outputText>
                                     <p:inputText autocomplete="off" id="txtName" value="#{theatreServiceController.current.name}" required="true" style="width: 400px;"></p:inputText>
                                     <h:outputText id="lblAddress" value="Printing Name" ></h:outputText>
@@ -97,7 +96,19 @@
                                     <h:outputText id="lblFullName" value="Full Name" ></h:outputText>
                                     <p:inputText autocomplete="off" id="txtFullName"   value="#{theatreServiceController.current.fullName}" style="width: 400px;" ></p:inputText>
                                     <p:outputLabel value="Item Code"/>
-                                    <p:inputText autocomplete="off" value="#{theatreServiceController.current.code}" style="width: 400px;"/>
+                                    <h:panelGroup class="d-flex gap-2">
+                                        <p:inputText id="ServiceCode" autocomplete="off" value="#{theatreServiceController.current.code}" style="width: 400px;"/>
+                                        <p:commandButton
+                                            class="ui-button-warning"
+                                            update="ServiceCode"
+                                            process="@this btnGenCode cmbIns cmbDep"
+                                            icon="fa fa-cog"
+                                            title="Auto Generate Code"
+                                            disabled="#{theatreServiceController.current.id ne null}"
+                                            id="btnGenCode"
+                                            action="#{theatreServiceController.generateCode()}">
+                                        </p:commandButton>
+                                    </h:panelGroup>
 
                                     <h:outputText value="Service Category/Sub Category" ></h:outputText>
                                     <p:autoComplete

--- a/src/main/webapp/admin/lims/investigation.xhtml
+++ b/src/main/webapp/admin/lims/investigation.xhtml
@@ -88,7 +88,21 @@
                                 <div class="row mt-2">
                                     <div class="col-md-3"><p:outputLabel value="Item Code"/></div>
                                     <div class="col-md-1"><h:outputLabel value=" : " style="text-align: center"/></div>
-                                    <div class="col-md-6"><p:inputText class="form-control" autocomplete="off" value="#{investigationController.current.code}"/></div>
+                                    <div class="col-md-6">
+                                        <h:panelGroup class="d-flex gap-2">
+                                            <p:inputText id="ServiceCode" class="form-control" autocomplete="off" value="#{investigationController.current.code}"/>
+                                            <p:commandButton
+                                                class="ui-button-warning"
+                                                update="ServiceCode"
+                                                process="@this btnGenCode cmbIns cmbDep"
+                                                icon="fa fa-cog"
+                                                title="Auto Generate Code"
+                                                disabled="#{investigationController.current.id ne null}"
+                                                id="btnGenCode"
+                                                action="#{investigationController.generateCode()}">
+                                            </p:commandButton>
+                                        </h:panelGroup>
+                                    </div>
                                 </div>
 
                                 <div class="row mt-2">


### PR DESCRIPTION
## Summary

Implements department-prefixed item coding (e.g. `LAB-000001`) across all item/service admin screens, with a manual **Generate Code** button and duplicate-code validation.

Closes #14854

## Changes

### Item code generation
- `ItemController.generateNextItemCode(institution, department)` builds the code from the (optional) institution code + department code + a zero-padded per-department sequence, using the `Item Codes Generate - *` config options. Guards against null institution/department so generating a code for a brand-new item no longer throws a `NullPointerException`.
- `generateCode()` actions and a **Generate Code** button (disabled when editing an existing record) added to every item/service form.

### Duplicate-code validation
- `ItemController.isItemCodeDuplicate(code, excludeId)` queries the base `Item` entity, so duplicates are detected across **all** item subtypes (Service, Investigation, etc.).
- Fixes the original validator, which used `id != :id` with a `null` id for new records — `id != NULL` matched zero rows and the check always passed, so duplicates were never caught for new items.
- `saveSelected()` on each screen now auto-generates a code when the department-code option is enabled and blocks duplicate codes with an error message.

### Screens updated
- `items.xhtml`, `opd_service.xhtml`, `inward_service.xhtml`, `theatre_service.xhtml`, `investigation.xhtml`
- The Generate Code button updates only the code field, so typed-but-unsaved values (e.g. Name) are preserved.
- Inward/theatre forms route validation/success messages to the growl so the duplicate-code error is displayed.

### Incidental fix
- `TheatreServiceController.ServiceControllerConverter.getAsObject` cast the resolved bean to `ServiceController` instead of `TheatreServiceController`, causing a `ClassCastException` when selecting a service from the list. Now casts correctly and uses the theatre facade.

## Testing
- Manual: generate codes and save with/without duplicate codes on each screen; verify the duplicate error shows and typed fields are retained.


## Configuration Options

The generated code is controlled by the following application configuration options (Administration → Application Configurations). All are read with safe defaults, so behaviour is unchanged until an admin enables them.

| Option Key | Type | Default | Effect |
|---|---|---|---|
| `Item Codes Generate - Automatically create Item Codes by Department.` | Boolean | `false` (off) | When **on**, a code is generated automatically on save for new records that have no code. When **off**, codes are only produced via the manual **Generate Code** button. |
| `Item Codes Generate - Use Item Institution Code` | Boolean | `false` (off) | When **on**, the item's Institution code is prepended to the generated code (followed by the separator). When **off**, the code starts at the department code. |
| `Item Codes Generate - The symbol used between the department number and the item number when automatically generating item codes.` | Short Text | `-` | Separator placed between the institution code, department code and the running number. |

**Resulting format:** `[InstitutionCode<sep>]DepartmentCode<sep>NNNNNN`

Examples (separator `-`, department code `LAB`):
- Institution code **off** → `LAB-000001`
- Institution code **on**, institution code `RH` → `RH-LAB-000001`
- Department has no code → `000001` (running number only)

`NNNNNN` is a 6-digit, zero-padded per-department running number (count of existing Services + Investigations in that department, + 1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic item code generation for items, services, investigations and related entities
  * "Auto Generate Code" buttons added to admin forms for on-demand code creation

* **Improvements**
  * Configurable enable/disable for automatic code generation
  * Save workflows now validate and block duplicate item codes before persisting
  * Admin forms updated to surface messages (growl) for save errors/successes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->