### PR TITLE
feat(inward): Last Processing snapshot summary on Inward Payment Bill and Admission Profile

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3037,20 +3037,29 @@ public class BhtSummeryController implements Serializable {
             grantTotal = adjustedTotal;
         }
 
-        paid = getInwardBean().getPaidValue(getPatientEncounter());
         paidByPatient = getInwardBean().getPaidByPatientValue(getPatientEncounter());
         paidByCompany = getInwardBean().getPaidByCompanyValue(getPatientEncounter());
+        paid = paidByPatient + paidByCompany;
 
         due = (grantTotal - discount) - paid;
 
-//        if (getPatientEncounter().getCreditLimit() != 0) {
-//            due -= getPatientEncounter().getCreditLimit();
-//        }
         changed = false;
 
         if (getPatientEncounter() != null && getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
             populateCreditCompanyAllocations();
         }
+        
+        //Update Last Processing Details
+        patientEncounter.setLastProcessBy(sessionController.getLoggedUser());
+        patientEncounter.setLastProcessAt(new Date());
+        patientEncounter.setTotalAtFinalProcessing(grantTotal);
+        patientEncounter.setTotalPatientPaidAtFinalProcessing(paidByPatient);
+        patientEncounter.setTotalCompanyPaidAtFinalProcessing(paidByCompany);
+        patientEncounter.setDiscountAvailableAtFinalProcessing(discount);
+        patientEncounter.setAmountDueAtFinalProcessing(due);
+        patientEncounterFacade.edit(patientEncounter);
+        System.out.println("Update Last Processing Details of " + patientEncounter.getBhtNo()); 
+        
     }
 
     public void changeIsMade() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3050,6 +3050,11 @@ public class BhtSummeryController implements Serializable {
         }
         
         //Update Last Processing Details
