### PR TITLE
feat(inward): item autocomplete and bill-level institution for outside charges

### DIFF
--- a/developer_docs/jsf/ajax-update-guidelines.md
+++ b/developer_docs/jsf/ajax-update-guidelines.md
@@ -181,6 +181,41 @@ update="lstItems focusForList actions growl"
 update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId}"
 ```
 
+---
+
+## Critical Rule: Never Use `this.disabled=true` on Submit Buttons
+
+### The Problem
+
+When a `p:commandButton` (or any submit button) has `ajax="false"`, the browser submits the form synchronously. If `onclick` calls `this.disabled=true`, the button is disabled **before** the POST is sent. Disabled form fields are excluded from the request payload by the browser — JSF never sees which button was clicked, so no action fires.
+
+### ❌ WRONG — disabling the button before submit
+
+```xhtml
+<p:commandButton
+    value="Settle"
+    ajax="false"
+    onclick="if (!confirm('Are you sure?')) { return false; }
+             this.disabled=true;"
+    action="#{bean.settle()}" />
+```
+
+### ✅ CORRECT — only return false to cancel; never disable
+
+```xhtml
+<p:commandButton
+    value="Settle"
+    ajax="false"
+    onclick="return confirm('Are you sure?');"
+    action="#{bean.settle()}" />
+```
+
+**Why it matters**: `this.disabled=true` is a common copy-paste pattern meant to prevent double-clicks, but it silently breaks JSF action dispatch. The confirmation dialog alone is sufficient to prevent accidental double-submission.
+
+**Root cause of issue #20731**: The Settle button on `inward_bill_outside_charge.xhtml` used this pattern, causing the `settle()` action to never fire.
+
+---
+
 ## Related JSF Concepts
 
 - **Component Tree**: Only JSF components are part of the component tree

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -148,7 +148,7 @@ public class InwardAdditionalChargeController implements Serializable {
             return true;
         }
 
-        if (getCurrent().getTotal() == null || getCurrent().getTotal() < 1) {
+        if (getCurrent().getTotal() < 1) {
             JsfUtil.addErrorMessage("Enter Added Charge Correctly");
             return true;
         }
@@ -174,7 +174,6 @@ public class InwardAdditionalChargeController implements Serializable {
         selectedItem = null;
         inwardChargeType = null;
         getCurrent().setTotal(null);
-        getCurrent().setComments(null);
 
         JsfUtil.addSuccessMessage("Charge Added");
     }
@@ -287,13 +286,15 @@ public class InwardAdditionalChargeController implements Serializable {
     }
 
     public List<Item> completeItem(String qry) {
-        String upper = qry.toUpperCase();
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("name", "%" + qry.toUpperCase() + "%");
         return itemFacade.findByJpql(
                 "select i from Item i where i.retired=false "
                 + "and (type(i) = com.divudi.core.entity.inward.InwardService "
                 + "  or type(i) = com.divudi.core.entity.Service) "
-                + "and upper(i.name) like '%" + upper + "%' "
-                + "order by i.name");
+                + "and upper(i.name) like :name "
+                + "order by i.name",
+                params);
     }
 
     public void onItemSelect() {

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -7,10 +7,12 @@
  * (94) 71 5812399
  */
 package com.divudi.bean.inward;
+import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
+import com.divudi.core.entity.ItemFee;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
@@ -71,10 +73,13 @@ public class InwardAdditionalChargeController implements Serializable {
     private AdmissionController admissionController;
     @Inject
     private ConfigOptionController configOptionController;
+    @Inject
+    private BillBeanController billBeanController;
     //////////////
     private BilledBill current;
     private Institution institution;
     private Item selectedItem;
+    private String itemComment;
     private List<BillItem> billItemList;
     private boolean printPreview;
     // Print configuration (paper format) — persisted via department-scoped config options
@@ -153,11 +158,6 @@ public class InwardAdditionalChargeController implements Serializable {
             return true;
         }
 
-        if (getCurrent().getComments() == null || getCurrent().getComments().isEmpty()) {
-            JsfUtil.addErrorMessage("Enter Description");
-            return true;
-        }
-
         return false;
     }
 
@@ -173,7 +173,8 @@ public class InwardAdditionalChargeController implements Serializable {
 
         selectedItem = null;
         inwardChargeType = null;
-        getCurrent().setTotal(null);
+        itemComment = null;
+        getCurrent().setTotal(0.0);
 
         JsfUtil.addSuccessMessage("Charge Added");
     }
@@ -183,6 +184,7 @@ public class InwardAdditionalChargeController implements Serializable {
         billItemList = null;
         inwardChargeType = null;
         selectedItem = null;
+        itemComment = null;
         printPreview = false;
         institution = sessionController.getInstitution();
     }
@@ -196,6 +198,7 @@ public class InwardAdditionalChargeController implements Serializable {
         billItemList = null;
         inwardChargeType = null;
         selectedItem = null;
+        itemComment = null;
         printPreview = false;
     }
 
@@ -215,6 +218,7 @@ public class InwardAdditionalChargeController implements Serializable {
         getCurrent().setPatientEncounter(p);
         inwardChargeType = null;
         selectedItem = null;
+        itemComment = null;
         JsfUtil.addSuccessMessage("Cleared Successfully");
     }
 
@@ -225,7 +229,8 @@ public class InwardAdditionalChargeController implements Serializable {
     public void makeChargesNull() {
         inwardChargeType = null;
         selectedItem = null;
-        current.setTotal(null);
+        itemComment = null;
+        current.setTotal(0.0);
         current.setComments(null);
     }
 
@@ -258,6 +263,7 @@ public class InwardAdditionalChargeController implements Serializable {
         if (selectedItem != null) {
             temBi.setInwardChargeType(selectedItem.getInwardChargeType());
         }
+        temBi.setDescreption(itemComment);
         temBi.setGrossValue(getCurrent().getTotal());
         temBi.setNetValue(getCurrent().getTotal());
         temBi.setCreatedAt(new Date());
@@ -272,21 +278,52 @@ public class InwardAdditionalChargeController implements Serializable {
     }
 
     private void saveBillFee(BillItem bt) {
-        BillFee bf = new BillFee();
-        Fee additional = getInwardBean().createAdditionalFee();
+        List<ItemFee> itemFees = (selectedItem != null) ? billBeanController.fillFees(selectedItem) : new ArrayList<>();
 
-        bf.setPatienEncounter(getCurrent().getPatientEncounter());
-        bf.setBill(getCurrent());
-        bf.setFee(additional);
-        bf.setBillItem(bt);
-        bf.setCreatedAt(new Date());
-        bf.setCreater(getSessionController().getLoggedUser());
-        bf.setFeeGrossValue(getCurrent().getTotal());
-        bf.setFeeValue(getCurrent().getTotal());
-
-        if (bf.getId() == null) {
+        if (!itemFees.isEmpty()) {
+            List<BillFee> created = new ArrayList<>();
+            for (ItemFee f : itemFees) {
+                BillFee bf = new BillFee();
+                bf.setBill(getCurrent());
+                bf.setBillItem(bt);
+                bf.setFee(f);
+                bf.setFeeAt(new Date());
+                bf.setCreatedAt(new Date());
+                bf.setCreater(getSessionController().getLoggedUser());
+                bf.setPatienEncounter(getCurrent().getPatientEncounter());
+                bf.setPatient(getCurrent().getPatient());
+                bf.setFeeValue(f.getFee());
+                bf.setFeeGrossValue(f.getFee());
+                bf.setFeeDiscount(0.0);
+                getBillFeeFacade().create(bf);
+                created.add(bf);
+            }
+            bt.setBillFees(created);
+        } else {
+            // Fallback: item has no ItemFee records — create a single generic fee
+            BillFee bf = new BillFee();
+            Fee additional = getInwardBean().createAdditionalFee();
+            bf.setPatienEncounter(getCurrent().getPatientEncounter());
+            bf.setPatient(getCurrent().getPatient());
+            bf.setBill(getCurrent());
+            bf.setFee(additional);
+            bf.setBillItem(bt);
+            bf.setCreatedAt(new Date());
+            bf.setCreater(getSessionController().getLoggedUser());
+            bf.setFeeGrossValue(getCurrent().getTotal());
+            bf.setFeeValue(getCurrent().getTotal());
             getBillFeeFacade().create(bf);
+            bt.setBillFees(new ArrayList<>());
+            bt.getBillFees().add(bf);
         }
+    }
+
+    public String getItemComment() {
+        return itemComment;
+    }
+
+    public void setItemComment(String itemComment) {
+        this.itemComment = itemComment;
     }
 
     public List<Item> completeItem(String qry) {

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -10,6 +10,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
@@ -27,6 +28,7 @@ import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BilledBillFacade;
 import com.divudi.core.facade.FeeFacade;
+import com.divudi.core.facade.ItemFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -58,6 +60,8 @@ public class InwardAdditionalChargeController implements Serializable {
     private BillItemFacade billItemFacade;
     @EJB
     private BillFeeFacade billFeeFacade;
+    @EJB
+    private ItemFacade itemFacade;
     @Inject
     InwardBeanController inwardBean;
     //////////////
@@ -70,6 +74,7 @@ public class InwardAdditionalChargeController implements Serializable {
     //////////////
     private BilledBill current;
     private Institution institution;
+    private Item selectedItem;
     private List<BillItem> billItemList;
     private boolean printPreview;
     // Print configuration (paper format) — persisted via department-scoped config options
@@ -134,26 +139,26 @@ public class InwardAdditionalChargeController implements Serializable {
         }
 
         if (getCurrent().getFromInstitution() == null) {
-            JsfUtil.addErrorMessage("Select Where Item From");
+            JsfUtil.addErrorMessage("Select Outside Institution");
             return true;
         }
 
-        if (getInwardChargeType() == null) {
+        if (selectedItem == null) {
+            JsfUtil.addErrorMessage("Select an Item");
             return true;
         }
 
-        if (getCurrent().getTotal() < 1) {
+        if (getCurrent().getTotal() == null || getCurrent().getTotal() < 1) {
             JsfUtil.addErrorMessage("Enter Added Charge Correctly");
             return true;
         }
 
-        if (getCurrent().getComments().isEmpty()) {
-            JsfUtil.addErrorMessage("Enter Discription");
+        if (getCurrent().getComments() == null || getCurrent().getComments().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter Description");
             return true;
         }
 
         return false;
-
     }
 
     public void addCharge() {
@@ -166,14 +171,19 @@ public class InwardAdditionalChargeController implements Serializable {
         getCurrent().setSingleBillItem(b);
         getBilledBillFacade().edit(current);
 
-        JsfUtil.addSuccessMessage("Additional Charges Added");
+        selectedItem = null;
+        inwardChargeType = null;
+        getCurrent().setTotal(null);
+        getCurrent().setComments(null);
 
+        JsfUtil.addSuccessMessage("Charge Added");
     }
 
     public void makeNull() {
         current = null;
         billItemList = null;
         inwardChargeType = null;
+        selectedItem = null;
         printPreview = false;
         institution = sessionController.getInstitution();
     }
@@ -186,6 +196,7 @@ public class InwardAdditionalChargeController implements Serializable {
         current = null;
         billItemList = null;
         inwardChargeType = null;
+        selectedItem = null;
         printPreview = false;
     }
 
@@ -204,12 +215,13 @@ public class InwardAdditionalChargeController implements Serializable {
         printPreview = false;
         getCurrent().setPatientEncounter(p);
         inwardChargeType = null;
+        selectedItem = null;
         JsfUtil.addSuccessMessage("Cleared Successfully");
     }
 
     public void makeChargesNull() {
         inwardChargeType = null;
-        current.setFromInstitution(null);
+        selectedItem = null;
         current.setTotal(null);
         current.setComments(null);
     }
@@ -239,7 +251,10 @@ public class InwardAdditionalChargeController implements Serializable {
     private BillItem saveBillItem() {
         BillItem temBi = new BillItem();
         temBi.setBill(getCurrent());
-        temBi.setInwardChargeType(inwardChargeType);
+        temBi.setItem(selectedItem);
+        if (selectedItem != null) {
+            temBi.setInwardChargeType(selectedItem.getInwardChargeType());
+        }
         temBi.setGrossValue(getCurrent().getTotal());
         temBi.setNetValue(getCurrent().getTotal());
         temBi.setCreatedAt(new Date());
@@ -251,7 +266,6 @@ public class InwardAdditionalChargeController implements Serializable {
         saveBillFee(temBi);
 
         return temBi;
-
     }
 
     private void saveBillFee(BillItem bt) {
@@ -270,6 +284,41 @@ public class InwardAdditionalChargeController implements Serializable {
         if (bf.getId() == null) {
             getBillFeeFacade().create(bf);
         }
+    }
+
+    public List<Item> completeItem(String qry) {
+        String upper = qry.toUpperCase();
+        return itemFacade.findByJpql(
+                "select i from Item i where i.retired=false "
+                + "and (type(i) = com.divudi.core.entity.inward.InwardService "
+                + "  or type(i) = com.divudi.core.entity.Service) "
+                + "and upper(i.name) like '%" + upper + "%' "
+                + "order by i.name");
+    }
+
+    public void onItemSelect() {
+        if (selectedItem != null && selectedItem.getTotal() != null && selectedItem.getTotal() > 0) {
+            getCurrent().setTotal(selectedItem.getTotal());
+        }
+        if (selectedItem != null) {
+            inwardChargeType = selectedItem.getInwardChargeType();
+        }
+    }
+
+    public Item getSelectedItem() {
+        return selectedItem;
+    }
+
+    public void setSelectedItem(Item selectedItem) {
+        this.selectedItem = selectedItem;
+    }
+
+    public ItemFacade getItemFacade() {
+        return itemFacade;
+    }
+
+    public void setItemFacade(ItemFacade itemFacade) {
+        this.itemFacade = itemFacade;
     }
 
     public BilledBillFacade getBilledBillFacade() {

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -218,6 +218,10 @@ public class InwardAdditionalChargeController implements Serializable {
         JsfUtil.addSuccessMessage("Cleared Successfully");
     }
 
+    public void clearFromInstitution() {
+        getCurrent().setFromInstitution(null);
+    }
+
     public void makeChargesNull() {
         inwardChargeType = null;
         selectedItem = null;
@@ -290,8 +294,7 @@ public class InwardAdditionalChargeController implements Serializable {
         params.put("name", "%" + qry.toUpperCase() + "%");
         return itemFacade.findByJpql(
                 "select i from Item i where i.retired=false "
-                + "and (type(i) = com.divudi.core.entity.inward.InwardService "
-                + "  or type(i) = com.divudi.core.entity.Service) "
+                + "and (type(i) = InwardService or type(i) = Service) "
                 + "and upper(i.name) like :name "
                 + "order by i.name",
                 params);

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -217,10 +217,7 @@
                                         value="Settle"
                                         ajax="false"
                                         rendered="#{!inwardAdditionalChargeController.printPreview}"
-                                        onclick="if (!confirm('Are you sure you want to settle this bill?')) {
-                                                    return false;
-                                                }
-                                                this.disabled=true;"
+                                        onclick="return confirm('Are you sure you want to settle this bill?');"
                                         action="#{inwardAdditionalChargeController.settle()}">
                                     </p:commandButton>
 
@@ -304,7 +301,7 @@
                                         <div class="col-5 ">
                                             <p:panel>
                                                 <f:facet name="header" >
-                                                    <h:outputText styleClass="fa fa-user-circle" /> 
+                                                    <h:outputText styleClass="fa fa-user-circle" />
                                                     <h:outputText value="Patient Details" class="mx-3"></h:outputText>
                                                 </f:facet>
                                                 <h:panelGroup id="panSearch2">
@@ -316,47 +313,39 @@
                                         <div class="col-7" >
                                             <p:panel>
                                                 <f:facet name="header" >
-                                                    <h:outputText styleClass="fa fa-money-bill-wave" /> 
+                                                    <h:outputText styleClass="fa fa-money-bill-wave" />
                                                     <h:outputText value="Charge Details" class="mx-3"></h:outputText>
                                                 </f:facet>
                                                 <div class="row">
                                                     <div class="row m-1">
                                                         <div class="col-4 d-flex align-items-center">
-                                                            <h:outputLabel value="Inward Charge Type"/>
-
+                                                            <h:outputLabel value="Outside Institution"/>
                                                         </div>
                                                         <div class="col-8">
-                                                            <div>
-                                                                <p:selectOneMenu class="w-100" value="#{inwardAdditionalChargeController.inwardChargeType}" filter="true" >
-                                                                    <f:selectItem itemLabel="Please select Charge"/>
-                                                                    <f:selectItems value="#{enumController.inwardChargeTypesForSetting}" var="i" itemLabel="#{i.label}" itemValue="#{i}"/>
-                                                                </p:selectOneMenu>
-                                                            </div>
+                                                            <p:selectOneMenu autoWidth="false" class="w-100" value="#{inwardAdditionalChargeController.current.fromInstitution}" filter="true" filterMatchMode="contains">
+                                                                <f:selectItem itemLabel="Select Institution"/>
+                                                                <f:selectItems value="#{institutionController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                                            </p:selectOneMenu>
                                                         </div>
                                                     </div>
                                                     <div class="row m-1">
                                                         <div class="col-4 d-flex align-items-center">
-                                                            <h:outputLabel value="From Institution"/>
+                                                            <h:outputLabel value="Item"/>
                                                         </div>
-                                                        <div class="col-8 ">
-<!--                                                            <p:autoComplete size="61" forceSelection="true" value="#{inwardAdditionalChargeController.current.fromInstitution}"
-                                                                            completeMethod="#{institutionController.completeIns}"
-                                                                            disabled="#{not empty inwardAdditionalChargeController.current.fromInstitution}"
-                                                                            var="ix" itemLabel="#{ix.name}" itemValue="#{ix}" >
-                                                                <p:column>
-                                                            #{ix.name}
-                                                        </p:column>
-                                                        <p:column>
-                                                            #{ix.institutionCode}
-                                                        </p:column>
-                                                    </p:autoComplete>-->
-
-                                                            <div>
-                                                                <p:selectOneMenu autoWidth="false" class="w-100" value="#{inwardAdditionalChargeController.current.fromInstitution}" filter="true" filterMatchMode="contains">
-                                                                    <f:selectItem itemLabel="Select Institution"/>
-                                                                    <f:selectItems value="#{institutionController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                                </p:selectOneMenu>
-                                                            </div>
+                                                        <div class="col-8">
+                                                            <p:autoComplete id="acItem"
+                                                                            class="w-100"
+                                                                            value="#{inwardAdditionalChargeController.selectedItem}"
+                                                                            completeMethod="#{inwardAdditionalChargeController.completeItem}"
+                                                                            var="itm"
+                                                                            itemValue="#{itm}"
+                                                                            itemLabel="#{itm.name}"
+                                                                            forceSelection="true"
+                                                                            minQueryLength="2"
+                                                                            placeholder="Type item name...">
+                                                                <p:ajax event="itemSelect" listener="#{inwardAdditionalChargeController.onItemSelect}" update="txtAmount" />
+                                                                <p:column>#{itm.name}</p:column>
+                                                            </p:autoComplete>
                                                         </div>
                                                     </div>
 
@@ -365,7 +354,7 @@
                                                             <p:outputLabel value="Amount"/>
                                                         </div>
                                                         <div class="col-8">
-                                                            <p:inputText class="w-100" autocomplete="off" value="#{inwardAdditionalChargeController.current.total}"/>
+                                                            <p:inputText id="txtAmount" class="w-100" autocomplete="off" value="#{inwardAdditionalChargeController.current.total}"/>
                                                         </div>
                                                     </div>
 
@@ -374,23 +363,23 @@
                                                             <p:outputLabel value="Description"/>
                                                         </div>
                                                         <div class="col-8">
-                                                            <p:inputTextarea value="#{inwardAdditionalChargeController.current.comments}" class="w-100" disabled="#{not empty inwardAdditionalChargeController.current.comments}"/>
+                                                            <p:inputTextarea value="#{inwardAdditionalChargeController.current.comments}" class="w-100"/>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <p:commandButton 
-                                                    class="m-1 ui-button-success" 
+                                                <p:commandButton
+                                                    class="m-1 ui-button-success"
                                                     id="btnAdd"
                                                     icon="fa fa-plus"
-                                                    value="Add"  
-                                                    ajax="false" 
+                                                    value="Add"
+                                                    ajax="false"
                                                     action="#{inwardAdditionalChargeController.addCharge}"/>
                                             </p:panel>
                                         </div>
                                     </div>
 
                                 </p:panel>
-                            </h:panelGroup>        
+                            </h:panelGroup>
                         </div>
 
                         <div class="row mt-2">
@@ -399,7 +388,12 @@
                                     <p:panel>
                                         <f:facet name="header">
                                             <h:outputText styleClass="fas fa-user-tie" />
-                                            <h:outputLabel class="mx-4" value="Inward OutSide Charges"/>
+                                            <h:outputLabel class="mx-4" value="Outside Charges"/>
+                                            <h:panelGroup rendered="#{inwardAdditionalChargeController.current.fromInstitution ne null}">
+                                                <span class="badge bg-secondary ms-2">
+                                                    <h:outputText value="#{inwardAdditionalChargeController.current.fromInstitution.name}" />
+                                                </span>
+                                            </h:panelGroup>
                                         </f:facet>
 
                                         <p:dataTable rowIndexVar="rowIndex" id="bFee" value="#{inwardAdditionalChargeController.billItemList}" var="bif" >
@@ -409,18 +403,15 @@
                                                 <h:outputLabel value="#{rowIndex+1}"/>
                                             </p:column>
                                             <p:column>
-                                                <f:facet name="header">Fee</f:facet>
-                                                <h:outputLabel  value="#{bif.inwardChargeType}">
-
-                                                </h:outputLabel>
+                                                <f:facet name="header">Item</f:facet>
+                                                <h:outputLabel value="#{bif.item.name}"/>
                                             </p:column>
-
                                             <p:column>
                                                 <f:facet name="header">Total</f:facet>
                                                 <h:outputLabel value="#{bif.netValue}"/>
                                             </p:column>
                                             <p:column>
-                                                <f:facet name="header">Comments</f:facet>
+                                                <f:facet name="header">Description</f:facet>
                                                 <h:outputLabel value="#{bif.bill.comments}"/>
                                             </p:column>
                                         </p:dataTable>

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -189,14 +189,45 @@
                     </p:panel>
                 </h:panelGroup>
 
-                <h:panelGrid rendered="#{inwardAdditionalChargeController.current.patientEncounter ne null}">
+                <h:panelGroup layout="block" style="width:100%" rendered="#{inwardAdditionalChargeController.current.patientEncounter ne null}">
                     <p:panel>
                         <f:facet name="header">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h:outputText styleClass="fa-solid fa-address-card fa-lg"/> 
+                            <div class="d-flex justify-content-between align-items-center w-100">
+                                <!-- Left: title -->
+                                <div class="d-flex align-items-center">
+                                    <h:outputText styleClass="fa-solid fa-address-card fa-lg"/>
                                     <p:outputLabel value="Add Outside Charges" class="m-2"/>
                                 </div>
+
+                                <!-- Centre: print actions (print preview only) -->
+                                <div class="d-flex gap-2 align-items-center">
+                                    <h:panelGroup rendered="#{inwardAdditionalChargeController.printPreview}">
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                value="Print"
+                                                class="ui-button-info"
+                                                icon="fa-solid fa-print"
+                                                ajax="false">
+                                                <p:printer target="gpOutsideBillPreview" />
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                                value="Print Configuration"
+                                                icon="fas fa-cog"
+                                                class="ui-button-secondary"
+                                                type="button"
+                                                onclick="PF('outsideChargeConfigDialog').show();" />
+                                            <p:commandButton
+                                                value="New Bill"
+                                                class="ui-button-success"
+                                                icon="fa fa-plus"
+                                                ajax="false"
+                                                action="#{inwardAdditionalChargeController.makeNull()}" />
+                                        </div>
+                                    </h:panelGroup>
+                                </div>
+
+                                <!-- Right: navigation buttons -->
                                 <div class="d-flex gap-2">
 
                                     <p:commandButton
@@ -227,6 +258,7 @@
                                         icon="fa fa-plus"
                                         value="New Bill"
                                         ajax="false"
+                                        rendered="#{!inwardAdditionalChargeController.printPreview}"
                                         action="#{inwardAdditionalChargeController.makeNull()}">
                                     </p:commandButton>
 
@@ -239,11 +271,11 @@
                                         action="#{inwardAdditionalChargeController.reset()}" >
                                     </p:commandButton>
 
-                                    <p:commandButton 
-                                        class="ui-button-warning " 
-                                        value="To Add Services" 
+                                    <p:commandButton
+                                        class="ui-button-warning "
+                                        value="To Add Services"
                                         icon ="fa fa-wrench"
-                                        ajax="false" 
+                                        ajax="false"
                                         action="/inward/inward_bill_service?faces-redirect=true" >
                                     </p:commandButton>
 
@@ -305,30 +337,45 @@
                                         <h:outputLabel value="Select Outside Institution"/>
                                     </div>
                                     <div class="col-8">
-                                        <p:selectOneMenu id="insFromMenu" autoWidth="false" class="w-100"
-                                                         value="#{inwardAdditionalChargeController.current.fromInstitution}"
-                                                         filter="true" filterMatchMode="contains">
-                                            <f:selectItem itemLabel="Select Institution"/>
-                                            <f:selectItems value="#{institutionController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                        </p:selectOneMenu>
+                                        <p:autoComplete id="acFromIns"
+                                                        style="width:100%"
+                                                        inputStyle="width:100%"
+                                                        value="#{inwardAdditionalChargeController.current.fromInstitution}"
+                                                        completeMethod="#{institutionController.completeIns}"
+                                                        var="ins"
+                                                        itemValue="#{ins}"
+                                                        itemLabel="#{ins.name}"
+                                                        forceSelection="true"
+                                                        minQueryLength="2"
+                                                        placeholder="Type institution name...">
+                                            <p:column>#{ins.name}</p:column>
+                                        </p:autoComplete>
                                     </div>
                                 </div>
                             </p:panel>
                         </h:panelGroup>
 
-                        <!-- Bill-level: Institution confirmed banner (shown after selection) -->
+                        <!-- Bill-level: Institution confirmed + Bill Note (shown after institution selected) -->
                         <h:panelGroup layout="block" rendered="#{inwardAdditionalChargeController.current.fromInstitution ne null}" class="col-12 mb-2">
-                            <div class="alert alert-info d-flex align-items-center justify-content-between py-2 px-3">
-                                <div>
-                                    <i class="fa fa-hospital me-2"/>
-                                    <strong>Outside Institution: </strong>
-                                    <h:outputText value="#{inwardAdditionalChargeController.current.fromInstitution.name}"/>
+                            <p:panel>
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fa fa-hospital" />
+                                    <h:outputText value=" #{inwardAdditionalChargeController.current.fromInstitution.name}" class="mx-2 fw-bold"/>
+                                    <p:commandButton value="Change" icon="fa fa-pencil"
+                                                     class="ui-button-secondary ui-button-sm ms-3"
+                                                     ajax="false"
+                                                     action="#{inwardAdditionalChargeController.clearFromInstitution}"/>
+                                </f:facet>
+                                <div class="row m-1">
+                                    <div class="col-3 d-flex align-items-center">
+                                        <p:outputLabel value="Bill Note"/>
+                                        <small class="text-muted ms-1">(whole bill)</small>
+                                    </div>
+                                    <div class="col-9">
+                                        <p:inputTextarea value="#{inwardAdditionalChargeController.current.comments}" class="w-100" rows="2"/>
+                                    </div>
                                 </div>
-                                <p:commandButton value="Change" icon="fa fa-pencil"
-                                                 class="ui-button-secondary ui-button-sm"
-                                                 ajax="false"
-                                                 action="#{inwardAdditionalChargeController.clearFromInstitution}"/>
-                            </div>
+                            </p:panel>
                         </h:panelGroup>
 
                         <div class="col-12">
@@ -361,7 +408,8 @@
                                                         </div>
                                                         <div class="col-8">
                                                             <p:autoComplete id="acItem"
-                                                                            class="w-100"
+                                                                            style="width:100%"
+                                                                            inputStyle="width:100%"
                                                                             value="#{inwardAdditionalChargeController.selectedItem}"
                                                                             completeMethod="#{inwardAdditionalChargeController.completeItem}"
                                                                             var="itm"
@@ -386,13 +434,15 @@
                                                     </div>
 
                                                     <div class="row m-1">
-                                                        <div class="col-4">
-                                                            <p:outputLabel value="Description"/>
+                                                        <div class="col-4 d-flex align-items-center">
+                                                            <p:outputLabel value="Item Note"/>
+                                                            <small class="text-muted ms-1">(per row)</small>
                                                         </div>
                                                         <div class="col-8">
-                                                            <p:inputTextarea value="#{inwardAdditionalChargeController.current.comments}" class="w-100"/>
+                                                            <p:inputTextarea id="txtItemComment" value="#{inwardAdditionalChargeController.itemComment}" class="w-100" rows="2"/>
                                                         </div>
                                                     </div>
+
                                                 </div>
                                                 <p:commandButton
                                                     class="m-1 ui-button-success"
@@ -423,8 +473,14 @@
                                             </h:panelGroup>
                                         </f:facet>
 
-                                        <p:dataTable rowIndexVar="rowIndex" id="bFee" value="#{inwardAdditionalChargeController.billItemList}" var="bif" >
+                                        <p:dataTable rowIndexVar="rowIndex" id="bFee"
+                                                     value="#{inwardAdditionalChargeController.billItemList}"
+                                                     var="bif"
+                                                     rowKey="#{bif.id}">
 
+                                            <p:column style="width:2.5rem">
+                                                <p:rowToggler/>
+                                            </p:column>
                                             <p:column>
                                                 <f:facet name="header">No</f:facet>
                                                 <h:outputLabel value="#{rowIndex+1}"/>
@@ -434,13 +490,35 @@
                                                 <h:outputLabel value="#{bif.item.name}"/>
                                             </p:column>
                                             <p:column>
-                                                <f:facet name="header">Total</f:facet>
+                                                <f:facet name="header">Amount</f:facet>
                                                 <h:outputLabel value="#{bif.netValue}"/>
                                             </p:column>
                                             <p:column>
-                                                <f:facet name="header">Description</f:facet>
-                                                <h:outputLabel value="#{bif.bill.comments}"/>
+                                                <f:facet name="header">Note</f:facet>
+                                                <h:outputLabel value="#{bif.descreption}"/>
                                             </p:column>
+
+                                            <p:rowExpansion>
+                                                <div class="p-3 ms-4 border-start border-primary" style="background-color:#f8f9fa;">
+                                                    <h6 class="mb-2 text-primary">
+                                                        <i class="fa fa-list me-1"/>Fee Breakdown
+                                                    </h6>
+                                                    <p:dataTable value="#{bif.billFees}" var="bf"
+                                                                 styleClass="table table-sm"
+                                                                 emptyMessage="No fees recorded">
+                                                        <p:column headerText="Fee">
+                                                            <h:outputText value="#{bf.fee.name}"/>
+                                                        </p:column>
+                                                        <p:column headerText="Fee Type">
+                                                            <h:outputText value="#{bf.fee.feeType}"/>
+                                                        </p:column>
+                                                        <p:column headerText="Amount">
+                                                            <h:outputText value="#{bf.feeValue}"/>
+                                                        </p:column>
+                                                    </p:dataTable>
+                                                </div>
+                                            </p:rowExpansion>
+
                                         </p:dataTable>
                                     </p:panel>
                                 </h:panelGroup>
@@ -452,25 +530,9 @@
 
                         <!-- ============================= PRINT PREVIEW ============================= -->
                         <h:panelGroup rendered="#{inwardAdditionalChargeController.printPreview}">
-                            <div class="d-flex justify-content-end gap-2 mb-3">
-                                <p:commandButton
-                                    value="Print"
-                                    class="ui-button-info"
-                                    ajax="false"
-                                    icon="fa-solid fa-print">
-                                    <p:printer target="gpOutsideBillPreview" />
-                                </p:commandButton>
-                                <p:commandButton
-                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-                                    value="Print Configuration"
-                                    icon="fas fa-cog"
-                                    class="ui-button-secondary"
-                                    type="button"
-                                    onclick="PF('outsideChargeConfigDialog').show();" />
-                            </div>
 
                             <div class="row justify-content-center">
-                                <div class="col-12 col-lg-8">
+                                <div class="col-12 col-md-10 col-lg-7 col-xl-6">
                                     <p:panel>
                                         <f:facet name="header">
                                             <h:outputText styleClass="fa-solid fa-receipt" />
@@ -497,7 +559,7 @@
                         </h:panelGroup>
 
                     </p:panel>
-                </h:panelGrid>
+                </h:panelGroup>
 
             </h:form>
 

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -293,6 +293,44 @@
 
                         <h:panelGroup rendered="#{!inwardAdditionalChargeController.printPreview}">
 
+                        <!-- Bill-level: Outside Institution selection (shown until selected) -->
+                        <h:panelGroup layout="block" rendered="#{inwardAdditionalChargeController.current.fromInstitution eq null}" class="col-12 mb-2">
+                            <p:panel>
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fa fa-hospital" />
+                                    <h:outputText value="Outside Institution" class="mx-3"/>
+                                </f:facet>
+                                <div class="row m-1">
+                                    <div class="col-4 d-flex align-items-center">
+                                        <h:outputLabel value="Select Outside Institution"/>
+                                    </div>
+                                    <div class="col-8">
+                                        <p:selectOneMenu id="insFromMenu" autoWidth="false" class="w-100"
+                                                         value="#{inwardAdditionalChargeController.current.fromInstitution}"
+                                                         filter="true" filterMatchMode="contains">
+                                            <f:selectItem itemLabel="Select Institution"/>
+                                            <f:selectItems value="#{institutionController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </h:panelGroup>
+
+                        <!-- Bill-level: Institution confirmed banner (shown after selection) -->
+                        <h:panelGroup layout="block" rendered="#{inwardAdditionalChargeController.current.fromInstitution ne null}" class="col-12 mb-2">
+                            <div class="alert alert-info d-flex align-items-center justify-content-between py-2 px-3">
+                                <div>
+                                    <i class="fa fa-hospital me-2"/>
+                                    <strong>Outside Institution: </strong>
+                                    <h:outputText value="#{inwardAdditionalChargeController.current.fromInstitution.name}"/>
+                                </div>
+                                <p:commandButton value="Change" icon="fa fa-pencil"
+                                                 class="ui-button-secondary ui-button-sm"
+                                                 ajax="false"
+                                                 action="#{inwardAdditionalChargeController.clearFromInstitution}"/>
+                            </div>
+                        </h:panelGroup>
+
                         <div class="col-12">
                             <h:panelGroup rendered="true" styleClass="opdPanel">
                                 <p:panel >
@@ -317,17 +355,6 @@
                                                     <h:outputText value="Charge Details" class="mx-3"></h:outputText>
                                                 </f:facet>
                                                 <div class="row">
-                                                    <div class="row m-1">
-                                                        <div class="col-4 d-flex align-items-center">
-                                                            <h:outputLabel value="Outside Institution"/>
-                                                        </div>
-                                                        <div class="col-8">
-                                                            <p:selectOneMenu autoWidth="false" class="w-100" value="#{inwardAdditionalChargeController.current.fromInstitution}" filter="true" filterMatchMode="contains">
-                                                                <f:selectItem itemLabel="Select Institution"/>
-                                                                <f:selectItems value="#{institutionController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}"/>
-                                                            </p:selectOneMenu>
-                                                        </div>
-                                                    </div>
                                                     <div class="row m-1">
                                                         <div class="col-4 d-flex align-items-center">
                                                             <h:outputLabel value="Item"/>


### PR DESCRIPTION
## Summary

- **Settle button fixed**: removed `this.disabled=true` from onclick — disabled buttons are excluded from the POST payload, silently preventing JSF from firing the `settle()` action
- **Institution moved to bill level**: selected once per bill with an autocomplete; confirmed with a banner + Change button; bill-level note textarea lives alongside the institution
- **Item autocomplete**: replaced the 188-entry InwardChargeType dropdown with a searchable autocomplete covering `InwardService` and `Service` items; `inwardChargeType` derived from the selected item
- **Amount auto-fill**: `onItemSelect` pre-fills the amount field from the item's `total` if set
- **Per-row note**: `BillItem.descreption` — cleared after each Add; bill-level note persists until Settle
- **Fee creation**: `saveBillFee()` iterates the item's `ItemFee` records via `BillBeanController.fillFees` and creates one `BillFee` per fee; falls back to a generic Additional fee if the item has no fees configured
- **Row expansion**: `p:rowToggler` / `p:rowExpansion` shows a nested fee breakdown table per bill item
- **Full-width layout**: replaced `h:panelGrid` (renders as HTML table, content-width only) with `h:panelGroup layout="block" style="width:100%"`
- **Print/Config buttons centred in panel header**: Print, Print Configuration, and New Bill moved into the centre column of the panel header (matches dashboard pattern); hidden from toolbar during print preview
- **Documentation**: added "Never Use `this.disabled=true` on Submit Buttons" section to `developer_docs/jsf/ajax-update-guidelines.md`

## Test plan

- [ ] Select a patient via BHT search → charge entry form appears full-width
- [ ] Institution autocomplete: type 2+ chars, select; confirmed banner + Bill Note textarea appear
- [ ] Change button clears institution and returns to selection panel
- [ ] Item autocomplete: type 2+ chars, results include both OPD and Inward service items; selecting one auto-fills the amount
- [ ] Add a charge → row appears in table; item note is cleared; bill note persists
- [ ] Expand a row → fee breakdown shows the item's fees (or fallback generic fee)
- [ ] Settle → confirm dialog fires; print preview appears full-width with Print / Print Configuration / New Bill centred in panel header
- [ ] Print Configuration dialog opens, paper format saves and re-renders correctly
- [ ] New Bill (centre header) resets to patient selection
- [ ] No NPE on Add or Settle

Closes #20731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item autocomplete for outside-charge entry, reorganized form layout, and amount auto-fill when an item is selected
  * Per-row description now always enabled and bound to item-specific notes; selected institution shown as a badge

* **Bug Fixes**
  * Simplified confirmation to ensure submit actions dispatch reliably
  * Table columns and print preview layout clarified

* **Documentation**
  * Added warning not to disable submit buttons in client-side handlers before submission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->