### PR TITLE
feat(inward): Provisional Emergency Admission — validation, terminology, navigation and UX improvements

### DIFF
--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -87,6 +87,92 @@ Example:
 
 ---
 
+### Panel Header — Three-Zone Layout (required for action-rich panels)
+
+When a panel header contains both navigation and actions, divide it into three zones using a full-width flex row. This layout is aligned with enterprise UI standards (SAP Fiori shell bar, IBM Carbon top navigation).
+
+```
+[title + config]          [navigation buttons]          [secondary actions → primary]
+LEFT                       CENTER                         RIGHT
+```
+
+**Zone rules:**
+
+| Zone | Contents | Button style |
+|------|----------|--------------|
+| **Left** | Panel title (icon + label) + contextual config button (admin-only) | Config: `ui-button-secondary ui-button-outlined` |
+| **Center** | Entity navigation buttons (e.g. Patient Lookup, Patient Profile) | `ui-button-info ui-button-outlined` |
+| **Right** | Page actions, **ordered left → right by ascending importance** | See action styles below |
+
+**Right-zone action ordering (left = least prominent → right = most prominent):**
+1. Rarely-used / dangerous / irreversible actions → `ui-button-secondary` (leftmost)
+2. Fast-path or warning actions → `ui-button-warning`
+3. **Primary action → `ui-button-success`, rightmost, with an icon and `style="min-width:120px"`**
+
+**Rules:**
+- The primary action MUST be the rightmost button. Users scan left-to-right; the last element is the natural "confirm" position.
+- Short-label primary buttons (e.g. "Admit", "Save", "Submit") look weak without an icon and minimum width. Always add `icon="pi pi-check-circle"` (or equivalent) and `style="min-width:120px"`.
+- Config belongs in the left zone, next to the title it configures — not on the far right. Wrap it in `rendered="#{webUserController.hasPrivilege('Admin')}"`.
+- Navigation buttons go in the center zone, never mixed into the action zone. Navigation style is `ui-button-info ui-button-outlined`.
+- Remove explicit `ms-*` / `mx-*` spacing classes from buttons inside a flex container; use `gap-2` on the parent instead.
+
+**Skeleton:**
+```xhtml
+<f:facet name="header">
+    <div class="d-flex justify-content-between align-items-center w-100">
+
+        <!-- LEFT: title + contextual config -->
+        <div class="d-flex align-items-center gap-2">
+            <h:outputText styleClass="fa fa-some-icon" />
+            <h:outputText value="Panel Title"/>
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                <p:commandButton value="Config" icon="fa fa-cog"
+                                 immediate="true" ajax="false"
+                                 title="Configure settings"
+                                 action="#{controller.navigateToConfig()}"
+                                 styleClass="ui-button-secondary ui-button-outlined"/>
+            </h:panelGroup>
+        </div>
+
+        <!-- CENTER: entity-level navigation -->
+        <div class="d-flex gap-2">
+            <p:commandButton value="Patient Lookup" icon="fa fa-search"
+                             ajax="false" immediate="true"
+                             action="#{patientController.navigateToSearchPatients()}"
+                             styleClass="ui-button-info ui-button-outlined"/>
+            <p:commandButton value="Patient Profile" icon="fa fa-user"
+                             ajax="false" immediate="true"
+                             action="#{patientController.navigateToOpdPatientProfile()}"
+                             styleClass="ui-button-info ui-button-outlined"/>
+        </div>
+
+        <!-- RIGHT: actions, left=least important → right=primary -->
+        <div class="d-flex gap-2 align-items-center">
+            <!-- Rare / dangerous — leftmost -->
+            <p:commandButton value="Dangerous Action" icon="fas fa-exclamation"
+                             styleClass="ui-button-secondary"
+                             onclick="PF('dlgConfirm').show();"/>
+            <!-- Warning fast-path — middle -->
+            <p:commandButton value="Emergency Action" icon="fas fa-bolt"
+                             styleClass="ui-button-warning"
+                             onclick="PF('dlgEmergency').show();"/>
+            <!-- Primary action — rightmost, widened -->
+            <p:commandButton id="btnPrimary"
+                             value="Save" icon="pi pi-check-circle"
+                             action="#{controller.save}"
+                             update="@form"
+                             style="min-width:120px"
+                             styleClass="ui-button-success"/>
+        </div>
+
+    </div>
+</f:facet>
+```
+
+Reference implementation: `src/main/webapp/inward/inward_admission.xhtml`
+
+---
+
 ## Forms and Input Patterns
 - Align labels and inputs with `p:outputLabel` + PrimeFaces components; include `for` attributes for accessibility.
 - Reuse controller state; avoid duplicating filters or adding new global variables when not required.

