### PR TITLE
feat(inward): Add 'Enforce Claimable for Credit' config; fix BhtEditController hardcoded claimable check

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -517,7 +517,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 current.setClaimable(true);
             }
         }
-        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Enforce Claimable for Credit", false)) {
+        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Show Claimable Field", true)
+                && configOptionApplicationController.getBooleanValueByKey("Inward Admission - Enforce Claimable for Credit", false)) {
             if (current.getPaymentMethod() == PaymentMethod.Credit) {
                 current.setClaimable(true);
             }
@@ -1674,12 +1675,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             boolean autoMarkCredit = configOptionApplicationController.getBooleanValueByKey(
                     "Inward Admission - Auto Mark Claimable for Credit Admissions", false);
             boolean claimableAllowed = isClaimableAllowed();
-            if (!autoMarkCredit && !enforceForCredit && !claimableAllowed && getCurrent().isClaimable()) {
+            boolean creditEnforced = enforceForCredit && getCurrent().getPaymentMethod() == PaymentMethod.Credit;
+            if (!autoMarkCredit && !creditEnforced && !claimableAllowed && getCurrent().isClaimable()) {
                 getCurrent().setClaimable(false);
                 JsfUtil.addErrorMessage("Claimable is not applicable for the selected payment method");
                 return true;
             }
-            if (!autoMarkCredit && !enforceForCredit && claimableAllowed && !getCurrent().isClaimable()) {
+            if (!autoMarkCredit && !creditEnforced && claimableAllowed && !getCurrent().isClaimable()) {
                 JsfUtil.addErrorMessage("Please mark the admission as Claimable");
                 return true;
             }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -517,6 +517,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 current.setClaimable(true);
             }
         }
+        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Enforce Claimable for Credit", false)) {
+            if (current.getPaymentMethod() == PaymentMethod.Credit) {
+                current.setClaimable(true);
+            }
+        }
         if (current.getPaymentMethod() == PaymentMethod.Credit && current.getPatient() != null) {
             // Prefer PatientInsurance profiles over last-admission lookup
             List<PatientInsurance> profiles = patientInsuranceController.findActiveProfiles(current.getPatient());
@@ -1477,6 +1482,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (!configOptionApplicationController.getBooleanValueByKey("Inward Admission - Show Claimable Field", true)) {
             return false;
         }
+        PaymentMethod pm = getCurrent() != null ? getCurrent().getPaymentMethod() : null;
+        if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Enforce Claimable for Credit", false)) {
+            // Credit is always locked at true; all other payment methods fall through to normal logic
+            if (pm == PaymentMethod.Credit) {
+                return false;
+            }
+        }
         if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Auto Mark Claimable for Credit Admissions", false)) {
             return true;
         }
@@ -1485,7 +1497,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if ("None".equalsIgnoreCase(claimableRequiredFor)) {
             return false;
         }
