### PR TITLE
feat(pharmacy): replace Procurement submenu with index page

### DIFF
--- a/src/main/webapp/pharmacy/procurement_index.xhtml
+++ b/src/main/webapp/pharmacy/procurement_index.xhtml
@@ -1,0 +1,169 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="content">
+
+        <div class="row">
+            <div class="col-12">
+                <p:messages id="messages" showDetail="true" closable="true" />
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-2">
+                <h:form>
+                    <p:accordionPanel activeIndex="0">
+                        <p:ajax event="tabChange" process="@this"/>
+
+                        <p:tab title="Purchase Orders">
+                            <p:panelGrid columns="1">
+                                <p:commandButton
+                                    value="Create PO"
+                                    ajax="false"
+                                    action="#{purchaseOrderRequestController.navigateToCreateNewPurchaseOrder()}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-plus-circle"
+                                    rendered="#{webUserController.hasPrivilege('CreatePurchaseOrder')}" />
+                                <p:commandButton
+                                    value="Auto Ordering - P Model"
+                                    ajax="false"
+                                    action="#{reorderController.autoOrderByDistributor()}"
+                                    class="ui-button-info w-100"
+                                    icon="fas fa-sync-alt"
+                                    rendered="#{webUserController.hasPrivilege('AutoOrderPModel')}" />
+                                <p:commandButton
+                                    value="Auto Ordering - Q Model"
+                                    ajax="false"
+                                    action="#{reorderController.autoOrderByDistributor()}"
+                                    class="ui-button-info w-100"
+                                    icon="fas fa-retweet"
+                                    rendered="#{webUserController.hasPrivilege('AutoOrderQModal')}" />
+                                <p:commandButton
+                                    value="Finalize POs"
+                                    ajax="false"
+                                    action="#{searchController.navigateToPurchaseOrderFinalize}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-tasks"
+                                    rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel') or webUserController.hasPrivilege('CreatePurchaseOrder')}" />
+                                <p:commandButton
+                                    value="PO Approval"
+                                    ajax="false"
+                                    action="#{searchController.navigateToPurchaseOrderApprove}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-clipboard-check"
+                                    rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel')}" />
+                            </p:panelGrid>
+                        </p:tab>
+
+                        <p:tab title="Direct Purchase">
+                            <p:panelGrid columns="1">
+                                <p:commandButton
+                                    value="Direct Purchase"
+                                    ajax="false"
+                                    action="#{pharmacyDirectPurchaseController.navigateToStartNewDirectPurchaseBill}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-hand-holding-usd"
+                                    rendered="#{webUserController.hasPrivilege('DirectPurchase') and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" />
+                                <p:commandButton
+                                    value="Direct Purchase"
+                                    ajax="false"
+                                    action="/pharmacy/pharmacy_purchase?faces-redirect=true"
+                                    actionListener="#{pharmacyPurchaseController.makeNull()}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-hand-holding-usd"
+                                    rendered="#{webUserController.hasPrivilege('DirectPurchase') and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" />
+                            </p:panelGrid>
+                        </p:tab>
+
+                        <p:tab title="GRN">
+                            <p:panelGrid columns="1">
+                                <p:commandButton
+                                    value="GRN"
+                                    ajax="false"
+                                    action="#{searchController.navigateToListPurchaseOrdersToReceive()}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-dolly-flatbed"
+                                    rendered="#{webUserController.hasPrivilege('GoodsRecipt')}" />
+                                <p:commandButton
+                                    value="Approved POs to Create GRN"
+                                    ajax="false"
+                                    action="#{searchController.navigateToListPurchaseOrdersToReceiveDto()}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-rocket"
+                                    rendered="#{webUserController.hasPrivilege('GoodsRecipt')}" />
+                                <p:commandButton
+                                    value="GRN Finalize"
+                                    ajax="false"
+                                    action="#{searchController.navigateToGrnListToFinalize()}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-clipboard-check"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyGrnFinalize')}" />
+                                <p:commandButton
+                                    value="GRN Approval"
+                                    ajax="false"
+                                    action="#{searchController.navigateToGrnListToApprove()}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-check-circle"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove')}" />
+                                <p:commandButton
+                                    value="Goods Receipt With Approval"
+                                    ajax="false"
+                                    action="/pharmacy/pharmacy_purchase_order_list_for_recieve_with_approval?faces-redirect=true"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    class="ui-button-info w-100"
+                                    icon="fas fa-dolly-flatbed"
+                                    rendered="#{webUserController.hasPrivilege('GoodsRecipt') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval')}" />
+                            </p:panelGrid>
+                        </p:tab>
+
+                        <p:tab title="Donations">
+                            <p:panelGrid columns="1">
+                                <p:commandButton
+                                    value="Pharmacy Donations"
+                                    ajax="false"
+                                    action="#{pharmacyDonationController.navigateToStartNewDonationBill}"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-donate"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDonation')}" />
+                            </p:panelGrid>
+                        </p:tab>
+
+                    </p:accordionPanel>
+                </h:form>
+            </div>
+            <div class="col-10">
+                <ui:insert name="subcontent">
+                    <p:panel header="Procurement Management">
+                        <div class="text-center p-5">
+                            <h3>Welcome to Procurement Management</h3>
+                            <p class="mt-3">
+                                Please select a function from the left menu to get started.
+                            </p>
+                            <div class="mt-4">
+                                <p:panelGrid columns="2" styleClass="mx-auto" style="max-width: 600px;">
+                                    <h:outputText value="Purchase Orders" styleClass="font-weight-bold"/>
+                                    <h:outputText value="Create, finalize, and approve purchase orders"/>
+
+                                    <h:outputText value="Direct Purchase" styleClass="font-weight-bold"/>
+                                    <h:outputText value="Record direct purchases from suppliers"/>
+
+                                    <h:outputText value="GRN" styleClass="font-weight-bold"/>
+                                    <h:outputText value="Receive goods and manage GRN finalization and approval"/>
+
+                                    <h:outputText value="Donations" styleClass="font-weight-bold"/>
+                                    <h:outputText value="Record pharmacy donations"/>
+                                </p:panelGrid>
+                            </div>
+                        </div>
+                    </p:panel>
+                </ui:insert>
+            </div>
+        </div>
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1129,108 +1129,12 @@
                     </p:submenu>
 
 
