### PR TITLE
feat(pharmacy): convert discharge prescription to discharge issue bill (#21334)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -153,6 +153,8 @@ public class InpatientClinicalDataController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     com.divudi.bean.pharmacy.PharmacyRequestForBhtController pharmacyRequestForBhtController;
+    @Inject
+    com.divudi.bean.pharmacy.PharmacySaleBhtController pharmacySaleBhtController;
 
     /**
      * Properties
@@ -227,6 +229,7 @@ public class InpatientClinicalDataController implements Serializable {
     private ClinicalFindingValue selectedWardMedicineToOmit;
     private String omissionReason;
     private ClinicalFindingValue[] selectedWardMedicinesToRequest;
+    private ClinicalFindingValue[] selectedDischargeMedicinesToIssue;
     private ClinicalFindingValue selectedWardMedicineToChange;
     private Double newDose;
     private MeasurementUnit newDoseUnit;
@@ -2270,6 +2273,73 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void setSelectedWardMedicinesToRequest(ClinicalFindingValue[] selectedWardMedicinesToRequest) {
         this.selectedWardMedicinesToRequest = selectedWardMedicinesToRequest;
+    }
+
+    /**
+     * Converts the discharge-medicine prescriptions the user ticked into a
+     * discharge issue bill (no inward service charge) dispensed from the
+     * logged-in pharmacy, then navigates to the discharge issue page where the
+     * pharmacist reviews batch/quantity and settles. Mirrors
+     * {@link #requestSelectedWardMedicinesFromPharmacy()} for the discharge flow.
+     * Issue #21334.
+     */
+    public String createDischargeIssueBillFromSelected() {
+        // The discharge issue bill must be attributed to the admission. When the
+        // page is reached from the assessment list, current is the assessment
+        // encounter and parentAdmission holds the admission; from the dashboard
+        // both are the admission. Prefer parentAdmission, fall back to current.
+        PatientEncounter admission = parentAdmission != null ? parentAdmission : current;
+        if (admission == null || admission.getId() == null) {
+            JsfUtil.addErrorMessage("No admission selected.");
+            return "";
+        }
+        if (selectedDischargeMedicinesToIssue == null || selectedDischargeMedicinesToIssue.length == 0) {
+            JsfUtil.addErrorMessage("Select at least one discharge medicine to issue.");
+            return "";
+        }
+
+        Long admissionId = admission.getId();
+        List<com.divudi.core.entity.clinical.Prescription> prescriptions = new ArrayList<>();
+        int skippedOtherAdmission = 0;
+        for (ClinicalFindingValue cfv : selectedDischargeMedicinesToIssue) {
+            if (cfv == null || cfv.getPrescription() == null || cfv.getEncounter() == null) {
+                continue;
+            }
+            // Guard against a stale (session-scoped) selection carried over from a
+            // previously-viewed admission: only issue medicines that belong to the
+            // current admission.
+            Long encounterId = cfv.getEncounter().getId();
+            Long parentEncounterId = cfv.getEncounter().getParentEncounter() != null
+                    ? cfv.getEncounter().getParentEncounter().getId()
+                    : null;
+            if (!admissionId.equals(encounterId) && !admissionId.equals(parentEncounterId)) {
+                skippedOtherAdmission++;
+                continue;
+            }
+            prescriptions.add(cfv.getPrescription());
+        }
+
+        if (prescriptions.isEmpty()) {
+            selectedDischargeMedicinesToIssue = null;
+            if (skippedOtherAdmission > 0) {
+                JsfUtil.addErrorMessage("The selected medicines do not belong to this admission. Please re-select.");
+            } else {
+                JsfUtil.addErrorMessage("Could not add any of the selected discharge medicines.");
+            }
+            return "";
+        }
+
+        String outcome = pharmacySaleBhtController.prepareDischargeIssueFromPrescriptions(admission, prescriptions);
+        selectedDischargeMedicinesToIssue = null;
+        return outcome;
+    }
+
+    public ClinicalFindingValue[] getSelectedDischargeMedicinesToIssue() {
+        return selectedDischargeMedicinesToIssue;
+    }
+
+    public void setSelectedDischargeMedicinesToIssue(ClinicalFindingValue[] selectedDischargeMedicinesToIssue) {
+        this.selectedDischargeMedicinesToIssue = selectedDischargeMedicinesToIssue;
     }
 
     public String navigateToWardMedicinesTimeline(PatientEncounter admission) {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -2299,10 +2299,19 @@ public class InpatientClinicalDataController implements Serializable {
         }
 
         Long admissionId = admission.getId();
+        List<ClinicalFindingValue> currentDischargeMedicines = getDischargeMedicines();
         List<com.divudi.core.entity.clinical.Prescription> prescriptions = new ArrayList<>();
         int skippedOtherAdmission = 0;
+        int skippedStale = 0;
         for (ClinicalFindingValue cfv : selectedDischargeMedicinesToIssue) {
             if (cfv == null || cfv.getPrescription() == null || cfv.getEncounter() == null) {
+                continue;
+            }
+            // Selection is session-scoped: reject any row that was deleted/retired
+            // (removed from the current discharge list) since it was selected, so a
+            // stale tick can never be converted into an issue line.
+            if (cfv.isRetired() || !currentDischargeMedicines.contains(cfv)) {
+                skippedStale++;
                 continue;
             }
             // Guard against a stale (session-scoped) selection carried over from a
@@ -2317,6 +2326,10 @@ public class InpatientClinicalDataController implements Serializable {
                 continue;
             }
             prescriptions.add(cfv.getPrescription());
+        }
+        if (skippedStale > 0) {
+            JsfUtil.addWarningMessage(skippedStale
+                    + " selected medicine(s) were removed from the list and were skipped.");
         }
 
         if (prescriptions.isEmpty()) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -207,6 +207,8 @@ public class PharmacySaleBhtController implements Serializable {
     @EJB
     PharmacyBean pharmacyBean;
     @EJB
+    private com.divudi.ejb.PrescriptionToItemService prescriptionToItemService;
+    @EJB
     private DirectIssueBatchService directIssueBatchService;
     @EJB
     private PersonFacade personFacade;
@@ -262,6 +264,10 @@ public class PharmacySaleBhtController implements Serializable {
     // When true, medicines are issued at retail rate with NO inward price-matrix
     // service charge (used by the Issue Discharge Medicines page).
     boolean dischargeIssueMode = false;
+    // Per-prescription conversion report shown on the discharge issue page so the
+    // pharmacist sees the original prescription against what was actually resolved
+    // (and any low/no-stock shortfall) — prevents silent omissions. Issue #21334.
+    private List<DischargeConversionRow> dischargeConversionReport = new ArrayList<>();
     Department department;
     String errorMessage = "";
     /////////////////
@@ -688,6 +694,7 @@ public class PharmacySaleBhtController implements Serializable {
         errorMessage = "";
         cachedMatrixByAdmissionDepartment = null;
         dischargeIssueMode = false;
+        dischargeConversionReport = new ArrayList<>();
     }
 
     /**
@@ -698,6 +705,316 @@ public class PharmacySaleBhtController implements Serializable {
     public void resetAllForDischargeIssue() {
         resetAll();
         dischargeIssueMode = true;
+    }
+
+    /**
+     * Prepares a discharge-medicine issue bill from a set of discharge-medicine
+     * prescriptions (selected on the inpatient assessment) for the given
+     * admission, then turns on discharge mode. Each prescription is converted to
+     * a bill item: the dispensable item and quantity are resolved via
+     * {@link com.divudi.ejb.PrescriptionToItemService}, and a FEFO (earliest
+     * expiry) stock batch with sufficient quantity is auto-picked from the
+     * logged-in pharmacy ({@code sessionController.getDepartment()}). The
+     * pharmacist can still change batch/quantity on the issue page before
+     * settling. Issue #21334.
+     *
+     * <p>Mirrors {@link PharmacyRequestForBhtController#addBillItemFromPrescription},
+     * but resolves a concrete stock + batch (a discharge issue dispenses
+     * immediately, unlike a ward request which is fulfilled later).</p>
+     *
+     * @param admission     the patient encounter the discharge medicines belong to
+     * @param prescriptions the selected discharge-medicine prescriptions
+     * @return navigation outcome to the discharge issue page, or "" to stay
+     */
+    public String prepareDischargeIssueFromPrescriptions(PatientEncounter admission,
+            List<com.divudi.core.entity.clinical.Prescription> prescriptions) {
+        if (admission == null || admission.getId() == null) {
+            JsfUtil.addErrorMessage("No admission selected.");
+            return "";
+        }
+        if (prescriptions == null || prescriptions.isEmpty()) {
+            JsfUtil.addErrorMessage("Select at least one discharge medicine.");
+            return "";
+        }
+        Department dispensingDepartment = getSessionController().getLoggedUser().getDepartment();
+        if (dispensingDepartment == null) {
+            JsfUtil.addErrorMessage("No dispensing pharmacy (logged-in department) found.");
+            return "";
+        }
+
+        resetAllForDischargeIssue();
+        setPatientEncounter(admission);
+        dischargeConversionReport = new ArrayList<>();
+
+        int added = 0;
+        int notAvailable = 0;
+        for (com.divudi.core.entity.clinical.Prescription sourcePrescription : prescriptions) {
+            DischargeConversionRow row = addDischargeBillItemFromPrescription(sourcePrescription, dispensingDepartment);
+            if (row != null) {
+                dischargeConversionReport.add(row);
+                if (row.getStatus() != DischargeConversionRow.Status.NOT_AVAILABLE) {
+                    added++;
+                } else {
+                    notAvailable++;
+                }
+            }
+        }
+
+        if (added == 0) {
+            JsfUtil.addErrorMessage("None of the selected medicines could be issued from "
+                    + dispensingDepartment.getName() + " (no available stock). Please add them manually.");
+            return "";
+        }
+        if (notAvailable > 0) {
+            JsfUtil.addWarningMessage(notAvailable + " medicine(s) had no available stock in "
+                    + dispensingDepartment.getName() + ". See the conversion report and add them manually if needed.");
+        }
+
+        calTotal();
+        return "/inward/pharmacy_discharge_medicine_issue?faces-redirect=true";
+    }
+
+    /**
+     * Converts one discharge-medicine prescription to a discharge issue bill item
+     * dispensed from {@code dispensingDepartment}, auto-picking the earliest-expiry
+     * (FEFO) stock batch with sufficient quantity. Falls back to qty=1 when the
+     * prescription is incomplete (so the pharmacist sets the real quantity on the
+     * issue page).
+     *
+     * <p>Always returns a {@link DischargeConversionRow} describing the original
+     * prescription against what was resolved/issued (including no-/low-stock
+     * shortfalls) so the pharmacist can see and act on any gap rather than a
+     * medicine being silently omitted. A bill item is added only when stock is
+     * available. Issue #21334.</p>
+     */
+    private DischargeConversionRow addDischargeBillItemFromPrescription(
+            com.divudi.core.entity.clinical.Prescription sourcePrescription, Department dispensingDepartment) {
+        if (sourcePrescription == null || sourcePrescription.getItem() == null) {
+            return null;
+        }
+
+        DischargeConversionRow row = new DischargeConversionRow();
+        row.setPrescribedText(sourcePrescription.getFormattedPrescription());
+
+        Item dispensableItem = sourcePrescription.getItem();
+        Double calculatedQty = null;
+        try {
+            com.divudi.ejb.PrescriptionToItemService.PrescriptionToItemResult result
+                    = prescriptionToItemService.calculateItemAndQuantity(sourcePrescription);
+            if (result != null && result.isSuccess()) {
+                if (result.getItem() != null) {
+                    dispensableItem = result.getItem();
+                }
+                if (result.getQuantity() != null) {
+                    calculatedQty = result.getQuantity();
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Discharge prescription conversion failed for {0}: {1}",
+                    new Object[]{dispensableItem.getName(), e.getMessage()});
+        }
+
+        boolean qtyDefaulted = false;
+        if (calculatedQty == null || calculatedQty <= 0) {
+            // Incomplete-prescription path: default to 1 and let the pharmacist
+            // adjust on the issue page before settling (mirrors the ward request).
+            calculatedQty = 1.0;
+            qtyDefaulted = true;
+        }
+
+        // Round up to whole units so we never request a fractional dispense.
+        double requiredQty = Math.ceil(calculatedQty);
+        row.setResolvedItemName(dispensableItem.getName());
+        row.setRequiredQty(requiredQty);
+
+        // FEFO via a lightweight DTO projection (NO entity graph loading — avoids
+        // the ~46-query Stock/ItemBatch/Item cascade noted in issue #20138 that
+        // made this slow). Earliest-expiry, in-date stock in the dispensing pharmacy.
+        List<StockDTO> availableStocks = findFefoStockDtosForItem(dispensableItem, dispensingDepartment);
+        if (availableStocks == null || availableStocks.isEmpty()) {
+            row.setIssuedQty(0.0);
+            row.setStatus(DischargeConversionRow.Status.NOT_AVAILABLE);
+            row.setMessage("No stock of " + dispensableItem.getName() + " in " + dispensingDepartment.getName()
+                    + ". Add manually from another batch/pharmacy or omit.");
+            return row;
+        }
+
+        double requestQty = requiredQty;
+        StockDTO chosenStock = null;
+        for (StockDTO s : availableStocks) {
+            if (s.getStockQty() != null && s.getStockQty() >= requestQty) {
+                chosenStock = s;
+                break;
+            }
+        }
+        boolean partial = false;
+        if (chosenStock == null) {
+            // No single batch covers the full quantity; take the earliest-expiry
+            // batch (the list is already FEFO-ordered) and cap qty to its stock.
+            chosenStock = availableStocks.get(0);
+            requestQty = Math.min(requestQty, chosenStock.getStockQty());
+            if (requestQty <= 0) {
+                row.setIssuedQty(0.0);
+                row.setStatus(DischargeConversionRow.Status.NOT_AVAILABLE);
+                row.setMessage("No usable stock of " + dispensableItem.getName() + " in "
+                        + dispensingDepartment.getName() + ".");
+                return row;
+            }
+            partial = true;
+        }
+
+        double retailRate = chosenStock.getRetailRate() != null ? chosenStock.getRetailRate() : 0.0;
+
+        // Build the bill item from the DTO using getReference() proxies — never
+        // find() — so no eager cascade fires (mirrors addBillItem(), issue #20138).
+        Item itemRef = getItemFacade().getReference(chosenStock.getItemId());
+        Stock stockRef = getStockFacade().getReference(chosenStock.getId());
+        ItemBatch itemBatchRef = getItemBatchFacade().getReference(chosenStock.getItemBatchId());
+
+        BillItem newBillItem = new BillItem();
+        newBillItem.setItem(itemRef);
+        newBillItem.setQty(requestQty);
+        newBillItem.setInwardChargeType(InwardChargeType.Medicine);
+        newBillItem.setBill(getPreBill());
+
+        PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+        pbi.setBillItem(newBillItem);
+        pbi.setStock(stockRef);
+        pbi.setItemBatchWithRates(itemBatchRef, retailRate,
+                chosenStock.getPurchaseRate() != null ? chosenStock.getPurchaseRate() : 0.0);
+        pbi.setDoe(chosenStock.getDateOfExpire());
+        pbi.setTransDisplayItemName(chosenStock.getItemName());
+        pbi.setFreeQty(0.0f);
+        pbi.setQty(0 - Math.abs(requestQty));
+        pbi.setQtyInUnit(0 - Math.abs(requestQty));
+        newBillItem.setPharmaceuticalBillItem(pbi);
+
+        // Carry the prescription details onto a detached in-memory prescription
+        // for the description (persisted later during settle).
+        com.divudi.core.entity.clinical.Prescription inMemoryPrescription
+                = new com.divudi.core.entity.clinical.Prescription();
+        inMemoryPrescription.setItem(itemRef);
+        inMemoryPrescription.setDose(sourcePrescription.getDose());
+        inMemoryPrescription.setDoseUnit(sourcePrescription.getDoseUnit());
+        inMemoryPrescription.setFrequencyUnit(sourcePrescription.getFrequencyUnit());
+        inMemoryPrescription.setDuration(sourcePrescription.getDuration());
+        inMemoryPrescription.setDurationUnit(sourcePrescription.getDurationUnit());
+        inMemoryPrescription.setComment(sourcePrescription.getComment());
+        inMemoryPrescription.setPatient(getPatientEncounter().getPatient());
+        inMemoryPrescription.setEncounter(getPatientEncounter());
+        inMemoryPrescription.setIndoor(true);
+        newBillItem.setPrescription(inMemoryPrescription);
+
+        // Build the description from the DTO name (avoids touching the Item proxy).
+        StringBuilder desc = new StringBuilder(chosenStock.getItemName());
+        if (sourcePrescription.getDose() != null) {
+            desc.append(" ").append(sourcePrescription.getDose());
+            if (sourcePrescription.getDoseUnit() != null) {
+                desc.append(" ").append(sourcePrescription.getDoseUnit().getName());
+            }
+        }
+        if (sourcePrescription.getFrequencyUnit() != null) {
+            desc.append(" ").append(sourcePrescription.getFrequencyUnit().getName());
+        }
+        if (sourcePrescription.getDuration() != null) {
+            desc.append(" for ").append(sourcePrescription.getDuration());
+            if (sourcePrescription.getDurationUnit() != null) {
+                desc.append(" ").append(sourcePrescription.getDurationUnit().getName());
+            }
+        }
+        if (sourcePrescription.getComment() != null && !sourcePrescription.getComment().trim().isEmpty()) {
+            desc.append(" - ").append(sourcePrescription.getComment());
+        }
+        newBillItem.setDescreption(desc.toString());
+
+        // Discharge: retail rate with ZERO inward margin (no service charge).
+        // Price directly from the DTO rate — no entity dereference, no price-matrix
+        // lookup — so the whole conversion stays free of heavy entity loading.
+        double grossValue = retailRate * requestQty;
+        newBillItem.setRate(retailRate);
+        newBillItem.setGrossValue(grossValue);
+        newBillItem.setMarginValue(0.0);
+        newBillItem.setMarginRate(0.0);
+        newBillItem.setNetValue(grossValue);
+        newBillItem.setNetRate(retailRate);
+        newBillItem.setAdjustedValue(grossValue);
+        newBillItem.setDiscount(0.0);
+
+        if (getPreBill().getBillItems() == null) {
+            getPreBill().setBillItems(new ArrayList<>());
+        }
+        newBillItem.setSearialNo(getPreBill().getBillItems().size() + 1);
+        getPreBill().getBillItems().add(newBillItem);
+
+        // Record the conversion outcome for the on-screen report.
+        row.setIssuedQty(requestQty);
+        if (partial) {
+            row.setStatus(DischargeConversionRow.Status.PARTIAL_LOW_STOCK);
+            row.setMessage("Only " + requestQty + " of " + requiredQty + " in stock at "
+                    + dispensingDepartment.getName() + ". Issued the available quantity from the earliest-expiry batch — split the rest manually or omit.");
+        } else if (qtyDefaulted) {
+            row.setStatus(DischargeConversionRow.Status.QTY_DEFAULTED);
+            row.setMessage("Quantity could not be calculated (incomplete prescription). Defaulted to "
+                    + requestQty + " — verify before settling.");
+        } else {
+            row.setStatus(DischargeConversionRow.Status.ISSUED_FULL);
+            row.setMessage("");
+        }
+        return row;
+    }
+
+    /**
+     * FEFO stock lookup for a prescribed item as lightweight {@link StockDTO}
+     * projections (stockId, itemBatchId, itemId, name, code, generic, retailRate,
+     * stockQty, doe) — NO entity loading. In-date, positive-stock rows in the
+     * dispensing pharmacy, earliest expiry first. For AMP/Ampp items the query is
+     * by the AMP itself; for VMP/VTM it resolves the candidate AMPs first.
+     * Issue #21334.
+     */
+    private List<StockDTO> findFefoStockDtosForItem(Item dispensableItem, Department dispensingDepartment) {
+        List<Amp> amps = pharmacyBean.resolveAmps(dispensableItem);
+        if (amps == null || amps.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("amps", amps);
+        params.put("d", dispensingDepartment);
+        params.put("s", 0.0);
+        params.put("doe", new Date());
+
+        String jpql = "SELECT NEW com.divudi.core.data.dto.StockDTO("
+                + "s.id, s.itemBatch.id, s.itemBatch.item.id, s.itemBatch.item.name, s.itemBatch.item.code, "
+                + "s.itemBatch.item.vmp.name, s.itemBatch.retailsaleRate, s.itemBatch.purcahseRate, "
+                + "s.stock, s.itemBatch.dateOfExpire) "
+                + "FROM Stock s "
+                + "WHERE s.itemBatch.item IN :amps "
+                + "AND s.department = :d "
+                + "AND s.stock > :s "
+                + "AND s.itemBatch.dateOfExpire > :doe "
+                + "ORDER BY s.itemBatch.dateOfExpire";
+
+        @SuppressWarnings("unchecked")
+        List<StockDTO> dtos = (List<StockDTO>) getStockFacade()
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        return dtos != null ? dtos : new ArrayList<>();
+    }
+
+    public List<DischargeConversionRow> getDischargeConversionReport() {
+        if (dischargeConversionReport == null) {
+            dischargeConversionReport = new ArrayList<>();
+        }
+        return dischargeConversionReport;
+    }
+
+    /** True when any converted line was not issued in full (needs pharmacist attention). */
+    public boolean isDischargeConversionHasAttentionItems() {
+        for (DischargeConversionRow r : getDischargeConversionReport()) {
+            if (r.isNeedsAttention()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void selectReplaceableStocksNew() {
@@ -3006,6 +3323,124 @@ public class PharmacySaleBhtController implements Serializable {
                 return stockDto.getId() != null ? stockDto.getId().toString() : "";
             }
             return value.toString();
+        }
+    }
+
+    /**
+     * One row of the prescription→dispensing conversion report shown on the
+     * discharge issue page. Captures the original prescription and what was
+     * actually resolved/issued, plus a human-readable status and severity so the
+     * pharmacist can spot low-/no-stock shortfalls and avoid silent omissions.
+     * Issue #21334.
+     */
+    public static class DischargeConversionRow implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public enum Status {
+            ISSUED_FULL,
+            QTY_DEFAULTED,
+            PARTIAL_LOW_STOCK,
+            NOT_AVAILABLE
+        }
+
+        private String prescribedText;
+        private String resolvedItemName;
+        private Double requiredQty;
+        private Double issuedQty;
+        private Status status;
+        private String message;
+
+        public DischargeConversionRow() {
+        }
+
+        public String getPrescribedText() {
+            return prescribedText;
+        }
+
+        public void setPrescribedText(String prescribedText) {
+            this.prescribedText = prescribedText;
+        }
+
+        public String getResolvedItemName() {
+            return resolvedItemName;
+        }
+
+        public void setResolvedItemName(String resolvedItemName) {
+            this.resolvedItemName = resolvedItemName;
+        }
+
+        public Double getRequiredQty() {
+            return requiredQty;
+        }
+
+        public void setRequiredQty(Double requiredQty) {
+            this.requiredQty = requiredQty;
+        }
+
+        public Double getIssuedQty() {
+            return issuedQty;
+        }
+
+        public void setIssuedQty(Double issuedQty) {
+            this.issuedQty = issuedQty;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        /** True when this row needs the pharmacist's attention (not fully issued). */
+        public boolean isNeedsAttention() {
+            return status != Status.ISSUED_FULL;
+        }
+
+        /** Bootstrap/PrimeFaces severity keyword for styling the row. */
+        public String getSeverity() {
+            if (status == null) {
+                return "info";
+            }
+            switch (status) {
+                case ISSUED_FULL:
+                    return "success";
+                case QTY_DEFAULTED:
+                case PARTIAL_LOW_STOCK:
+                    return "warning";
+                case NOT_AVAILABLE:
+                    return "danger";
+                default:
+                    return "info";
+            }
+        }
+
+        public String getStatusLabel() {
+            if (status == null) {
+                return "";
+            }
+            switch (status) {
+                case ISSUED_FULL:
+                    return "Issued in full";
+                case QTY_DEFAULTED:
+                    return "Qty defaulted — verify";
+                case PARTIAL_LOW_STOCK:
+                    return "Partial — low stock";
+                case NOT_AVAILABLE:
+                    return "Not available";
+                default:
+                    return "";
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -762,12 +762,12 @@ public class PharmacySaleBhtController implements Serializable {
 
         if (added == 0) {
             JsfUtil.addErrorMessage("None of the selected medicines could be issued from "
-                    + dispensingDepartment.getName() + " (no available stock). Please add them manually.");
+                    + dispensingDepartment.getName() + ". See the conversion report and add them manually.");
             return "";
         }
         if (notAvailable > 0) {
-            JsfUtil.addWarningMessage(notAvailable + " medicine(s) had no available stock in "
-                    + dispensingDepartment.getName() + ". See the conversion report and add them manually if needed.");
+            JsfUtil.addWarningMessage(notAvailable + " medicine(s) could not be issued from "
+                    + dispensingDepartment.getName() + " (no stock or conversion failed). See the conversion report and add them manually if needed.");
         }
 
         calTotal();
@@ -789,15 +789,25 @@ public class PharmacySaleBhtController implements Serializable {
      */
     private DischargeConversionRow addDischargeBillItemFromPrescription(
             com.divudi.core.entity.clinical.Prescription sourcePrescription, Department dispensingDepartment) {
-        if (sourcePrescription == null || sourcePrescription.getItem() == null) {
-            return null;
-        }
-
+        // Never silently drop a selected prescription: a prescription with no
+        // medicine still gets a visible report row so the omission is surfaced.
         DischargeConversionRow row = new DischargeConversionRow();
+        if (sourcePrescription == null || sourcePrescription.getItem() == null) {
+            row.setPrescribedText(sourcePrescription != null
+                    ? sourcePrescription.getFormattedPrescription() : "Unknown prescription");
+            row.setResolvedItemName("");
+            row.setRequiredQty(0.0);
+            row.setIssuedQty(0.0);
+            row.setStatus(DischargeConversionRow.Status.NOT_AVAILABLE);
+            row.setMessage("Prescription has no medicine selected. Review and add manually.");
+            return row;
+        }
         row.setPrescribedText(sourcePrescription.getFormattedPrescription());
 
         Item dispensableItem = sourcePrescription.getItem();
         Double calculatedQty = null;
+        boolean conversionFailed = false;
+        String conversionError = null;
         try {
             com.divudi.ejb.PrescriptionToItemService.PrescriptionToItemResult result
                     = prescriptionToItemService.calculateItemAndQuantity(sourcePrescription);
@@ -808,10 +818,35 @@ public class PharmacySaleBhtController implements Serializable {
                 if (result.getQuantity() != null) {
                     calculatedQty = result.getQuantity();
                 }
+            } else {
+                // The conversion did NOT succeed. Distinguish a genuine failure
+                // (e.g. no suitable AMP for a VTM/VMP, unit-conversion error) from
+                // a merely incomplete prescription. Only incomplete prescriptions
+                // get the qty=1 fallback; a real failure is flagged and skipped so
+                // the bill is never settled with an arbitrary under-dose.
+                if (prescriptionToItemService.isCalculationPossible(sourcePrescription)) {
+                    conversionFailed = true;
+                    conversionError = (result != null && result.getErrorMessage() != null)
+                            ? result.getErrorMessage()
+                            : "could not be converted to a dispensable item";
+                }
             }
         } catch (Exception e) {
+            conversionFailed = true;
+            conversionError = e.getMessage();
             LOGGER.log(Level.FINE, "Discharge prescription conversion failed for {0}: {1}",
                     new Object[]{dispensableItem.getName(), e.getMessage()});
+        }
+
+        row.setResolvedItemName(dispensableItem.getName());
+
+        if (conversionFailed) {
+            row.setRequiredQty(0.0);
+            row.setIssuedQty(0.0);
+            row.setStatus(DischargeConversionRow.Status.NOT_AVAILABLE);
+            row.setMessage(dispensableItem.getName() + ": " + conversionError
+                    + ". Not added — please add manually or omit.");
+            return row;
         }
 
         boolean qtyDefaulted = false;
@@ -824,7 +859,6 @@ public class PharmacySaleBhtController implements Serializable {
 
         // Round up to whole units so we never request a fractional dispense.
         double requiredQty = Math.ceil(calculatedQty);
-        row.setResolvedItemName(dispensableItem.getName());
         row.setRequiredQty(requiredQty);
 
         // FEFO via a lightweight DTO projection (NO entity graph loading — avoids

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -761,9 +761,14 @@ public class PharmacySaleBhtController implements Serializable {
         }
 
         if (added == 0) {
-            JsfUtil.addErrorMessage("None of the selected medicines could be issued from "
-                    + dispensingDepartment.getName() + ". See the conversion report and add them manually.");
-            return "";
+            // Still navigate to the issue page so the conversion report (which the
+            // message tells the pharmacist to review) is visible — every selected
+            // medicine failed (no stock or conversion failure), so nothing is on
+            // the bill, but the per-medicine outcomes must not be hidden.
+            JsfUtil.addWarningMessage("None of the selected medicines could be issued from "
+                    + dispensingDepartment.getName() + ". Review the conversion report and add them manually if needed.");
+            calTotal();
+            return "/inward/pharmacy_discharge_medicine_issue?faces-redirect=true";
         }
         if (notAvailable > 0) {
             JsfUtil.addWarningMessage(notAvailable + " medicine(s) could not be issued from "

--- a/src/main/java/com/divudi/core/data/dto/StockDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StockDTO.java
@@ -78,6 +78,16 @@ public class StockDTO implements Serializable {
         this(stockId, itemBatchId, itemId, itemName, code, genericName, (Double) retailRate, (Double) stockQty, dateOfExpire);
     }
 
+    // Optimized FEFO discharge-issue projection: ids + name/code/generic + retail
+    // AND purchase rate (for COGS) + stock + expiry. (issue #21334)
+    // ItemBatch.purcahseRate is primitive double on the entity, so EclipseLink
+    // requires an exact-type constructor parameter for the projection.
+    public StockDTO(Long stockId, Long itemBatchId, Long itemId, String itemName, String code,
+                    String genericName, double retailRate, double purchaseRate, double stockQty, Date dateOfExpire) {
+        this(stockId, itemBatchId, itemId, itemName, code, genericName, (Double) retailRate, (Double) stockQty, dateOfExpire);
+        this.purchaseRate = purchaseRate;
+    }
+
     // Same as above, with allowFractions
     public StockDTO(Long id, String itemName, String code, String genericName,
                     Double retailRate, Double stockQty, Date dateOfExpire,

--- a/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
+++ b/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
@@ -4,8 +4,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:emr="http://xmlns.jcp.org/jsf/composite/ezcomp/emr">
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
@@ -52,9 +51,19 @@
                             <div class="col-12">
                                 <p:panel id="panelDischargeMedicines" class="w-100 m-1 p-0">
                                     <f:facet name="header">
-                                        <p:outputLabel value="Discharge Medications"
-                                                       styleClass="d-flex align-items-center w-100 fw-bold"
-                                                       style="background-color:#0d6efd; color:#ffffff; margin:-0.75rem -1rem; padding:0.6rem 1rem; border-top-left-radius:0.25rem; border-top-right-radius:0.25rem;" />
+                                        <div class="d-flex align-items-center justify-content-between w-100 fw-bold"
+                                             style="background-color:#0d6efd; color:#ffffff; margin:-0.75rem -1rem; padding:0.6rem 1rem; border-top-left-radius:0.25rem; border-top-right-radius:0.25rem;">
+                                            <p:outputLabel value="Discharge Medications" />
+                                            <p:commandButton id="btnCreateDischargeIssueBill"
+                                                             value="Create Discharge Issue Bill"
+                                                             icon="fa fa-prescription-bottle-alt"
+                                                             ajax="false"
+                                                             rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
+                                                             title="Issue the ticked discharge medicines from your pharmacy (no service charge)"
+                                                             styleClass="ui-button-warning ui-button-sm"
+                                                             process="@form"
+                                                             action="#{inpatientClinicalDataController.createDischargeIssueBillFromSelected()}" />
+                                        </div>
                                     </f:facet>
                                     <div class="container-fluid m-0 p-2 w-100">
                                         <div class="row g-3 align-items-end">
@@ -122,11 +131,43 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <emr:patient_medicines
-                                        id="tblDischargeRxx"
-                                        editable="true"
-                                        medicines="#{inpatientClinicalDataController.dischargeMedicines}">
-                                    </emr:patient_medicines>
+                                    <p:dataTable id="tblDischargeRxx"
+                                                 value="#{inpatientClinicalDataController.dischargeMedicines}"
+                                                 var="drx"
+                                                 rowKey="#{drx.id}"
+                                                 selection="#{inpatientClinicalDataController.selectedDischargeMedicinesToIssue}"
+                                                 selectionMode="multiple"
+                                                 selectionPageOnly="false"
+                                                 styleClass="w-100"
+                                                 stripedRows="true"
+                                                 size="small"
+                                                 emptyMessage="No discharge medicines prescribed">
+                                        <p:column selectionBox="true" style="width:3rem; text-align:center;"
+                                                  rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}" />
+                                        <p:column headerText="Medications">
+                                            <h:outputText value="#{drx.prescription.formattedPrescription}" />
+                                        </p:column>
+                                        <p:column headerText="Prescribed By" style="width: 160px;">
+                                            <h:outputText value="#{drx.prescription.prescribedBy.name}" />
+                                        </p:column>
+                                        <p:column headerText="Prescribed At" style="width: 150px;">
+                                            <h:outputText value="#{drx.prescription.prescribedAt}">
+                                                <f:convertDateTime pattern="yyyy-MM-dd HH:mm" timeZone="Asia/Colombo" />
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Comment">
+                                            <h:outputText value="#{drx.prescription.comment}" />
+                                        </p:column>
+                                        <p:column headerText="" style="width:4rem; text-align:center;">
+                                            <p:commandButton icon="pi pi-times"
+                                                             styleClass="ui-button-danger ui-button-sm"
+                                                             title="Remove this discharge medicine"
+                                                             process="@this"
+                                                             update=":formDischargeMedicines:growlDischargeMedicines :formDischargeMedicines:panelDischargeMedicines"
+                                                             onclick="if (!confirm('Are you sure you want to delete this prescription?')) return false;"
+                                                             action="#{inpatientClinicalDataController.removeClinicalFindingValueForComposite(inpatientClinicalDataController.dischargeMedicines, drx)}" />
+                                        </p:column>
+                                    </p:dataTable>
                                 </p:panel>
                             </div>
                         </div>

--- a/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
+++ b/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
@@ -57,11 +57,11 @@
                                             <p:commandButton id="btnCreateDischargeIssueBill"
                                                              value="Create Discharge Issue Bill"
                                                              icon="fa fa-prescription-bottle-alt"
-                                                             ajax="false"
+                                                             ajax="true"
                                                              rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
                                                              title="Issue the ticked discharge medicines from your pharmacy (no service charge)"
                                                              styleClass="ui-button-warning ui-button-sm"
-                                                             process="@form"
+                                                             process="@this :formDischargeMedicines:tblDischargeRxx"
                                                              action="#{inpatientClinicalDataController.createDischargeIssueBillFromSelected()}" />
                                         </div>
                                     </f:facet>
@@ -160,6 +160,7 @@
                                         </p:column>
                                         <p:column headerText="" style="width:4rem; text-align:center;">
                                             <p:commandButton icon="pi pi-times"
+                                                             id="btnRemoveDischargeRx"
                                                              styleClass="ui-button-danger ui-button-sm"
                                                              title="Remove this discharge medicine"
                                                              process="@this"

--- a/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
+++ b/src/main/webapp/inward/inward_assessment_discharge_medicines.xhtml
@@ -62,6 +62,7 @@
                                                              title="Issue the ticked discharge medicines from your pharmacy (no service charge)"
                                                              styleClass="ui-button-warning ui-button-sm"
                                                              process="@this :formDischargeMedicines:tblDischargeRxx"
+                                                             update=":formDischargeMedicines:growlDischargeMedicines"
                                                              action="#{inpatientClinicalDataController.createDischargeIssueBillFromSelected()}" />
                                         </div>
                                     </f:facet>

--- a/src/main/webapp/inward/pharmacy_discharge_medicine_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_discharge_medicine_issue.xhtml
@@ -239,6 +239,64 @@
                         </div>
                     </div>
 
+                    <h:panelGroup layout="block" styleClass="row mb-3"
+                                  rendered="#{not empty pharmacySaleBhtController.dischargeConversionReport}">
+                        <div class="col-12">
+                            <p:panel id="panelDischargeConversionReport" class="w-100"
+                                     toggleable="true"
+                                     collapsed="#{not pharmacySaleBhtController.dischargeConversionHasAttentionItems}">
+                                <f:facet name="header">
+                                    <div class="d-flex align-items-center w-100">
+                                        <h:outputText styleClass="fas fa-exchange-alt me-2" />
+                                        <p:outputLabel value="Prescription → Dispensing Report" styleClass="fw-bold" />
+                                        <p:tag styleClass="ms-3"
+                                               value="Review — not all issued in full"
+                                               severity="warning"
+                                               rendered="#{pharmacySaleBhtController.dischargeConversionHasAttentionItems}" />
+                                        <p:tag styleClass="ms-3"
+                                               value="All issued in full"
+                                               severity="success"
+                                               rendered="#{not pharmacySaleBhtController.dischargeConversionHasAttentionItems}" />
+                                    </div>
+                                </f:facet>
+                                <p:dataTable id="tblDischargeConversionReport"
+                                             value="#{pharmacySaleBhtController.dischargeConversionReport}"
+                                             var="cr"
+                                             styleClass="w-100"
+                                             stripedRows="true"
+                                             size="small">
+                                    <p:column headerText="Prescribed">
+                                        <h:outputText value="#{cr.prescribedText}" />
+                                    </p:column>
+                                    <p:column headerText="Dispensing as" style="min-width:14em;">
+                                        <h:outputText value="#{cr.resolvedItemName}" />
+                                    </p:column>
+                                    <p:column headerText="Required" style="width:7em;" styleClass="text-end">
+                                        <h:outputText value="#{cr.requiredQty}">
+                                            <f:convertNumber pattern="#,##0.##" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Issued" style="width:7em;" styleClass="text-end">
+                                        <h:outputText value="#{cr.issuedQty}">
+                                            <f:convertNumber pattern="#,##0.##" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Status" style="width:12em;">
+                                        <p:tag value="#{cr.statusLabel}" severity="#{cr.severity}" />
+                                    </p:column>
+                                    <p:column headerText="Note">
+                                        <h:outputText value="#{cr.message}" styleClass="text-muted" />
+                                    </p:column>
+                                </p:dataTable>
+                                <h:panelGroup layout="block" styleClass="alert alert-warning m-2"
+                                              rendered="#{pharmacySaleBhtController.dischargeConversionHasAttentionItems}">
+                                    <i class="fa fa-exclamation-triangle me-2"></i>
+                                    <h:outputText value="One or more prescribed medicines were not issued in full (low or no stock, or a defaulted quantity). Add them manually or confirm the omission before settling — do not settle assuming everything was dispensed." />
+                                </h:panelGroup>
+                            </p:panel>
+                        </div>
+                    </h:panelGroup>
+
                     <div class="row">
 
                         <div class="col-12 col-md-3" id="gpDetail">


### PR DESCRIPTION
## Summary

One-click conversion of an inpatient's **Discharge Medicines prescription** into a **discharge issue bill** (retail rate, **no inward service charge**), dispensed from the **logged-in pharmacy**. Builds on #21329 / PR #21330 (the discharge issue page + `DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE` atomic).

Closes #21334.

## User flow

1. Pharmacist opens the patient's **Inpatient Dashboard** → **Discharge Medicines** (`inward_assessment_discharge_medicines.xhtml`).
2. The **Discharge Medications** list is now a single selectable table — tick one, several, or all.
3. Click **Create Discharge Issue Bill** (header button, privilege-gated).
4. Each prescription is converted to a discharge issue line (FEFO batch from the logged pharmacy + calculated qty) and the page navigates to `pharmacy_discharge_medicine_issue.xhtml` with the lines pre-filled and editable.
5. Pharmacist reviews batch/qty and settles → `DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE` (no service charge), counted in all reports already covered by #21329.

## Key changes

**`InpatientClinicalDataController`**
- `createDischargeIssueBillFromSelected()` (mirrors `requestSelectedWardMedicinesFromPharmacy()`): validates the admission (prefers `parentAdmission`), guards against stale cross-admission selections, delegates to the pharmacy controller.
- `selectedDischargeMedicinesToIssue` selection holder; injected `PharmacySaleBhtController`.

**`PharmacySaleBhtController`**
- `prepareDischargeIssueFromPrescriptions(admission, prescriptions)` — orchestrates conversion + builds the on-screen report.
- `addDischargeBillItemFromPrescription(...)` — resolves item+qty via `PrescriptionToItemService` (incomplete → qty 1 + warning), picks FEFO stock, builds the bill item.
- `findFefoStockDtosForItem(...)` — **lightweight `StockDTO` projection** (`findLightsByJpqlWithoutCache`), FEFO-ordered, **no entity-graph load**; bill item built with `getReference()` proxies and priced directly from the DTO retail rate with zero margin. This is the performance fix (avoids the ~46-query Stock→ItemBatch→Item cascade of issue #20138).
- `DischargeConversionRow` DTO + report getters powering the **Prescription → Dispensing** report.

**`StockDTO`** — one new projection constructor adding `purcahseRate` (for COGS) to the ids+rates+stock+expiry shape.

**`inward_assessment_discharge_medicines.xhtml`** — single selectable Discharge Medications table (tick boxes gated by `PharmacyDischargeMedicineIssue`), in-row remove, header **Create Discharge Issue Bill** button. Removed the redundant second list and the read-only `patient_medicines` composite; add/remove now refresh the list in place.

**`pharmacy_discharge_medicine_issue.xhtml`** — **Prescription → Dispensing report** panel: lists each prescribed medicine vs. what was resolved/issued, colour-coded status (Issued in full / Qty defaulted / Partial – low stock / Not available) with a warning banner so shortfalls are visible and omissions are prevented before settling.

## Behaviour decisions (confirmed with maintainer)

- Dispensing department is always `sessionController.getDepartment()` (the logged pharmacy).
- FEFO batch auto-pick, editable on the issue page.
- Incomplete prescription → qty 1 + warning (matches the ward "Request Selected" behaviour).
- No/low stock → the medicine is shown in the report (not silently dropped) for manual handling.

## Testing

Verified locally on Ruhunu: select → create → pre-filled issue lines at retail/zero-margin → settle; add/remove refresh the list in place; conversion is fast (DTO path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discharge medicine issuance workflow: select inpatient prescriptions and create discharge issue bills.
  * Automated prescription→dispensing conversion with per-prescription conversion report and attention flags.
* **UI**
  * Refactored discharge medicines table with multi-select, prescriber, date, comments and per-row removal.
  * "Create Discharge Issue Bill" button for authorized users.
  * Warnings/alerts shown when issued quantities are incomplete and require manual confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->