### PR TITLE
feat(inward): fix document upload and add inline viewer on admission documents page

### DIFF
--- a/src/main/java/com/divudi/bean/common/StreamedContentController.java
+++ b/src/main/java/com/divudi/bean/common/StreamedContentController.java
@@ -73,7 +73,7 @@ public class StreamedContentController {
             Map m = new HashMap();
             m.put("id", l);
             Upload temImg = getUploadFacade().findFirstByJpql(j, m);
-            if (temImg != null) {
+            if (temImg != null && !temImg.isRetired()) {
                 byte[] imgArr = null;
                 try {
                     imgArr = temImg.getBaImage();

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -20,6 +20,7 @@ import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
+import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
 import org.primefaces.model.file.UploadedFile;
@@ -44,6 +45,7 @@ public class InwardDocumentUploadController implements Serializable {
     private UploadType selectedUploadType;
     private String comments;
     private UploadedFile file;
+    private Upload selectedDocument;
 
     private static final long SIZE_LIMIT = 10240000;
     private static final String ALLOWED_FILE_TYPES_REGEX = "(?i)\\.(pdf|jpeg|jpg|png)$";
@@ -81,15 +83,6 @@ public class InwardDocumentUploadController implements Serializable {
             JsfUtil.addErrorMessage("Please select a file.");
             return;
         }
-        if (file.getSize() > SIZE_LIMIT) {
-            JsfUtil.addErrorMessage("File size exceeds the maximum limit of 10 MB.");
-            return;
-        }
-        String fileName = file.getFileName();
-        if (!fileName.matches(".*" + ALLOWED_FILE_TYPES_REGEX)) {
-            JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
-            return;
-        }
         if (selectedUploadType == null) {
             JsfUtil.addErrorMessage("Please select a document type.");
             return;
@@ -98,16 +91,23 @@ public class InwardDocumentUploadController implements Serializable {
             JsfUtil.addErrorMessage("No admission selected.");
             return;
         }
+        String fileName = file.getFileName();
+        if (!fileName.matches(".*" + ALLOWED_FILE_TYPES_REGEX)) {
+            JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
+            return;
+        }
+        if (file.getSize() > SIZE_LIMIT) {
+            JsfUtil.addErrorMessage("File size exceeds the maximum limit of 10 MB.");
+            return;
+        }
         try {
             InputStream in = file.getInputStream();
             byte[] fileContent = IOUtils.toByteArray(in);
-
             String detectedContentType = detectContentType(fileContent, fileName);
             if (detectedContentType == null) {
                 JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
                 return;
             }
-
             Upload upload = new Upload();
             upload.setUploadType(selectedUploadType);
             upload.setPatientEncounter(currentEncounter);
@@ -119,7 +119,6 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
             uploadFacade.create(upload);
-
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
             file = null;
             selectedUploadType = null;
@@ -128,6 +127,61 @@ public class InwardDocumentUploadController implements Serializable {
         } catch (IOException e) {
             JsfUtil.addErrorMessage("Error uploading file: " + e.getMessage());
         }
+    }
+
+    public void handleFileUpload(FileUploadEvent event) {
+        UploadedFile uploadedFile = event.getFile();
+        if (uploadedFile == null || uploadedFile.getSize() == 0) {
+            JsfUtil.addErrorMessage("Please select a file.");
+            return;
+        }
+        if (uploadedFile.getSize() > SIZE_LIMIT) {
+            JsfUtil.addErrorMessage("File size exceeds the maximum limit of 10 MB.");
+            return;
+        }
+        if (selectedUploadType == null) {
+            JsfUtil.addErrorMessage("Please select a document type.");
+            return;
+        }
+        if (currentEncounter == null) {
+            JsfUtil.addErrorMessage("No admission selected.");
+            return;
+        }
+        String fileName = uploadedFile.getFileName();
+        if (!fileName.matches(".*" + ALLOWED_FILE_TYPES_REGEX)) {
+            JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
+            return;
+        }
+        try {
+            InputStream in = uploadedFile.getInputStream();
+            byte[] fileContent = IOUtils.toByteArray(in);
+            String detectedContentType = detectContentType(fileContent, fileName);
+            if (detectedContentType == null) {
+                JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
+                return;
+            }
+            Upload upload = new Upload();
+            upload.setUploadType(selectedUploadType);
+            upload.setPatientEncounter(currentEncounter);
+            upload.setBaImage(fileContent);
+            upload.setFileName(fileName);
+            upload.setFileType(detectedContentType);
+            upload.setComments(comments);
+            upload.setCreatedAt(new Date());
+            upload.setCreater(sessionController.getLoggedUser());
+            upload.setRetired(false);
+            uploadFacade.create(upload);
+            JsfUtil.addSuccessMessage("Document uploaded successfully.");
+            selectedUploadType = null;
+            comments = null;
+            loadDocuments();
+        } catch (IOException e) {
+            JsfUtil.addErrorMessage("Error uploading file: " + e.getMessage());
+        }
+    }
+
+    public void viewDocument(Upload doc) {
+        selectedDocument = doc;
     }
 
     public void removeDocument(Upload u) {
@@ -220,6 +274,14 @@ public class InwardDocumentUploadController implements Serializable {
         this.comments = comments;
     }
 
+    public Upload getSelectedDocument() {
+        return selectedDocument;
+    }
+
+    public void setSelectedDocument(Upload selectedDocument) {
+        this.selectedDocument = selectedDocument;
+    }
+
     public UploadedFile getFile() {
         return file;
     }
@@ -227,5 +289,6 @@ public class InwardDocumentUploadController implements Serializable {
     public void setFile(UploadedFile file) {
         this.file = file;
     }
+
     // </editor-fold>
 }

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -101,8 +101,10 @@ public class InwardDocumentUploadController implements Serializable {
             return;
         }
         try {
-            InputStream in = file.getInputStream();
-            byte[] fileContent = IOUtils.toByteArray(in);
+            byte[] fileContent;
+            try (InputStream in = file.getInputStream()) {
+                fileContent = IOUtils.toByteArray(in);
+            }
             String detectedContentType = detectContentType(fileContent, fileName);
             if (detectedContentType == null) {
                 JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");
@@ -153,8 +155,10 @@ public class InwardDocumentUploadController implements Serializable {
             return;
         }
         try {
-            InputStream in = uploadedFile.getInputStream();
-            byte[] fileContent = IOUtils.toByteArray(in);
+            byte[] fileContent;
+            try (InputStream in = uploadedFile.getInputStream()) {
+                fileContent = IOUtils.toByteArray(in);
+            }
             String detectedContentType = detectContentType(fileContent, fileName);
             if (detectedContentType == null) {
                 JsfUtil.addErrorMessage("Invalid file type. Only PDF, JPEG, JPG, and PNG are allowed.");

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -22,60 +22,69 @@
                         </f:facet>
 
                         <!-- Upload section -->
-                        <div class="row g-2 mb-3">
-                            <div class="col-md-3">
-                                <p:outputLabel for="cmbDocType" value="Document Type" />
-                                <p:selectOneMenu id="cmbDocType"
-                                                value="#{inwardDocumentUploadController.selectedUploadType}"
-                                                class="w-100">
-                                    <f:selectItem itemLabel="-- Select Type --" itemValue="#{null}" />
-                                    <f:selectItems value="#{inwardDocumentUploadController.inwardUploadTypes}"
-                                                   var="t"
-                                                   itemLabel="#{t.label}"
-                                                   itemValue="#{t}" />
-                                </p:selectOneMenu>
+                        <p:fieldset legend="Upload New Document" class="mb-3">
+                            <div class="row g-2 mb-2">
+                                <div class="col-md-4">
+                                    <p:outputLabel for="cmbDocType" value="Document Type" />
+                                    <p:selectOneMenu id="cmbDocType"
+                                                    value="#{inwardDocumentUploadController.selectedUploadType}"
+                                                    class="w-100">
+                                        <f:selectItem itemLabel="-- Select Type --" itemValue="#{null}" />
+                                        <f:selectItems value="#{inwardDocumentUploadController.inwardUploadTypes}"
+                                                       var="t"
+                                                       itemLabel="#{t.label}"
+                                                       itemValue="#{t}" />
+                                    </p:selectOneMenu>
+                                </div>
+                                <div class="col-md-8">
+                                    <p:outputLabel for="txtDocComments" value="Comments (optional)" />
+                                    <p:inputTextarea id="txtDocComments"
+                                                    value="#{inwardDocumentUploadController.comments}"
+                                                    rows="2"
+                                                    class="w-100"
+                                                    autoResize="true"
+                                                    placeholder="Enter any notes about this document..." />
+                                </div>
                             </div>
-                            <div class="col-md-5">
-                                <p:outputLabel for="txtDocComments" value="Comments" />
-                                <p:inputTextarea id="txtDocComments"
-                                                value="#{inwardDocumentUploadController.comments}"
-                                                rows="2"
-                                                class="w-100"
-                                                autoResize="true" />
+                            <div class="row g-2 align-items-end">
+                                <div class="col-md-10">
+                                    <p:fileUpload id="fuDocument"
+                                                 value="#{inwardDocumentUploadController.file}"
+                                                 mode="simple"
+                                                 skinSimple="true"
+                                                 accept=".pdf,.jpeg,.jpg,.png,application/pdf,image/jpeg,image/png"
+                                                 sizeLimit="10240000"
+                                                 label="Choose File"
+                                                 class="w-100" />
+                                </div>
+                                <div class="col-md-2">
+                                    <p:commandButton
+                                        id="btnUpload"
+                                        value="Upload"
+                                        icon="fa fa-upload"
+                                        action="#{inwardDocumentUploadController.uploadDocument()}"
+                                        ajax="false"
+                                        class="w-100" />
+                                </div>
                             </div>
-                            <div class="col-md-3 d-flex align-items-end">
-                                <p:fileUpload id="fuDocument"
-                                             value="#{inwardDocumentUploadController.file}"
-                                             mode="simple"
-                                             skinSimple="true"
-                                             accept=".pdf,.jpeg,.jpg,.png,application/pdf,image/jpeg,image/png"
-                                             sizeLimit="10240000"
-                                             label="Choose File"
-                                             class="w-100" />
+                            <div class="row mt-1">
+                                <div class="col-12">
+                                    <small class="text-muted">Accepted formats: PDF, JPEG, PNG — maximum 10 MB</small>
+                                </div>
                             </div>
-                            <div class="col-md-1 d-flex align-items-end">
-                                <p:commandButton
-                                    id="btnUpload"
-                                    value="Upload"
-                                    icon="fa fa-upload"
-                                    action="#{inwardDocumentUploadController.uploadDocument()}"
-                                    process="fuDocument cmbDocType txtDocComments btnUpload"
-                                    update="tblDocuments fuDocument cmbDocType txtDocComments"
-                                    class="w-100" />
-                            </div>
-                        </div>
+                        </p:fieldset>
 
                         <!-- Documents list -->
                         <p:dataTable id="tblDocuments"
                                     value="#{inwardDocumentUploadController.documents}"
                                     var="doc"
-                                    emptyMessage="No documents uploaded."
+                                    emptyMessage="No documents uploaded yet."
                                     paginator="true"
                                     rows="10"
                                     paginatorAlwaysVisible="false"
                                     paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
                                     class="w-100">
-                            <p:column headerText="Type" width="160">
+                            <p:column headerText="Type" width="180">
                                 <h:outputText value="#{doc.uploadType.label}" />
                             </p:column>
                             <p:column headerText="File Name">
@@ -91,9 +100,17 @@
                                 </h:outputText>
                             </p:column>
                             <p:column headerText="Uploaded By" width="160">
-                                <h:outputText value="#{doc.creater.person.name}" />
+                                <h:outputText value="#{doc.creater.name}" />
                             </p:column>
-                            <p:column headerText="Actions" width="110">
+                            <p:column headerText="Actions" width="145">
+                                <p:commandButton
+                                    icon="fa fa-eye"
+                                    title="View"
+                                    class="ui-button-success me-1"
+                                    process="@this"
+                                    update=":formDocuments:dlgViewContent"
+                                    action="#{inwardDocumentUploadController.viewDocument(doc)}"
+                                    oncomplete="PF('dlgView').show()" />
                                 <p:commandButton
                                     icon="fa fa-download"
                                     title="Download"
@@ -102,12 +119,11 @@
                                     <p:fileDownload value="#{inwardDocumentUploadController.getDownloadStream(doc)}" />
                                 </p:commandButton>
                                 <p:commandButton
-                                    id="btnRemove"
                                     icon="fa fa-trash"
                                     title="Remove"
                                     class="ui-button-danger"
                                     process="@this"
-                                    update="tblDocuments"
+                                    update="tblDocuments growl"
                                     action="#{inwardDocumentUploadController.removeDocument(doc)}">
                                     <p:confirm header="Confirm Remove"
                                                message="Remove this document?"
@@ -116,6 +132,36 @@
                             </p:column>
                         </p:dataTable>
                     </p:panel>
+
+                    <!-- Document viewer dialog -->
+                    <p:dialog id="dlgView"
+                              widgetVar="dlgView"
+                              header="#{inwardDocumentUploadController.selectedDocument.uploadType.label} — #{inwardDocumentUploadController.selectedDocument.fileName}"
+                              modal="true"
+                              resizable="false"
+                              closeOnEscape="true"
+                              width="860">
+                        <h:panelGroup id="dlgViewContent">
+                            <h:panelGroup rendered="#{inwardDocumentUploadController.selectedDocument != null and inwardDocumentUploadController.selectedDocument.image}">
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{streamedContentController.imageByUploadId}"
+                                    style="max-width:100%; display:block; margin:auto;">
+                                    <f:param name="id" value="#{inwardDocumentUploadController.selectedDocument.id}" />
+                                </p:graphicImage>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{inwardDocumentUploadController.selectedDocument != null and inwardDocumentUploadController.selectedDocument.pdf}">
+                                <p:media
+                                    cache="false"
+                                    value="#{streamedContentController.imageByUploadId}"
+                                    player="pdf"
+                                    width="100%"
+                                    height="540px">
+                                    <f:param name="id" value="#{inwardDocumentUploadController.selectedDocument.id}" />
+                                </p:media>
+                            </h:panelGroup>
+                        </h:panelGroup>
+                    </p:dialog>
 
                     <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
                         <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-danger" icon="pi pi-check" />


### PR DESCRIPTION
## Summary

- **Fix upload button**: `p:fileUpload mode="simple"` with AJAX never transmits file bytes in a partial request. Changed Upload button to `ajax="false"` so the entire form submits as multipart.
- **Fix table render crash**: `doc.creater.person.name` failed because `WebUser` has no `person` property — corrected to `doc.creater.name`.
- **Inline document viewer**: New View button (green eye icon) opens a modal dialog. Images (JPEG/PNG) display via `p:graphicImage`; PDFs display via `p:media player="pdf"`. Reuses the existing `StreamedContentController.getImageByUploadId()` already in the codebase.
- **UI improvements**: Upload section wrapped in `p:fieldset`, wider Comments field, accepted-formats hint text, Actions column widened for three buttons (view / download / delete).

## Test plan

- [ ] Upload a JPEG image — table refreshes, View opens image in dialog
- [ ] Upload a PNG image — View opens image in dialog
- [ ] Upload a PDF — View opens PDF in browser's inline PDF viewer
- [ ] Upload with no file selected — error message shown
- [ ] Upload with no document type selected — error message shown
- [ ] Download button still works for all file types
- [ ] Delete button still works (confirm dialog, table refreshes)

Closes #21293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a document viewer dialog to preview uploaded images and PDFs.

* **Bug Fixes / Improvements**
  * Strengthened upload validation (file type/size and content-type detection) and clearer success/error handling.
  * Improved upload workflow to reset form state and reload documents after upload/remove.
  * Updated documents table labels, empty-state message, column layouts, and uploader display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->