+        persistLastProcessingSnapshot();
+        
+    }
+    
+    private void persistLastProcessingSnapshot() {
         patientEncounter.setLastProcessBy(sessionController.getLoggedUser());
         patientEncounter.setLastProcessAt(new Date());
         patientEncounter.setTotalAtFinalProcessing(grantTotal);
@@ -3059,7 +3064,6 @@ public class BhtSummeryController implements Serializable {
         patientEncounter.setAmountDueAtFinalProcessing(due);
         patientEncounterFacade.edit(patientEncounter);
         System.out.println("Update Last Processing Details of " + patientEncounter.getBhtNo()); 
-        
     }
 
     public void changeIsMade() {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2019,10 +2019,11 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "SELECT  sum(b.netTotal) FROM Bill b "
                 + " WHERE b.retired=false "
-                + "  and b.billType=:btp "
+                + " and b.billType=:btp "
                 + " and b.patientEncounter=:pe ";
         hm.put("btp", BillType.InwardPaymentBill);
         hm.put("pe", patientEncounter);
+       
         double dbl = getBillFacade().findDoubleByJpql(sql, hm, TemporalType.TIMESTAMP);
 
         return dbl;
@@ -2034,12 +2035,13 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "SELECT  sum(b.netTotal) FROM Bill b "
                 + " WHERE b.retired=false "
-                + "  and b.billType=:btp "
+                + " and b.billType=:btp "
                 + " and b.paymentMethod !=:pm "
                 + " and b.patientEncounter=:pe ";
         hm.put("btp", BillType.InwardPaymentBill);
         hm.put("pm", PaymentMethod.Credit);
         hm.put("pe", patientEncounter);
+
         double dbl = getBillFacade().findDoubleByJpql(sql, hm, TemporalType.TIMESTAMP);
 
         return dbl;
@@ -2051,12 +2053,13 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "SELECT  sum(b.netTotal) FROM Bill b "
                 + " WHERE b.retired=false "
-                + "  and b.billTypeAtomic in :bts "
+                + " and b.billTypeAtomic in :bts "
                 + " and b.patientEncounter=:pe ";
         List<BillTypeAtomic> bts = new ArrayList<>();
         bts.add(BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
         hm.put("bts", bts);
         hm.put("pe", patientEncounter);
+
         double dbl = getBillFacade().findDoubleByJpql(sql, hm, TemporalType.TIMESTAMP);
 
         return dbl;

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -200,9 +200,60 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     private ClinicalEntity primaryReason;
     private String referringMethod;
     private boolean roomAdmitted;
-    
+
     @ManyToOne
     private Reservation encounterReservation;
+
+    @Lob
+    String comments;
+    @Lob
+    private String planOfAction;
+
+    // Clinical discharge content fields — used on the child ClinicalDischarge record
+    @ManyToOne
+    private ClinicalEntity dischargeCondition;
+    @Lob
+    private String followUpPlan;
+    @Lob
+    private String activityInstructions;
+    @Lob
+    private String dietInstructions;
+    @Transient
+    List<ClinicalFindingValue> diagnosis;
+    @ManyToOne
+    Department department;
+    @ManyToOne
+    private Institution institution;
+
+    @Transient
+    List<ClinicalFindingValue> investigations;
+
+    @Transient
+    List<ClinicalFindingValue> symptoms;
+
+    @Transient
+    List<ClinicalFindingValue> signs;
+
+    @Transient
+    List<ClinicalFindingValue> procedures;
+
+    @Transient
+    List<ClinicalFindingValue> plans;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date printingAdmissionTime;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date printingDischargeTime;
+
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date lastProcessAt;
+    @ManyToOne
+    private WebUser lastProcessBy;
+    private double totalAtFinalProcessing;
+    private double discountAvailableAtFinalProcessing;
+    private double totalPatientPaidAtFinalProcessing;
+    private double totalCompanyPaidAtFinalProcessing;
+    private double amountDueAtFinalProcessing;
 
     // Transient method for BP
     public String getBp() {
@@ -330,46 +381,6 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     public void setClaimable(boolean claimable) {
         this.claimable = claimable;
     }
-    @Lob
-    String comments;
-    @Lob
-    private String planOfAction;
-
-    // Clinical discharge content fields — used on the child ClinicalDischarge record
-    @ManyToOne
-    private ClinicalEntity dischargeCondition;
-    @Lob
-    private String followUpPlan;
-    @Lob
-    private String activityInstructions;
-    @Lob
-    private String dietInstructions;
-    @Transient
-    List<ClinicalFindingValue> diagnosis;
-    @ManyToOne
-    Department department;
-    @ManyToOne
-    private Institution institution;
-
-    @Transient
-    List<ClinicalFindingValue> investigations;
-
-    @Transient
-    List<ClinicalFindingValue> symptoms;
-
-    @Transient
-    List<ClinicalFindingValue> signs;
-
-    @Transient
-    List<ClinicalFindingValue> procedures;
-
-    @Transient
-    List<ClinicalFindingValue> plans;
-
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date printingAdmissionTime;
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date printingDischargeTime;
 
     public List<ClinicalFindingValue> getDiagnosis() {
         if (diagnosis == null) {
@@ -528,10 +539,10 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     /**
      * Guarantees the encounter flag is never persisted as NULL. New entities
-     * already carry the STANDARD field default; this hook additionally back-fills
-     * STANDARD on the next write of any legacy row whose column is still NULL, so
-     * persisted rows progressively converge on a non-null value alongside the
-     * one-time DB migration (v2.1.20). (Issue #21182)
+     * already carry the STANDARD field default; this hook additionally
+     * back-fills STANDARD on the next write of any legacy row whose column is
+     * still NULL, so persisted rows progressively converge on a non-null value
+     * alongside the one-time DB migration (v2.1.20). (Issue #21182)
      */
     @PrePersist
     @PreUpdate
@@ -1274,5 +1285,61 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setEncounterReservation(Reservation encounterReservation) {
         this.encounterReservation = encounterReservation;
+    }
+
+    public Date getLastProcessAt() {
+        return lastProcessAt;
+    }
+
+    public void setLastProcessAt(Date lastProcessAt) {
+        this.lastProcessAt = lastProcessAt;
+    }
+
+    public WebUser getLastProcessBy() {
+        return lastProcessBy;
+    }
+
+    public void setLastProcessBy(WebUser lastProcessBy) {
+        this.lastProcessBy = lastProcessBy;
+    }
+
+    public double getTotalAtFinalProcessing() {
+        return totalAtFinalProcessing;
+    }
+
+    public void setTotalAtFinalProcessing(double totalAtFinalProcessing) {
+        this.totalAtFinalProcessing = totalAtFinalProcessing;
+    }
+
+    public double getTotalPatientPaidAtFinalProcessing() {
+        return totalPatientPaidAtFinalProcessing;
+    }
+
+    public void setTotalPatientPaidAtFinalProcessing(double totalPatientPaidAtFinalProcessing) {
+        this.totalPatientPaidAtFinalProcessing = totalPatientPaidAtFinalProcessing;
+    }
+
+    public double getTotalCompanyPaidAtFinalProcessing() {
+        return totalCompanyPaidAtFinalProcessing;
+    }
+
+    public void setTotalCompanyPaidAtFinalProcessing(double totalCompanyPaidAtFinalProcessing) {
+        this.totalCompanyPaidAtFinalProcessing = totalCompanyPaidAtFinalProcessing;
+    }
+
+    public double getAmountDueAtFinalProcessing() {
+        return amountDueAtFinalProcessing;
+    }
+
+    public void setAmountDueAtFinalProcessing(double amountDueAtFinalProcessing) {
+        this.amountDueAtFinalProcessing = amountDueAtFinalProcessing;
+    }
+
+    public double getDiscountAvailableAtFinalProcessing() {
+        return discountAvailableAtFinalProcessing;
+    }
+
+    public void setDiscountAvailableAtFinalProcessing(double discountAvailableAtFinalProcessing) {
+        this.discountAvailableAtFinalProcessing = discountAvailableAtFinalProcessing;
     }
 }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -278,6 +278,101 @@
                         </p:panel>
 
                         <p:panel header="Billing" class="m-1" rendered="#{admissionController.current.parentEncounter == null}">
+                            <h:panelGroup layout="block" rendered="#{webUserController.hasPrivilege('Developers')}">
+                                <div class="border border-warning rounded p-2 mb-2 shadow-sm" style="background-color:#fffdf5;">
+                                    <div class="d-flex justify-content-between align-items-center mb-2 pb-1 border-bottom">
+                                        <span class="fw-bold text-uppercase small text-warning">
+                                            <i class="fa fa-receipt me-1"/> Last Processing Summary
+                                        </span>
+                                        <span class="d-inline-flex align-items-center gap-1">
+                                            <h:panelGroup rendered="#{admissionController.current.lastProcessAt != null}">
+                                                <p:tag value="Snapshot - Not Live" icon="fa fa-clock-rotate-left" severity="warning" class="small"/>
+                                            </h:panelGroup>
+                                            <p:tag value="Developer" icon="fa fa-code" severity="info" class="small"/>
+                                        </span>
+                                    </div>
+
+                                    <h:panelGroup layout="block" rendered="#{admissionController.current.lastProcessAt != null}">
+                                        <div class="d-flex align-items-center py-2 px-3 mb-2 rounded shadow-sm"
+                                             role="alert"
+                                             style="border-left:8px solid #dc3545; background-color:#fdecea; color:#842029;">
+                                            <i class="fa fa-triangle-exclamation fa-lg me-2 text-danger"/>
+                                            <span class="fw-semibold">
+                                                Totals are <span class="fw-bold text-danger text-decoration-underline">NOT current</span> &#8212; snapshot only. Re-process for live values.
+                                            </span>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" rendered="#{admissionController.current.lastProcessAt == null}">
+                                        <div class="text-center text-muted small py-2">
+                                            <i class="fa fa-circle-info me-1"/> Not processed yet
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" rendered="#{admissionController.current.lastProcessAt != null}">
+                                        <div class="d-flex flex-wrap justify-content-between align-items-center small mb-2 p-2 rounded border border-warning" style="background-color:#fff3cd;">
+                                            <span class="text-muted">
+                                                <i class="fa fa-user me-1"/>
+                                                By <span class="fw-semibold text-dark">#{admissionController.current.lastProcessBy.webUserPerson.nameWithTitle}</span>
+                                            </span>
+                                            <span class="d-inline-flex align-items-center fw-bold px-2 py-1 rounded text-white" style="background-color:#fd7e14;">
+                                                <i class="fa fa-clock-rotate-left me-2"/>
+                                                Last Processed:&nbsp;
+                                                <h:outputText value="#{admissionController.current.lastProcessAt}">
+                                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                </h:outputText>
+                                            </span>
+                                        </div>
+
+                                        <div class="fst-italic" style="opacity:0.85;">
+                                            <div class="d-flex justify-content-between border-bottom py-1">
+                                                <span class="text-muted">Total</span>
+                                                <span class="fw-semibold">
+                                                    <h:outputText value="#{admissionController.current.totalAtFinalProcessing}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+                                            <div class="d-flex justify-content-between border-bottom py-1">
+                                                <span class="text-muted">Discount</span>
+                                                <span class="fw-semibold text-success">
+                                                    <h:outputText value="#{admissionController.current.discountAvailableAtFinalProcessing}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+                                            <div class="d-flex justify-content-between border-bottom py-1">
+                                                <span class="text-muted">Patient Paid</span>
+                                                <span class="fw-semibold">
+                                                    <h:outputText value="#{admissionController.current.totalPatientPaidAtFinalProcessing}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+                                            <div class="d-flex justify-content-between border-bottom py-1">
+                                                <span class="text-muted">Credit Company Paid</span>
+                                                <span class="fw-semibold">
+                                                    <h:outputText value="#{admissionController.current.totalCompanyPaidAtFinalProcessing}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+                                        </div>
+
+                                        <div class="d-flex justify-content-between align-items-center mt-2 p-2 rounded border #{admissionController.current.amountDueAtFinalProcessing gt 0 ? 'border-danger bg-danger-subtle' : 'border-success bg-success-subtle'}">
+                                            <span class="fw-bold text-uppercase">
+                                                <i class="fa fa-money-bill-wave me-1"/> Due Amount
+                                            </span>
+                                            <span class="fw-bold fs-5 #{admissionController.current.amountDueAtFinalProcessing gt 0 ? 'text-danger' : 'text-success'}">
+                                                <h:outputText value="#{admissionController.current.amountDueAtFinalProcessing}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </span>
+                                        </div>
+                                    </h:panelGroup>
+                                </div>
+                            </h:panelGroup>
+
                             <div class="row g-2">
                                 <div class="col-12">
                                     <p:commandButton

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -153,7 +153,7 @@
 
                                 <div class="row mt-1">
                                     <div class="col-md-2">
-                                        <h:outputLabel value="Payment Mode"/>
+                                        <h:outputLabel value="Payment Mode" class="mt-2"/>
                                     </div>
                                     <div class="col-md-3">
                                         <p:selectOneMenu 
@@ -178,38 +178,138 @@
                                 </div>
 
                                 <h:panelGroup rendered="#{!inwardPaymentController.current.patientEncounter.paymentFinalized}" id="notFinalized">
-                                    <div class="row my-3">
-                                        <div class="col-md-2">
-                                            <h:outputLabel value="Due"/>
+
+                                    <div class="border border-warning rounded p-2 mb-3 shadow-sm mt-3" style="background-color:#fffdf5;">
+                                        <div class="d-flex align-items-center justify-content-center gap-2 py-2 px-3 mb-2 rounded text-white"
+                                             style="background-color:#fd7e14;">
+                                            <i class="fa fa-hourglass-half fa-lg"/>
+                                            <span class="fw-bold text-uppercase fs-6" style="letter-spacing:0.5px;">
+                                                Payment Details are not Finalized
+                                            </span>
                                         </div>
-                                        <div class="col-md-5">
-                                            <h:outputLabel value="Payment Details are not Finalized"/>
+
+
+                                        <div class="d-flex justify-content-between align-items-center mb-2 pb-1 border-bottom">
+                                            <span class="fw-bold text-uppercase small text-warning">
+                                                <i class="fa fa-receipt me-1"/> Last Processing Summary
+                                            </span>
+                                            <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.lastProcessAt != null}">
+                                                <p:tag value="Snapshot - Not Live" icon="fa fa-clock-rotate-left" severity="warning" class="small"/>
+                                            </h:panelGroup>
                                         </div>
+
+                                        <h:panelGroup layout="block" rendered="#{inwardPaymentController.current.patientEncounter.lastProcessAt != null}">
+                                            <div class="d-flex align-items-center py-2 px-3 mb-2 rounded shadow-sm"
+                                                 role="alert"
+                                                 style="border-left:8px solid #dc3545; background-color:#fdecea; color:#842029;">
+                                                <i class="fa fa-triangle-exclamation fa-lg me-2 text-danger"/>
+                                                <span class="fw-semibold">
+                                                    Totals are <span class="fw-bold text-danger text-decoration-underline">NOT current</span> &#8212; snapshot only. Re-process for live values.
+                                                </span>
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup layout="block" rendered="#{inwardPaymentController.current.patientEncounter.lastProcessAt == null}">
+                                            <div class="text-center text-muted small py-2">
+                                                <i class="fa fa-circle-info me-1"/> Not processed yet
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup layout="block" rendered="#{inwardPaymentController.current.patientEncounter.lastProcessAt != null}">
+                                            <div class="d-flex flex-wrap justify-content-between align-items-center small mb-2 p-2 rounded border border-warning" style="background-color:#fff3cd;">
+                                                <span class="text-muted">
+                                                    <i class="fa fa-user me-1"/>
+                                                    By <span class="fw-semibold text-dark">#{inwardPaymentController.current.patientEncounter.lastProcessBy.webUserPerson.nameWithTitle}</span>
+                                                </span>
+                                                <span class="d-inline-flex align-items-center fw-bold px-2 py-1 rounded text-white" style="background-color:#fd7e14;">
+                                                    <i class="fa fa-clock-rotate-left me-2"/>
+                                                    Last Processed:&nbsp;
+                                                    <h:outputText value="#{inwardPaymentController.current.patientEncounter.lastProcessAt}">
+                                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+
+                                            <div class="fst-italic" style="opacity:0.85;">
+                                                <div class="d-flex justify-content-between border-bottom py-1">
+                                                    <span class="text-muted">Total</span>
+                                                    <span class="fw-semibold">
+                                                        <h:outputText value="#{inwardPaymentController.current.patientEncounter.totalAtFinalProcessing}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </h:outputText>
+                                                    </span>
+                                                </div>
+                                                <div class="d-flex justify-content-between border-bottom py-1">
+                                                    <span class="text-muted">Discount</span>
+                                                    <span class="fw-semibold text-success">
+                                                        <h:outputText value="#{inwardPaymentController.current.patientEncounter.discountAvailableAtFinalProcessing}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </h:outputText>
+                                                    </span>
+                                                </div>
+                                                <div class="d-flex justify-content-between border-bottom py-1">
+                                                    <span class="text-muted">Patient Paid</span>
+                                                    <span class="fw-semibold">
+                                                        <h:outputText value="#{inwardPaymentController.current.patientEncounter.totalPatientPaidAtFinalProcessing}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </h:outputText>
+                                                    </span>
+                                                </div>
+                                                <div class="d-flex justify-content-between border-bottom py-1">
+                                                    <span class="text-muted">Credit Company Paid</span>
+                                                    <span class="fw-semibold">
+                                                        <h:outputText value="#{inwardPaymentController.current.patientEncounter.totalCompanyPaidAtFinalProcessing}">
+                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                        </h:outputText>
+                                                    </span>
+                                                </div>
+                                            </div>
+
+                                            <div class="d-flex justify-content-between align-items-center mt-2 p-2 rounded border #{inwardPaymentController.current.patientEncounter.amountDueAtFinalProcessing gt 0 ? 'border-danger bg-danger-subtle' : 'border-success bg-success-subtle'}">
+                                                <span class="fw-bold text-uppercase">
+                                                    <i class="fa fa-money-bill-wave me-1"/> Due Amount
+                                                </span>
+                                                <span class="fw-bold fs-5 #{inwardPaymentController.current.patientEncounter.amountDueAtFinalProcessing gt 0 ? 'text-danger' : 'text-success'}">
+                                                    <h:outputText value="#{inwardPaymentController.current.patientEncounter.amountDueAtFinalProcessing}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </span>
+                                            </div>
+                                        </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
 
                                 <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter.paymentFinalized}"  id="finalized">
-                                    <div class="row mt-3">
-                                        <div class="col-md-2">
-                                            <h:outputLabel value="Due"/>
+                                    <div class="border border-success rounded p-2 mb-3 shadow-sm mt-3" style="background-color:#f5fff7;">
+                                        <div class="d-flex align-items-center justify-content-center gap-2 py-2 px-3 mb-2 rounded text-white"
+                                             style="background-color:#198754;">
+                                            <i class="fa fa-circle-check fa-lg"/>
+                                            <span class="fw-bold text-uppercase fs-6" style="letter-spacing:0.5px;">
+                                                Payment Details Finalized
+                                            </span>
                                         </div>
-                                        <div class="col-md-3">
-                                            <h:outputLabel class="w-100" value="#{inwardPaymentController.due}">
-                                                <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
+
+                                        <div class="d-flex justify-content-between align-items-center p-2 rounded border #{inwardPaymentController.due gt 0 ? 'border-danger bg-danger-subtle' : 'border-success bg-success-subtle'}">
+                                            <span class="fw-bold text-uppercase">
+                                                <i class="fa fa-money-bill-wave me-1"/> Due
+                                            </span>
+                                            <span class="fw-bold fs-5 #{inwardPaymentController.due gt 0 ? 'text-danger' : 'text-success'}">
+                                                <h:outputText value="#{inwardPaymentController.due}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputText>
+                                            </span>
                                         </div>
                                     </div>
                                 </h:panelGroup>
-                                
+
 
                                 <div class="row ">
-                                    <div class="col-md-2"></div>
                                     <div class="col-md-8">
                                         <h:panelGroup id="paymentDetails">
 
                                             <h:panelGroup rendered="#{inwardPaymentController.paymentMethod eq 'Cash'}">
                                                 <div class="row">
-                                                    <div class="col-md-2">
+                                                    <div class="col-md-3">
                                                         <h:outputLabel value="Paying Amount"  class="mt-2"/>
                                                     </div>
                                                     <div class="col-md-3">
@@ -220,50 +320,56 @@
                                                 </div>
                                             </h:panelGroup>
 
-                                            <h:panelGroup 
-                                                id="creditCard" 
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'Card'}">
-                                                <pa:creditCard paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
-                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{inwardPaymentController.paymentMethod ne 'Cash'}">
+                                                <div class="row">
+                                                    <div class="col-md-3"></div>
+                                                    <div class="col-md-9">
+                                                        <h:panelGroup 
+                                                            id="creditCard" 
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'Card'}">
+                                                            <pa:creditCard paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        </h:panelGroup>
 
-                                            <h:panelGroup 
-                                                id="cheque"
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'Cheque'}">
-                                                <pa:cheque paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
-                                            </h:panelGroup>
+                                                        <h:panelGroup 
+                                                            id="cheque"
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'Cheque'}">
+                                                            <pa:cheque paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        </h:panelGroup>
 
