### PR TITLE
feat(inward): settle, print preview and paper-format config for outside charge bill (#20731)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -7,6 +7,7 @@
  * (94) 71 5812399
  */
 package com.divudi.bean.inward;
+import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.inward.Admission;
@@ -64,10 +65,17 @@ public class InwardAdditionalChargeController implements Serializable {
     private SessionController sessionController;
     @Inject
     private AdmissionController admissionController;
+    @Inject
+    private ConfigOptionController configOptionController;
     //////////////
     private BilledBill current;
     private Institution institution;
     private List<BillItem> billItemList;
+    private boolean printPreview;
+    // Print configuration (paper format) — persisted via department-scoped config options
+    private boolean posPaper;
+    private boolean fiveFivePaper;
+    private boolean a4Paper;
 
     public InwardBeanController getInwardBean() {
         return inwardBean;
@@ -83,8 +91,30 @@ public class InwardAdditionalChargeController implements Serializable {
     }
 
     public String navigateToAddOutsideChargeFromInpatientProfile() {
+        // The caller passes the patient via f:setPropertyActionListener, which
+        // fires before this action. Reset all state (including printPreview) but
+        // keep the encounter that was just selected.
+        PatientEncounter pe = getCurrent().getPatientEncounter();
+        makeNull();
+        getCurrent().setPatientEncounter(pe);
         institution = sessionController.getInstitution();
         return "/inward/inward_bill_outside_charge?faces-redirect=true";
+    }
+
+    /**
+     * Finalize the current outside-charge bill and switch the page to the print
+     * preview. The charges have already been persisted by {@link #addCharge()};
+     * this exposes the accumulated bill items to the print composites and flips
+     * the {@code printPreview} flag.
+     */
+    public void settle() {
+        if (getBillItemList().isEmpty()) {
+            JsfUtil.addErrorMessage("Add at least one charge before settling");
+            return;
+        }
+        current.setBillItems(getBillItemList());
+        printPreview = true;
+        JsfUtil.addSuccessMessage("Bill Settled");
     }
 
     private boolean errorCheck() {
@@ -134,6 +164,7 @@ public class InwardAdditionalChargeController implements Serializable {
         current = null;
         billItemList = null;
         inwardChargeType = null;
+        printPreview = false;
         institution = sessionController.getInstitution();
     }
 
@@ -145,6 +176,7 @@ public class InwardAdditionalChargeController implements Serializable {
         current = null;
         billItemList = null;
         inwardChargeType = null;
+        printPreview = false;
     }
 
     public Institution getInstitution() {
@@ -159,6 +191,7 @@ public class InwardAdditionalChargeController implements Serializable {
         PatientEncounter p = current.getPatientEncounter();
         current = null;
         billItemList = null;
+        printPreview = false;
         getCurrent().setPatientEncounter(p);
         inwardChargeType = null;
         JsfUtil.addSuccessMessage("Cleared Successfully");
@@ -307,5 +340,61 @@ public class InwardAdditionalChargeController implements Serializable {
 
     public void setBillItemList(List<BillItem> billItemList) {
         this.billItemList = billItemList;
+    }
+
+    public boolean isPrintPreview() {
+        return printPreview;
+    }
+
+    public void setPrintPreview(boolean printPreview) {
+        this.printPreview = printPreview;
+    }
+
+    // ------------------------------------------------------------------
+    // Print (paper format) configuration — opened from the preview dialog
+    // ------------------------------------------------------------------
+    public void loadPrintConfig() {
+        posPaper = configOptionController.getBooleanValueByKey("Inward Outside Charge Bill is POS Paper", false);
+        fiveFivePaper = configOptionController.getBooleanValueByKey("Inward Outside Charge Bill is 5x5 Paper", true);
+        a4Paper = configOptionController.getBooleanValueByKey("Inward Outside Charge Bill is A4 Paper", false);
+    }
+
+    public void savePrintConfig() {
+        configOptionController.setBooleanValueByKey("Inward Outside Charge Bill is POS Paper", posPaper);
+        configOptionController.setBooleanValueByKey("Inward Outside Charge Bill is 5x5 Paper", fiveFivePaper);
+        configOptionController.setBooleanValueByKey("Inward Outside Charge Bill is A4 Paper", a4Paper);
+        JsfUtil.addSuccessMessage("Print configuration saved");
+    }
+
+    public boolean isPosPaper() {
+        return posPaper;
+    }
+
+    public void setPosPaper(boolean posPaper) {
+        this.posPaper = posPaper;
+    }
+
+    public boolean isFiveFivePaper() {
+        return fiveFivePaper;
+    }
+
+    public void setFiveFivePaper(boolean fiveFivePaper) {
+        this.fiveFivePaper = fiveFivePaper;
+    }
+
+    public boolean isA4Paper() {
+        return a4Paper;
+    }
+
+    public void setA4Paper(boolean a4Paper) {
+        this.a4Paper = a4Paper;
+    }
+
+    public ConfigOptionController getConfigOptionController() {
+        return configOptionController;
+    }
+
+    public void setConfigOptionController(ConfigOptionController configOptionController) {
+        this.configOptionController = configOptionController;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -112,6 +112,16 @@ public class InwardAdditionalChargeController implements Serializable {
             JsfUtil.addErrorMessage("Add at least one charge before settling");
             return;
         }
+        // saveBill() overwrites total/netTotal with the last single entry on every
+        // Add, so recompute the settled amount from all accumulated charges before
+        // showing the preview (otherwise a multi-charge bill prints only the last value).
+        double settledTotal = 0.0;
+        for (BillItem bi : getBillItemList()) {
+            settledTotal += bi.getNetValue();
+        }
+        current.setTotal(settledTotal);
+        current.setNetTotal(settledTotal);
+        getBilledBillFacade().edit(current);
         current.setBillItems(getBillItemList());
         printPreview = true;
         JsfUtil.addSuccessMessage("Bill Settled");

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -217,8 +217,10 @@
                                         value="Settle"
                                         ajax="false"
                                         rendered="#{!inwardAdditionalChargeController.printPreview}"
-                                        onclick="if (!confirm('Are you sure you want to settle this bill?'))
-                                                    return false;"
+                                        onclick="if (!confirm('Are you sure you want to settle this bill?')) {
+                                                    return false;
+                                                }
+                                                this.disabled=true;"
                                         action="#{inwardAdditionalChargeController.settle()}">
                                     </p:commandButton>
 

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -6,7 +6,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:print="http://xmlns.jcp.org/jsf/composite/ezcomp/prints">
 
 
     <ui:define name="content">
@@ -210,19 +211,32 @@
                                     </p:commandButton>
 
                                     <p:commandButton
+                                        class="ui-button-info"
+                                        id="btnSettle"
+                                        icon="fa fa-check"
+                                        value="Settle"
+                                        ajax="false"
+                                        rendered="#{!inwardAdditionalChargeController.printPreview}"
+                                        onclick="if (!confirm('Are you sure you want to settle this bill?'))
+                                                    return false;"
+                                        action="#{inwardAdditionalChargeController.settle()}">
+                                    </p:commandButton>
+
+                                    <p:commandButton
                                         class="ui-button-success"
                                         id="btnNew"
                                         icon="fa fa-plus"
-                                        value="New Bill"  
-                                        ajax="false" 
+                                        value="New Bill"
+                                        ajax="false"
                                         action="#{inwardAdditionalChargeController.makeNull()}">
                                     </p:commandButton>
 
-                                    <p:commandButton 
-                                        class="ui-button-danger" 
+                                    <p:commandButton
+                                        class="ui-button-danger"
                                         value="Clear"
                                         icon="fa fa-ban"
-                                        ajax="false" 
+                                        ajax="false"
+                                        rendered="#{!inwardAdditionalChargeController.printPreview}"
                                         action="#{inwardAdditionalChargeController.reset()}" >
                                     </p:commandButton>
 
@@ -277,6 +291,8 @@
                                 </div>
                             </div>
                         </f:facet>
+
+                        <h:panelGroup rendered="#{!inwardAdditionalChargeController.printPreview}">
 
                         <div class="col-12">
                             <h:panelGroup rendered="true" styleClass="opdPanel">
@@ -411,10 +427,115 @@
                             </div>
 
                         </div>
+
+                        </h:panelGroup>
+
+                        <!-- ============================= PRINT PREVIEW ============================= -->
+                        <h:panelGroup rendered="#{inwardAdditionalChargeController.printPreview}">
+                            <div class="d-flex justify-content-end gap-2 mb-3">
+                                <p:commandButton
+                                    value="Print"
+                                    class="ui-button-info"
+                                    ajax="false"
+                                    icon="fa-solid fa-print">
+                                    <p:printer target="gpOutsideBillPreview" />
+                                </p:commandButton>
+                                <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Print Configuration"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary"
+                                    type="button"
+                                    onclick="PF('outsideChargeConfigDialog').show();" />
+                            </div>
+
+                            <div class="row justify-content-center">
+                                <div class="col-12 col-lg-8">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa-solid fa-receipt" />
+                                            <h:outputLabel value="Bill Preview" class="mx-2" />
+                                        </f:facet>
+                                        <h:panelGroup id="gpOutsideBillPreview" layout="block">
+
+                                            <h:panelGroup rendered="#{inwardAdditionalChargeController.configOptionController.getBooleanValueByKey('Inward Outside Charge Bill is POS Paper', false)}">
+                                                <print:posBill_inward_outside bill="#{inwardAdditionalChargeController.current}" />
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardAdditionalChargeController.configOptionController.getBooleanValueByKey('Inward Outside Charge Bill is 5x5 Paper', true)}">
+                                                <print:five_five_inward_outside bill="#{inwardAdditionalChargeController.current}" />
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardAdditionalChargeController.configOptionController.getBooleanValueByKey('Inward Outside Charge Bill is A4 Paper', false)}">
+                                                <print:A4_inward_outside bill="#{inwardAdditionalChargeController.current}" />
+                                            </h:panelGroup>
+
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+
                     </p:panel>
                 </h:panelGrid>
 
             </h:form>
+
+            <!-- ===================== PRINT (PAPER FORMAT) CONFIGURATION ===================== -->
+            <p:dialog id="outsideChargeConfigDialog"
+                      header="Outside Charge Bill — Print Configuration"
+                      widgetVar="outsideChargeConfigDialog"
+                      modal="true"
+                      width="520"
+                      resizable="false"
+                      closeOnEscape="true">
+
+                <p:ajax event="open" listener="#{inwardAdditionalChargeController.loadPrintConfig}" update="outsideChargeConfigForm" />
+
+                <h:form id="outsideChargeConfigForm">
+                    <div class="card">
+                        <div class="card-header">
+                            <h6 class="m-0"><i class="fas fa-file-alt"></i> Paper Format</h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted small">Select the paper format used to print outside charge bills for this department.</p>
+
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="cfgPos" value="#{inwardAdditionalChargeController.posPaper}" />
+                                <h:outputLabel for="cfgPos" value="POS Paper" class="ms-2 fw-bold" />
+                                <small class="form-text text-muted d-block">Thermal POS receipt format.</small>
+                            </div>
+
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="cfgFiveFive" value="#{inwardAdditionalChargeController.fiveFivePaper}" />
+                                <h:outputLabel for="cfgFiveFive" value="5 x 5 inch Paper (Impact / Epson)" class="ms-2 fw-bold" />
+                                <small class="form-text text-muted d-block">5 inch x 5 inch format tuned for impact / dot-matrix printers.</small>
+                            </div>
+
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="cfgA4" value="#{inwardAdditionalChargeController.a4Paper}" />
+                                <h:outputLabel for="cfgA4" value="A4 Paper" class="ms-2 fw-bold" />
+                                <small class="form-text text-muted d-block">Full-page A4 invoice format.</small>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="d-flex gap-2 mt-3">
+                        <p:commandButton
+                            value="Apply &amp; Close"
+                            icon="fas fa-save"
+                            class="ui-button-success"
+                            ajax="false"
+                            action="#{inwardAdditionalChargeController.savePrintConfig}" />
+                        <p:commandButton
+                            value="Cancel"
+                            icon="fas fa-times"
+                            class="ui-button-secondary"
+                            type="button"
+                            onclick="PF('outsideChargeConfigDialog').hide(); return false;" />
+                    </div>
+                </h:form>
+            </p:dialog>
 
         </h:panelGroup>
 

--- a/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- A4 bill for Inward Outside Charges -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false" />
+    </cc:interface>
+
+    <cc:implementation>
+        <style>
+            .a4-outside-bill {
+                width: 19cm;
+                margin: 0 auto;
+                font-family: "Times New Roman", Georgia, serif;
+                color: #000;
+                font-size: 13px;
+            }
+            .a4-outside-bill .inst { text-align: center; font-weight: bold; font-size: 22px; }
+            .a4-outside-bill .inst-sub { text-align: center; font-size: 12px; }
+            .a4-outside-bill .title {
+                text-align: center; font-weight: bold; font-size: 16px;
+                margin: 10px 0; letter-spacing: 1px; text-decoration: underline;
+            }
+            .a4-outside-bill .meta td { padding: 2px 6px; vertical-align: top; }
+            .a4-outside-bill table.items { width: 100%; border-collapse: collapse; margin-top: 8px; }
+            .a4-outside-bill table.items th,
+            .a4-outside-bill table.items td { border: 1px solid #000; padding: 5px 8px; }
+            .a4-outside-bill table.items th { background-color: #f0f0f0; }
+            @media print {
+                .a4-outside-bill { width: 100%; }
+                .a4-outside-bill table.items th { background-color: #f0f0f0 !important; -webkit-print-color-adjust: exact; }
+            }
+        </style>
+
+        <div class="a4-outside-bill">
+
+            <div class="inst"><h:outputLabel value="#{cc.attrs.bill.institution.name}" /></div>
+            <div class="inst-sub"><h:outputLabel value="#{cc.attrs.bill.department.name}" /></div>
+            <div class="inst-sub"><h:outputLabel value="#{cc.attrs.bill.department.address}" /></div>
+            <div class="inst-sub">
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null}" />
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone2}" />
+            </div>
+
+            <div class="title">
+                OUTSIDE CHARGE BILL
+                <h:outputLabel value=" — DUPLICATE" rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value=" — CANCELLED" rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <table class="meta" style="width: 100%;">
+                <tr>
+                    <td style="width: 12%;"><strong>Bill No</strong></td>
+                    <td style="width: 38%;"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                    <td style="width: 12%;"><strong>Date</strong></td>
+                    <td style="width: 38%;">
+                        <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                            <f:convertDateTime pattern="dd MMM yyyy hh:mm a" timeZone="Asia/Colombo" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong>Patient</strong></td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" /></td>
+                    <td><strong>BHT No</strong></td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" /></td>
+                </tr>
+                <tr>
+                    <td><strong>Age / Sex</strong></td>
+                    <td>
+                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.ageAsShortString}" />
+                        <h:outputLabel value=" / #{cc.attrs.bill.patientEncounter.patient.person.sex.label}"
+                                       rendered="#{cc.attrs.bill.patientEncounter.patient.person.sex ne null}" />
+                    </td>
+                    <td><strong>Room</strong></td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" /></td>
+                </tr>
+                <h:panelGroup rendered="#{cc.attrs.bill.fromInstitution ne null}">
+                    <tr>
+                        <td><strong>From Institution</strong></td>
+                        <td colspan="3"><h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" /></td>
+                    </tr>
+                </h:panelGroup>
+            </table>
+
+            <table class="items">
+                <thead>
+                    <tr>
+                        <th style="width: 8%; text-align: center;">No</th>
+                        <th style="text-align: left;">Charge Type</th>
+                        <th style="width: 22%; text-align: right;">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" varStatus="s">
+                        <tr>
+                            <td style="text-align: center;">#{s.index + 1}</td>
+                            <td style="text-transform: capitalize;">
+                                <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                            </td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{bip.netValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                    <tr>
+                        <td colspan="2" style="text-align: right; font-weight: bold;">Net Total</td>
+                        <td style="text-align: right; font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h:panelGroup rendered="#{cc.attrs.bill.comments ne null and not empty cc.attrs.bill.comments}">
+                <div style="margin-top: 10px;">
+                    <strong>Note:</strong> <h:outputLabel value="#{cc.attrs.bill.comments}" />
+                </div>
+            </h:panelGroup>
+
+            <table style="width: 100%; margin-top: 40px;">
+                <tr>
+                    <td style="text-align: left;">
+                        Billed by : <h:outputLabel value="#{cc.attrs.bill.creater.name}" />
+                    </td>
+                    <td style="text-align: right;">
+                        ............................................<br />
+                        Authorized Signature
+                    </td>
+                </tr>
+            </table>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
@@ -80,7 +80,14 @@
                                        rendered="#{cc.attrs.bill.patientEncounter.patient.person.sex ne null}" />
                     </td>
                     <td><strong>Room</strong></td>
-                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" /></td>
+                    <td>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter.currentPatientRoom ne null}">
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" />
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter.currentPatientRoom eq null}">
+                            <h:outputLabel value="Not assigned" />
+                        </h:panelGroup>
+                    </td>
                 </tr>
                 <h:panelGroup rendered="#{cc.attrs.bill.fromInstitution ne null}">
                     <tr>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
@@ -87,7 +87,14 @@
                     <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" /></td>
                     <td>Room</td>
                     <td>:</td>
-                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" /></td>
+                    <td>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter.currentPatientRoom ne null}">
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" />
+                        </h:panelGroup>
+                        <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter.currentPatientRoom eq null}">
+                            <h:outputLabel value="Not assigned" />
+                        </h:panelGroup>
+                    </td>
                 </tr>
                 <h:panelGroup rendered="#{cc.attrs.bill.fromInstitution ne null}">
                     <tr>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
@@ -1,0 +1,156 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!--
+        5 inch x 5 inch bill for Inward Outside Charges.
+        Tuned for impact / dot-matrix printers (e.g. Epson LX/FX series):
+        a single clean sans-serif font, solid black text, no background fills.
+    -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false" />
+    </cc:interface>
+
+    <cc:implementation>
+        <style>
+            .five-outside-bill {
+                width: 12.7cm; /* 5 inch */
+                font-family: Arial, "Liberation Sans", sans-serif;
+                color: #000;
+                font-size: 12px;
+                line-height: 1.35;
+                padding: 0.3cm;
+                box-sizing: border-box;
+            }
+            .five-outside-bill table { width: 100%; border-collapse: collapse; }
+            .five-outside-bill .sep { border-top: 1px solid #000; margin: 4px 0; }
+            .five-outside-bill .title { text-align: center; font-weight: bold; font-size: 14px; }
+            .five-outside-bill .inst { text-align: center; font-weight: bold; font-size: 15px; }
+            .five-outside-bill .items th, .five-outside-bill .items td { padding: 2px 0; }
+            @media print {
+                .five-outside-bill {
+                    width: 12.7cm !important;
+                    min-height: 12.7cm; /* 5 inch */
+                    page-break-after: always;
+                }
+            }
+        </style>
+
+        <div class="five-outside-bill">
+
+            <div class="inst">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div style="text-align: center; font-size: 11px;">
+                <h:outputLabel value="#{cc.attrs.bill.department.address}" />
+            </div>
+            <div style="text-align: center; font-size: 11px;">
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null}" />
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone2}" />
+            </div>
+
+            <div class="title" style="margin-top: 4px;">
+                <h:outputLabel value="OUTSIDE CHARGE BILL" />
+                <h:outputLabel value=" **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value=" **Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="sep"></div>
+
+            <table>
+                <tr>
+                    <td style="width: 18%;">Bill No</td>
+                    <td style="width: 3%;">:</td>
+                    <td style="width: 32%;"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                    <td style="width: 15%;">Date</td>
+                    <td style="width: 3%;">:</td>
+                    <td style="width: 29%;">
+                        <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                            <f:convertDateTime pattern="dd/MM/yyyy hh:mm a" timeZone="Asia/Colombo" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Name</td>
+                    <td>:</td>
+                    <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" /></td>
+                </tr>
+                <tr>
+                    <td>BHT No</td>
+                    <td>:</td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" /></td>
+                    <td>Room</td>
+                    <td>:</td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" /></td>
+                </tr>
+                <h:panelGroup rendered="#{cc.attrs.bill.fromInstitution ne null}">
+                    <tr>
+                        <td>From</td>
+                        <td>:</td>
+                        <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" /></td>
+                    </tr>
+                </h:panelGroup>
+            </table>
+
+            <div class="sep"></div>
+
+            <table class="items">
+                <thead>
+                    <tr style="font-weight: bold; border-bottom: 1px solid #000;">
+                        <th style="text-align: left; width: 8%;">No</th>
+                        <th style="text-align: left;">Charge</th>
+                        <th style="text-align: right; width: 28%;">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" varStatus="s">
+                        <tr>
+                            <td style="text-align: left;">#{s.index + 1}</td>
+                            <td style="text-align: left; text-transform: capitalize;">
+                                <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                            </td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{bip.netValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </tbody>
+            </table>
+
+            <div class="sep"></div>
+
+            <table>
+                <tr style="font-weight: bold; font-size: 13px;">
+                    <td style="text-align: left;">Net Total</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+            </table>
+
+            <h:panelGroup rendered="#{cc.attrs.bill.comments ne null and not empty cc.attrs.bill.comments}">
+                <div style="font-size: 11px; margin-top: 4px;">
+                    <h:outputLabel value="Note: #{cc.attrs.bill.comments}" />
+                </div>
+            </h:panelGroup>
+
+            <table style="margin-top: 10px; font-size: 11px;">
+                <tr>
+                    <td style="text-align: left;">Billed by : <h:outputLabel value="#{cc.attrs.bill.creater.name}" /></td>
+                    <td style="text-align: right;">Signature : ______________</td>
+                </tr>
+            </table>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/prints/posBill_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posBill_inward_outside.xhtml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- POS (thermal) receipt for Inward Outside Charge bills -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false" />
+    </cc:interface>
+
+    <cc:implementation>
+        <div style="width: 7.4cm; margin: 0 auto; font-family: Arial, Helvetica, sans-serif; color: #000;">
+
+            <div style="text-align: center; font-weight: bold; font-size: 16px;">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div style="text-align: center; font-size: 11px; line-height: 1.3;">
+                <div><h:outputLabel value="#{cc.attrs.bill.department.address}" /></div>
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                    <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null}" />
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}" />
+                </div>
+            </div>
+
+            <div style="text-align: center; font-weight: bold; font-size: 13px; margin-top: 4px;">
+                <h:outputLabel value="OUTSIDE CHARGE BILL" />
+                <h:outputLabel value=" **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value=" **Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div style="border-top: 1px dashed #000; margin: 4px 0;"></div>
+
+            <table style="width: 100%; font-size: 11px;">
+                <tr>
+                    <td style="width: 35%; text-align: left;">Bill No</td>
+                    <td style="width: 5%;">:</td>
+                    <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;">Date</td>
+                    <td>:</td>
+                    <td style="text-align: left;">
+                        <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                            <f:convertDateTime pattern="dd/MM/yyyy hh:mm a" timeZone="Asia/Colombo" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;">Name</td>
+                    <td>:</td>
+                    <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" /></td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;">BHT No</td>
+                    <td>:</td>
+                    <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" /></td>
+                </tr>
+                <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter.currentPatientRoom ne null}">
+                    <tr>
+                        <td style="text-align: left;">Room</td>
+                        <td>:</td>
+                        <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" /></td>
+                    </tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.fromInstitution ne null}">
+                    <tr>
+                        <td style="text-align: left;">From</td>
+                        <td>:</td>
+                        <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.fromInstitution.name}" /></td>
+                    </tr>
+                </h:panelGroup>
+            </table>
+
+            <div style="border-top: 1px dashed #000; margin: 4px 0;"></div>
+
+            <table style="width: 100%; font-size: 11px;">
+                <tr style="font-weight: bold;">
+                    <td style="text-align: left;">Charge</td>
+                    <td style="text-align: right;">Value</td>
+                </tr>
+                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                    <tr>
+                        <td style="text-align: left; text-transform: capitalize;">
+                            <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                        </td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{bip.netValue}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </ui:repeat>
+            </table>
+
+            <div style="border-top: 1px dashed #000; margin: 4px 0;"></div>
+
+            <table style="width: 100%; font-size: 12px; font-weight: bold;">
+                <tr>
+                    <td style="text-align: left;">Net Total</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+            </table>
+
+            <h:panelGroup rendered="#{cc.attrs.bill.comments ne null and not empty cc.attrs.bill.comments}">
+                <div style="font-size: 10px; margin-top: 4px;">
+                    <h:outputLabel value="Note: #{cc.attrs.bill.comments}" />
+                </div>
+            </h:panelGroup>
+
+            <div style="font-size: 10px; margin-top: 6px;">
+                <h:outputLabel value="Billed by : #{cc.attrs.bill.creater.name}" />
+            </div>
+            <div style="font-size: 10px; margin-top: 10px;">
+                Signature : ____________________
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Issue
Closes #20731 — Out Side charge print (`/inward/inward_bill_outside_charge.xhtml`)