--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -91,7 +91,7 @@ Example:
 
 When a panel header contains both navigation and actions, divide it into three zones using a full-width flex row. This layout is aligned with enterprise UI standards (SAP Fiori shell bar, IBM Carbon top navigation).
 
-```
+```text
 [title + config]          [navigation buttons]          [secondary actions → primary]
 LEFT                       CENTER                         RIGHT
 ```

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1613,6 +1613,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     private void saveGuardian() {
         Person temG = getCurrent().getGuardian();
+        if (temG == null) {
+            return;
+        }
         temG.setCreatedAt(Calendar.getInstance().getTime());
         temG.setCreater(getSessionController().getLoggedUser());
 
@@ -1642,7 +1645,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             JsfUtil.addErrorMessage("Please select Admission Type");
             return true;
         }
-        if (getCurrent().getParentEncounter() == null && getCurrent().getPaymentMethod() == null) {
+        if (!isRapidTempAe() && getCurrent().getParentEncounter() == null && getCurrent().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Select Paymentmethod");
             return true;
         }
@@ -1703,42 +1706,51 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             }
         }
 
-        if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
-            if (getPatientRoom().getRoomFacilityCharge() == null) {
-                JsfUtil.addErrorMessage("Select Room ");
-                return true;
-            }
-        }
-        if (sessionController.getApplicationPreference().isInwardMoChargeCalculateInitialTime()) {
-            if (getPatientRoom().getRoomFacilityCharge().getTimedItemFee().getDurationDaysForMoCharge() == 0.0) {
-                JsfUtil.addErrorMessage("Plase Add Duration Days For Mo Charge");
-                return true;
-            }
-            if (getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration() == null) {
-                JsfUtil.addErrorMessage("Plase Add Charge for After Duration Days");
-                return true;
-            }
-            if (getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration().equals("") || getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration().equals(0.0)) {
-                JsfUtil.addErrorMessage("Plase Add Charge for After Duration Days");
-                return true;
-            }
-        }
-
-        if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
-            if (getPatientRoom() != null) {
-                if (getInwardBean().isRoomFilled(getPatientRoom().getRoomFacilityCharge().getRoom())) {
-                    JsfUtil.addErrorMessage("Select Empty Room");
+        // Rapid / Temp A&E admissions skip room and referring consultant requirements;
+        // both can be completed once the patient is stabilised. (Issue #21183)
+        if (!isRapidTempAe()) {
+            if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
+                if (getPatientRoom().getRoomFacilityCharge() == null) {
+                    JsfUtil.addErrorMessage("Select Room ");
                     return true;
                 }
-            } else {
-                JsfUtil.addErrorMessage("Room is Empty");
+            }
+            if (sessionController.getApplicationPreference().isInwardMoChargeCalculateInitialTime()) {
+                if (getPatientRoom().getRoomFacilityCharge().getTimedItemFee().getDurationDaysForMoCharge() == 0.0) {
+                    JsfUtil.addErrorMessage("Plase Add Duration Days For Mo Charge");
+                    return true;
+                }
+                if (getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration() == null) {
+                    JsfUtil.addErrorMessage("Plase Add Charge for After Duration Days");
+                    return true;
+                }
+                if (getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration().equals("") || getPatientRoom().getRoomFacilityCharge().getMoChargeForAfterDuration().equals(0.0)) {
+                    JsfUtil.addErrorMessage("Plase Add Charge for After Duration Days");
+                    return true;
+                }
+            }
+
+            if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
+                if (getPatientRoom() != null) {
+                    if (getInwardBean().isRoomFilled(getPatientRoom().getRoomFacilityCharge().getRoom())) {
+                        JsfUtil.addErrorMessage("Select Empty Room");
+                        return true;
+                    }
+                } else {
+                    JsfUtil.addErrorMessage("Room is Empty");
+                    return true;
+                }
+            }
+
+            if (getCurrent().getReferringConsultant() == null) {
+                JsfUtil.addErrorMessage("Please Select Referring Doctor");
                 return true;
             }
-        }
 
-        if (getCurrent().getReferringConsultant() == null) {
-            JsfUtil.addErrorMessage("Please Select Referring Doctor");
-            return true;
+            if (getCurrent().getOpdDoctor() == null) {
+                JsfUtil.addErrorMessage("Please Select Medical Officer");
+                return true;
+            }
         }
 
         if (getCurrent().getPatient() == null) {
@@ -1832,19 +1844,19 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referring Doctor Required", false)) {
+            if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referring Doctor Required", false)) {
                 if (getCurrent().getReferringDoctor() == null) {
                     JsfUtil.addErrorMessage("Doctor who referred the patient is Required");
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referring Staff Required", false)) {
+            if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referring Staff Required", false)) {
                 if (getCurrent().getReferringStaff() == null) {
                     JsfUtil.addErrorMessage("Staff who referred the patient is Required");
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referral Institution Required", false)) {
+            if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referral Institution Required", false)) {
                 if (getCurrent().getReferredByInstitution() == null) {
                     JsfUtil.addErrorMessage("Referral Institution is Required");
                     return true;
@@ -1856,13 +1868,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referral Number Required", false)) {
+            if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Inward Admission - Referral Number Required", false)) {
                 if (getCurrent().getReferralId() == null || getCurrent().getReferralId().trim().isEmpty()) {
                     JsfUtil.addErrorMessage("Referral Number is Required");
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Patient Admit - Require Referred From in Patient Admission", false)) {
+            if (!isRapidTempAe() && configOptionApplicationController.getBooleanValueByKey("Patient Admit - Require Referred From in Patient Admission", false)) {
                 if (getCurrent().getReferringMethod() == null || getCurrent().getReferringMethod().trim().isEmpty()) {
                     JsfUtil.addErrorMessage("Referred From is Required");
                     return true;
@@ -2204,7 +2216,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             JsfUtil.addSuccessMessage("Patient admitted successfully with BHT No: " + getCurrent().getBhtNo());
         }
 
-        if (getCurrent().getAdmissionType().isRoomChargesAllowed() || getPatientRoom().getRoomFacilityCharge() != null) {
+        // Only create a PatientRoom record when a facility charge is actually selected.
+        // For Rapid / Temp A&E admissions the room validation is skipped, so
+        // getRoomFacilityCharge() may be null; attempting to save it would NPE. (Issue #21183)
+        if (getPatientRoom().getRoomFacilityCharge() != null) {
             PatientRoom currentPatientRoom = new PatientRoom();
             if (configOptionApplicationController.getBooleanValueByKey("Patient admission and room assignment are simultaneous processes.", true)) {
                 currentPatientRoom = getInwardBean().savePatientRoom(getPatientRoom(), null, getPatientRoom().getRoomFacilityCharge(), getCurrent(), getCurrent().getDateOfAdmission(), getSessionController().getLoggedUser());

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1706,8 +1706,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             }
         }
 
-        // Rapid / Temp A&E admissions skip room and referring consultant requirements;
-        // both can be completed once the patient is stabilised. (Issue #21183)
+        // Rapid / Temp A&E admissions skip the "room is required" check and the
+        // MO-charge validation, but room occupancy is always enforced when a room
+        // is voluntarily provided — an occupied room must never be double-assigned
+        // regardless of admission type. (Issue #21183)
         if (!isRapidTempAe()) {
             if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
                 if (getPatientRoom().getRoomFacilityCharge() == null) {
@@ -1729,19 +1731,17 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
+        }
 
-            if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
-                if (getPatientRoom() != null) {
-                    if (getInwardBean().isRoomFilled(getPatientRoom().getRoomFacilityCharge().getRoom())) {
-                        JsfUtil.addErrorMessage("Select Empty Room");
-                        return true;
-                    }
-                } else {
-                    JsfUtil.addErrorMessage("Room is Empty");
-                    return true;
-                }
-            }
+        // Occupancy check applies to every admission whenever a room is provided,
+        // including Provisional Emergency admissions where room selection is optional.
+        if (getPatientRoom().getRoomFacilityCharge() != null
+                && getInwardBean().isRoomFilled(getPatientRoom().getRoomFacilityCharge().getRoom())) {
+            JsfUtil.addErrorMessage("Select Empty Room");
+            return true;
+        }
 
+        if (!isRapidTempAe()) {
             if (getCurrent().getReferringConsultant() == null) {
                 JsfUtil.addErrorMessage("Please Select Referring Doctor");
                 return true;

--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -241,9 +241,10 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
                 "BHT: " + current.getBhtNo() +
                 " is now assigned to " + newPatient.getPerson().getName());
 
-            // Navigate to the admission profile (admissionController.current still
-            // holds the updated admission; navigateToAdmissionProfilePage sets up
-            // bhtSummeryController and other state needed by the profile page).
+            // Explicitly sync admissionController before navigating — when this
+            // flow is launched from the search page (not the profile), current may
+            // differ from admissionController.current. (Issue #21275)
+            admissionController.setCurrent(current);
             String destination = admissionController.navigateToAdmissionProfilePage();
             prepareForNew();
             return destination;

--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -82,10 +82,25 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
     // <editor-fold defaultstate="collapsed" desc="Functions">
 
     /**
-     * Navigate to the Change Patient for Admission page
+     * Navigate to the Change Patient for Admission page with no pre-selected
+     * admission (user must search and pick one on the page).
      */
     public String navigateToChangeAdmissionPatient() {
         prepareForNew();
+        return "/inward/inward_change_patient?faces-redirect=true";
+    }
+
+    /**
+     * Navigate to the Change Patient page with the admission already loaded
+     * from the Admission Profile context. Skips the admission-search step so
+     * the user goes straight to selecting the new patient.
+     */
+    public String navigateToChangeAdmissionPatientFromProfile() {
+        prepareForNew();
+        current = admissionController.getCurrent();
+        if (current != null) {
+            loadAdmission();
+        }
         return "/inward/inward_change_patient?faces-redirect=true";
     }
 
@@ -190,17 +205,18 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
     }
 
     /**
-     * Confirm and save the patient change
+     * Confirm and save the patient change, then navigate to the admission
+     * profile so the user can see the updated record immediately.
      */
-    public void confirmPatientChange() {
+    public String confirmPatientChange() {
         if (current == null || newPatient == null) {
             JsfUtil.addErrorMessage("Invalid operation");
-            return;
+            return "";
         }
 
         if (originalPatient.getId().equals(newPatient.getId())) {
             JsfUtil.addErrorMessage("Cannot change to the same patient");
-            return;
+            return "";
         }
 
         try {
@@ -225,12 +241,16 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
                 "BHT: " + current.getBhtNo() +
                 " is now assigned to " + newPatient.getPerson().getName());
 
-            // Reset for next operation
+            // Navigate to the admission profile (admissionController.current still
+            // holds the updated admission; navigateToAdmissionProfilePage sets up
+            // bhtSummeryController and other state needed by the profile page).
+            String destination = admissionController.navigateToAdmissionProfilePage();
             prepareForNew();
+            return destination;
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error changing patient: " + e.getMessage());
-            e.printStackTrace();
+            return "";
         }
     }
 

--- a/src/main/java/com/divudi/core/data/inward/EncounterRegistrationFlag.java
+++ b/src/main/java/com/divudi/core/data/inward/EncounterRegistrationFlag.java
@@ -17,7 +17,7 @@ public enum EncounterRegistrationFlag {
 
     STANDARD("Standard"),                       // normal admission — default value, no badge shown
     ON_ADMISSION_DEATH("On Admission Death"),   // patient arrived dead or died before registration was completed
-    RAPID_TEMP_AE("Rapid / Temp A&E");          // quick/temporary A&E registration — demographics may be incomplete (see separate issue)
+    RAPID_TEMP_AE("Provisional Emergency");      // quick/temporary A&E registration — demographics may be incomplete (see separate issue)
 
     private final String label;
 

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -67,11 +67,11 @@
                     <div class="alert alert-warning d-flex justify-content-between align-items-center flex-wrap gap-2 my-2" role="alert">
                         <div>
                             <h:outputText styleClass="fas fa-triangle-exclamation me-2"/>
-                            <h:outputText value="Temporary A&amp;E admission — patient demographics may be incomplete. Please complete the patient details, or change to the correct patient if this is a duplicate record."/>
+                            <h:outputText value="Provisional Emergency Admission — patient demographics may be incomplete. Please add the patient data, or change to the correct patient if this is a duplicate record."/>
                         </div>
                         <div class="d-flex gap-2">
                             <p:commandButton
-                                value="Complete Registration"
+                                value="Add Patient Data"
                                 ajax="false"
                                 icon="fa fa-user-edit"
                                 class="ui-button-success"
@@ -81,14 +81,20 @@
                                     target="#{patientController.current}" />
                             </p:commandButton>
                             <p:commandButton
+                                value="Edit Admission Details"
+                                ajax="false"
+                                icon="fa fa-file-medical"
+                                class="ui-button-info"
+                                action="#{admissionController.navigateToEditAdmission()}"/>
+                            <p:commandButton
                                 value="Change Patient"
                                 ajax="false"
                                 icon="fa fa-user-friends"
                                 class="ui-button-warning"
-                                action="#{admissionPatientChangeController.navigateToChangeAdmissionPatient()}"/>
+                                action="#{admissionPatientChangeController.navigateToChangeAdmissionPatientFromProfile()}"/>
                             <p:commandButton
-                                value="Mark as Complete"
-                                icon="fa fa-check"
+                                value="Mark as Verified"
+                                icon="fa fa-check-circle"
                                 class="ui-button-secondary"
                                 process="@this"
                                 update="form"

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -196,11 +196,17 @@
                                         <p:column headerText="Patient Name"  >
                                             <h:outputText value="#{a.patient.person.nameWithTitle}" ></h:outputText>
                                             <!-- Encounter flag badge — hidden for the STANDARD default. (Issue #21182) -->
-                                            <ui:fragment rendered="#{a.encounterRegistrationFlag ne null and a.encounterRegistrationFlag ne 'STANDARD'}">
+                                            <ui:fragment rendered="#{a.encounterRegistrationFlag eq 'ON_ADMISSION_DEATH'}">
                                                 <br/>
                                                 <p:tag value="#{a.encounterRegistrationFlag.label}"
                                                        icon="fas fa-cross"
                                                        style="background-color:#455a64; color:#ffffff;"/>
+                                            </ui:fragment>
+                                            <ui:fragment rendered="#{a.encounterRegistrationFlag eq 'RAPID_TEMP_AE'}">
+                                                <br/>
+                                                <p:tag value="#{a.encounterRegistrationFlag.label}"
+                                                       icon="fas fa-truck-medical"
+                                                       style="background-color:#f0ad4e; color:#212529;"/>
                                             </ui:fragment>
                                         </p:column>
                                         <p:column headerText="Phone/Mobile" >

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -17,39 +17,18 @@
             <h:panelGroup id="gpDetail" rendered="#{!admissionController.printPreview}" >
                 <p:panel >
                     <f:facet name="header">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
+                        <!--
+                            Three-zone panel header layout (see UI guidelines § Panel Header Three-Zone Layout):
+                            LEFT  : panel title + contextual config button (admin-only, next to the label it configures)
+                            CENTER: entity-level navigation buttons (Patient Lookup, Patient Profile)
+                            RIGHT : page actions ordered left→right by ascending importance; primary action rightmost
+                        -->
+                        <div class="d-flex justify-content-between align-items-center w-100">
+
+                            <!-- LEFT: title + config -->
+                            <div class="d-flex align-items-center gap-2">
                                 <h:outputText styleClass="fa fa-hospital" />
-                                <h:outputText class="mx-4" value="Admit a Patient"/>
-                            </div>
-                            <div>
-                                <p:commandButton
-                                    id="admt"
-                                    action="#{admissionController.checkBeforeAdmit}"
-                                    update="@form"
-                                    class="ui-button-success mx-1"
-                                    value="Admit">
-                                </p:commandButton>
-
-                                <p:commandButton 
-                                    ajax="false" 
-                                    immediate="true"
-                                    value="Patient Lookup" 
-                                    class="ui-button-warning mx-1" 
-                                    action="#{patientController.navigateToSearchPatients()}" 
-                                    icon="fa fa-search" >
-                                </p:commandButton>
-
-                                <p:commandButton
-                                    ajax="false"
-                                    immediate="true"
-                                    class="ui-button-warning mx-1"
-                                    value="Patient Profile"
-                                    action="#{patientController.navigateToOpdPatientProfile()}"
-                                    icon="fa fa-user" > <!-- Font Awesome icon for user -->
-                                    <f:setPropertyActionListener value="#{admissionController.current.patient}" target="#{patientController.current}" />
-                                </p:commandButton>
-
+                                <h:outputText value="Admit a Patient"/>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                     <p:commandButton
                                         value="Config"
@@ -58,32 +37,62 @@
                                         title="Configure Admission Settings"
                                         action="#{admissionController.navigateToAdmissionConfig()}"
                                         ajax="false"
-                                        styleClass="ui-button-secondary ms-5">
+                                        styleClass="ui-button-secondary ui-button-outlined">
                                     </p:commandButton>
                                 </h:panelGroup>
+                            </div>
 
-                                <!-- Secondary, non-prominent action positioned away from the primary
-                                     "Admit" button. Opens a confirmation dialog before flagging the
-                                     admission as On Admission Death. (Issue #21182) -->
+                            <!-- CENTER: navigation (page-to-page, entity-related) -->
+                            <div class="d-flex gap-2">
+                                <p:commandButton
+                                    ajax="false"
+                                    immediate="true"
+                                    value="Patient Lookup"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    action="#{patientController.navigateToSearchPatients()}"
+                                    icon="fa fa-search">
+                                </p:commandButton>
+                                <p:commandButton
+                                    ajax="false"
+                                    immediate="true"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    value="Patient Profile"
+                                    action="#{patientController.navigateToOpdPatientProfile()}"
+                                    icon="fa fa-user">
+                                    <f:setPropertyActionListener value="#{admissionController.current.patient}" target="#{patientController.current}" />
+                                </p:commandButton>
+                            </div>
+
+                            <!-- RIGHT: actions — left=least important, right=primary -->
+                            <div class="d-flex gap-2 align-items-center">
+                                <!-- Rarely used, least prominent — leftmost in the action zone -->
                                 <p:commandButton
                                     type="button"
                                     value="On Admission Death"
                                     icon="fas fa-cross"
                                     title="Record this admission as an On Admission Death (patient arrived dead, or died before registration was completed)"
-                                    styleClass="ui-button-secondary ms-5"
+                                    styleClass="ui-button-secondary"
                                     onclick="PF('dlgOnAdmissionDeath').show();"/>
-
-                                <!-- Rapid / Temp A&E admission. Opens a confirmation dialog, then admits
-                                     immediately with placeholder demographics that staff complete later.
-                                     (Issue #21183) -->
+                                <!-- Warning / dangerous fast-path — middle -->
                                 <p:commandButton
                                     type="button"
-                                    value="Rapid / Temp Admit (A&amp;E)"
+                                    value="Provisional Emergency Admit"
                                     icon="fas fa-truck-medical"
-                                    title="Quickly admit an A&amp;E patient with incomplete demographics. Blank name/address are filled with placeholders and demographic checks are skipped; complete the details later."
-                                    styleClass="ui-button-warning ms-2"
+                                    title="Admit an emergency patient with incomplete demographics. Blank name/address are filled with placeholders and demographic checks are skipped; complete the details later."
+                                    styleClass="ui-button-warning"
                                     onclick="PF('dlgRapidTempAe').show();"/>
+                                <!-- Primary action — rightmost, widened, with icon -->
+                                <p:commandButton
+                                    id="admt"
+                                    action="#{admissionController.checkBeforeAdmit}"
+                                    update="@form"
+                                    styleClass="ui-button-success"
+                                    icon="pi pi-check-circle"
+                                    style="min-width:120px"
+                                    value="Admit">
+                                </p:commandButton>
                             </div>
+
                         </div>
                     </f:facet>
 
@@ -175,13 +184,11 @@
                                         </p:datePicker>     
 
                                         <p:outputLabel value="Consultant*" />
-                                        <p:autoComplete 
-                                            forceSelection="true" 
-                                            value="#{admissionController.current.referringConsultant}" 
+                                        <p:autoComplete
+                                            forceSelection="true"
+                                            value="#{admissionController.current.referringConsultant}"
                                             id="refCon"
-                                            required="true" 
-                                            requiredMessage="Please select referring consultant"
-                                            completeMethod="#{consultantController.completeConsultant}" 
+                                            completeMethod="#{consultantController.completeConsultant}"
                                             var="mysp"
                                             itemLabel="#{mysp.person.nameWithTitle}" 
                                             itemValue="#{mysp}"
@@ -193,11 +200,9 @@
                                         </p:autoComplete>
 
                                         <p:outputLabel value="Medical Officer*"/>
-                                        <p:autoComplete 
-                                            required="true" 
-                                            requiredMessage="Please select referring doctor"
-                                            forceSelection="true" 
-                                            id="scStaff" 
+                                        <p:autoComplete
+                                            forceSelection="true"
+                                            id="scStaff"
                                             maxResults="15"
                                             placeholder="OPD Doctor"
                                             value="#{admissionController.current.opdDoctor}" 
@@ -651,14 +656,14 @@
             <!-- Rapid / Temp A&E confirmation dialog (Issue #21183) -->
             <p:dialog id="dlgRapidTempAe"
                       widgetVar="dlgRapidTempAe"
-                      header="Confirm Rapid / Temp A&amp;E Admission"
+                      header="Confirm Provisional Emergency Admission"
                       modal="true"
                       resizable="false"
                       closable="true"
                       style="width:520px">
                 <div style="padding:12px">
                     <p style="font-weight:bold; font-size:1.05em;">
-                        Admit this patient as a <strong>Rapid / Temp A&amp;E</strong> registration?
+                        Admit this patient as a <strong>Provisional Emergency</strong> admission?
                     </p>
                     <p>
                         Use this for emergency admissions where full demographics are not
@@ -668,7 +673,7 @@
                         immediately.
                     </p>
                     <p class="text-muted">
-                        The admission will be flagged <strong>Rapid / Temp A&amp;E</strong>.
+                        The admission will be flagged <strong>Provisional Emergency</strong>.
                         Please complete the patient details later from the Inpatient Dashboard.
                     </p>
                     <div class="d-flex justify-content-end gap-2 mt-3">
@@ -679,7 +684,7 @@
                             class="ui-button-secondary"
                             onclick="PF('dlgRapidTempAe').hide(); return false;"/>
                         <p:commandButton
-                            value="Confirm — Rapid / Temp Admit"
+                            value="Confirm — Provisional Emergency Admit"
                             icon="fas fa-truck-medical"
                             class="ui-button-warning"
                             action="#{admissionController.checkBeforeAdmitRapidTempAe}"


### PR DESCRIPTION
## Summary

Follow-up to #21183. Fixes and improves the Provisional Emergency Admission (formerly "Rapid / Temp A&E") feature across validation, terminology, navigation, and the change-patient workflow.

- **Validation**: Rapid/Provisional Emergency admissions can now proceed without room, payment method, referring consultant, medical officer, or referral details — all gated on `!isRapidTempAe()`
- **NPE fixes**: `saveGuardian()` handles null guardian; room-saving block guarded by `getRoomFacilityCharge() != null`
- **JSF validation**: Removed `required="true"` from `refCon`/`scStaff` (was blocking the rapid action before Java ran); unconditional server-side checks added inside `!isRapidTempAe()` block
- **Terminology**: "Rapid / Temp A&E" → **Provisional Emergency** throughout (enum, buttons, dialog, banner, search badge)
- **Search badge**: Now renders per-flag icon/colour (amber + truck-medical vs. dark-grey + cross)
- **Admission profile banner**: Buttons renamed and "Edit Admission Details" added
- **Change patient**: New `navigateToChangeAdmissionPatientFromProfile()` skips admission-search step; redirects to profile after save
- **Panel header**: Admission form refactored to three-zone layout; pattern documented in UI guidelines

## Test plan

- [ ] Provisional Emergency Admit button opens dialog with updated wording
- [ ] Rapid admission completes without room, payment method, consultant, or guardian
- [ ] Standard admission still requires room, payment method, consultant, and medical officer
- [ ] Admission profile banner shows correct buttons and labels
- [ ] "Add Patient Data" navigates to patient edit; "Edit Admission Details" navigates to BHT edit
- [ ] "Change Patient" from admission profile lands directly on the change form (no re-select step)
- [ ] After confirming patient change, redirects to admission profile
- [ ] "Mark as Verified" clears the Provisional Emergency banner
- [ ] Inpatient search badge shows amber/truck for Provisional Emergency, dark-grey/cross for On Admission Death
- [ ] Enum label shows "Provisional Emergency" after build

Closes #21275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive UI panel header guidelines.

* **New Features**
  * Patient-change flow accessible from admission profile.
  * "Mark as Verified" action for Provisional Emergency admissions.

* **Improvements**
  * Renamed "Rapid / Temp A&E" to "Provisional Emergency."
  * Encounter flag badges clarified in patient search.
  * Admission panel header reorganized into a three-zone layout.
  * Referring consultant and medical officer fields made optional.

* **Bug Fixes**
  * Prevented creation of room records without facility charges; relaxed some validations for provisional emergency admissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->