-                                            <h:panelGroup 
-                                                id="slip" 
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'Slip'}">
-                                                <pa:slip paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
-                                            </h:panelGroup>
+                                                        <h:panelGroup 
+                                                            id="slip" 
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'Slip'}">
+                                                            <pa:slip paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        </h:panelGroup>
 
-                                            <h:panelGroup
-                                                id="eWallet"  
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'ewallet'}" >
-                                                <pa:ewallet paymentMethodData="#{inwardPaymentController.paymentMethodData}" />
-                                            </h:panelGroup>
+                                                        <h:panelGroup
+                                                            id="eWallet"  
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'ewallet'}" >
+                                                            <pa:ewallet paymentMethodData="#{inwardPaymentController.paymentMethodData}" />
+                                                        </h:panelGroup>
 
-                                            <h:panelGroup
-                                                id="patientDeposit"  
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'PatientDeposit'}" >
-                                                <pa:patient_deposit_with_paid_value paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
-                                            </h:panelGroup>
+                                                        <h:panelGroup
+                                                            id="patientDeposit"  
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'PatientDeposit'}" >
+                                                            <pa:patient_deposit_with_paid_value paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        </h:panelGroup>
 
-                                            <h:panelGroup
-                                                id="onlinePayment"  
-                                                rendered="#{inwardPaymentController.paymentMethod eq 'OnlineSettlement'}" >
-                                                <pa:online_settlement paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        <h:panelGroup
+                                                            id="onlinePayment"  
+                                                            rendered="#{inwardPaymentController.paymentMethod eq 'OnlineSettlement'}" >
+                                                            <pa:online_settlement paymentMethodData="#{inwardPaymentController.paymentMethodData}"/>
+                                                        </h:panelGroup>
+                                                    </div>
+                                                </div>
                                             </h:panelGroup>