## Problem
The Outside Charge page had **no settle / print flow at all** — charges could be
added but there was no way to finalize and print the bill, and no paper-format
choice. The page also did not reset its state (including any preview status) when
navigated into.

## What this PR adds
1. **Settle button** — finalizes the accumulated outside charges and switches the
   page into a print preview. Backed by a new `printPreview` flag on
   `InwardAdditionalChargeController`. Data-entry UI is hidden during preview.
2. **Print Configuration (gear) dialog** — follows the documented
   [config-button / printer-configuration pattern](../blob/development/developer_docs/configuration/printer-configuration-system.md):
   department-scoped `ConfigOptionController` keys, gated by the
   `ChangeReceiptPrintingPaperTypes` privilege. Lets the department pick the paper
   format. (Per the doc, the deprecated `departmentPreference.*BillPaperType`
   approach was **not** used.)
3. **Three new print composites** for the outside charge bill:
   - `posBill_inward_outside.xhtml` — professional thermal **POS** receipt
   - `five_five_inward_outside.xhtml` — **5×5 inch**, tuned for impact / Epson
     dot-matrix printers (single clean sans-serif font, solid black text, no fills)
   - `A4_inward_outside.xhtml` — full-page **A4** invoice
4. **Full state reset on navigation** — `printPreview` (and existing state) is now
   reset in `makeNull`, `onInstitutionChange`, `reset`, and both navigation
   methods. The from-inpatient-profile navigation preserves the encounter passed
   via `f:setPropertyActionListener` while still resetting everything else.

## Config keys (department-scoped, default)
| Key | Default |
|-----|---------|
| `Inward Outside Charge Bill is POS Paper` | false |
| `Inward Outside Charge Bill is 5x5 Paper` | true |
| `Inward Outside Charge Bill is A4 Paper` | false |

## Files
- `InwardAdditionalChargeController.java` — `settle()`, `printPreview`, print-config load/save, state resets
- `inward_bill_outside_charge.xhtml` — Settle button, preview section, print + config-dialog
- `resources/ezcomp/prints/{posBill,five_five,A4}_inward_outside.xhtml` — new composites

## Testing notes
- JSF/XHTML + Java change. Not yet compiled locally (project rule: no auto-compile);
  CI will build. Recommended manual test: select an inpatient → add one or more
  charges → **Settle** → verify preview renders in the configured format →
  **Print Configuration** → switch format → reprint → **New Bill** resets everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Print preview for outside-charge bills with selectable paper formats (POS, 5x5, A4) and a print/config dialog.
  * New "Settle" action to validate and finalize outside-charge bills and trigger print preview.

* **Bug Fixes**
  * Preserve selected inpatient encounter across navigation and ensure print-preview state resets when clearing or changing context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->