-                    <p:submenu
-                        id="submenuPharmacy"
-                        label="Procurement" 
-                        icon="fas fa-shopping-cart" 
-                        rendered="#{webUserController.hasPrivilege('PharmacyProcurementMenu')}">
-                        <!--Procurement Menu Items with Titles-->
-                        <p:menuitem
-                            ajax="false"
-                            action="#{purchaseOrderRequestController.navigateToCreateNewPurchaseOrder()}"
-                            value="Create PO"
-                            title="Create a new Purchase Order"
-                            icon="fas fa-plus-circle"
-                            rendered="#{webUserController.hasPrivilege('CreatePurchaseOrder')}" ></p:menuitem>
-                        <p:menuitem  
-                            ajax="false" 
-                            action="#{reorderController.autoOrderByDistributor()}"  
-                            value="Auto Ordering - P Model" 
-                            title="Auto Ordering - P Model"
-                            icon="fas fa-sync-alt"
-                            rendered="#{webUserController.hasPrivilege('AutoOrderPModel')}" ></p:menuitem>
-                        <p:menuitem  
-                            ajax="false" 
-                            action="#{reorderController.autoOrderByDistributor()}"  
-                            value="Auto Ordering - Q Model" 
-                            title="Auto Ordering - Q Model"
-                            icon="fas fa-retweet"
-                            rendered="#{webUserController.hasPrivilege('AutoOrderQModal')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{pharmacyDirectPurchaseController.navigateToStartNewDirectPurchaseBill}"
-                            value="Direct Purchase"
-                            title="Direct Purchase"
-                            icon="fas fa-hand-holding-usd"
-                            rendered="#{webUserController.hasPrivilege('DirectPurchase') and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" >
-                        </p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{pharmacyDonationController.navigateToStartNewDonationBill}"
-                            value="Pharmacy Donations"
-                            title="Pharmacy Donations"
-                            icon="fas fa-donate"
-                            rendered="#{webUserController.hasPrivilege('PharmacyDonation')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{searchController.navigateToPurchaseOrderFinalize}"
-                            value="Finalize POs"
-                            title="Finalize Purchase Orders"
-                            icon="fas fa-tasks"
-                            rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel') or webUserController.hasPrivilege('CreatePurchaseOrder')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{searchController.navigateToPurchaseOrderApprove}"
-                            value="PO Approval"
-                            title="Purchase Order Approval"
-                            icon="fas fa-clipboard-check"
-                            rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel')}" ></p:menuitem>
-                        <p:menuitem  
-                            ajax="false" 
-                            action="/pharmacy/pharmacy_purchase?faces-redirect=true"  
-                            value="Direct Purchase" 
-                            title="Direct Purchase"
-                            icon="fas fa-hand-holding-usd"
-                            rendered="#{webUserController.hasPrivilege('DirectPurchase') and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" 
-                            actionListener="#{pharmacyPurchaseController.makeNull()}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{searchController.navigateToListPurchaseOrdersToReceive()}"
-                            value="GRN"
-                            title="Goods Receipt (GRN)"
-                            icon="fas fa-dolly-flatbed"
-                            rendered="#{webUserController.hasPrivilege('GoodsRecipt')}"  ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{searchController.navigateToListPurchaseOrdersToReceiveDto()}"
-                            value="Approved POs to Create GRN"
-                            title="Optimized list of Approved Purchase Orders for GRN Creation - Fast Loading"
-                            icon="fas fa-rocket"
-                            styleClass="ui-menuitem-success"
-                            rendered="#{webUserController.hasPrivilege('GoodsRecipt')}"  ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="#{searchController.navigateToGrnListToFinalize()}"
-                            value="GRN Finalize"
-                            icon="fas fa-clipboard-check"
-                            rendered="#{webUserController.hasPrivilege('PharmacyGrnFinalize')}" ></p:menuitem>
-                        <p:menuitem  
-                            ajax="false" 
-                            action="#{searchController.navigateToGrnListToApprove()}"  
-                            value="GRN Approval"  
-                            icon="fas fa-check-circle"
-                            rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove')}" ></p:menuitem>
-
-                        <p:menuitem  
-                            ajax="false" 
-                            action="/pharmacy/pharmacy_purchase_order_list_for_recieve_with_approval?faces-redirect=true"  
-                            value="Goods Receipt With Approval"  
-                            title="Goods Receipt With Approval"
-                            icon="fas fa-dolly-flatbed"
-                            actionListener="#{searchController.makeListNull()}" 
-                            rendered="#{webUserController.hasPrivilege('GoodsRecipt') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval')}" ></p:menuitem>
-
-                    </p:submenu>
+                    <p:menuitem
+                        ajax="false"
+                        action="/pharmacy/procurement_index?faces-redirect=true"
+                        value="Procurement"
+                        rendered="#{webUserController.hasPrivilege('PharmacyProcurementMenu')}"
+                        icon="fas fa-shopping-cart" />
                     <p:submenu label="Disposal" icon="fas fa-trash-alt" rendered="#{webUserController.hasPrivilege('PharmacyDisposalMenue')}">
                         <p:menuitem
                             ajax="false"


### PR DESCRIPTION
## Summary

- Created `procurement_index.xhtml` following the Disbursement index page pattern (2-col layout: left accordion navigation + right welcome/content panel)
- Accordion groups: **Purchase Orders**, **Direct Purchase**, **GRN**, **Donations** — all 13 original actions preserved with their privilege guards and actionListeners
- Replaced the 13-item `p:submenu` block in `menu.xhtml` with a single `p:menuitem` pointing to `/pharmacy/procurement_index`

## Test plan

- [ ] Navigate to Pharmacy → Procurement — should open the new index page
- [ ] Each accordion tab expands correctly
- [ ] Each button navigates to the correct destination page
- [ ] Privilege-gated buttons render only for users with the relevant privilege
- [ ] Config-conditional buttons (Manage Costing, Pharmacy Good Recipt With Approval) render correctly
- [ ] No regression on Disbursement or other Pharmacy menu items

Closes #21319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Pharmacy Procurement dashboard centralizing Purchase Orders, Direct Purchase, GRN, and Donations with quick-access navigation buttons.
  * Streamlined Pharmacy Procurement menu to route directly to the new unified procurement management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->