### PR TITLE
fix(lab): update all sibling PIs in recordSampleSendingProcess

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -730,10 +730,29 @@ public class PatientInvestigationController implements Serializable {
         }
 
         //Update PatientInvestigation Data — collect all PIs linked to the processed samples
+        Set<Long> canProcessSampleIds = new HashSet<>();
+        for (PatientSample ps : canProcessSamples) {
+            canProcessSampleIds.add(ps.getId());
+        }
+
         Map<Long, PatientInvestigation> allLinkedPIs = new HashMap<>();
         for (PatientSample ps : canProcessSamples) {
             for (PatientInvestigation pi : getPatientInvestigationsBySample(ps)) {
-                allLinkedPIs.putIfAbsent(pi.getId(), pi);
+                if (pi.getId().equals(patientInvestigation.getId())) {
+                    // Always include the originally requested PI
+                    allLinkedPIs.putIfAbsent(pi.getId(), pi);
+                    continue;
+                }
+                // Only include a sibling PI if ALL of its samples are being processed now
+                // or are already at/beyond SAMPLE_ACCEPTED — prevents prematurely accepting
+                // a PI that has another pending sample not in this batch.
+                List<PatientSample> siblingAllSamples = getPatientSamplesByInvestigation(pi);
+                boolean allReady = siblingAllSamples.stream().allMatch(s
+                        -> canProcessSampleIds.contains(s.getId())
+                        || s.getStatus() != null && s.getStatus().ordinal() >= PatientInvestigationStatus.SAMPLE_ACCEPTED.ordinal());
+                if (allReady) {
+                    allLinkedPIs.putIfAbsent(pi.getId(), pi);
+                }
             }
         }
         // Ensure the originally requested PI is always included (e.g. when no sample component exists yet)

--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -729,25 +729,36 @@ public class PatientInvestigationController implements Serializable {
             patientSampleFacade.edit(ps);
         }
 
-        //Update PatientInvestigation Data
-        patientInvestigation.setSampleCollected(true);
-        patientInvestigation.setSampleCollectedAt(new Date());
-        patientInvestigation.setSampleCollectedBy(sessionController.getLoggedUser());
+        //Update PatientInvestigation Data — collect all PIs linked to the processed samples
+        Map<Long, PatientInvestigation> allLinkedPIs = new HashMap<>();
+        for (PatientSample ps : canProcessSamples) {
+            for (PatientInvestigation pi : getPatientInvestigationsBySample(ps)) {
+                allLinkedPIs.putIfAbsent(pi.getId(), pi);
+            }
+        }
+        // Ensure the originally requested PI is always included (e.g. when no sample component exists yet)
+        allLinkedPIs.putIfAbsent(patientInvestigation.getId(), patientInvestigation);
 
-        patientInvestigation.setSampleSent(true);
-        patientInvestigation.setSampleTransportedToLabByStaff(sessionController.getLoggedUser().getStaff());
-        patientInvestigation.setSampleSentAt(new Date());
-        patientInvestigation.setSampleSentBy(sessionController.getLoggedUser());
+        for (PatientInvestigation pi : allLinkedPIs.values()) {
+            pi.setSampleCollected(true);
+            pi.setSampleCollectedAt(new Date());
+            pi.setSampleCollectedBy(sessionController.getLoggedUser());
 
-        patientInvestigation.setSampleAccepted(true);
-        patientInvestigation.setSampleAcceptedAt(new Date());
-        patientInvestigation.setSampleAcceptedBy(sessionController.getLoggedUser());
-        patientInvestigation.setReceived(true);
-        patientInvestigation.setReceivedAt(new Date());
-        patientInvestigation.setReceiveDepartment(sessionController.getDepartment());
-        patientInvestigation.setReceiveInstitution(sessionController.getInstitution());
-        patientInvestigation.setStatus(PatientInvestigationStatus.SAMPLE_ACCEPTED);
-        ejbFacade.edit(patientInvestigation);
+            pi.setSampleSent(true);
+            pi.setSampleTransportedToLabByStaff(sessionController.getLoggedUser().getStaff());
+            pi.setSampleSentAt(new Date());
+            pi.setSampleSentBy(sessionController.getLoggedUser());
+
+            pi.setSampleAccepted(true);
+            pi.setSampleAcceptedAt(new Date());
+            pi.setSampleAcceptedBy(sessionController.getLoggedUser());
+            pi.setReceived(true);
+            pi.setReceivedAt(new Date());
+            pi.setReceiveDepartment(sessionController.getDepartment());
+            pi.setReceiveInstitution(sessionController.getInstitution());
+            pi.setStatus(PatientInvestigationStatus.SAMPLE_ACCEPTED);
+            ejbFacade.edit(pi);
+        }
 
         //Update Bill Data
         bill.setStatus(PatientInvestigationStatus.SAMPLE_ACCEPTED);


### PR DESCRIPTION
## Summary

- `recordSampleSendingProcess` iterated over N `PatientSample` records but only updated the **single** `PatientInvestigation` passed as a parameter
- On multi-test bills (e.g. FBC + SGOT/SGPT), sibling investigations were left with `sampleCollectedAt = null` / `sampleCollected = false` after the bypass report path was used for one test
- Fix mirrors the map-based pattern already used in `collectSamples()` and `collectDTOSamples()`: gather all PIs linked to the processed samples, then update all of them

## Test plan

- [ ] Create a bill with two or more lab tests
- [ ] Use the bypass path (`navigateToCreatePatientReportBypassingSampleProcess`) for one of the tests
- [ ] Verify all PatientInvestigations on the bill have `sampleCollectedAt` set and `sampleCollected = true`
- [ ] Verify single-test bills still work correctly

Closes #21315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the sample sending workflow in the laboratory module to process multiple related patient investigation records in a single operation, improving the efficiency of sample lifecycle status updates from collection through acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->