### PR TITLE
fix(opd-reports): wire Service Department/Site/Institution filters in OPD Income Report DTO

### DIFF
--- a/src/main/java/com/divudi/bean/opd/OpdReportController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdReportController.java
@@ -592,7 +592,8 @@ public class OpdReportController implements Serializable {
 
             opdIncomeReportDtos = billService.fetchOpdIncomeReportDTOs(
                     fromDate, toDate, institution, site, department, webUser,
-                    billTypeAtomics, admissionType, paymentScheme);
+                    billTypeAtomics, admissionType, paymentScheme,
+                    toInstitution, toSite, toDepartment);
 
             System.out.println("Results returned: " + (opdIncomeReportDtos != null ? opdIncomeReportDtos.size() : 0));
 

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2165,7 +2165,10 @@ public class BillService {
             WebUser webUser,
             List<BillTypeAtomic> billTypeAtomics,
             AdmissionType admissionType,
-            PaymentScheme paymentScheme) {
+            PaymentScheme paymentScheme,
+            Institution toInstitution,
+            Institution toSite,
+            Department toDepartment) {
 
         if (fromDate == null || toDate == null) {
             throw new IllegalArgumentException("fromDate and toDate cannot be null");
@@ -2216,6 +2219,18 @@ public class BillService {
         if (paymentScheme != null) {
             jpql += " and b.paymentScheme=:paymentScheme";
             params.put("paymentScheme", paymentScheme);
+        }
+        if (toInstitution != null) {
+            jpql += " and b.toInstitution=:toIns";
+            params.put("toIns", toInstitution);
+        }
+        if (toSite != null) {
+            jpql += " and b.toDepartment.site=:toSite";
+            params.put("toSite", toSite);
+        }
+        if (toDepartment != null) {
+            jpql += " and b.toDepartment=:toDep";
+            params.put("toDep", toDepartment);
         }
 
         jpql += " order by b.createdAt desc";

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2165,6 +2165,19 @@ public class BillService {
             WebUser webUser,
             List<BillTypeAtomic> billTypeAtomics,
             AdmissionType admissionType,
+            PaymentScheme paymentScheme) {
+        return fetchOpdIncomeReportDTOs(fromDate, toDate, institution, site, department,
+                webUser, billTypeAtomics, admissionType, paymentScheme, null, null, null);
+    }
+
+    public List<OpdIncomeReportDTO> fetchOpdIncomeReportDTOs(Date fromDate,
+            Date toDate,
+            Institution institution,
+            Institution site,
+            Department department,
+            WebUser webUser,
+            List<BillTypeAtomic> billTypeAtomics,
+            AdmissionType admissionType,
             PaymentScheme paymentScheme,
             Institution toInstitution,
             Institution toSite,
@@ -2224,7 +2237,7 @@ public class BillService {
             jpql += " and b.toInstitution=:toIns";
             params.put("toIns", toInstitution);
         }
-        if (toSite != null) {
+        if (toSite != null && toDepartment == null) {
             jpql += " and b.toDepartment.site=:toSite";
             params.put("toSite", toSite);
         }


### PR DESCRIPTION
## Summary

- `BillService.fetchOpdIncomeReportDTOs()` lacked `toInstitution`, `toSite`, and `toDepartment` parameters — JPQL never filtered on `b.toInstitution`, `b.toDepartment.site`, or `b.toDepartment`
- `OpdReportController.generateOpdIncomeReportDto()` did not forward the three "Service" filter fields to the service call

## Test plan

- [ ] Open OPD Income Report DTO, set **Service Department** to a specific department and run — results should be scoped to that department only
- [ ] Set **Service Site** only — results should include all departments under that site
- [ ] Set **Service Institution** only — results should include all departments under that institution
- [ ] Leave all three "Service" filters as "All" — full results returned (no regression)
- [ ] Combined: set both Service Site and Service Department — department filter takes precedence correctly

Closes #21280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OPD income reports now support filtering by destination institution, site, and department for enhanced report customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->