-
                                         </h:panelGroup>
                                     </div>
                                 </div>
 
                                 <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Get Payment Type Instead of Comment',false)}">
-                                    <div class="row my-1">
+                                    <div class="row my-1 mt-3">
                                         <div class="col-md-2">
-                                            <h:outputLabel value="Comments"/>
+                                            <h:outputLabel value="Comments" class="mt-2"/>
                                         </div>
                                         <div class="col-md-3">
                                             <p:inputText class="w-100"  value="#{inwardPaymentController.comment}" id="comment"/>
@@ -274,7 +380,7 @@
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Get Payment Type Instead of Comment',false)}">
                                     <div class="row my-1">
                                         <div class="col-md-2">
-                                            <h:outputLabel value="Payment Type"/>
+                                            <h:outputLabel value="Payment Type" class="mt-2"/>
                                         </div>
                                         <div class="col-md-3">
                                             <p:selectOneMenu 


### PR DESCRIPTION
## Summary

Adds a **Last Processing snapshot** to the inpatient billing flow and surfaces it with a clear, highlighted UI on both the **Inward Payment Bill** and **Admission Profile** pages. Staff can now see who last processed the bill, when, and the figures captured at that point — with an explicit warning that those totals are a snapshot and not live values.

Closes #21270

## Changes (commit by commit)