-        PaymentMethod pm = getCurrent() != null ? getCurrent().getPaymentMethod() : null;
         if ("All".equalsIgnoreCase(claimableRequiredFor)) {
             return true;
         } else if ("Credit".equalsIgnoreCase(claimableRequiredFor)) {
@@ -1655,15 +1666,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         boolean showClaimable = configOptionApplicationController.getBooleanValueByKey(
                 "Inward Admission - Show Claimable Field", true);
         if (showClaimable) {
+            boolean enforceForCredit = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Admission - Enforce Claimable for Credit", false);
+            if (enforceForCredit && getCurrent().getPaymentMethod() == PaymentMethod.Credit) {
+                getCurrent().setClaimable(true);
+            }
             boolean autoMarkCredit = configOptionApplicationController.getBooleanValueByKey(
                     "Inward Admission - Auto Mark Claimable for Credit Admissions", false);
             boolean claimableAllowed = isClaimableAllowed();
-            if (!autoMarkCredit && !claimableAllowed && getCurrent().isClaimable()) {
+            if (!autoMarkCredit && !enforceForCredit && !claimableAllowed && getCurrent().isClaimable()) {
                 getCurrent().setClaimable(false);
                 JsfUtil.addErrorMessage("Claimable is not applicable for the selected payment method");
                 return true;
             }
-            if (!autoMarkCredit && claimableAllowed && !getCurrent().isClaimable()) {
+            if (!autoMarkCredit && !enforceForCredit && claimableAllowed && !getCurrent().isClaimable()) {
                 JsfUtil.addErrorMessage("Please mark the admission as Claimable");
                 return true;
             }

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -500,12 +500,25 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         boolean showClaimable = configOptionApplicationController.getBooleanValueByKey(
                 "Inward Admission - Show Claimable Field", true);
         if (showClaimable) {
+            PaymentMethod pm = getCurrent().getPaymentMethod();
             boolean enforceForCredit = configOptionApplicationController.getBooleanValueByKey(
                     "Inward Admission - Enforce Claimable for Credit", false);
-            if (enforceForCredit && getCurrent().getPaymentMethod() == PaymentMethod.Credit
-                    && !getCurrent().isClaimable()) {
+            if (enforceForCredit && pm == PaymentMethod.Credit && !getCurrent().isClaimable()) {
                 JsfUtil.addErrorMessage("Credit admissions must be marked as Claimable");
                 return;
+            }
+            boolean autoMarkCredit = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Admission - Auto Mark Claimable for Credit Admissions", false);
+            if (!enforceForCredit && !autoMarkCredit) {
+                String claimableRequiredFor = configOptionApplicationController.getShortTextValueByKey(
+                        "Inward Admission - Claimable Required For", "Credit");
+                boolean required = "All".equalsIgnoreCase(claimableRequiredFor)
+                        || ("Credit".equalsIgnoreCase(claimableRequiredFor) && pm == PaymentMethod.Credit)
+                        || ("Cash".equalsIgnoreCase(claimableRequiredFor) && pm == PaymentMethod.Cash);
+                if (required && !getCurrent().isClaimable()) {
+                    JsfUtil.addErrorMessage("Please mark the admission as Claimable");
+                    return;
+                }
             }
         }
         // Apply patient name capitalization based on configuration settings

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -497,9 +497,14 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             return;
         }
 
-        if (getCurrent().getPaymentMethod() == PaymentMethod.Credit) {
-            if (!getCurrent().isClaimable()) {
-                JsfUtil.addErrorMessage("Please mark as Claimable");
+        boolean showClaimable = configOptionApplicationController.getBooleanValueByKey(
+                "Inward Admission - Show Claimable Field", true);
+        if (showClaimable) {
+            boolean enforceForCredit = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Admission - Enforce Claimable for Credit", false);
+            if (enforceForCredit && getCurrent().getPaymentMethod() == PaymentMethod.Credit
+                    && !getCurrent().isClaimable()) {
+                JsfUtil.addErrorMessage("Credit admissions must be marked as Claimable");
                 return;
             }
         }


### PR DESCRIPTION
## Summary

- **New config `Inward Admission - Enforce Claimable for Credit`** (Boolean, default `false`): when enabled, Credit admissions always have Claimable = true and the checkbox is **locked (disabled)** so the user cannot uncheck it. Switching away from Credit leaves the user in control.
- **Fix `BhtEditController.saveCurrent()`**: replaces a hardcoded `if (Credit && !claimable) → error` check with the same config-driven logic. Previously this fired even when the Claimable feature was turned off entirely, producing a spurious validation error (fixes #20506).
- **`AdmissionController.errorCheck()`**: adds a safety-net that auto-corrects `claimable=true` for Credit when enforce is active, and gates the old `claimableAllowed` validation so it does not conflict.

## Config priority (highest → lowest)

1. `Show Claimable Field = false` — master off; field hidden, no validation anywhere
2. `Enforce Claimable for Credit = true` — Credit locked at true; others fall through
3. `Auto Mark Claimable for Credit Admissions = true` — auto-check, editable, no forced validation
4. `Claimable Required For` — required-for rule with save-time error

## Test plan

- [ ] With `Enforce Claimable for Credit = true`: select Credit on admission → Claimable auto-checked and checkbox is disabled (grey, cannot uncheck)
- [ ] With `Enforce Claimable for Credit = true`: switch to Cash → Claimable checkbox becomes editable
- [ ] With `Enforce Claimable for Credit = true`: attempt to save a Credit admission with Claimable manually set to false (e.g. via dev tools) → system auto-corrects to true
- [ ] With `Show Claimable Field = false` + `Enforce Claimable for Credit = true`: field hidden, no validation errors on save for any payment method
- [ ] Edit Admission Details (BhtEditController): Credit admission with `Enforce = true` and `Claimable = false` → correct error message shown. With `Show Claimable Field = false` → no error shown.

## Related

- Closes #21273
- Closes #21196 (auto-mark claimable for credit, now also locks)
- Closes #20506 (validation error when claimable feature disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Inward Admission - Enforce Claimable for Credit" option and integrated it with claimable-field behavior.
  * Claimable visibility now respects "Inward Admission - Show Claimable Field" and optional auto-mark settings.

* **Bug Fixes**
  * Admission save/validation now consistently enforces configured claimable rules and surfaces clearer validation messages when saving is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->