### PR TITLE
fix(pharmacy): transfer request/issue UX and staff search improvements

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -952,21 +952,24 @@ public class StaffController implements Serializable {
     }
 
     public List<Staff> completeStaffWithoutDoctors(String query) {
-        List<Staff> suggestions;
-        String sql;
-        if (query == null) {
-            suggestions = new ArrayList<>();
-        } else {
-            sql = "select p from Staff p where p.retired=false and "
-                    + "((p.person.name) like :q or "
-                    + " (p.code) like :q or "
-                    + " (p.staffCode) like :q ) and type(p) != Doctor"
-                    + " order by p.person.name";
-            HashMap hm = new HashMap();
-            hm.put("q", "%" + query.toUpperCase() + "%");
-            suggestions = getFacade().findByJpql(sql, hm, 20);
+        if (query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
         }
-        return suggestions;
+        // Split on whitespace and require every token to match (in any order) across
+        // name/code/staffCode, so a full name like "Dulmin Perera" matches reliably.
+        String[] tokens = query.trim().split("\\s+");
+        StringBuilder sql = new StringBuilder(
+                "select p from Staff p where p.retired=false and type(p) != Doctor");
+        HashMap hm = new HashMap();
+        for (int i = 0; i < tokens.length; i++) {
+            String paramName = "q" + i;
+            sql.append(" and ((p.person.name) like :").append(paramName)
+                    .append(" or (p.code) like :").append(paramName)
+                    .append(" or (p.staffCode) like :").append(paramName).append(")");
+            hm.put(paramName, "%" + tokens[i].toUpperCase() + "%");
+        }
+        sql.append(" order by p.person.name");
+        return getFacade().findByJpql(sql.toString(), hm, 20);
     }
 
     public String saveSignature() {

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -199,12 +199,15 @@
 
 
                                 <h:outputLabel value="Select Staff Name" />
-                                <p:autoComplete 
+                                <p:autoComplete
                                     class="w-100"
                                     inputStyleClass="w-100"
                                     completeMethod="#{staffController.completeStaffWithoutDoctors}"
                                     forceSelection="true"
-                                    var="w" itemLabel="#{w.person.name}" 
+                                    minQueryLength="3"
+                                    queryDelay="600"
+                                    maxResults="10"
+                                    var="w" itemLabel="#{w.person.name}"
                                     itemValue="#{w}"
                                     value="#{transferIssueForRequestsController.issuedBill.toStaff}" >
                                     <p:column headerText="Name">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -153,6 +153,8 @@
                                             class="w-100"
                                             inputStyleClass="w-100"
                                             minQueryLength="3" queryDelay="300"
+                                            maxResults="10"
+                                            onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                             completeMethod="#{transferRequestController.completeAmpAmppVmpVmppItemsForRequestingDepartment}"
                                             var="vt"
                                             itemLabel="#{vt.name}"
@@ -182,7 +184,9 @@
                                         <p:outputLabel value="Quantity" for="txtQty"/>
                                         <p:inputText id="txtQty" autocomplete="off" class="w-100"
                                                      value="#{transferRequestController.currentBillItem.qty}"
-                                                     onfocus="this.select();">
+                                                     onfocus="this.select();"
+                                                     onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                     onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAddItem',view).clientId}'; setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }">
                                             <p:ajax event="keyup" listener="#{transferRequestController.onCurrentQtyChange}" update="panelValueInput requestTotals" />
                                         </p:inputText>
                                     </div>
@@ -209,6 +213,7 @@
                                     <div class="col-1">
                                         <p:outputLabel value="&nbsp;"/>
                                         <p:commandButton
+                                            id="btnAddItem"
                                             value="Add Item"
                                             icon="fas fa-plus"
                                             class="ui-button-success w-100"


### PR DESCRIPTION
## Summary

UX, accessibility, and search-correctness fixes for the pharmacy transfer **Request** and **Issue** pages, discovered while running an end-to-end transfer Request → Issue → Receive test.

These are follow-ups to #21297 (the transfer-receive duplicate-BillItem fix); they touch the *request* and *issue* sides of the same workflow.

## Changes

### 1. Transfer Request page — Enter no longer wipes the bill (`pharmacy_transfer_request.xhtml`)
Pressing **Enter** in the Item or Quantity field submitted the form through the "Add Item" command button, which cleared/corrupted the in-progress request bill.

- **Item autocomplete** `onkeydown`: when the suggestion panel is open, Enter selects the highlighted suggestion (PrimeFaces default) without submitting; when the panel is closed, Enter is blocked from submitting.
- **Quantity field**: Enter no longer submits the form. Instead it commits the typed quantity and then clicks **Add Item**, so the natural keyboard flow is *type item → Enter → type qty → Enter → row added*. A small delay lets the quantity's `keyup` AJAX commit the value before the row is added (otherwise the row was added with an empty quantity).
- Gave the **Add Item** button a stable `id="btnAddItem"` so the qty-Enter handler can target it via `p:resolveFirstComponentWithId`.
- Added `maxResults="10"` to the item autocomplete to bound the dropdown.

### 2. Transfer Issue page — staff autocomplete tuning (`pharmacy_transfer_issue.xhtml`)
The "Select Staff Name" autocomplete fired on the first keystroke and returned a large unbounded list.

- Added `minQueryLength="3"`, `queryDelay="600"`, `maxResults="10"`.

### 3. Staff search — multi-word full names now match (`StaffController.completeStaffWithoutDoctors`)
Typing a full name like **"Dulmin Perera"** frequently returned no results, while a single token ("Dul") worked.

- The query now splits on whitespace and requires **every token** to match across name / code / staffCode, in any order. So "Dulmin Perera" and "Perera Dulmin" both match "Dulmin Perera".
- This method is shared by ~17 pages, so the improvement applies broadly.

## Testing

Verified manually end-to-end against a local database:

- Transfer Request: keyboard flow (Enter to select item, Enter to add row) works; Enter no longer clears the bill; rows persist with correct quantities; 7-item request saved/finalized/approved successfully.
- Transfer Issue: staff autocomplete returns a bounded list; multi-word name search returns the expected staff; 6-item issue completed with correct stock movement.
- Transfer Receive (covered by #21297): completed with no duplicate BillItems.

## Notes

- JSF-only changes (1 + 2) need a redeploy; the Java change (3) needs a recompile.
- A separate batch-auto-selection bug found during the same test is tracked in #21313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Staff search now supports multi-word queries with improved matching across staff names and codes
  * Enhanced keyboard navigation in the pharmacy transfer request form to prevent accidental form submission when using Enter key with auto-complete suggestions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->