### PR TITLE
feat(inward): add credit company to inward discount and price adjustment matrices

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -88,6 +88,44 @@ public class PriceMatrixController implements Serializable {
 
     }
 
+    public PriceMatrix fetchInwardMargin(BillItem billItem, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
+        if (creditCompany != null) {
+            PriceMatrix result = fetchInwardMarginWithCreditCompany(billItem, serviceValue, department, paymentMethod, creditCompany);
+            if (result != null) {
+                return result;
+            }
+        }
+        return fetchInwardMargin(billItem, serviceValue, department, paymentMethod);
+    }
+
+    private PriceMatrix fetchInwardMarginWithCreditCompany(BillItem billItem, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
+        boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
+        Category category;
+        if (billItem.getItem() instanceof Investigation) {
+            if (configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
+                category = ((Investigation) billItem.getItem()).getCategory();
+            } else {
+                category = ((Investigation) billItem.getItem()).getInvestigationCategory();
+            }
+        } else {
+            category = billItem.getItem().getCategory();
+        }
+        PriceMatrix result;
+        if (isPaymentMethodAllowedInInwardMatrix) {
+            result = getInwardPriceAdjustment(department, serviceValue, category, paymentMethod, creditCompany);
+        } else {
+            result = getInwardPriceAdjustment(department, serviceValue, category, creditCompany);
+        }
+        if (result == null && category != null) {
+            if (isPaymentMethodAllowedInInwardMatrix) {
+                result = getInwardPriceAdjustment(department, serviceValue, category.getParentCategory(), paymentMethod, creditCompany);
+            } else {
+                result = getInwardPriceAdjustment(department, serviceValue, category.getParentCategory(), creditCompany);
+            }
+        }
+        return result;
+    }
+
     public PriceMatrix fetchInwardMargin(Item item, double serviceValue, Department department) {
 
         PriceMatrix inwardPriceAdjustment;
@@ -172,6 +210,46 @@ public class PriceMatrixController implements Serializable {
         hm.put("tPrice", dbl);
         hm.put("cat", category);
 
+        return (InwardPriceAdjustment) getPriceMatrixFacade().findFirstByJpql(sql, hm);
+    }
+
+    public InwardPriceAdjustment getInwardPriceAdjustment(Department department, double dbl, Category category, Institution creditCompany) {
+        if (creditCompany == null) {
+            return getInwardPriceAdjustment(department, dbl, category);
+        }
+        String sql = "select a from InwardPriceAdjustment a "
+                + " where a.retired=false"
+                + " and a.category=:cat "
+                + " and a.department=:dep"
+                + " and (a.fromPrice < :frPrice and a.toPrice > :tPrice)"
+                + " and a.creditCompany=:cc";
+        HashMap hm = new HashMap();
+        hm.put("dep", department);
+        hm.put("frPrice", dbl);
+        hm.put("tPrice", dbl);
+        hm.put("cat", category);
+        hm.put("cc", creditCompany);
+        return (InwardPriceAdjustment) getPriceMatrixFacade().findFirstByJpql(sql, hm);
+    }
+
+    public InwardPriceAdjustment getInwardPriceAdjustment(Department department, double dbl, Category category, PaymentMethod paymentMethod, Institution creditCompany) {
+        if (creditCompany == null) {
+            return getInwardPriceAdjustment(department, dbl, category, paymentMethod);
+        }
+        String sql = "select a from InwardPriceAdjustment a "
+                + " where a.retired=false"
+                + " and a.category=:cat "
+                + " and a.department=:dep"
+                + " and (a.fromPrice < :frPrice and a.toPrice > :tPrice)"
+                + " and a.paymentMethod=:pm"
+                + " and a.creditCompany=:cc";
+        HashMap hm = new HashMap();
+        hm.put("pm", paymentMethod);
+        hm.put("dep", department);
+        hm.put("frPrice", dbl);
+        hm.put("tPrice", dbl);
+        hm.put("cat", category);
+        hm.put("cc", creditCompany);
         return (InwardPriceAdjustment) getPriceMatrixFacade().findFirstByJpql(sql, hm);
     }
 
@@ -1079,13 +1157,37 @@ public class PriceMatrixController implements Serializable {
      */
     public double getInwardDiscountPercent(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Item item) {
+        return getInwardDiscountPercent(bhtType, scheme, admissionType, department, item, null);
+    }
+
+    public double getInwardDiscountPercent(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Item item, Institution creditCompany) {
         if (bhtType == null || admissionType == null) {
             return 0.0;
         }
 
-        Category category = null;
-        if (item != null) {
-            category = item.getCategory();
+        Category category = item != null ? item.getCategory() : null;
+
+        if (creditCompany != null) {
+            Double pct = fetchInwardDiscountPercentForItem(bhtType, scheme, admissionType, item, creditCompany);
+            if (pct == null) {
+                pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category, creditCompany);
+            }
+            if (pct == null && category != null) {
+                pct = fetchInwardDiscountPercentForCategory(bhtType, scheme, admissionType, department, category.getParentCategory(), creditCompany);
+            }
+            if (pct == null) {
+                pct = fetchInwardDiscountPercentForDepartment(bhtType, scheme, admissionType, department, creditCompany);
+            }
+            if (pct == null) {
+                pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, null, creditCompany);
+                if (pct == null && scheme != null) {
+                    pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, null, null, null, creditCompany);
+                }
+            }
+            if (pct != null) {
+                return pct;
+            }
         }
 
         Double pct = fetchInwardDiscountPercentForItem(bhtType, scheme, admissionType, item);
@@ -1098,7 +1200,6 @@ public class PriceMatrixController implements Serializable {
         if (pct == null) {
             pct = fetchInwardDiscountPercentForDepartment(bhtType, scheme, admissionType, department);
         }
-        // Global wildcard: rows with null dept/category/item apply to everything
         if (pct == null) {
             pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, null);
             if (pct == null && scheme != null) {
@@ -1120,6 +1221,18 @@ public class PriceMatrixController implements Serializable {
         return pct;
     }
 
+    private Double fetchInwardDiscountPercentForItem(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Item item, Institution creditCompany) {
+        if (item == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, null, null, item, creditCompany);
+        if (pct == null && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, null, null, item, creditCompany);
+        }
+        return pct;
+    }
+
     private Double fetchInwardDiscountPercentForCategory(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category) {
         if (category == null) {
@@ -1128,6 +1241,18 @@ public class PriceMatrixController implements Serializable {
         Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, category, null);
         if (pct == null && scheme != null) {
             pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, category, null);
+        }
+        return pct;
+    }
+
+    private Double fetchInwardDiscountPercentForCategory(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Category category, Institution creditCompany) {
+        if (category == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, category, null, creditCompany);
+        if (pct == null && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, category, null, creditCompany);
         }
         return pct;
     }
@@ -1144,6 +1269,18 @@ public class PriceMatrixController implements Serializable {
         return pct;
     }
 
+    private Double fetchInwardDiscountPercentForDepartment(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Institution creditCompany) {
+        if (department == null) {
+            return null;
+        }
+        Double pct = fetchInwardDiscountMatrixPercent(bhtType, scheme, admissionType, department, null, null, creditCompany);
+        if (pct == null && scheme != null) {
+            pct = fetchInwardDiscountMatrixPercent(bhtType, null, admissionType, department, null, null, creditCompany);
+        }
+        return pct;
+    }
+
     /**
      * Single-row matrix fetch for service/pharmacy discounts (rows where
      * inwardChargeType IS NULL). Each argument except bhtType and admissionType
@@ -1152,7 +1289,12 @@ public class PriceMatrixController implements Serializable {
      */
     private Double fetchInwardDiscountMatrixPercent(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category, Item item) {
-        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, department, category, item, null, false);
+        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, department, category, item, null, false, null);
+    }
+
+    private Double fetchInwardDiscountMatrixPercent(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, Department department, Category category, Item item, Institution creditCompany) {
+        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, department, category, item, null, false, creditCompany);
     }
 
     /**
@@ -1162,7 +1304,12 @@ public class PriceMatrixController implements Serializable {
      */
     private Double fetchInwardDiscountMatrixPercentForChargeType(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, InwardChargeType chargeType) {
-        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, null, null, null, chargeType, true);
+        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, null, null, null, chargeType, true, null);
+    }
+
+    private Double fetchInwardDiscountMatrixPercentForChargeType(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, InwardChargeType chargeType, Institution creditCompany) {
+        return fetchInwardDiscountMatrixPercentCore(bhtType, scheme, admissionType, null, null, null, chargeType, true, creditCompany);
     }
 
     /**
@@ -1173,7 +1320,7 @@ public class PriceMatrixController implements Serializable {
      */
     private Double fetchInwardDiscountMatrixPercentCore(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category, Item item,
-            InwardChargeType chargeType, boolean chargeTypeSpecific) {
+            InwardChargeType chargeType, boolean chargeTypeSpecific, Institution creditCompany) {
         StringBuilder jpql = new StringBuilder(
                 "select a.discountPercent from InwardDiscountMatrix a"
                 + " where a.retired = false");
@@ -1219,12 +1366,16 @@ public class PriceMatrixController implements Serializable {
             jpql.append(" and a.item is null");
         }
         if (chargeTypeSpecific) {
-            // Room-charge-type lookup: match the specific charge type
             jpql.append(" and a.inwardChargeType = :chargeType");
             params.put("chargeType", chargeType);
         } else {
-            // Service/pharmacy lookup: only rows with no charge-type restriction
             jpql.append(" and a.inwardChargeType is null");
+        }
+        if (creditCompany != null) {
+            jpql.append(" and a.creditCompany = :cc");
+            params.put("cc", creditCompany);
+        } else {
+            jpql.append(" and a.creditCompany is null");
         }
         // Prefer specific rows over wildcards: non-null fields rank higher
         jpql.append(" order by"
@@ -1262,12 +1413,23 @@ public class PriceMatrixController implements Serializable {
      */
     public double getInwardDiscountPercentForChargeType(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, InwardChargeType chargeType) {
+        return getInwardDiscountPercentForChargeType(bhtType, scheme, admissionType, chargeType, null);
+    }
+
+    public double getInwardDiscountPercentForChargeType(PaymentMethod bhtType, PaymentScheme scheme,
+            AdmissionType admissionType, InwardChargeType chargeType, Institution creditCompany) {
         if (bhtType == null || admissionType == null || chargeType == null) {
             return 0.0;
         }
-        // Try charge-type-specific row first; no fallback to service/pharmacy
-        // wildcard rows (inwardChargeType IS NULL) — absence of a room-charge
-        // row means 0% discount, not inheritance of a service discount.
+        if (creditCompany != null) {
+            Double pct = fetchInwardDiscountMatrixPercentForChargeType(bhtType, scheme, admissionType, chargeType, creditCompany);
+            if (pct == null && scheme != null) {
+                pct = fetchInwardDiscountMatrixPercentForChargeType(bhtType, null, admissionType, chargeType, creditCompany);
+            }
+            if (pct != null) {
+                return pct;
+            }
+        }
         Double pct = fetchInwardDiscountMatrixPercentForChargeType(bhtType, scheme, admissionType, chargeType);
         if (pct == null && scheme != null) {
             pct = fetchInwardDiscountMatrixPercentForChargeType(bhtType, null, admissionType, chargeType);

--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -184,7 +184,8 @@ public class PriceMatrixController implements Serializable {
                 + " where a.retired=false"
                 + " and a.category=:cat "
                 + " and  a.department=:dep"
-                + " and (a.fromPrice< :frPrice and a.toPrice >:tPrice)";
+                + " and (a.fromPrice< :frPrice and a.toPrice >:tPrice)"
+                + " and a.creditCompany is null";
         HashMap hm = new HashMap();
         hm.put("dep", department);
         hm.put("frPrice", dbl);
@@ -200,7 +201,8 @@ public class PriceMatrixController implements Serializable {
                 + " and a.category=:cat "
                 + " and  a.department=:dep"
                 + " and (a.fromPrice< :frPrice and a.toPrice >:tPrice)"
-                + " and a.paymentMethod=:pm";
+                + " and a.paymentMethod=:pm"
+                + " and a.creditCompany is null";
 
         HashMap hm = new HashMap();
 

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2628,6 +2628,20 @@ public class BhtSummeryController implements Serializable {
         this.billFeeFacade = billFeeFacade;
     }
 
+    private com.divudi.core.entity.Institution resolveSingleCreditCompany(PatientEncounter encounter) {
+        if (encounter == null) {
+            return null;
+        }
+        String jpql = "select e from EncounterCreditCompany e where e.retired = false and e.patientEncounter = :enc";
+        java.util.HashMap<String, Object> hm = new java.util.HashMap<>();
+        hm.put("enc", encounter);
+        List<EncounterCreditCompany> list = encounterCreditCompanyFacade.findByJpql(jpql, hm, 2);
+        if (list != null && list.size() == 1) {
+            return list.get(0).getInstitution();
+        }
+        return null;
+    }
+
     private List<PatientRoom> createPatientRooms() {
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
@@ -2643,14 +2657,16 @@ public class BhtSummeryController implements Serializable {
         PaymentScheme scheme = getPatientEncounter().getPaymentScheme();
         AdmissionType admType = getPatientEncounter().getAdmissionType();
 
+        com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(getPatientEncounter());
+
         // Fetch all discount percentages once per recalculation (not per room)
-        double roomPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.RoomCharges);
-        double maintainPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MaintainCharges);
-        double linenPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.LinenCharges);
-        double nursingPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.NursingCharges);
-        double moPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MOCharges);
-        double adminPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.AdministrationCharge);
-        double medicalCarePct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MedicalCareICU);
+        double roomPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.RoomCharges, creditCompany);
+        double maintainPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MaintainCharges, creditCompany);
+        double linenPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.LinenCharges, creditCompany);
+        double nursingPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.NursingCharges, creditCompany);
+        double moPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MOCharges, creditCompany);
+        double adminPct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.AdministrationCharge, creditCompany);
+        double medicalCarePct = getPriceMatrixController().getInwardDiscountPercentForChargeType(pm, scheme, admType, InwardChargeType.MedicalCareICU, creditCompany);
 
         for (PatientRoom p : patientRooms) {
             if (p.getAdmittedAt() == null) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -111,6 +111,8 @@ public class InwardBeanController implements Serializable {
     private PatientEncounterFacade encounterFacade;
     @EJB
     BillNumberGenerator billNumberGenerator;
+    @EJB
+    private com.divudi.core.facade.EncounterCreditCompanyFacade encounterCreditCompanyFacade;
 
     @Inject
     BillBeanController billBean;
@@ -2435,30 +2437,7 @@ public class InwardBeanController implements Serializable {
     }
 
     public void setBillFeeMargin(BillFee billFee, Item item, PriceMatrix priceMatrix, PatientEncounter patientEncounter) {
-        if (billFee == null || item.isMarginNotAllowed()
-                || billFee.getFee() == null
-                || Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())) {
-            // Fix C: clear stale discount and recompute net so calTotals() sees correct feeValue
-            if (billFee != null) {
-                billFee.setFeeDiscount(0.0);
-                billFee.setFeeUnitDiscount(0.0);
-                double gross = billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() : 0.0;
-                double uQty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
-                        ? billFee.getBillItem().getQty() : 1.0;
-                billFee.setFeeUnitValue(gross / uQty);
-                billFee.setFeeValue(gross);
-            }
-            return;
-        }
-        if (patientEncounter == null || patientEncounter.getAdmissionType() == null) {
-            // Fix C: clear stale discount and recompute net so calTotals() sees correct feeValue
-            billFee.setFeeDiscount(0.0);
-            billFee.setFeeUnitDiscount(0.0);
-            double gross = billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() : 0.0;
-            double uQty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
-                    ? billFee.getBillItem().getQty() : 1.0;
-            billFee.setFeeUnitValue(gross / uQty);
-            billFee.setFeeValue(gross);
+        if (billFee == null || item == null || billFee.getFee() == null) {
             return;
         }
 
@@ -2468,27 +2447,69 @@ public class InwardBeanController implements Serializable {
                 ? billFee.getFeeUnitGrossValue()
                 : (billFee.getFeeGrossValue() != null ? billFee.getFeeGrossValue() / qty : 0.0);
 
+        // Margin and discount are independent — a fee that disallows margin can still receive a discount.
+        boolean marginEligible = !item.isMarginNotAllowed()
+                && !Boolean.FALSE.equals(billFee.getFee().getMarginAllowed())
+                && billFee.getFee().getFeeType() != FeeType.Staff
+                && patientEncounter != null
+                && patientEncounter.getAdmissionType() != null
+                && patientEncounter.getAdmissionType().isAllowToCalculateMargin();
+
         double unitMargin = 0;
-        if (patientEncounter.getAdmissionType().isAllowToCalculateMargin()) {
-            if (billFee.getFee().getFeeType() != FeeType.Staff && priceMatrix != null) {
-                unitMargin = (unitGross * priceMatrix.getMargin()) / 100;
+        if (marginEligible) {
+            // Try CC-specific priceMatrix first; fall back to the caller-provided one.
+            PriceMatrix effectivePriceMatrix = priceMatrix;
+            com.divudi.core.entity.Institution cc = resolveSingleCreditCompany(patientEncounter);
+            if (cc != null && billFee.getBillItem() != null) {
+                BillItem bi = billFee.getBillItem();
+                double svcValue = bi.getRate() != 0.0 ? Math.abs(bi.getRate()) : unitGross;
+                Department dept = item.getDepartment() != null ? item.getDepartment()
+                        : (bi.getBill() != null ? bi.getBill().getDepartment() : null);
+                PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(bi, svcValue, dept,
+                        patientEncounter.getPaymentMethod(), cc);
+                if (ccMatrix != null) {
+                    effectivePriceMatrix = ccMatrix;
+                }
+            }
+            if (effectivePriceMatrix != null) {
+                unitMargin = (unitGross * effectivePriceMatrix.getMargin()) / 100;
                 billFee.setFeeUnitMargin(unitMargin);
                 billFee.setFeeMargin(unitMargin * qty);
                 billFeeFacade.edit(billFee);
             }
         }
 
-        // Fix A: reset discount before applyInwardDiscountToBillFee so stale values
-        // don't survive if that method exits early without setting a new discount
+        // Reset discount fields before applying so stale values don't survive.
         billFee.setFeeUnitDiscount(0.0);
         billFee.setFeeDiscount(0.0);
 
-        applyInwardDiscountToBillFee(billFee, item, patientEncounter);
+        // Apply discount (has its own eligibility guards inside).
+        if (patientEncounter != null && patientEncounter.getAdmissionType() != null) {
+            applyInwardDiscountToBillFee(billFee, item, patientEncounter);
+        } else {
+            billFee.setFeeUnitValue(unitGross);
+            billFee.setFeeValue(unitGross * qty);
+            return;
+        }
 
         double unitDiscount = (billFee.getFeeUnitDiscount() != null) ? billFee.getFeeUnitDiscount() : 0.0;
         double unitNet = (unitGross + unitMargin) - unitDiscount;
         billFee.setFeeUnitValue(unitNet);
         billFee.setFeeValue(unitNet * qty);
+    }
+
+    private com.divudi.core.entity.Institution resolveSingleCreditCompany(PatientEncounter encounter) {
+        if (encounter == null) {
+            return null;
+        }
+        String jpql = "select e from EncounterCreditCompany e where e.retired = false and e.patientEncounter = :enc";
+        java.util.HashMap<String, Object> hm = new java.util.HashMap<>();
+        hm.put("enc", encounter);
+        List<com.divudi.core.entity.EncounterCreditCompany> list = encounterCreditCompanyFacade.findByJpql(jpql, hm, 2);
+        if (list != null && list.size() == 1) {
+            return list.get(0).getInstitution();
+        }
+        return null;
     }
 
     /**
@@ -2498,6 +2519,8 @@ public class InwardBeanController implements Serializable {
      * item does not allow discount or the fee does not allow discount.
      * The discount scheme is taken from the admission/encounter itself
      * (set at admission time). BHT type is the encounter's paymentMethod.
+     * When exactly one credit company is on the encounter, a credit-company-
+     * specific matrix row is tried first before falling back to generic rows.
      * When no matrix row matches the discount is 0, so existing behaviour is
      * preserved for sites that have not configured the matrix.
      */
@@ -2517,12 +2540,14 @@ public class InwardBeanController implements Serializable {
         if (matrixDept == null && billFee.getBillItem() != null && billFee.getBillItem().getBill() != null) {
             matrixDept = billFee.getBillItem().getBill().getDepartment();
         }
+        com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(patientEncounter);
         double pct = priceMatrixController.getInwardDiscountPercent(
                 patientEncounter.getPaymentMethod(),
                 patientEncounter.getPaymentScheme(),
                 patientEncounter.getAdmissionType(),
                 matrixDept,
-                item);
+                item,
+                creditCompany);
         double qty = (billFee.getBillItem() != null && billFee.getBillItem().getQty() != null && billFee.getBillItem().getQty() > 0)
                 ? billFee.getBillItem().getQty() : 1.0;
         double unitGross = (billFee.getFeeUnitGrossValue() != null)
@@ -2534,14 +2559,25 @@ public class InwardBeanController implements Serializable {
     }
 
     public void updateBillItemMargin(BillItem billItem, double serviceValue, PatientEncounter patientEncounter, Department matrixDepartment, PriceMatrix priceMatrix) {
+        PriceMatrix effectivePriceMatrix = priceMatrix;
+        if (patientEncounter != null) {
+            com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(patientEncounter);
+            if (creditCompany != null) {
+                PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(billItem, serviceValue, matrixDepartment,
+                        patientEncounter.getPaymentMethod(), creditCompany);
+                if (ccMatrix != null) {
+                    effectivePriceMatrix = ccMatrix;
+                }
+            }
+        }
 
         List<BillFee> billFees = getBillBean().getBillFee(billItem);
 
         for (BillFee billFee : billFees) {
             if (patientEncounter != null && patientEncounter.getAdmissionType() != null) {
-                setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
+                setBillFeeMargin(billFee, billItem.getItem(), effectivePriceMatrix, patientEncounter);
             } else {
-                setBillFeeMargin(billFee, billItem.getItem(), priceMatrix);
+                setBillFeeMargin(billFee, billItem.getItem(), effectivePriceMatrix);
             }
 
             if (billFee.getId() != null) {
@@ -2552,11 +2588,22 @@ public class InwardBeanController implements Serializable {
     }
 
     public void updateBillItemMargin(BillFee billFee, double serviceValue, PatientEncounter patientEncounter, Department matrixDepartment, PriceMatrix priceMatrix) {
+        PriceMatrix effectivePriceMatrix = priceMatrix;
+        if (patientEncounter != null && billFee.getBillItem() != null) {
+            com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(patientEncounter);
+            if (creditCompany != null) {
+                PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(billFee.getBillItem(), serviceValue,
+                        matrixDepartment, patientEncounter.getPaymentMethod(), creditCompany);
+                if (ccMatrix != null) {
+                    effectivePriceMatrix = ccMatrix;
+                }
+            }
+        }
 
         if (patientEncounter != null && patientEncounter.getAdmissionType() != null) {
-            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), priceMatrix, patientEncounter);
+            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), effectivePriceMatrix, patientEncounter);
         } else {
-            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), priceMatrix);
+            setBillFeeMargin(billFee, billFee.getBillItem().getItem(), effectivePriceMatrix);
         }
 
         if (billFee.getId() != null) {

--- a/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
@@ -12,6 +12,7 @@ import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.inward.AdmissionType;
@@ -61,6 +62,7 @@ public class InwardDiscountMatrixController implements Serializable {
     private PaymentScheme paymentScheme;
     private double discountPercent;
     private InwardChargeType inwardChargeType;
+    private Institution creditCompany;
 
     // -------------------------------------------------------------------------
     // Navigation
@@ -93,6 +95,7 @@ public class InwardDiscountMatrixController implements Serializable {
         paymentScheme = null;
         discountPercent = 0.0;
         inwardChargeType = null;
+        creditCompany = null;
         items = null;
         filterItems = null;
     }
@@ -150,6 +153,7 @@ public class InwardDiscountMatrixController implements Serializable {
         entry.setPaymentMethod(paymentMethod);
         entry.setPaymentScheme(paymentScheme);
         entry.setDiscountPercent(discountPercent);
+        entry.setCreditCompany(creditCompany);
         if (department != null) {
             entry.setInstitution(department.getInstitution());
         }
@@ -166,6 +170,7 @@ public class InwardDiscountMatrixController implements Serializable {
         paymentScheme = null;
         discountPercent = 0.0;
         inwardChargeType = null;
+        creditCompany = null;
     }
 
     // -------------------------------------------------------------------------
@@ -316,5 +321,13 @@ public class InwardDiscountMatrixController implements Serializable {
 
     public void setInwardChargeType(InwardChargeType inwardChargeType) {
         this.inwardChargeType = inwardChargeType;
+    }
+
+    public Institution getCreditCompany() {
+        return creditCompany;
+    }
+
+    public void setCreditCompany(Institution creditCompany) {
+        this.creditCompany = creditCompany;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -70,11 +70,13 @@ public class InwardPriceAdjustmntController implements Serializable {
     double toPrice;
     double margin;
     private Category roomLocation;
+    private Institution creditCompany;
 
     private void recreateModel() {
         fromPrice = toPrice + 1;
         toPrice = 0.0;
         margin = 0;
+        creditCompany = null;
         items = null;
     }
 
@@ -82,6 +84,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         fromPrice = toPrice + 1;
         toPrice = 0.0;
         margin = 0;
+        creditCompany = null;
         items = null;
     }
 
@@ -148,6 +151,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setInstitution(department.getInstitution());
         a.setPaymentMethod(paymentMethod);
         a.setMargin(margin);
+        a.setCreditCompany(creditCompany);
         a.setCreatedAt(new Date());
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
@@ -184,6 +188,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             a.setInstitution(department.getInstitution());
             a.setPaymentMethod(paymentMethod);
             a.setMargin(margin);
+            a.setCreditCompany(creditCompany);
             a.setCreatedAt(new Date());
             a.setCreater(getSessionController().getLoggedUser());
             if (a.getId() == null) {
@@ -441,6 +446,14 @@ public class InwardPriceAdjustmntController implements Serializable {
 
     public void setFilterItems(List<PriceMatrix> filterItems) {
         this.filterItems = filterItems;
+    }
+
+    public Institution getCreditCompany() {
+        return creditCompany;
+    }
+
+    public void setCreditCompany(Institution creditCompany) {
+        this.creditCompany = creditCompany;
     }
 
     /**

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3164,22 +3164,42 @@ public class AnthropicApiService implements Serializable {
 
         // ── Inward Discount Matrix ────────────────────────────────────────────
         appendModule(sb, "Inward Discount Matrix", "/inward-discount-matrix",
-                "Manage inward discount matrix entries (backs the two UI pages "
-                + "inward_discount_matrix_service_investigation.xhtml and inward_discount_matrix_pharmacy.xhtml). "
+                "Manage inward discount matrix entries (backs three UI pages for service/investigation, pharmacy, and room charges). "
                 + "Use scope=service or scope=pharmacy to choose the category universe. "
+                + "Optional creditCompanyId creates a CC-specific row; generic (no-CC) rows are the fallback. "
                 + "POST rejects duplicates with 409 + existing id. "
                 + "Lookup sub-paths resolve names to IDs.",
                 null,
                 new String[][]{
-                    {"GET",    "/inward-discount-matrix?scope=X",                               "List entries. Filters: scope, departmentId, categoryId, admissionTypeId, paymentSchemeId, paymentMethod, limit"},
+                    {"GET",    "/inward-discount-matrix?scope=X",                               "List entries. Filters: scope, departmentId, categoryId, admissionTypeId, paymentSchemeId, paymentMethod, creditCompanyId, limit"},
                     {"GET",    "/inward-discount-matrix/{id}",                                   "Fetch one entry"},
-                    {"POST",   "/inward-discount-matrix",                                         "Create. Body: scope (required), paymentSchemeId (required), discountPercent (required), departmentId, categoryId, admissionTypeId, paymentMethod"},
+                    {"POST",   "/inward-discount-matrix",                                         "Create. Body: scope (required), discountPercent (required), paymentSchemeId, departmentId, categoryId, admissionTypeId, paymentMethod, creditCompanyId"},
                     {"PUT",    "/inward-discount-matrix/{id}",                                   "Update. Body fields all optional; send null to clear a field"},
                     {"DELETE", "/inward-discount-matrix/{id}",                                   "Soft-retire entry. Optional: retireComments"},
                     {"GET",    "/inward-discount-matrix/admission-types/search?query=",          "AdmissionType name → id lookup"},
                     {"GET",    "/inward-discount-matrix/payment-schemes/search?query=",           "PaymentScheme name → id lookup"},
                     {"GET",    "/inward-discount-matrix/pharmaceutical-item-categories/search?query=", "PharmaceuticalItemCategory name → id lookup"},
-                    {"GET",    "/inward-discount-matrix/payment-methods",                         "List PaymentMethod enum values (Cash, Credit, Card, ...)"}
+                    {"GET",    "/inward-discount-matrix/payment-methods",                         "List PaymentMethod enum values"},
+                    {"GET",    "/inward-discount-matrix/credit-companies/search?query=",          "Credit company (Institution) name → id lookup"}
+                });
+
+        // ── Inward Price Adjustment (Margin) Matrix ───────────────────────────
+        appendModule(sb, "Inward Price Adjustment", "/inward-price-adjustment",
+                "Manage inward price adjustment (margin/service charge) matrix entries for service, investigation, and pharmacy. "
+                + "Each row maps a gross-value price range (fromPrice, toPrice) to a margin %. "
+                + "Optional creditCompanyId creates a CC-specific row; generic (no-CC) rows are the fallback. "
+                + "POST rejects duplicates with 409 + existing id.",
+                null,
+                new String[][]{
+                    {"GET",    "/inward-price-adjustment?scope=X",                               "List entries. Filters: scope, departmentId, categoryId, paymentMethod, creditCompanyId, limit"},
+                    {"GET",    "/inward-price-adjustment/{id}",                                   "Fetch one entry"},
+                    {"POST",   "/inward-price-adjustment",                                         "Create. Body: scope (required), fromPrice (required), toPrice (required), margin (required), departmentId, categoryId, paymentMethod, creditCompanyId"},
+                    {"PUT",    "/inward-price-adjustment/{id}",                                   "Update. Body fields all optional"},
+                    {"DELETE", "/inward-price-adjustment/{id}",                                   "Soft-retire entry. Optional: retireComments"},
+                    {"GET",    "/inward-price-adjustment/categories/search?scope=X&query=",       "Category name → id lookup (requires scope)"},
+                    {"GET",    "/inward-price-adjustment/departments/search?query=",              "Department name → id lookup"},
+                    {"GET",    "/inward-price-adjustment/payment-methods",                         "List PaymentMethod enum values"},
+                    {"GET",    "/inward-price-adjustment/credit-companies/search?query=",          "Credit company name → id lookup"}
                 });
 
         appendModule(sb, "Inward Room Management", "/inward/room-categories, /inward/rooms, /inward/room-facility-charges",

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -479,6 +479,65 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject inwardPriceAdjustmentTool = Json.createObjectBuilder()
+                .add("name", "manage_inward_price_adjustment")
+                .add("description",
+                        "Manage Inward Price Adjustment (margin/service charge) matrix entries for services, investigations, and pharmacy. "
+                        + "Each row maps a gross-value price range (fromPrice, toPrice) to a margin %. "
+                        + "Methods: LIST, GET, POST (create), PUT (update), DELETE (soft-retire). "
+                        + "Optional creditCompanyId creates a CC-specific row; rows without creditCompanyId are the generic fallback. "
+                        + "Lookup helpers: LOOKUP_DEPARTMENTS, LOOKUP_CATEGORIES, LIST_PAYMENT_METHODS, LOOKUP_CREDIT_COMPANIES. "
+                        + "Always resolve names to IDs via lookups before POST/PUT.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("LIST").add("GET").add("POST").add("PUT").add("DELETE")
+                                                .add("LOOKUP_DEPARTMENTS").add("LOOKUP_CATEGORIES")
+                                                .add("LIST_PAYMENT_METHODS").add("LOOKUP_CREDIT_COMPANIES"))
+                                        .add("description", "Operation to perform."))
+                                .add("scope", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("service").add("pharmacy"))
+                                        .add("description", "Required for POST. Optional filter for LIST."))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Entry id. Required for GET, PUT, DELETE."))
+                                .add("departmentId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Department id. Optional."))
+                                .add("categoryId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Category id. Optional."))
+                                .add("paymentMethod", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "PaymentMethod enum name, e.g. Cash, Credit. Optional."))
+                                .add("fromPrice", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Lower bound of the gross value range. Required for POST."))
+                                .add("toPrice", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Upper bound of the gross value range. Required for POST."))
+                                .add("margin", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Margin percentage to apply. Required for POST."))
+                                .add("creditCompanyId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Institution id of the credit company. Optional."))
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Search text for LOOKUP_* operations. Optional."))
+                                .add("limit", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Max results (1–200). Optional."))
+                                .add("retireComments", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Reason for retirement. Optional for DELETE.")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         JsonObject inwardRoomsTool = Json.createObjectBuilder()
                 .add("name", "manage_inward_rooms")
                 .add("description",
@@ -860,6 +919,7 @@ public class AnthropicApiService implements Serializable {
                 .add(clinicalMetadataTool)
                 .add(collectingCentreFeesTool)
                 .add(inwardDiscountMatrixTool)
+                .add(inwardPriceAdjustmentTool)
                 .add(inwardRoomsTool)
                 .add(manageInvestigationsTool)
                 .add(manageInvestigationFormatTool)
@@ -944,6 +1004,24 @@ public class AnthropicApiService implements Serializable {
                     return callInwardDiscountMatrixApi(method, scope, id, departmentId, categoryId,
                             admissionTypeId, paymentSchemeId, paymentMethodStr, discountPercent,
                             creditCompanyId, query, limit, retireComments, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_inward_price_adjustment": {
+                    String method         = toolInput.getString("method", "LIST");
+                    String scope          = toolInput.containsKey("scope")          ? toolInput.getString("scope", "")          : "";
+                    String id             = toolInput.containsKey("id")             ? toolInput.getString("id", "")             : "";
+                    String departmentId   = toolInput.containsKey("departmentId")   ? toolInput.getString("departmentId", "")   : "";
+                    String categoryId     = toolInput.containsKey("categoryId")     ? toolInput.getString("categoryId", "")     : "";
+                    String paymentMethod2 = toolInput.containsKey("paymentMethod")  ? toolInput.getString("paymentMethod", "")  : "";
+                    String fromPrice      = toolInput.containsKey("fromPrice")      ? toolInput.getString("fromPrice", "")      : "";
+                    String toPrice        = toolInput.containsKey("toPrice")        ? toolInput.getString("toPrice", "")        : "";
+                    String margin         = toolInput.containsKey("margin")         ? toolInput.getString("margin", "")         : "";
+                    String creditCompanyId2 = toolInput.containsKey("creditCompanyId") ? toolInput.getString("creditCompanyId", "") : "";
+                    String query2         = toolInput.containsKey("query")          ? toolInput.getString("query", "")          : "";
+                    String limit2         = toolInput.containsKey("limit")          ? toolInput.getString("limit", "")          : "";
+                    String retireComments2 = toolInput.containsKey("retireComments") ? toolInput.getString("retireComments", "") : "";
+                    return callInwardPriceAdjustmentApi(method, scope, id, departmentId, categoryId,
+                            paymentMethod2, fromPrice, toPrice, margin, creditCompanyId2,
+                            query2, limit2, retireComments2, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_investigations": {
                     String method = toolInput.getString("method", "GET");
@@ -1655,6 +1733,176 @@ public class AnthropicApiService implements Serializable {
             return "Inward discount matrix API call interrupted.";
         } catch (Exception e) {
             return "Inward discount matrix API error: " + e.getMessage();
+        }
+    }
+
+    private String callInwardPriceAdjustmentApi(
+            String method, String scope, String id, String departmentId, String categoryId,
+            String paymentMethod, String fromPrice, String toPrice, String margin,
+            String creditCompanyId, String query, String limit, String retireComments,
+            String hmisBaseUrl, String hmisApiKey) {
+
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String root = hmisBaseUrl.trim().replaceAll("/+$", "");
+            String base = root + "/api/inward-price-adjustment";
+            String url;
+            String requestBody = null;
+            String httpMethod;
+
+            switch (method == null ? "" : method.toUpperCase()) {
+                case "LIST": {
+                    StringBuilder urlBuilder = new StringBuilder(base);
+                    boolean first = true;
+                    if (scope != null && !scope.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("scope=")
+                                .append(URLEncoder.encode(scope, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (departmentId != null && !departmentId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("departmentId=").append(departmentId);
+                        first = false;
+                    }
+                    if (categoryId != null && !categoryId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("categoryId=").append(categoryId);
+                        first = false;
+                    }
+                    if (paymentMethod != null && !paymentMethod.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("paymentMethod=")
+                                .append(URLEncoder.encode(paymentMethod, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (creditCompanyId != null && !creditCompanyId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("creditCompanyId=").append(creditCompanyId);
+                        first = false;
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("limit=").append(limit);
+                        first = false;
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "GET": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for GET.";
+                    url = base + "/" + id.trim();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "POST": {
+                    url = base;
+                    httpMethod = "POST";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (scope != null && !scope.isEmpty()) bodyBuilder.add("scope", scope);
+                    if (departmentId != null && !departmentId.trim().isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (categoryId != null && !categoryId.trim().isEmpty()) bodyBuilder.add("categoryId", Long.parseLong(categoryId.trim()));
+                    if (paymentMethod != null && !paymentMethod.isEmpty()) bodyBuilder.add("paymentMethod", paymentMethod);
+                    if (fromPrice != null && !fromPrice.trim().isEmpty()) bodyBuilder.add("fromPrice", Double.parseDouble(fromPrice.trim()));
+                    if (toPrice != null && !toPrice.trim().isEmpty()) bodyBuilder.add("toPrice", Double.parseDouble(toPrice.trim()));
+                    if (margin != null && !margin.trim().isEmpty()) bodyBuilder.add("margin", Double.parseDouble(margin.trim()));
+                    if (creditCompanyId != null && !creditCompanyId.trim().isEmpty()) bodyBuilder.add("creditCompanyId", Long.parseLong(creditCompanyId.trim()));
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "PUT": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for PUT.";
+                    url = base + "/" + id.trim();
+                    httpMethod = "PUT";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (scope != null && !scope.isEmpty()) bodyBuilder.add("scope", scope);
+                    if (departmentId != null && !departmentId.trim().isEmpty()) bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                    if (categoryId != null && !categoryId.trim().isEmpty()) bodyBuilder.add("categoryId", Long.parseLong(categoryId.trim()));
+                    if (paymentMethod != null && !paymentMethod.isEmpty()) bodyBuilder.add("paymentMethod", paymentMethod);
+                    if (fromPrice != null && !fromPrice.trim().isEmpty()) bodyBuilder.add("fromPrice", Double.parseDouble(fromPrice.trim()));
+                    if (toPrice != null && !toPrice.trim().isEmpty()) bodyBuilder.add("toPrice", Double.parseDouble(toPrice.trim()));
+                    if (margin != null && !margin.trim().isEmpty()) bodyBuilder.add("margin", Double.parseDouble(margin.trim()));
+                    if (creditCompanyId != null && !creditCompanyId.trim().isEmpty()) bodyBuilder.add("creditCompanyId", Long.parseLong(creditCompanyId.trim()));
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "DELETE": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for DELETE.";
+                    StringBuilder urlBuilder = new StringBuilder(base).append("/").append(id.trim());
+                    if (retireComments != null && !retireComments.isEmpty()) {
+                        urlBuilder.append("?retireComments=")
+                                .append(URLEncoder.encode(retireComments, StandardCharsets.UTF_8));
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "DELETE";
+                    break;
+                }
+                case "LOOKUP_DEPARTMENTS": {
+                    url = lookupUrl(base + "/departments/search", query, limit);
+                    httpMethod = "GET";
+                    break;
+                }
+                case "LOOKUP_CATEGORIES": {
+                    StringBuilder urlBuilder = new StringBuilder(base + "/categories/search");
+                    boolean first = true;
+                    if (scope != null && !scope.isEmpty()) {
+                        urlBuilder.append("?scope=").append(URLEncoder.encode(scope, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (query != null && !query.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("query=")
+                                .append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("limit=").append(limit);
+                        first = false;
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "LIST_PAYMENT_METHODS": {
+                    url = base + "/payment-methods";
+                    httpMethod = "GET";
+                    break;
+                }
+                case "LOOKUP_CREDIT_COMPANIES": {
+                    url = lookupUrl(base + "/credit-companies/search", query, limit);
+                    httpMethod = "GET";
+                    break;
+                }
+                default:
+                    return "Error: Unknown method: " + method;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .header("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                reqBuilder.method(httpMethod, HttpRequest.BodyPublishers.ofString(requestBody));
+            } else if ("DELETE".equals(httpMethod)) {
+                reqBuilder.DELETE();
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Inward price adjustment API call interrupted.";
+        } catch (Exception e) {
+            return "Inward price adjustment API error: " + e.getMessage();
         }
     }
 

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -413,13 +413,16 @@ public class AnthropicApiService implements Serializable {
         JsonObject inwardDiscountMatrixTool = Json.createObjectBuilder()
                 .add("name", "manage_inward_discount_matrix")
                 .add("description",
-                        "Manage Inward Discount Matrix entries (backs the two UI pages "
-                        + "inward_discount_matrix_service_investigation.xhtml and inward_discount_matrix_pharmacy.xhtml). "
+                        "Manage Inward Discount Matrix entries (backs the three UI pages "
+                        + "inward_discount_matrix_service_investigation.xhtml, inward_discount_matrix_pharmacy.xhtml, "
+                        + "and inward_discount_matrix_room_charges.xhtml). "
                         + "Methods: LIST (filter+list), GET (one), POST (create — rejects duplicates), "
                         + "PUT (update), DELETE (soft-retire). "
+                        + "Optional creditCompanyId sets a credit-company-specific discount row; rows without creditCompanyId "
+                        + "are the generic fallback used when no CC-specific row matches. "
                         + "Lookup helpers: LOOKUP_DEPARTMENTS, LOOKUP_SERVICE_CATEGORIES, "
                         + "LOOKUP_PHARMACEUTICAL_ITEM_CATEGORIES, LOOKUP_ADMISSION_TYPES, "
-                        + "LOOKUP_PAYMENT_SCHEMES, LIST_PAYMENT_METHODS. "
+                        + "LOOKUP_PAYMENT_SCHEMES, LIST_PAYMENT_METHODS, LOOKUP_CREDIT_COMPANIES. "
                         + "Always resolve names to IDs via the lookups before POST/PUT.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")
@@ -433,7 +436,8 @@ public class AnthropicApiService implements Serializable {
                                                 .add("LOOKUP_PHARMACEUTICAL_ITEM_CATEGORIES")
                                                 .add("LOOKUP_ADMISSION_TYPES")
                                                 .add("LOOKUP_PAYMENT_SCHEMES")
-                                                .add("LIST_PAYMENT_METHODS"))
+                                                .add("LIST_PAYMENT_METHODS")
+                                                .add("LOOKUP_CREDIT_COMPANIES"))
                                         .add("description", "Operation to perform."))
                                 .add("scope", Json.createObjectBuilder()
                                         .add("type", "string")
@@ -466,6 +470,9 @@ public class AnthropicApiService implements Serializable {
                                 .add("limit", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Max results (1–200). Optional."))
+                                .add("creditCompanyId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Institution id of the credit company. Optional. When set, this row applies only when the admission has exactly that one credit company."))
                                 .add("retireComments", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Reason for retirement. Optional for DELETE.")))
@@ -930,12 +937,13 @@ public class AnthropicApiService implements Serializable {
                     String paymentSchemeId   = toolInput.containsKey("paymentSchemeId")  ? toolInput.getString("paymentSchemeId", "")  : "";
                     String paymentMethodStr  = toolInput.containsKey("paymentMethod")    ? toolInput.getString("paymentMethod", "")    : "";
                     String discountPercent   = toolInput.containsKey("discountPercent")  ? toolInput.getString("discountPercent", "")  : "";
+                    String creditCompanyId   = toolInput.containsKey("creditCompanyId")  ? toolInput.getString("creditCompanyId", "")  : "";
                     String query             = toolInput.containsKey("query")            ? toolInput.getString("query", "")            : "";
                     String limit             = toolInput.containsKey("limit")            ? toolInput.getString("limit", "")            : "";
                     String retireComments    = toolInput.containsKey("retireComments")   ? toolInput.getString("retireComments", "")   : "";
                     return callInwardDiscountMatrixApi(method, scope, id, departmentId, categoryId,
                             admissionTypeId, paymentSchemeId, paymentMethodStr, discountPercent,
-                            query, limit, retireComments, hmisBaseUrl, hmisApiKey);
+                            creditCompanyId, query, limit, retireComments, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_investigations": {
                     String method = toolInput.getString("method", "GET");
@@ -1461,8 +1469,8 @@ public class AnthropicApiService implements Serializable {
     private String callInwardDiscountMatrixApi(
             String method, String scope, String id, String departmentId, String categoryId,
             String admissionTypeId, String paymentSchemeId, String paymentMethod,
-            String discountPercent, String query, String limit, String retireComments,
-            String hmisBaseUrl, String hmisApiKey) {
+            String discountPercent, String creditCompanyId, String query, String limit,
+            String retireComments, String hmisBaseUrl, String hmisApiKey) {
 
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
             return "Error: HMIS base URL is not configured.";
@@ -1512,6 +1520,10 @@ public class AnthropicApiService implements Serializable {
                                 .append(URLEncoder.encode(paymentMethod, StandardCharsets.UTF_8));
                         first = false;
                     }
+                    if (creditCompanyId != null && !creditCompanyId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("creditCompanyId=").append(creditCompanyId);
+                        first = false;
+                    }
                     if (limit != null && !limit.isEmpty()) {
                         urlBuilder.append(first ? "?" : "&").append("limit=").append(limit);
                         first = false;
@@ -1537,6 +1549,7 @@ public class AnthropicApiService implements Serializable {
                     if (paymentSchemeId != null && !paymentSchemeId.trim().isEmpty()) bodyBuilder.add("paymentSchemeId", Long.parseLong(paymentSchemeId.trim()));
                     if (paymentMethod != null && !paymentMethod.isEmpty()) bodyBuilder.add("paymentMethod", paymentMethod);
                     if (discountPercent != null && !discountPercent.trim().isEmpty()) bodyBuilder.add("discountPercent", Double.parseDouble(discountPercent.trim()));
+                    if (creditCompanyId != null && !creditCompanyId.trim().isEmpty()) bodyBuilder.add("creditCompanyId", Long.parseLong(creditCompanyId.trim()));
                     requestBody = bodyBuilder.build().toString();
                     break;
                 }
@@ -1552,6 +1565,7 @@ public class AnthropicApiService implements Serializable {
                     if (paymentSchemeId != null && !paymentSchemeId.trim().isEmpty()) bodyBuilder.add("paymentSchemeId", Long.parseLong(paymentSchemeId.trim()));
                     if (paymentMethod != null && !paymentMethod.isEmpty()) bodyBuilder.add("paymentMethod", paymentMethod);
                     if (discountPercent != null && !discountPercent.trim().isEmpty()) bodyBuilder.add("discountPercent", Double.parseDouble(discountPercent.trim()));
+                    if (creditCompanyId != null && !creditCompanyId.trim().isEmpty()) bodyBuilder.add("creditCompanyId", Long.parseLong(creditCompanyId.trim()));
                     requestBody = bodyBuilder.build().toString();
                     break;
                 }
@@ -1607,6 +1621,11 @@ public class AnthropicApiService implements Serializable {
                 }
                 case "LIST_PAYMENT_METHODS": {
                     url = base + "/payment-methods";
+                    httpMethod = "GET";
+                    break;
+                }
+                case "LOOKUP_CREDIT_COMPANIES": {
+                    url = lookupUrl(base + "/credit-companies/search", query, limit);
                     httpMethod = "GET";
                     break;
                 }
@@ -2430,13 +2449,24 @@ public class AnthropicApiService implements Serializable {
         sb.append("### manage_collecting_centre_fees\n");
         sb.append("List, create, update, retire, or recalculate item fees for a collecting centre.\n\n");
         sb.append("### manage_inward_discount_matrix\n");
-        sb.append("Manage Inward Discount Matrix entries for services/investigations and pharmacy. ")
+        sb.append("Manage Inward Discount Matrix entries for services/investigations, pharmacy, and room charges. ")
           .append("Use scope='service' or scope='pharmacy' to pick the correct category universe. ")
+          .append("Optional creditCompanyId links a row to a specific credit company; rows without creditCompanyId are the generic fallback. ")
+          .append("The system tries credit-company-specific rows first, then falls back to generic rows. ")
           .append("Resolve names to IDs first using the lookup methods (LOOKUP_DEPARTMENTS, LOOKUP_SERVICE_CATEGORIES, ")
-          .append("LOOKUP_PHARMACEUTICAL_ITEM_CATEGORIES, LOOKUP_ADMISSION_TYPES, LOOKUP_PAYMENT_SCHEMES, LIST_PAYMENT_METHODS), ")
+          .append("LOOKUP_PHARMACEUTICAL_ITEM_CATEGORIES, LOOKUP_ADMISSION_TYPES, LOOKUP_PAYMENT_SCHEMES, ")
+          .append("LIST_PAYMENT_METHODS, LOOKUP_CREDIT_COMPANIES), ")
           .append("then POST to create, PUT to update, or DELETE to retire. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live inward billing discounts. ")
           .append("POST returns 'already_exists' with the existing id when a duplicate combination already exists.\n\n");
+        sb.append("### manage_inward_price_adjustment\n");
+        sb.append("Manage Inward Price Adjustment (margin) Matrix entries for services/investigations and pharmacy. ")
+          .append("Each row defines a gross-value price range (fromPrice, toPrice) and a margin percentage to apply. ")
+          .append("Optional creditCompanyId links the row to a specific credit company (0 margin for a CC means no markup). ")
+          .append("The system tries credit-company-specific rows first, then falls back to generic rows. ")
+          .append("Use scope='service' or scope='pharmacy'. Lookup helpers: LOOKUP_DEPARTMENTS, ")
+          .append("LOOKUP_CATEGORIES (/categories/search?scope=service|pharmacy), LIST_PAYMENT_METHODS, LOOKUP_CREDIT_COMPANIES. ")
+          .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
         sb.append("### manage_investigations\n");
         sb.append("Search, retrieve, create, update, activate, or deactivate investigation master records ")
           .append("(lab/diagnostic tests such as CBC, PCR, blood gas, X-ray managed as investigations). ")

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -62,6 +62,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
+        resources.add(com.divudi.ws.inward.InwardPriceAdjustmentApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomCategoryApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomFacilityChargeApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -134,9 +134,20 @@ public class CapabilityStatementResource {
                 .add(resource("Inward Discount Matrix", "/api/inward-discount-matrix",
                         "Manage inward discount matrix entries for services/investigations and pharmacy. "
                         + "Supports scope=service|pharmacy to restrict category types. "
+                        + "Optional creditCompanyId filters or sets a credit-company-specific override row. "
                         + "Lookup sub-paths for resolving names to IDs: "
                         + "/admission-types/search, /payment-schemes/search, "
-                        + "/pharmaceutical-item-categories/search, /payment-methods. "
+                        + "/pharmaceutical-item-categories/search, /payment-methods, /credit-companies/search. "
+                        + "POST returns HTTP 409 with existing id when a duplicate combination exists.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Inward Price Adjustment", "/api/inward-price-adjustment",
+                        "Manage inward price adjustment (margin) matrix entries for services, investigations, and pharmacy. "
+                        + "Supports scope=service|pharmacy to restrict category types. "
+                        + "Optional creditCompanyId sets a credit-company-specific margin override. "
+                        + "Price range lookup: fromPrice/toPrice define the gross value range to which the margin applies. "
+                        + "Lookup sub-paths: /categories/search?scope=service|pharmacy, /departments/search, "
+                        + "/payment-methods, /credit-companies/search. "
                         + "POST returns HTTP 409 with existing id when a duplicate combination exists.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))

--- a/src/main/java/com/divudi/ws/inward/InwardDiscountMatrixApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardDiscountMatrixApi.java
@@ -19,6 +19,7 @@ import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.InwardDiscountMatrix;
 import com.divudi.core.entity.lab.InvestigationCategory;
 import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
+import com.divudi.core.data.InstitutionType;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.facade.CategoryFacade;
 import com.divudi.core.facade.DepartmentFacade;
@@ -758,8 +759,10 @@ public class InwardDiscountMatrixApi {
             String query = param("query");
             int limit = intParam("limit", 30, 1, 200);
             StringBuilder jpql = new StringBuilder(
-                    "select i from Institution i where i.retired = false");
+                    "select i from Institution i where i.retired = false"
+                    + " and i.institutionType = :type");
             Map<String, Object> params = new HashMap<>();
+            params.put("type", InstitutionType.CreditCompany);
             if (query != null && !query.trim().isEmpty()) {
                 jpql.append(" and upper(i.name) like :q");
                 params.put("q", "%" + query.trim().toUpperCase() + "%");

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -10,20 +10,17 @@ import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
-import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.ServiceCategory;
 import com.divudi.core.entity.ServiceSubCategory;
 import com.divudi.core.entity.WebUser;
-import com.divudi.core.entity.inward.AdmissionType;
-import com.divudi.core.entity.inward.InwardDiscountMatrix;
+import com.divudi.core.entity.inward.InwardPriceAdjustment;
 import com.divudi.core.entity.lab.InvestigationCategory;
 import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
-import com.divudi.core.entity.Institution;
 import com.divudi.core.facade.CategoryFacade;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
-import com.divudi.core.facade.PaymentSchemeFacade;
 import com.divudi.core.facade.PriceMatrixFacade;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -46,7 +43,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -54,19 +50,20 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * REST API for Inward Discount Matrix management.
- * Backs the two UI pages
- *   /inward/inward_discount_matrix_service_investigation.xhtml
- *   /inward/inward_discount_matrix_pharmacy.xhtml
+ * REST API for Inward Price Adjustment (margin) Matrix management.
+ * Backs the UI pages:
+ *   /inward/inward_price_adjustment_service.xhtml
+ *   /inward/inward_price_adjustment_investigation.xhtml
+ *   /inward/inward_price_adjustment_pharmacy.xhtml
  *
- * Single endpoint, scope-scoped (service|pharmacy) — scope controls which
- * category types are allowed.
+ * Scope controls which category types are permitted (service|pharmacy).
+ * Optional creditCompanyId creates a credit-company-specific margin override row.
  *
  * @author Dr M H B Ariyaratne
  */
-@Path("inward-discount-matrix")
+@Path("inward-price-adjustment")
 @RequestScoped
-public class InwardDiscountMatrixApi {
+public class InwardPriceAdjustmentApi {
 
     @Context
     private HttpServletRequest requestContext;
@@ -87,8 +84,6 @@ public class InwardDiscountMatrixApi {
     private CategoryFacade categoryFacade;
 
     @EJB
-    private PaymentSchemeFacade paymentSchemeFacade;
-    @EJB
     private InstitutionFacade institutionFacade;
 
     private static final Gson gson = new GsonBuilder()
@@ -96,13 +91,12 @@ public class InwardDiscountMatrixApi {
             .create();
 
     // =========================================================================
-    // Discount matrix CRUD
+    // CRUD
     // =========================================================================
 
     /**
-     * List discount matrix entries with optional filters.
-     *
-     * GET /api/inward-discount-matrix?scope=service|pharmacy&...
+     * List price adjustment entries with optional filters.
+     * GET /api/inward-price-adjustment?scope=service|pharmacy&...
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -116,11 +110,9 @@ public class InwardDiscountMatrixApi {
             String scope = param("scope");
             if (scope != null) scope = scope.trim().toLowerCase();
 
-            Long departmentId     = longParam("departmentId");
-            Long categoryId       = longParam("categoryId");
-            Long admissionTypeId  = longParam("admissionTypeId");
-            Long paymentSchemeId  = longParam("paymentSchemeId");
-            Long creditCompanyId  = longParam("creditCompanyId");
+            Long departmentId    = longParam("departmentId");
+            Long categoryId      = longParam("categoryId");
+            Long creditCompanyId = longParam("creditCompanyId");
             String paymentMethodStr = param("paymentMethod");
             int limit = intParam("limit", 200, 1, 1000);
 
@@ -134,7 +126,7 @@ public class InwardDiscountMatrixApi {
             }
 
             StringBuilder jpql = new StringBuilder(
-                    "select a from InwardDiscountMatrix a where a.retired = false");
+                    "select a from InwardPriceAdjustment a where a.retired = false");
             Map<String, Object> params = new HashMap<>();
 
             if ("service".equals(scope)) {
@@ -160,14 +152,6 @@ public class InwardDiscountMatrixApi {
                 jpql.append(" and a.category.id = :cid");
                 params.put("cid", categoryId);
             }
-            if (admissionTypeId != null) {
-                jpql.append(" and a.admissionType.id = :aid");
-                params.put("aid", admissionTypeId);
-            }
-            if (paymentSchemeId != null) {
-                jpql.append(" and a.paymentScheme.id = :psid");
-                params.put("psid", paymentSchemeId);
-            }
             if (paymentMethod != null) {
                 jpql.append(" and a.paymentMethod = :pm");
                 params.put("pm", paymentMethod);
@@ -177,7 +161,7 @@ public class InwardDiscountMatrixApi {
                 params.put("ccid", creditCompanyId);
             }
 
-            jpql.append(" order by a.paymentScheme.name, a.department.name, a.category.name");
+            jpql.append(" order by a.department.name, a.category.name, a.fromPrice");
 
             List<PriceMatrix> rows = priceMatrixFacade.findByJpql(jpql.toString(), params, limit);
             List<Map<String, Object>> payload = new ArrayList<>();
@@ -197,7 +181,7 @@ public class InwardDiscountMatrixApi {
 
     /**
      * Fetch one entry by id.
-     * GET /api/inward-discount-matrix/{id}
+     * GET /api/inward-price-adjustment/{id}
      */
     @GET
     @Path("/{id}")
@@ -209,8 +193,8 @@ public class InwardDiscountMatrixApi {
                 return errorResponse("Not a valid key", 401);
             }
             PriceMatrix pm = priceMatrixFacade.find(id);
-            if (pm == null || pm.isRetired() || !(pm instanceof InwardDiscountMatrix)) {
-                return errorResponse("Discount matrix entry not found: " + id, 404);
+            if (pm == null || pm.isRetired() || !(pm instanceof InwardPriceAdjustment)) {
+                return errorResponse("Price adjustment entry not found: " + id, 404);
             }
             return successResponse(toDto(pm));
         } catch (Exception e) {
@@ -220,7 +204,7 @@ public class InwardDiscountMatrixApi {
 
     /**
      * Create a new entry. Rejects duplicates with 409 + existing id.
-     * POST /api/inward-discount-matrix
+     * POST /api/inward-price-adjustment
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -251,22 +235,14 @@ public class InwardDiscountMatrixApi {
                 return errorResponse("Invalid scope. Use 'service' or 'pharmacy'.", 400);
             }
 
-            PaymentScheme paymentScheme = null;
-            Long paymentSchemeId = asLong(body.get("paymentSchemeId"));
-            if (paymentSchemeId != null) {
-                paymentScheme = paymentSchemeFacade.find(paymentSchemeId);
-                if (paymentScheme == null || paymentScheme.isRetired()) {
-                    return errorResponse("PaymentScheme not found: " + paymentSchemeId, 400);
-                }
+            Double fromPrice = asDouble(body.get("fromPrice"));
+            Double toPrice   = asDouble(body.get("toPrice"));
+            Double margin    = asDouble(body.get("margin"));
+            if (fromPrice == null || toPrice == null || margin == null) {
+                return errorResponse("fromPrice, toPrice, and margin are required", 400);
             }
-
-            Double discountPercent = asDouble(body.get("discountPercent"));
-            if (discountPercent == null) {
-                return errorResponse("discountPercent is required", 400);
-            }
-            if (discountPercent.isNaN() || discountPercent.isInfinite()
-                    || discountPercent < 0.0 || discountPercent > 100.0) {
-                return errorResponse("discountPercent must be a finite number between 0 and 100", 400);
+            if (fromPrice >= toPrice) {
+                return errorResponse("fromPrice must be less than toPrice", 400);
             }
 
             Department department = null;
@@ -291,16 +267,6 @@ public class InwardDiscountMatrixApi {
                 }
             }
 
-            AdmissionType admissionType = null;
-            Long admissionTypeId = asLong(body.get("admissionTypeId"));
-            if (admissionTypeId != null) {
-                Category c = categoryFacade.find(admissionTypeId);
-                if (c == null || c.isRetired() || !(c instanceof AdmissionType)) {
-                    return errorResponse("AdmissionType not found: " + admissionTypeId, 400);
-                }
-                admissionType = (AdmissionType) c;
-            }
-
             PaymentMethod paymentMethod = null;
             String paymentMethodStr = asString(body.get("paymentMethod"));
             if (paymentMethodStr != null && !paymentMethodStr.trim().isEmpty()) {
@@ -320,25 +286,25 @@ public class InwardDiscountMatrixApi {
                 }
             }
 
-            InwardDiscountMatrix existing = findDuplicate(
-                    department, category, admissionType, paymentMethod, paymentScheme, creditCompany);
+            InwardPriceAdjustment existing = findDuplicate(
+                    department, category, paymentMethod, fromPrice, toPrice, creditCompany);
             if (existing != null) {
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("status", "already_exists");
                 payload.put("code", 409);
                 payload.put("message",
-                        "An active discount matrix entry with the same combination already exists.");
+                        "An active price adjustment entry with the same combination already exists.");
                 payload.put("id", existing.getId());
                 return Response.status(409).entity(gson.toJson(payload)).build();
             }
 
-            InwardDiscountMatrix entry = new InwardDiscountMatrix();
+            InwardPriceAdjustment entry = new InwardPriceAdjustment();
             entry.setDepartment(department);
             entry.setCategory(category);
-            entry.setAdmissionType(admissionType);
             entry.setPaymentMethod(paymentMethod);
-            entry.setPaymentScheme(paymentScheme);
-            entry.setDiscountPercent(discountPercent);
+            entry.setFromPrice(fromPrice);
+            entry.setToPrice(toPrice);
+            entry.setMargin(margin);
             entry.setCreditCompany(creditCompany);
             if (department != null) {
                 entry.setInstitution(department.getInstitution());
@@ -357,8 +323,8 @@ public class InwardDiscountMatrixApi {
     }
 
     /**
-     * Update an entry. All fields optional; scope is required when categoryId is supplied.
-     * PUT /api/inward-discount-matrix/{id}
+     * Update an entry.
+     * PUT /api/inward-price-adjustment/{id}
      */
     @PUT
     @Path("/{id}")
@@ -372,10 +338,10 @@ public class InwardDiscountMatrixApi {
             }
 
             PriceMatrix pm = priceMatrixFacade.find(id);
-            if (pm == null || pm.isRetired() || !(pm instanceof InwardDiscountMatrix)) {
-                return errorResponse("Discount matrix entry not found: " + id, 404);
+            if (pm == null || pm.isRetired() || !(pm instanceof InwardPriceAdjustment)) {
+                return errorResponse("Price adjustment entry not found: " + id, 404);
             }
-            InwardDiscountMatrix entry = (InwardDiscountMatrix) pm;
+            InwardPriceAdjustment entry = (InwardPriceAdjustment) pm;
 
             Map<?, ?> body;
             try {
@@ -416,9 +382,6 @@ public class InwardDiscountMatrixApi {
                         return errorResponse("scope is required when categoryId is supplied", 400);
                     }
                     scope = scope.trim().toLowerCase();
-                    if (!"service".equals(scope) && !"pharmacy".equals(scope)) {
-                        return errorResponse("Invalid scope. Use 'service' or 'pharmacy'.", 400);
-                    }
                     String mismatch = validateCategoryForScope(c, scope);
                     if (mismatch != null) {
                         return errorResponse(mismatch, 400);
@@ -427,54 +390,38 @@ public class InwardDiscountMatrixApi {
                 }
             }
 
-            if (body.containsKey("admissionTypeId")) {
-                Long admissionTypeId = asLong(body.get("admissionTypeId"));
-                if (admissionTypeId == null) {
-                    entry.setAdmissionType(null);
-                } else {
-                    Category c = categoryFacade.find(admissionTypeId);
-                    if (c == null || c.isRetired() || !(c instanceof AdmissionType)) {
-                        return errorResponse("AdmissionType not found: " + admissionTypeId, 400);
-                    }
-                    entry.setAdmissionType((AdmissionType) c);
-                }
-            }
-
-            if (body.containsKey("paymentSchemeId")) {
-                Long paymentSchemeId = asLong(body.get("paymentSchemeId"));
-                if (paymentSchemeId == null) {
-                    entry.setPaymentScheme(null);
-                } else {
-                    PaymentScheme ps = paymentSchemeFacade.find(paymentSchemeId);
-                    if (ps == null || ps.isRetired()) {
-                        return errorResponse("PaymentScheme not found: " + paymentSchemeId, 400);
-                    }
-                    entry.setPaymentScheme(ps);
-                }
-            }
-
             if (body.containsKey("paymentMethod")) {
-                String pm2 = asString(body.get("paymentMethod"));
-                if (pm2 == null || pm2.trim().isEmpty()) {
+                String pmStr = asString(body.get("paymentMethod"));
+                if (pmStr == null || pmStr.trim().isEmpty()) {
                     entry.setPaymentMethod(null);
                 } else {
                     try {
-                        entry.setPaymentMethod(PaymentMethod.valueOf(pm2.trim()));
+                        entry.setPaymentMethod(PaymentMethod.valueOf(pmStr.trim()));
                     } catch (IllegalArgumentException e) {
-                        return errorResponse("Invalid paymentMethod: " + pm2, 400);
+                        return errorResponse("Invalid paymentMethod: " + pmStr, 400);
                     }
                 }
             }
 
-            if (body.containsKey("discountPercent")) {
-                Double dp = asDouble(body.get("discountPercent"));
-                if (dp == null) {
-                    return errorResponse("discountPercent cannot be null", 400);
-                }
-                if (dp.isNaN() || dp.isInfinite() || dp < 0.0 || dp > 100.0) {
-                    return errorResponse("discountPercent must be a finite number between 0 and 100", 400);
-                }
-                entry.setDiscountPercent(dp);
+            if (body.containsKey("fromPrice")) {
+                Double fp = asDouble(body.get("fromPrice"));
+                if (fp == null) return errorResponse("fromPrice cannot be null", 400);
+                entry.setFromPrice(fp);
+            }
+            if (body.containsKey("toPrice")) {
+                Double tp = asDouble(body.get("toPrice"));
+                if (tp == null) return errorResponse("toPrice cannot be null", 400);
+                entry.setToPrice(tp);
+            }
+            if (entry.getFromPrice() != null && entry.getToPrice() != null
+                    && entry.getFromPrice() >= entry.getToPrice()) {
+                return errorResponse("fromPrice must be less than toPrice", 400);
+            }
+
+            if (body.containsKey("margin")) {
+                Double m = asDouble(body.get("margin"));
+                if (m == null) return errorResponse("margin cannot be null", 400);
+                entry.setMargin(m);
             }
 
             if (body.containsKey("creditCompanyId")) {
@@ -490,15 +437,15 @@ public class InwardDiscountMatrixApi {
                 }
             }
 
-            InwardDiscountMatrix dup = findDuplicate(
-                    entry.getDepartment(), entry.getCategory(), entry.getAdmissionType(),
-                    entry.getPaymentMethod(), entry.getPaymentScheme(), entry.getCreditCompany());
+            InwardPriceAdjustment dup = findDuplicate(
+                    entry.getDepartment(), entry.getCategory(), entry.getPaymentMethod(),
+                    entry.getFromPrice(), entry.getToPrice(), entry.getCreditCompany());
             if (dup != null && !dup.getId().equals(entry.getId())) {
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("status", "already_exists");
                 payload.put("code", 409);
                 payload.put("message",
-                        "Another active discount matrix entry with the same combination already exists.");
+                        "Another active price adjustment entry with the same combination already exists.");
                 payload.put("id", dup.getId());
                 return Response.status(409).entity(gson.toJson(payload)).build();
             }
@@ -515,7 +462,7 @@ public class InwardDiscountMatrixApi {
 
     /**
      * Soft-retire an entry.
-     * DELETE /api/inward-discount-matrix/{id}?retireComments=reason
+     * DELETE /api/inward-price-adjustment/{id}
      */
     @DELETE
     @Path("/{id}")
@@ -527,8 +474,8 @@ public class InwardDiscountMatrixApi {
                 return errorResponse("Not a valid key", 401);
             }
             PriceMatrix pm = priceMatrixFacade.find(id);
-            if (pm == null || !(pm instanceof InwardDiscountMatrix)) {
-                return errorResponse("Discount matrix entry not found: " + id, 404);
+            if (pm == null || !(pm instanceof InwardPriceAdjustment)) {
+                return errorResponse("Price adjustment entry not found: " + id, 404);
             }
             if (pm.isRetired()) {
                 return errorResponse("Entry is already retired: " + id, 400);
@@ -553,45 +500,44 @@ public class InwardDiscountMatrixApi {
     }
 
     // =========================================================================
-    // Lookup endpoints (for name → id resolution)
+    // Lookup endpoints
     // =========================================================================
 
     /**
-     * Search AdmissionType by name.
-     * GET /api/inward-discount-matrix/admission-types/search?query=&limit=
+     * Search categories by scope.
+     * GET /api/inward-price-adjustment/categories/search?scope=service|pharmacy&query=&limit=
      */
     @GET
-    @Path("/admission-types/search")
+    @Path("/categories/search")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response searchAdmissionTypes() {
-        return searchCategoryByType(AdmissionType.class, "at");
-    }
-
-    /**
-     * Search PharmaceuticalItemCategory by name.
-     * GET /api/inward-discount-matrix/pharmaceutical-item-categories/search?query=&limit=
-     */
-    @GET
-    @Path("/pharmaceutical-item-categories/search")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response searchPharmaceuticalItemCategories() {
-        return searchCategoryByType(PharmaceuticalItemCategory.class, "pic");
-    }
-
-    private Response searchCategoryByType(Class<? extends Category> type, String paramKey) {
+    public Response searchCategories() {
         try {
             WebUser user = validateApiKey(requestContext.getHeader("Finance"));
             if (user == null) {
                 return errorResponse("Not a valid key", 401);
             }
+            String scope = param("scope");
+            if (scope == null) scope = "service";
+            scope = scope.trim().toLowerCase();
+
             String query = param("query");
             int limit = intParam("limit", 30, 1, 200);
 
-            StringBuilder jpql = new StringBuilder(
-                    "select c from Category c where c.retired = false and type(c) = :")
-                    .append(paramKey);
+            StringBuilder jpql = new StringBuilder("select c from Category c where c.retired = false");
             Map<String, Object> params = new HashMap<>();
-            params.put(paramKey, type);
+
+            if ("service".equals(scope)) {
+                jpql.append(" and (type(c) = :svc or type(c) = :sub or type(c) = :inv)");
+                params.put("svc", ServiceCategory.class);
+                params.put("sub", ServiceSubCategory.class);
+                params.put("inv", InvestigationCategory.class);
+            } else if ("pharmacy".equals(scope)) {
+                jpql.append(" and type(c) = :pharm");
+                params.put("pharm", PharmaceuticalItemCategory.class);
+            } else {
+                return errorResponse("Invalid scope. Use 'service' or 'pharmacy'.", 400);
+            }
+
             if (query != null && !query.trim().isEmpty()) {
                 jpql.append(" and upper(c.name) like :q");
                 params.put("q", "%" + query.trim().toUpperCase() + "%");
@@ -605,6 +551,7 @@ public class InwardDiscountMatrixApi {
                     Map<String, Object> row = new LinkedHashMap<>();
                     row.put("id", c.getId());
                     row.put("name", c.getName());
+                    row.put("type", c.getClass().getSimpleName());
                     payload.add(row);
                 }
             }
@@ -616,13 +563,13 @@ public class InwardDiscountMatrixApi {
     }
 
     /**
-     * Search PaymentScheme by name.
-     * GET /api/inward-discount-matrix/payment-schemes/search?query=&limit=
+     * Search departments by name.
+     * GET /api/inward-price-adjustment/departments/search?query=&limit=
      */
     @GET
-    @Path("/payment-schemes/search")
+    @Path("/departments/search")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response searchPaymentSchemes() {
+    public Response searchDepartments() {
         try {
             WebUser user = validateApiKey(requestContext.getHeader("Finance"));
             if (user == null) {
@@ -631,23 +578,25 @@ public class InwardDiscountMatrixApi {
             String query = param("query");
             int limit = intParam("limit", 30, 1, 200);
 
-            StringBuilder jpql = new StringBuilder(
-                    "select p from PaymentScheme p where p.retired = false");
+            StringBuilder jpql = new StringBuilder("select d from Department d where d.retired = false");
             Map<String, Object> params = new HashMap<>();
             if (query != null && !query.trim().isEmpty()) {
-                jpql.append(" and upper(p.name) like :q");
+                jpql.append(" and upper(d.name) like :q");
                 params.put("q", "%" + query.trim().toUpperCase() + "%");
             }
-            jpql.append(" order by p.name");
+            jpql.append(" order by d.name");
 
-            List<PaymentScheme> results = paymentSchemeFacade.findByJpql(
-                    jpql.toString(), params, limit);
+            List<Department> results = departmentFacade.findByJpql(jpql.toString(), params, limit);
             List<Map<String, Object>> payload = new ArrayList<>();
             if (results != null) {
-                for (PaymentScheme p : results) {
+                for (Department d : results) {
                     Map<String, Object> row = new LinkedHashMap<>();
-                    row.put("id", p.getId());
-                    row.put("name", p.getName());
+                    row.put("id", d.getId());
+                    row.put("name", d.getName());
+                    if (d.getInstitution() != null) {
+                        row.put("institutionId", d.getInstitution().getId());
+                        row.put("institutionName", d.getInstitution().getName());
+                    }
                     payload.add(row);
                 }
             }
@@ -659,8 +608,8 @@ public class InwardDiscountMatrixApi {
     }
 
     /**
-     * List all PaymentMethod enum values (no search — small set).
-     * GET /api/inward-discount-matrix/payment-methods
+     * List all PaymentMethod enum values.
+     * GET /api/inward-price-adjustment/payment-methods
      */
     @GET
     @Path("/payment-methods")
@@ -684,67 +633,9 @@ public class InwardDiscountMatrixApi {
         }
     }
 
-    // =========================================================================
-    // Helpers
-    // =========================================================================
-
-    private InwardDiscountMatrix findDuplicate(Department department, Category category,
-            AdmissionType admissionType, PaymentMethod paymentMethod, PaymentScheme paymentScheme,
-            Institution creditCompany) {
-
-        StringBuilder jpql = new StringBuilder(
-                "select a from InwardDiscountMatrix a where a.retired = false");
-        Map<String, Object> params = new HashMap<>();
-
-        if (department == null) {
-            jpql.append(" and a.department is null");
-        } else {
-            jpql.append(" and a.department = :dep");
-            params.put("dep", department);
-        }
-        if (category == null) {
-            jpql.append(" and a.category is null");
-        } else {
-            jpql.append(" and a.category = :cat");
-            params.put("cat", category);
-        }
-        if (admissionType == null) {
-            jpql.append(" and a.admissionType is null");
-        } else {
-            jpql.append(" and a.admissionType = :at");
-            params.put("at", admissionType);
-        }
-        if (paymentMethod == null) {
-            jpql.append(" and a.paymentMethod is null");
-        } else {
-            jpql.append(" and a.paymentMethod = :pm");
-            params.put("pm", paymentMethod);
-        }
-        if (paymentScheme == null) {
-            jpql.append(" and a.paymentScheme is null");
-        } else {
-            jpql.append(" and a.paymentScheme = :ps");
-            params.put("ps", paymentScheme);
-        }
-        if (creditCompany == null) {
-            jpql.append(" and a.creditCompany is null");
-        } else {
-            jpql.append(" and a.creditCompany = :cc");
-            params.put("cc", creditCompany);
-        }
-
-        @SuppressWarnings("unchecked")
-        List<InwardDiscountMatrix> list = (List<InwardDiscountMatrix>) (List<?>)
-                priceMatrixFacade.findByJpql(jpql.toString(), params, 1);
-        if (list == null || list.isEmpty()) {
-            return null;
-        }
-        return list.get(0);
-    }
-
     /**
      * Search credit companies (institutions) by name.
-     * GET /api/inward-discount-matrix/credit-companies/search?query=&limit=
+     * GET /api/inward-price-adjustment/credit-companies/search?query=&limit=
      */
     @GET
     @Path("/credit-companies/search")
@@ -781,6 +672,59 @@ public class InwardDiscountMatrixApi {
         }
     }
 
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private InwardPriceAdjustment findDuplicate(Department department, Category category,
+            PaymentMethod paymentMethod, Double fromPrice, Double toPrice, Institution creditCompany) {
+
+        StringBuilder jpql = new StringBuilder(
+                "select a from InwardPriceAdjustment a where a.retired = false");
+        Map<String, Object> params = new HashMap<>();
+
+        if (department == null) {
+            jpql.append(" and a.department is null");
+        } else {
+            jpql.append(" and a.department = :dep");
+            params.put("dep", department);
+        }
+        if (category == null) {
+            jpql.append(" and a.category is null");
+        } else {
+            jpql.append(" and a.category = :cat");
+            params.put("cat", category);
+        }
+        if (paymentMethod == null) {
+            jpql.append(" and a.paymentMethod is null");
+        } else {
+            jpql.append(" and a.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        if (fromPrice != null) {
+            jpql.append(" and a.fromPrice = :fp");
+            params.put("fp", fromPrice);
+        }
+        if (toPrice != null) {
+            jpql.append(" and a.toPrice = :tp");
+            params.put("tp", toPrice);
+        }
+        if (creditCompany == null) {
+            jpql.append(" and a.creditCompany is null");
+        } else {
+            jpql.append(" and a.creditCompany = :cc");
+            params.put("cc", creditCompany);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<InwardPriceAdjustment> list = (List<InwardPriceAdjustment>) (List<?>)
+                priceMatrixFacade.findByJpql(jpql.toString(), params, 1);
+        if (list == null || list.isEmpty()) {
+            return null;
+        }
+        return list.get(0);
+    }
+
     private String validateCategoryForScope(Category category, String scope) {
         if ("service".equals(scope)) {
             if (!(category instanceof ServiceCategory
@@ -801,16 +745,9 @@ public class InwardDiscountMatrixApi {
     private Map<String, Object> toDto(PriceMatrix pm) {
         Map<String, Object> row = new LinkedHashMap<>();
         row.put("id", pm.getId());
-        row.put("discountPercent", pm.getDiscountPercent());
-
-        if (pm.getPaymentScheme() != null) {
-            Map<String, Object> ps = new LinkedHashMap<>();
-            ps.put("id", pm.getPaymentScheme().getId());
-            ps.put("name", pm.getPaymentScheme().getName());
-            row.put("paymentScheme", ps);
-        } else {
-            row.put("paymentScheme", null);
-        }
+        row.put("fromPrice", pm.getFromPrice());
+        row.put("toPrice", pm.getToPrice());
+        row.put("margin", pm.getMargin());
 
         if (pm.getDepartment() != null) {
             Map<String, Object> d = new LinkedHashMap<>();
@@ -835,16 +772,8 @@ public class InwardDiscountMatrixApi {
             row.put("category", null);
         }
 
-        if (pm.getAdmissionType() != null) {
-            Map<String, Object> at = new LinkedHashMap<>();
-            at.put("id", pm.getAdmissionType().getId());
-            at.put("name", pm.getAdmissionType().getName());
-            row.put("admissionType", at);
-        } else {
-            row.put("admissionType", null);
-        }
-
         row.put("paymentMethod", pm.getPaymentMethod() != null ? pm.getPaymentMethod().name() : null);
+
         if (pm.getCreditCompany() != null) {
             Map<String, Object> cc = new LinkedHashMap<>();
             cc.put("id", pm.getCreditCompany().getId());
@@ -853,6 +782,7 @@ public class InwardDiscountMatrixApi {
         } else {
             row.put("creditCompany", null);
         }
+
         row.put("retired", pm.isRetired());
         return row;
     }
@@ -944,11 +874,5 @@ public class InwardDiscountMatrixApi {
         response.put("code", 200);
         response.put("data", data);
         return response;
-    }
-
-    // Unused helper kept in case future scopes add more types
-    @SuppressWarnings("unused")
-    private static List<String> scopeTypes() {
-        return new ArrayList<>(Arrays.asList("service", "pharmacy"));
     }
 }

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -6,6 +6,7 @@
 package com.divudi.ws.inward;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.InstitutionType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Category;
@@ -241,6 +242,11 @@ public class InwardPriceAdjustmentApi {
             if (fromPrice == null || toPrice == null || margin == null) {
                 return errorResponse("fromPrice, toPrice, and margin are required", 400);
             }
+            if (fromPrice.isNaN() || fromPrice.isInfinite()
+                    || toPrice.isNaN() || toPrice.isInfinite()
+                    || margin.isNaN() || margin.isInfinite()) {
+                return errorResponse("fromPrice, toPrice, and margin must be finite numbers", 400);
+            }
             if (fromPrice >= toPrice) {
                 return errorResponse("fromPrice must be less than toPrice", 400);
             }
@@ -382,6 +388,9 @@ public class InwardPriceAdjustmentApi {
                         return errorResponse("scope is required when categoryId is supplied", 400);
                     }
                     scope = scope.trim().toLowerCase();
+                    if (!"service".equals(scope) && !"pharmacy".equals(scope)) {
+                        return errorResponse("Invalid scope. Use 'service' or 'pharmacy'.", 400);
+                    }
                     String mismatch = validateCategoryForScope(c, scope);
                     if (mismatch != null) {
                         return errorResponse(mismatch, 400);
@@ -406,11 +415,13 @@ public class InwardPriceAdjustmentApi {
             if (body.containsKey("fromPrice")) {
                 Double fp = asDouble(body.get("fromPrice"));
                 if (fp == null) return errorResponse("fromPrice cannot be null", 400);
+                if (fp.isNaN() || fp.isInfinite()) return errorResponse("fromPrice must be a finite number", 400);
                 entry.setFromPrice(fp);
             }
             if (body.containsKey("toPrice")) {
                 Double tp = asDouble(body.get("toPrice"));
                 if (tp == null) return errorResponse("toPrice cannot be null", 400);
+                if (tp.isNaN() || tp.isInfinite()) return errorResponse("toPrice must be a finite number", 400);
                 entry.setToPrice(tp);
             }
             if (entry.getFromPrice() != null && entry.getToPrice() != null
@@ -421,6 +432,7 @@ public class InwardPriceAdjustmentApi {
             if (body.containsKey("margin")) {
                 Double m = asDouble(body.get("margin"));
                 if (m == null) return errorResponse("margin cannot be null", 400);
+                if (m.isNaN() || m.isInfinite()) return errorResponse("margin must be a finite number", 400);
                 entry.setMargin(m);
             }
 
@@ -649,8 +661,10 @@ public class InwardPriceAdjustmentApi {
             String query = param("query");
             int limit = intParam("limit", 30, 1, 200);
             StringBuilder jpql = new StringBuilder(
-                    "select i from Institution i where i.retired = false");
+                    "select i from Institution i where i.retired = false"
+                    + " and i.institutionType = :type");
             Map<String, Object> params = new HashMap<>();
+            params.put("type", InstitutionType.CreditCompany);
             if (query != null && !query.trim().isEmpty()) {
                 jpql.append(" and upper(i.name) like :q");
                 params.put("q", "%" + query.trim().toUpperCase() + "%");

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
@@ -132,7 +132,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -228,9 +230,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
@@ -120,6 +120,26 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="Discount %" class="mt-2"/>
                                     </div>
                                     <div class="col-4">
@@ -204,6 +224,13 @@
 
                                 <p:column headerText="BHT Type">
                                     <h:outputText value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_discount_matrix_room_charges.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_room_charges.xhtml
@@ -99,6 +99,26 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="Discount %" class="mt-2"/>
                                     </div>
                                     <div class="col-4">
@@ -176,6 +196,13 @@
 
                                 <p:column headerText="BHT Type">
                                     <h:outputText value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_discount_matrix_room_charges.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_room_charges.xhtml
@@ -111,7 +111,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -200,9 +202,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
@@ -133,7 +133,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -229,9 +231,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_service_investigation.xhtml
@@ -121,6 +121,26 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardDiscountMatrixController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="Discount %" class="mt-2"/>
                                     </div>
                                     <div class="col-4">
@@ -205,6 +225,13 @@
 
                                 <p:column headerText="BHT Type">
                                     <h:outputText value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">

--- a/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
@@ -143,7 +143,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -279,9 +281,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
@@ -122,10 +122,30 @@
                                         <h:outputLabel value="Margin" class="mt-2"></h:outputLabel>
                                     </div>
                                     <div class="col-4">
-                                        <p:inputText 
+                                        <p:inputText
                                             class="w-100"
-                                            autocomplete="off" 
+                                            autocomplete="off"
                                             value="#{inwardPriceAdjustmntController.margin}" />
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardPriceAdjustmntController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
                                     </div>
                                 </div>
                             </div>
@@ -255,6 +275,13 @@
                                     <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:inputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -132,10 +132,30 @@
                                         <h:outputLabel value="Margin" class="mt-2"></h:outputLabel>
                                     </div>
                                     <div class="col-4">
-                                        <p:inputText 
+                                        <p:inputText
                                             class="w-100"
-                                            autocomplete="off" 
+                                            autocomplete="off"
                                             value="#{inwardPriceAdjustmntController.margin}" />
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardPriceAdjustmntController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
                                     </div>
                                 </div>
                             </div>
@@ -260,6 +280,13 @@
                                     <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:inputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -153,7 +153,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -284,9 +286,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -129,6 +129,26 @@
                                             value="#{inwardPriceAdjustmntController.margin}" />
                                     </div>
                                 </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Credit Company" class="mt-2"/>
+                                    </div>
+                                    <div class="col-10">
+                                        <p:autoComplete
+                                            value="#{inwardPriceAdjustmntController.creditCompany}"
+                                            forceSelection="true"
+                                            completeMethod="#{institutionController.completeIns}"
+                                            var="cc"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            itemLabel="#{cc.name}"
+                                            itemValue="#{cc}"
+                                            placeholder="Leave blank to apply to all companies">
+                                            <p:column headerText="Name">#{cc.name}</p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
                             </div>
 
                         </p:panel>
@@ -264,6 +284,14 @@
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:inputText>
                                 </p:column>
+
+                                <p:column
+                                    headerText="Credit Company"
+                                    filterBy="#{a.creditCompany.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                </p:column>
+
                                 <p:column headerText="Action" width="12%" >
                                     <div class="d-flex">
                                         <p:commandButton

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -144,7 +144,9 @@
                                             class="w-100"
                                             itemLabel="#{cc.name}"
                                             itemValue="#{cc}"
-                                            placeholder="Leave blank to apply to all companies">
+                                            placeholder="Leave blank to apply to all companies"
+                                            maxResults="20"
+                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -287,9 +289,9 @@
 
                                 <p:column
                                     headerText="Credit Company"
-                                    filterBy="#{a.creditCompany.name}"
+                                    filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains">
-                                    <h:outputText value="#{a.creditCompany.name}"/>
+                                    <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="12%" >


### PR DESCRIPTION
Closes #21331

## Summary

- **Credit-company-specific discount rows**: When an inpatient admission has exactly one `EncounterCreditCompany`, the system tries a CC-specific row first in the discount matrix walk (item → category → parent category → department → global). Falls back to generic rows if no CC-specific row matches. Admissions with zero or multiple credit companies use existing logic unchanged.
- **Credit-company-specific margin rows**: Same override logic applied to `InwardPriceAdjustment` (service charge / margin matrix). CC-specific margin is resolved inside `setBillFeeMargin`, so it works regardless of which controller initiates the billing.
- **Margin and discount decoupled in `setBillFeeMargin`**: Previously a fee with `MARGINALLOWED=0` would early-return and also block the discount. Now margin and discount eligibility are evaluated independently — a fee that does not allow margin can still receive a CC-specific discount.
- **New `InwardPriceAdjustmentApi`**: Full REST CRUD (`GET`, `POST`, `PUT`, `DELETE`) for the margin matrix with credit company support, mirroring the existing `InwardDiscountMatrixApi` structure.
- **`InwardDiscountMatrixApi` extended**: `paymentSchemeId` made optional (supports admissions with no payment scheme); `creditCompanyId` added to all filters/bodies; `/credit-companies/search` lookup endpoint added; `findDuplicate` now includes credit company in the unique key.
- **UI (6 pages)**: Credit company autocomplete field in the add-entry panel and credit company column in the datatable on all three discount matrix pages and all three price adjustment pages.

## Test plan

- [ ] Open an inward discount matrix page, add a row with a credit company selected — verify it saves and displays the credit company column
- [ ] Open an inward price adjustment page, add a margin row with a credit company — verify it saves correctly
- [ ] Admit a patient with exactly one credit company matching a CC-specific matrix row; add a service item — verify CC-specific discount % and margin % are applied
- [ ] Admit a patient with two credit companies — verify fallback to generic matrix (no CC override)
- [ ] Admit a patient with no credit company — verify existing generic behavior is unchanged
- [ ] Room charge recalculation (BHT Summary) — verify CC-specific room charge discounts apply correctly
- [ ] `POST /api/inward-discount-matrix` with `creditCompanyId` → HTTP 201; `GET` with `creditCompanyId` filter → filtered results
- [ ] `POST /api/inward-price-adjustment` with `creditCompanyId` → HTTP 201; `GET` with `creditCompanyId` filter → filtered results
- [ ] `POST /api/inward-discount-matrix` duplicate with same CC → HTTP 409 with existing id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Credit company-specific discount and margin pricing rules for inward billing
* Ability to assign discount and price adjustment configurations to individual credit companies

**Enhancements**
* Pricing calculations now prioritize credit company-specific rules with fallback to general pricing rules
* Added credit company lookup and filtering across inward pricing configuration screens
* New REST API for managing price adjustments with credit company support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->