### PR TITLE
feat(pharmacy): Save/Finalize/Approve workflow for Direct Purchase

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -7158,6 +7158,50 @@ public class SearchController implements Serializable {
         }
     }
 
+    public void createDirectPurchaseTableToFinalize() {
+        bills = null;
+        String jpql = "Select b From Bill b "
+                + " where b.retired=false "
+                + " and b.billTypeAtomic = :bTp "
+                + " and b.completed = :completed "
+                + " and b.department = :dept "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " order by b.createdAt desc";
+
+        HashMap params = new HashMap();
+        params.put("bTp", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE);
+        params.put("completed", false);
+        params.put("dept", sessionController.getDepartment());
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+
+        bills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
+    }
+
+    public void createDirectPurchaseTableToApprove() {
+        bills = null;
+        String jpql = "Select b From Bill b "
+                + " where b.retired=false "
+                + " and b.billTypeAtomic = :bTp "
+                + " and b.institution = :ins "
+                + " and b.department = :dept "
+                + " and b.completed = :completed "
+                + " and b.checked = :checked "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " order by b.createdAt desc";
+
+        HashMap params = new HashMap();
+        params.put("bTp", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE);
+        params.put("ins", getSessionController().getInstitution());
+        params.put("dept", sessionController.getDepartment());
+        params.put("completed", true);
+        params.put("checked", false);
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+
+        bills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
+    }
+
     private List<Bill> getReturnBill(Bill b, BillType bt) {
         String sql = "Select b From Bill b where b.retired=false and b.creater is not null"
                 + " and  b.billType=:btp and "
@@ -16655,6 +16699,16 @@ public class SearchController implements Serializable {
     public String navigateToGrnListToApprove() {
         makeListNull();
         return "/pharmacy/pharmacy_grn_list_to_approve?faces-redirect=true";
+    }
+
+    public String navigateToDirectPurchaseListToFinalize() {
+        makeListNull();
+        return "/pharmacy/pharmacy_direct_purchase_list_to_finalize?faces-redirect=true";
+    }
+
+    public String navigateToDirectPurchaseListToApprove() {
+        makeListNull();
+        return "/pharmacy/pharmacy_direct_purchase_list_to_approve?faces-redirect=true";
     }
 
     public String navigateToPurchaseOrderApprove() {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -755,6 +755,9 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyAutoOrderPModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderPModel, "Auto Order (P Model)"), ProcumentNode);
         TreeNode pharmacyAutoOrderQModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderQModal, "Auto Order (Q Model)"), ProcumentNode);
         TreeNode pharmacyDirectPurchase = new DefaultTreeNode(new PrivilegeHolder(Privileges.DirectPurchase, "Direct Purchase"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseSave, "Pharmacy Direct Purchase Save"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseFinalize, "Pharmacy Direct Purchase Finalize"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseApprove, "Pharmacy Direct Purchase Approve"), ProcumentNode);
         TreeNode pharmacyPurchaseOrderApprovel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrdersApprovel, "Purchase Orders Approvel"), ProcumentNode);
         TreeNode pharmacyGoodRecipt = new DefaultTreeNode(new PrivilegeHolder(Privileges.GoodsRecipt, "Pharmacy Good Recipt"), ProcumentNode);
         TreeNode pharmacyGrnSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnSave, "Pharmacy GRN Save"), ProcumentNode);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -155,6 +155,8 @@ public class PharmacyBillSearch implements Serializable {
     SaleReturnController saleReturnController;
     @Inject
     PharmacyReturnwithouttresing pharmacyReturnwithouttresing;
+    @Inject
+    PharmacyDirectPurchaseController pharmacyDirectPurchaseController;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
     private UploadedFile file;
@@ -1308,6 +1310,18 @@ public class PharmacyBillSearch implements Serializable {
         }
         grnController.setCurrentGrnBillPre(bill);
         return grnController.navigateToEditGrn();
+    }
+
+    public String navigateToEditSavedDirectPurchase() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE) {
+            JsfUtil.addErrorMessage("Selected bill is not a saved Direct Purchase (PRE).");
+            return null;
+        }
+        return pharmacyDirectPurchaseController.loadDraftForEditing(bill);
     }
 
     public String navigateToEditSavedGrnCosting() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1342,6 +1342,28 @@ public class PharmacyDirectPurchaseController implements Serializable {
             getBillFacade().edit(getBill());
         }
 