1. **`feat(inward): add Last Processing snapshot fields to PatientEncounter`**
   Adds `lastProcessAt`, `lastProcessBy`, `totalAtFinalProcessing`, `discountAvailableAtFinalProcessing`, `totalPatientPaidAtFinalProcessing`, `totalCompanyPaidAtFinalProcessing`, `amountDueAtFinalProcessing` with getters/setters.

2. **`feat(inward): capture Last Processing snapshot during billing processing`**
   `BhtSummeryController` persists the snapshot during processing and computes `paid` as `paidByPatient + paidByCompany`. `InwardBeanController` JPQL formatting cleanup.

3. **`feat(inward): show Last Processing Summary on Inward Payment Bill page`**
   Not-finalized status banner, Last Processing Summary card, highlighted Last Processed time, compact "NOT current" warning, and a restyled green finalized section with a prominent Due figure.

4. **`feat(inward): restyle Last Processing Summary on Admission Profile page`**
   Matching restyle of the Billing section's Last Processing Summary (remains Developer-gated).

## Captured fields

- `lastProcessAt`, `lastProcessBy`
- `totalAtFinalProcessing`, `discountAvailableAtFinalProcessing`
- `totalPatientPaidAtFinalProcessing`, `totalCompanyPaidAtFinalProcessing`, `amountDueAtFinalProcessing`

## Testing notes

- Process an inpatient bill, then open **Inward Payment Bill** for the BHT → the Last Processing Summary card shows the captured by/when and totals, flagged as a non-live snapshot.
- Open **Admission Profile** (Developer privilege) → Billing section shows the matching summary.
- When an encounter has never been processed, the card shows "Not processed yet".

## Notes

- `persistence.xml` is intentionally **not** included (local JNDI config).
- No privilege changes; the Admission Profile summary remains gated to the Developer privilege.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Last Processing Summary" snapshot in billing showing processor, timestamp and final billing snapshot.

* **Improvements**
  * Payment calculations now show separate patient and company contributions and updated due amounts.
  * Payment status display enhanced with totals, discounts and styled due indicators.
  * Reorganized payment-method selection and layout for clearer input of non-cash payment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->