+        // Retire any previously persisted items that were removed from the session list
+        if (getBill().getId() != null) {
+            java.util.Map<String, Object> retireParams = new java.util.HashMap<>();
+            retireParams.put("billId", getBill().getId());
+            List<BillItem> persistedItems = getBillItemFacade().findByJpql(
+                "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId AND bi.retired = false",
+                retireParams);
+            java.util.Set<Long> sessionIds = new java.util.HashSet<>();
+            for (BillItem bi : getBillItems()) {
+                if (bi.getId() != null) {
+                    sessionIds.add(bi.getId());
+                }
+            }
+            for (BillItem persisted : persistedItems) {
+                if (!sessionIds.contains(persisted.getId())) {
+                    persisted.setRetired(true);
+                    persisted.setRetireComments("Removed during draft edit");
+                    getBillItemFacade().edit(persisted);
+                }
+            }
+        }
+
         // Save each bill item (PharmaceuticalBillItem cascades automatically)
         int serial = 0;
         for (BillItem bi : getBillItems()) {
@@ -1445,6 +1467,11 @@ public class PharmacyDirectPurchaseController implements Serializable {
         getBill().setDeptId(deptId);
         getBill().setInsId(insId);
         getBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        // Mark checked=true BEFORE the stock loop so a concurrent approve request
+        // that reloads the bill will see it already approved and abort
+        getBill().setChecked(true);
+        getBill().setCheckeAt(new Date());
+        getBill().setCheckedBy(getSessionController().getLoggedUser());
         getBillFacade().edit(getBill());
 
         // Reload bill items from DB to ensure we have the persisted state

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -86,6 +86,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
     private BillItem currentExpense;
     private List<BillItem> billExpenses;
     private String warningMessage;
+    private boolean draftMode;
 
     // </editor-fold>  
     // <editor-fold defaultstate="collapsed" desc="Constructors">
@@ -93,6 +94,37 @@ public class PharmacyDirectPurchaseController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Navigation Methods">
     public String navigateToStartNewDirectPurchaseBill() {
         prepareForNewDIrectPurchaseBill();
+        draftMode = false;
+        return "/pharmacy/direct_purchase?faces-redirect=true";
+    }
+
+    public String navigateToStartNewDirectPurchaseDraft() {
+        prepareForNewDIrectPurchaseBill();
+        draftMode = true;
+        return "/pharmacy/direct_purchase?faces-redirect=true";
+    }
+
+    public String loadDraftForEditing(com.divudi.core.entity.Bill draft) {
+        if (draft == null) {
+            com.divudi.core.util.JsfUtil.addErrorMessage("No draft selected");
+            return null;
+        }
+        com.divudi.core.entity.Bill freshBill = billService.reloadBill(draft);
+        if (freshBill == null) {
+            com.divudi.core.util.JsfUtil.addErrorMessage("Draft bill could not be loaded");
+            return null;
+        }
+        prepareForNewDIrectPurchaseBill();
+        bill = (com.divudi.core.entity.BilledBill) freshBill;
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("billId", freshBill.getId());
+        billItems = billItemFacade.findByJpql(
+            "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId AND bi.retired = false ORDER BY bi.searialNo",
+            params);
+        String expJpql = "SELECT be FROM BillItem be WHERE be.expenseBill.id = :billId AND be.retired = false ORDER BY be.searialNo";
+        billExpenses = billItemFacade.findByJpql(expJpql, params);
+        draftMode = true;
+        printPreview = false;
         return "/pharmacy/direct_purchase?faces-redirect=true";
     }
 
@@ -472,6 +504,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
     PaymentService paymentService;
     @EJB
     PharmacyCostingService pharmacyCostingService;
+    @EJB
+    com.divudi.service.BillService billService;
 
     /**
      * Controllers
@@ -1280,6 +1314,214 @@ public class PharmacyDirectPurchaseController implements Serializable {
     }
     
     
+    // <editor-fold defaultstate="collapsed" desc="Draft Workflow Methods">
+
+    public void saveDraftDirectPurchase() {
+        if (getBillItems() == null || getBillItems().isEmpty()) {
+            JsfUtil.addErrorMessage("Please add items before saving");
+            return;
+        }
+        if (getBill().getFromInstitution() == null) {
+            JsfUtil.addErrorMessage("Please select a Supplier");
+            return;
+        }
+
+        // Save bill header as PRE type — no bill number yet, no stock
+        getBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE);
+        getBill().setBillType(com.divudi.core.data.BillType.PharmacyPurchaseBill);
+        getBill().setDepartment(getSessionController().getDepartment());
+        getBill().setInstitution(getSessionController().getInstitution());
+        getBill().setCreatedAt(new Date());
+        getBill().setCreater(getSessionController().getLoggedUser());
+        getBill().setChecked(false);
+        getBill().setCompleted(false);
+
+        if (getBill().getId() == null) {
+            getBillFacade().create(getBill());
+        } else {
+            getBillFacade().edit(getBill());
+        }
+
+        // Save each bill item (PharmaceuticalBillItem cascades automatically)
+        int serial = 0;
+        for (BillItem bi : getBillItems()) {
+            bi.setSearialNo(serial++);
+            bi.setBill(getBill());
+            bi.setCreatedAt(new Date());
+            bi.setCreater(getSessionController().getLoggedUser());
+            if (bi.getId() == null) {
+                getBillItemFacade().create(bi);
+            } else {
+                getBillItemFacade().edit(bi);
+            }
+        }
+
+        getBillFacade().edit(getBill());
+        JsfUtil.addSuccessMessage("Direct Purchase draft saved successfully.");
+        draftMode = true;
+    }
+
+    public void finalizeDraftDirectPurchase() {
+        if (bill == null || bill.getId() == null) {
+            JsfUtil.addErrorMessage("No draft loaded. Please save the draft first.");
+            return;
+        }
+
+        // Fresh DB read to guard against concurrent finalization
+        com.divudi.core.entity.Bill freshBill = billService.reloadBill(bill);
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Draft bill not found in database.");
+            return;
+        }
+        if (freshBill.isCompleted()) {
+            JsfUtil.addErrorMessage("This draft was already finalized by another user. Please refresh the list.");
+            return;
+        }
+
+        freshBill.setCompleted(true);
+        freshBill.setCompletedAt(new Date());
+        freshBill.setCompletedBy(getSessionController().getLoggedUser());
+        freshBill.setEditedAt(new Date());
+        freshBill.setEditor(getSessionController().getLoggedUser());
+        getBillFacade().edit(freshBill);
+        bill = (com.divudi.core.entity.BilledBill) freshBill;
+
+        JsfUtil.addSuccessMessage("Direct Purchase finalized. It is now pending approval.");
+        printPreview = false;
+    }
+
+    public void approveDirectPurchaseDraft() {
+        if (bill == null || bill.getId() == null) {
+            JsfUtil.addErrorMessage("No draft loaded.");
+            return;
+        }
+
+        // Fresh DB read to guard against concurrent approval
+        com.divudi.core.entity.Bill freshBill = billService.reloadBill(bill);
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Draft bill not found in database.");
+            return;
+        }
+        if (!freshBill.isCompleted()) {
+            JsfUtil.addErrorMessage("Bill must be finalized before it can be approved.");
+            return;
+        }
+        if (freshBill.isChecked()) {
+            JsfUtil.addErrorMessage("This bill was already approved by another user. Please refresh the list.");
+            return;
+        }
+
+        // Switch session bill to the fresh DB copy so finalizeBill()/approveBill() operate on it
+        bill = (com.divudi.core.entity.BilledBill) freshBill;
+
+        // Generate real bill number (mirrors saveBill())
+        String deptId;
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Direct Purchase - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false)) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        } else if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        } else {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        }
+
+        String insId;
+        if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Institution Id is Prefix Ins Year Count", false)) {
+            insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        } else {
+            if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)
+                    || configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Ins Year Count", false)) {
+                insId = deptId;
+            } else {
+                insId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+            }
+        }
+
+        getBill().setDeptId(deptId);
+        getBill().setInsId(insId);
+        getBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+        getBillFacade().edit(getBill());
+
+        // Reload bill items from DB to ensure we have the persisted state
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("billId", getBill().getId());
+        billItems = billItemFacade.findByJpql(
+            "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId AND bi.retired = false ORDER BY bi.searialNo",
+            params);
+        String expJpql = "SELECT be FROM BillItem be WHERE be.expenseBill.id = :billId AND be.retired = false ORDER BY be.searialNo";
+        billExpenses = billItemFacade.findByJpql(expJpql, params);
+
+        // Add stock for each item (mirrors settleDirectPurchaseBillFinally())
+        billItemsTotalQty = 0;
+        for (BillItem i : getBillItems()) {
+            if (i.getPharmaceuticalBillItem().getQty() + i.getPharmaceuticalBillItem().getFreeQty() == 0.0) {
+                continue;
+            }
+            double lastPurchaseRate = getPharmacyBean().getLastPurchaseRate(i.getItem());
+            billItemsTotalQty += i.getPharmaceuticalBillItem().getQty() + i.getPharmaceuticalBillItem().getFreeQty();
+            i.setCreatedAt(Calendar.getInstance().getTime());
+            i.setCreater(getSessionController().getLoggedUser());
+            i.setBill(getBill());
+            getBillItemFacade().edit(i);
+            saveBillFee(i);
+
+            ItemBatch itemBatch = getPharmacyBillBean().saveItemBatchWithCosting(i);
+            double addingQty = BigDecimalUtil.valueOrZero(i.getBillItemFinanceDetails().getTotalQuantityByUnits()).doubleValue();
+            i.getPharmaceuticalBillItem().setItemBatch(itemBatch);
+            Stock stock = getPharmacyBean().addToStockForCosting(i, Math.abs(addingQty), getSessionController().getDepartment());
+            i.getPharmaceuticalBillItem().setLastPurchaseRate(lastPurchaseRate);
+            i.getPharmaceuticalBillItem().setStock(stock);
+            getBill().getBillItems().add(i);
+        }
+
+        calculateBillTotalsFromItems();
+
+        if (getBill().getDiscount() != 0.0 || getBill().getTax() != 0.0 || getBill().getExpensesTotalConsideredForCosting() != 0.0) {
+            distributeProportionalBillValuesToItems();
+            for (BillItem item : getBillItems()) {
+                getBillItemFacade().edit(item);
+            }
+            recalculateBillFinanceDetailsCostAggregates();
+        }
+
+        if (billExpenses != null && !billExpenses.isEmpty()) {
+            getBill().setBillExpenses(billExpenses);
+            double totalForExpenses = 0;
+            for (BillItem expense : getBillExpenses()) {
+                totalForExpenses += expense.getNetValue();
+            }
+            getBill().setExpenseTotal(-Math.abs(totalForExpenses));
+        }
+
+        getBillFacade().edit(getBill());
+        finalizeBill();
+        approveBill();
+
+        boolean generatePayments = configOptionApplicationController.getBooleanValueByKey(
+            "Generate Payments for GRN, GRN Returns, Direct Purchase, and Direct Purchase Returns", false);
+        if (generatePayments) {
+            paymentService.createPayment(getBill(), getPaymentMethodData());
+        }
+
+        JsfUtil.addSuccessMessage("Direct Purchase approved. Bill number: " + deptId + ". Stock updated.");
+        printPreview = true;
+    }
+
+    public boolean isDraftMode() {
+        return draftMode;
+    }
+
+    public void setDraftMode(boolean draftMode) {
+        this.draftMode = draftMode;
+    }
+
+    // </editor-fold>
+
     public double getNetTotal() {
         // If NetTotal has already been calculated by the service (includes expenses), return it as-is
         if (getBill().getNetTotal() != 0.0) {

--- a/src/main/java/com/divudi/core/data/BillTypeAtomic.java
+++ b/src/main/java/com/divudi/core/data/BillTypeAtomic.java
@@ -143,6 +143,7 @@ public enum BillTypeAtomic {
     PHARMACY_DIRECT_PURCHASE("Pharmacy Direct Purchase", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.CASH_OUT, CountedServiceType.PHARMACY, PaymentCategory.NON_CREDIT_SPEND, BillType.PharmacyPurchaseBill),
     PHARMACY_DIRECT_PURCHASE_CANCELLED("Pharmacy Direct Purchase Cancelled", BillCategory.CANCELLATION, ServiceType.PHARMACY, BillFinanceType.CASH_IN, CountedServiceType.PHARMACY, PaymentCategory.NON_CREDIT_SPEND, BillType.PharmacyPurchaseBill),
     PHARMACY_DIRECT_PURCHASE_REFUND("Pharmacy Direct Purchase Refund", BillCategory.REFUND, ServiceType.PHARMACY, BillFinanceType.CASH_IN, CountedServiceType.PHARMACY, PaymentCategory.NON_CREDIT_SPEND, BillType.PurchaseReturn),
+    PHARMACY_DIRECT_PURCHASE_PRE("Pharmacy Direct Purchase Pre", BillCategory.PREBILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.NON_CREDIT_SPEND, BillType.PharmacyPurchaseBill),
     PHARMACY_GRN("Pharmacy GRN", BillCategory.BILL, ServiceType.PHARMACY, BillFinanceType.CASH_OUT, CountedServiceType.PHARMACY, PaymentCategory.CREDIT_SPEND, BillType.PharmacyGrnBill),
     PHARMACY_GRN_PRE("Pharmacy GRN Pre", BillCategory.PREBILL, ServiceType.PHARMACY, BillFinanceType.NO_FINANCE_TRANSACTIONS, CountedServiceType.PHARMACY, PaymentCategory.CREDIT_SPEND, BillType.PharmacyGrnBill),
     @Deprecated // Use PHARMACY_WHOLESALE_GRN_BILL. Can not Remove this as it is already in the databases.

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -602,6 +602,9 @@ public enum Privileges {
     AutoOrderPModel("Auto Order P Model"),
     AutoOrderQModal("Auto Order Q Model"),
     DirectPurchase("Direct Purchase"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
     PurchaseOrdersApprovel("Purchase Orders Approval"),
     TransferReciveApproval("Transfer Receive Approval"),
     GoodsRecipt("Goods Receipt"),
@@ -907,6 +910,9 @@ public enum Privileges {
             case AutoOrderPModel:
             case AutoOrderQModal:
             case DirectPurchase:
+            case PharmacyDirectPurchaseSave:
+            case PharmacyDirectPurchaseFinalize:
+            case PharmacyDirectPurchaseApprove:
             case PurchaseOrdersApprovel:
             case GoodsRecipt:
             case ReturnReceviedGoods:

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -45,7 +45,7 @@
                                     styleClass="ui-button-info"
                                     ajax="false"
                                     icon="pi pi-save"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false) and !pharmacyDirectPurchaseController.bill.completed}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false) and !pharmacyDirectPurchaseController.bill.completed and webUserController.hasPrivilege('PharmacyDirectPurchaseSave')}"
                                     style="margin-right: 8px;">
                                 </p:commandButton>
 

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -24,17 +24,57 @@
                             </div>
                             <div>
 
+                                <!-- Single-step Settle: shown when draft workflow is NOT active -->
                                 <p:commandButton
                                     id="btnSettle"
                                     value="Settle"
-                                    onclick="if (!confirm('Are you sure?'))
-                                                return false"
+                                    onclick="if (!confirm('Are you sure?')) return false"
                                     action="#{pharmacyDirectPurchaseController.settleDirectPurchaseBillFinally}"
                                     styleClass="ui-button-success"
                                     ajax="false"
                                     icon="pi pi-check-circle"
+                                    rendered="#{!pharmacyDirectPurchaseController.draftMode and !configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false)}"
                                     style="margin-right: 8px;">
                                 </p:commandButton>
+
+                                <!-- Save Draft: shown in draft workflow mode -->
+                                <p:commandButton
+                                    id="btnSaveDraft"
+                                    value="Save Draft"
+                                    action="#{pharmacyDirectPurchaseController.saveDraftDirectPurchase}"
+                                    styleClass="ui-button-info"
+                                    ajax="false"
+                                    icon="pi pi-save"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false) and !pharmacyDirectPurchaseController.bill.completed}"
+                                    style="margin-right: 8px;">
+                                </p:commandButton>
+
+                                <!-- Finalize: shown when draft is saved but not yet finalized -->
+                                <p:commandButton
+                                    id="btnFinalize"
+                                    value="Finalize"
+                                    onclick="if (!confirm('Finalize this Direct Purchase?')) return false"
+                                    action="#{pharmacyDirectPurchaseController.finalizeDraftDirectPurchase}"
+                                    styleClass="ui-button-warning"
+                                    ajax="false"
+                                    icon="pi pi-check"
+                                    rendered="#{pharmacyDirectPurchaseController.draftMode and pharmacyDirectPurchaseController.bill.id ne null and !pharmacyDirectPurchaseController.bill.completed and webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}"
+                                    style="margin-right: 8px;">
+                                </p:commandButton>
+
+                                <!-- Approve: shown when draft is finalized but not yet approved -->
+                                <p:commandButton
+                                    id="btnApprove"
+                                    value="Approve"
+                                    onclick="if (!confirm('Approve this Direct Purchase? Stock will be updated.')) return false"
+                                    action="#{pharmacyDirectPurchaseController.approveDirectPurchaseDraft}"
+                                    styleClass="ui-button-success"
+                                    ajax="false"
+                                    icon="pi pi-check-circle"
+                                    rendered="#{pharmacyDirectPurchaseController.draftMode and pharmacyDirectPurchaseController.bill.completed and !pharmacyDirectPurchaseController.bill.checked and webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}"
+                                    style="margin-right: 8px;">
+                                </p:commandButton>
+
                                 <p:commandButton
                                     value="New Direct Purchase Bill"
                                     ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_list_to_approve.xhtml
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="content">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}">You are NOT authorized</h:panelGroup>
+        <h:panelGroup id="gpDirectPurchaseApprove" rendered="#{webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}">
+        <h:form>
+            <p:panel styleClass="shadow-sm border-0">
+                <f:facet name="header">
+                    <div class="d-flex align-items-center">
+                        <i class="fas fa-check-circle text-success me-2"></i>
+                        <h4 class="mb-0 text-success">Direct Purchase List - To Approve</h4>
+                    </div>
+                </f:facet>
+
+                <div class="row g-3">
+                    <div class="col-lg-3 col-md-4">
+                        <p:panel header="Search Filters" styleClass="h-100 shadow-sm">
+                            <div class="mb-3">
+                                <label class="form-label fw-bold text-secondary">
+                                    <i class="fas fa-calendar-alt me-1"></i>From Date
+                                </label>
+                                <p:calendar
+                                    id="fromDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.fromDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    placeholder="Select start date">
+                                </p:calendar>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label fw-bold text-secondary">
+                                    <i class="fas fa-calendar-alt me-1"></i>To Date
+                                </label>
+                                <p:calendar
+                                    id="toDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    placeholder="Select end date">
+                                </p:calendar>
+                            </div>
+                            <div class="mb-4">
+                                <p:commandButton
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-search"
+                                    id="btnSearch"
+                                    ajax="false"
+                                    value="Search Direct Purchases to Approve"
+                                    action="#{searchController.createDirectPurchaseTableToApprove}"
+                                    style="min-height: 45px;"/>
+                            </div>
+                        </p:panel>
+                    </div>
+                    <div class="col-lg-9 col-md-8">
+                        <p:panel header="Direct Purchases Pending Approval" styleClass="shadow-sm">
+                            <p:dataTable
+                                id="tblDirectPurchaseApprove"
+                                value="#{searchController.bills}"
+                                var="g"
+                                paginator="true"
+                                rows="10"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                rowsPerPageTemplate="5,10,15,25"
+                                styleClass="table-striped"
+                                emptyMessage="No Direct Purchases found matching your criteria"
+                                sortMode="multiple"
+                                resizableColumns="true"
+                                reflow="true">
+
+                            <p:column headerText="Created" width="8em">
+                                <h:outputLabel value="#{g.createdAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Department" width="6em">
+                                <h:outputLabel value="#{g.department.name}"/>
+                            </p:column>
+
+                            <p:column headerText="Created By" width="8em">
+                                <h:outputLabel value="#{g.creater.webUserPerson.name}"/>
+                            </p:column>
+
+                            <p:column headerText="Supplier" width="12em">
+                                <h:outputLabel value="#{g.fromInstitution.name}"/>
+                            </p:column>
+
+                            <p:column headerText="Invoice No" width="8em">
+                                <h:outputLabel value="#{g.invoiceNumber}"/>
+                            </p:column>
+
+                            <p:column headerText="Finalized By" width="8em">
+                                <h:outputLabel value="#{g.completedBy.webUserPerson.name}"/>
+                            </p:column>
+
+                            <p:column headerText="Value" width="8em" styleClass="text-end" sortBy="#{g.netTotal}">
+                                <div class="d-flex align-items-center justify-content-end">
+                                    <i class="fas fa-coins text-success me-2"></i>
+                                    <span class="fw-bold text-success fs-6">
+                                        <h:outputLabel value="#{g.netTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </span>
+                                </div>
+                            </p:column>
+
+                            <p:column headerText="Actions" styleClass="text-center" exportable="false" width="120">
+                                <p:commandButton
+                                    class="ui-button-success"
+                                    icon="fas fa-check"
+                                    value="Approve"
+                                    title="Open and Approve Direct Purchase"
+                                    ajax="false"
+                                    action="#{pharmacyBillSearch.navigateToEditSavedDirectPurchase()}"
+                                    style="min-width: 80px;">
+                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{g}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                        </p:panel>
+                    </div>
+                </div>
+            </p:panel>
+        </h:form>
+        </h:panelGroup>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_list_to_finalize.xhtml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="content">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}">You are NOT authorized</h:panelGroup>
+        <p:panel
+            id="gpDirectPurchaseFinalize"
+            rendered="#{webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}">
+            <f:facet name="header">
+                <div class="d-flex align-items-center">
+                    <i class="fas fa-clipboard-check text-warning me-2"></i>
+                    <h:outputText value="Direct Purchase List to Finalize" class="mb-0 text-warning"></h:outputText>
+                </div>
+            </f:facet>
+            <h:form>
+                <div class="row g-3">
+                    <div class="col-lg-3 col-md-4">
+                        <p:panel header="Search Filters" styleClass="h-100 shadow-sm">
+                            <div class="mb-3">
+                                <label class="form-label fw-bold text-secondary">
+                                    <i class="fas fa-calendar-alt me-1"></i>From Date
+                                </label>
+                                <p:calendar
+                                    id="fromDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.fromDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    placeholder="Select start date">
+                                </p:calendar>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label fw-bold text-secondary">
+                                    <i class="fas fa-calendar-alt me-1"></i>To Date
+                                </label>
+                                <p:calendar
+                                    id="toDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    placeholder="Select end date">
+                                </p:calendar>
+                            </div>
+                            <p:commandButton
+                                class="ui-button-warning w-100"
+                                icon="fas fa-search"
+                                id="btnSearch"
+                                ajax="false"
+                                value="Search"
+                                action="#{searchController.createDirectPurchaseTableToFinalize}"
+                                style="min-height: 45px;"/>
+                        </p:panel>
+                    </div>
+                    <div class="col-lg-9 col-md-8">
+
+                        <p:dataTable
+                            id="tblDirectPurchaseFinalize"
+                            value="#{searchController.bills}"
+                            var="g"
+                            paginator="true"
+                            rows="15"
+                            paginatorPosition="both"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="10,15,25,50"
+                            styleClass="ui-table-condensed"
+                            emptyMessage="No saved Direct Purchases found matching your criteria"
+                            sortMode="multiple"
+                            resizableColumns="true"
+                            reflow="true"
+                            size="small"
+                            style="font-size: 0.9em;">
+
+                            <p:column headerText="Created" width="80px" sortBy="#{g.createdAt}" styleClass="text-center">
+                                <h:outputLabel value="#{g.createdAt}" styleClass="text-muted small">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MM/yy" />
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Department" width="100px" sortBy="#{g.department.name}">
+                                <h:outputLabel value="#{g.department.name}" title="#{g.department.name}" styleClass="text-truncate d-block"/>
+                            </p:column>
+
+                            <p:column headerText="Created By" width="120px" sortBy="#{g.creater.webUserPerson.name}">
+                                <h:outputLabel value="#{g.creater.webUserPerson.name}" title="#{g.creater.webUserPerson.name}" styleClass="text-truncate d-block small"/>
+                            </p:column>
+
+                            <p:column headerText="Supplier" width="150px" sortBy="#{g.fromInstitution.name}">
+                                <h:outputLabel value="#{g.fromInstitution.name}" title="#{g.fromInstitution.name}" styleClass="text-truncate d-block fw-medium"/>
+                            </p:column>
+
+                            <p:column headerText="Invoice No" width="100px" sortBy="#{g.invoiceNumber}" styleClass="text-center">
+                                <h:outputLabel value="#{g.invoiceNumber}" styleClass="small text-muted"/>
+                            </p:column>
+
+                            <p:column headerText="Value" width="100px" styleClass="text-end" sortBy="#{g.netTotal}">
+                                <div class="d-flex align-items-center justify-content-end">
+                                    <i class="fas fa-coins text-success me-1" style="font-size: 0.8em;"></i>
+                                    <span class="fw-bold text-success small">
+                                        <h:outputLabel value="#{g.netTotal}">
+                                            <f:convertNumber pattern="#,##0" />
+                                        </h:outputLabel>
+                                    </span>
+                                </div>
+                            </p:column>
+
+                            <p:column headerText="Action" styleClass="text-center" exportable="false" width="100px">
+                                <p:commandButton
+                                    styleClass="ui-button ui-button-warning ui-button-sm"
+                                    icon="fas fa-check-circle"
+                                    value="Finalize"
+                                    title="Open and Finalize Direct Purchase"
+                                    ajax="false"
+                                    action="#{pharmacyBillSearch.navigateToEditSavedDirectPurchase()}"
+                                    style="font-size: 0.85em; padding: 0.375rem 0.75rem;">
+                                    <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{g}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+
+                    </div>
+                </div>
+            </h:form>
+
+        </p:panel>
+
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/pharmacy/procurement_index.xhtml
+++ b/src/main/webapp/pharmacy/procurement_index.xhtml
@@ -76,6 +76,20 @@
                                     class="ui-button-success w-100"
                                     icon="fas fa-hand-holding-usd"
                                     rendered="#{webUserController.hasPrivilege('DirectPurchase') and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}" />
+                                <p:commandButton
+                                    value="Finalize Direct Purchase"
+                                    ajax="false"
+                                    action="#{searchController.navigateToDirectPurchaseListToFinalize()}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-clipboard-check"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}" />
+                                <p:commandButton
+                                    value="Approve Direct Purchase"
+                                    ajax="false"
+                                    action="#{searchController.navigateToDirectPurchaseListToApprove()}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-check-circle"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}" />
                             </p:panelGrid>
                         </p:tab>
 


### PR DESCRIPTION
## Summary

- Adds a 3-step Save → Finalize → Approve workflow for Pharmacy Direct Purchase, matching the existing GRN pattern
- Stock changes only occur at **Approve** — not at Save or Finalize
- Existing single-step **Settle** flow is preserved behind config flag `Use Save Finalize Approve Workflow for Direct Purchase`
- Fresh DB read guard at Finalize and Approve steps to prevent concurrent double-processing

## Changes

**New data layer**
- `PHARMACY_DIRECT_PURCHASE_PRE` BillTypeAtomic (PREBILL category, no finance transactions) — mirrors `PHARMACY_GRN_PRE`
- Three new privileges: `PharmacyDirectPurchaseSave`, `PharmacyDirectPurchaseFinalize`, `PharmacyDirectPurchaseApprove` (enum values + `getCategory()` cases + `UserPrivilageController` tree nodes — all 3 steps per privilege guide)

**PharmacyDirectPurchaseController**
- `saveDraftDirectPurchase()` — saves bill as PRE type, no bill number, no stock
- `finalizeDraftDirectPurchase()` — fresh DB read guard, sets `completed=true`
- `approveDirectPurchaseDraft()` — fresh DB read guard, generates bill number, processes ItemBatch + Stock (mirrors `settleDirectPurchaseBillFinally`), promotes type to `PHARMACY_DIRECT_PURCHASE`
- `loadDraftForEditing(Bill)` — reloads draft from DB and opens it in the form
- No existing methods modified

**SearchController**
- `createDirectPurchaseTableToFinalize()` — queries `PHARMACY_DIRECT_PURCHASE_PRE + completed=false`
- `createDirectPurchaseTableToApprove()` — queries `PHARMACY_DIRECT_PURCHASE_PRE + completed=true + checked=false`
- `navigateToDirectPurchaseListToFinalize/Approve()`

**PharmacyBillSearch**
- `navigateToEditSavedDirectPurchase()` — validates PRE type, delegates to `loadDraftForEditing()`

**New XHTML pages**
- `pharmacy_direct_purchase_list_to_finalize.xhtml`
- `pharmacy_direct_purchase_list_to_approve.xhtml`

**Updated XHTML**
- `direct_purchase.xhtml` — Save Draft / Finalize / Approve buttons shown conditionally based on `draftMode` and bill status; Settle kept behind config flag
- `procurement_index.xhtml` — Finalize and Approve Direct Purchase buttons added to the Direct Purchase accordion tab

## Test plan

- [ ] Config flag OFF → only Settle button shown (existing behaviour unchanged)
- [ ] Config flag ON → Save Draft button visible; Settle hidden
- [ ] Save Draft → bill created as PRE type, no stock movement, no bill number
- [ ] Finalize Draft → `completed=true` set; Approve button appears; Finalize disappears
- [ ] Approve → bill number generated, stock added, type changes to `PHARMACY_DIRECT_PURCHASE`
- [ ] Concurrent finalize/approve blocked by fresh DB read guard (second attempt shows error message)
- [ ] Finalize list (`procurement_index → Finalize Direct Purchase`) shows only PRE + not completed
- [ ] Approve list shows only PRE + completed + not checked
- [ ] Privilege gates: PharmacyDirectPurchaseFinalize / Approve hide buttons from unauthorized users

Closes #21322

🤖 Generated with [Claude Code](https://claude.com/claude-code)