### PR TITLE
feat(pharmacy): Save → Finalize → Approve workflow for Transfer Receive (#21337)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -16821,12 +16821,13 @@ public class SearchController implements Serializable {
         bills = null;
         String jpql = "Select b From Bill b "
                 + " where b.retired=false "
+                + " and b.cancelled=false "
                 + " and b.billTypeAtomic = :bTp "
                 + " and b.department = :dept "
                 + " and b.checkedBy is null "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " order by b.createdAt desc";
-        HashMap params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("bTp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
         params.put("dept", sessionController.getDepartment());
         params.put("fromDate", getFromDate());
@@ -16838,12 +16839,13 @@ public class SearchController implements Serializable {
         bills = null;
         String jpql = "Select b From Bill b "
                 + " where b.retired=false "
+                + " and b.cancelled=false "
                 + " and b.billTypeAtomic = :bTp "
                 + " and b.department = :dept "
                 + " and b.checkedBy is not null "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " order by b.createdAt desc";
-        HashMap params = new HashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("bTp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
         params.put("dept", sessionController.getDepartment());
         params.put("fromDate", getFromDate());

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4255,6 +4255,44 @@ public class SearchController implements Serializable {
                 dto.setReceivedBills(byIssued.getOrDefault(dto.getBillId(), new ArrayList<>()));
             }
         }
+        populatePendingReceivePre(transferIssuedListDtos);
+    }
+
+    private void populatePendingReceivePre(List<PharmacyTransferIssuedListDTO> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return;
+        }
+        List<Long> issuedBillIds = dtos.stream()
+                .map(PharmacyTransferIssuedListDTO::getBillId)
+                .collect(Collectors.toList());
+        String jpql = "SELECT b FROM Bill b "
+                + "WHERE b.retired = false "
+                + "AND b.cancelled = false "
+                + "AND b.billTypeAtomic = :btp "
+                + "AND b.backwardReferenceBill.id IN :issuedIds";
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
+        params.put("issuedIds", issuedBillIds);
+        List<Bill> preBills = getBillFacade().findByJpql(jpql, params);
+        if (preBills == null || preBills.isEmpty()) {
+            return;
+        }
+        Map<Long, Long[]> preByIssued = new HashMap<>();
+        for (Bill preBill : preBills) {
+            if (preBill.getBackwardReferenceBill() == null) {
+                continue;
+            }
+            Long issuedId = preBill.getBackwardReferenceBill().getId();
+            boolean isFinalized = preBill.getCheckedBy() != null;
+            preByIssued.put(issuedId, new Long[]{preBill.getId(), isFinalized ? 1L : 0L});
+        }
+        for (PharmacyTransferIssuedListDTO dto : dtos) {
+            Long[] preInfo = preByIssued.get(dto.getBillId());
+            if (preInfo != null) {
+                dto.setPendingReceiveBillId(preInfo[0]);
+                dto.setPendingReceiveIsFinalized(preInfo[1] == 1L);
+            }
+        }
     }
 
     private List<PharmacyTransferReceivedListDTO> fetchReceivedBillsForIssuedIds(List<Long> issuedBillIds) {
@@ -16767,6 +16805,50 @@ public class SearchController implements Serializable {
     public String navigateToIssueForRequestListToApprove() {
         makeListNull();
         return "/pharmacy/pharmacy_issue_for_request_list_to_approve?faces-redirect=true";
+    }
+
+    public String navigateToReceiveListToFinalize() {
+        makeListNull();
+        return "/pharmacy/pharmacy_receive_list_to_finalize?faces-redirect=true";
+    }
+
+    public String navigateToReceiveListToApprove() {
+        makeListNull();
+        return "/pharmacy/pharmacy_receive_list_to_approve?faces-redirect=true";
+    }
+
+    public void createReceiveTableToFinalize() {
+        bills = null;
+        String jpql = "Select b From Bill b "
+                + " where b.retired=false "
+                + " and b.billTypeAtomic = :bTp "
+                + " and b.department = :dept "
+                + " and b.checkedBy is null "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " order by b.createdAt desc";
+        HashMap params = new HashMap();
+        params.put("bTp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
+        params.put("dept", sessionController.getDepartment());
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+        bills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
+    }
+
+    public void createReceiveTableToApprove() {
+        bills = null;
+        String jpql = "Select b From Bill b "
+                + " where b.retired=false "
+                + " and b.billTypeAtomic = :bTp "
+                + " and b.department = :dept "
+                + " and b.checkedBy is not null "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " order by b.createdAt desc";
+        HashMap params = new HashMap();
+        params.put("bTp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
+        params.put("dept", sessionController.getDepartment());
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+        bills = getBillFacade().findByJpql(jpql, params, TemporalType.TIMESTAMP, 50);
     }
 
     public String navigateToPurchaseOrderApprove() {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -732,6 +732,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode issueForRequestApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestApprove, "Issue for Request Approve"), disbursementNode);
         TreeNode disbursementDirectIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementDirectIssue, "Direct Issue"), disbursementNode);
         TreeNode disbursementRecieve = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRecieve, "Recieve"), disbursementNode);
+        TreeNode receiveFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveFinalize, "Receive Finalize"), disbursementNode);
+        TreeNode receiveApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveApprove, "Receive Approve"), disbursementNode);
         TreeNode TransferReciveApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.TransferReciveApproval, "Recieve Approval"), disbursementNode);
         TreeNode PharmacyDisbursementReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementReports, "Pharmacy Disbursement Reports"), disbursementNode);
         TreeNode PharmacyTransferViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferViewRates, "Pharmacy Transfer View Rates"), disbursementNode);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -109,6 +109,8 @@ public class TransferReceiveController implements Serializable {
     private PageMetadataRegistry pageMetadataRegistry;
     @Inject
     private com.divudi.bean.common.SearchController searchController;
+    @Inject
+    private TransferReceiveNativeSqlController transferReceiveNativeSqlController;
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
     private BillItem selectedBillItem;
@@ -143,6 +145,13 @@ public class TransferReceiveController implements Serializable {
         return "/pharmacy/pharmacy_transfer_issued_list?faces-redirect=true";
     }
 
+    /**
+     * @deprecated The issued-list now uses the native SQL path exclusively
+     * ({@link TransferReceiveNativeSqlController#navigateToReceiveRequestNative()}).
+     * This method is retained for backward-compatibility only and will be removed
+     * once TransferReceiveController is fully retired.
+     */
+    @Deprecated
     public String navigateToRecieveRequest() {
         if (issuedBill == null) {
             JsfUtil.addErrorMessage("Nothing to received");
@@ -153,15 +162,24 @@ public class TransferReceiveController implements Serializable {
             JsfUtil.addErrorMessage("Already Received!");
             return null;
         }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Use Save Finalize Approve Workflow for Transfer Receive", false)) {
+            transferReceiveNativeSqlController.setIssuedBillId(issuedBill.getId());
+            return transferReceiveNativeSqlController.navigateToReceiveRequestNative();
+        }
         printPreview=false;
         generateBillComponent();
         return "/pharmacy/pharmacy_transfer_receive?faces-redirect=true";
     }
 
+    /** @deprecated Use {@link TransferReceiveNativeSqlController#navigateToEditReceiveIssue()} instead. */
+    @Deprecated
     public String navigateToEditRecieveIssue() {
         return "/pharmacy/pharmacy_transfer_receive_with_approval?faces-redirect=true";
     }
 
+    /** @deprecated Use {@link TransferReceiveNativeSqlController#navigateToApproveReceiveIssue()} instead. */
+    @Deprecated
     public String navigateToAproveRecieveIssue() {
         return "/pharmacy/pharmacy_transfer_receive_approval?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -472,6 +472,12 @@ public class TransferReceiveNativeSqlController implements Serializable {
         savedBill.setCheckedBy(sessionController.getLoggedUser());
         billFacade.edit(savedBill);
 
+        printDto = transferReceiveNativeSqlService.loadPrintDtoByBillId(receivedBillId);
+        if (printDto != null) {
+            enrichPrintDto(printDto, savedBill);
+        }
+        printPreview = true;
+
         JsfUtil.addSuccessMessage("Request Finalized Successfully");
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -128,6 +128,15 @@ public class TransferReceiveNativeSqlController implements Serializable {
             return null;
         }
 
+        // When Save→Finalize→Approve is enabled, block if a PRE is already in progress
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Use Save Finalize Approve Workflow for Transfer Receive", false)) {
+            if (findActivePre(issuedBill.getId()) != null) {
+                JsfUtil.addErrorMessage("A receive is already in progress. Please finalize or cancel it from the list.");
+                return null;
+            }
+        }
+
         printPreview = false;
         printDto = null;
         comments = null;
@@ -147,6 +156,10 @@ public class TransferReceiveNativeSqlController implements Serializable {
 
         resolveAmpItemIds(itemRowList);
 
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Use Save Finalize Approve Workflow for Transfer Receive", false)) {
+            return "/pharmacy/pharmacy_transfer_receive_native_with_approval?faces-redirect=true";
+        }
         return "/pharmacy/pharmacy_transfer_receive_native?faces-redirect=true";
     }
 
@@ -164,6 +177,109 @@ public class TransferReceiveNativeSqlController implements Serializable {
 
     public String navigateToApproveReceiveIssue() {
         return "/pharmacy/pharmacy_transfer_receive_native_approval?faces-redirect=true";
+    }
+
+    public String loadPendingReceiveForFinalize(Long preBillId) {
+        if (preBillId == null) {
+            JsfUtil.addErrorMessage("No pending receive selected.");
+            return null;
+        }
+        Bill preBill = billFacade.find(preBillId);
+        if (preBill == null || preBill.isRetired()) {
+            JsfUtil.addErrorMessage("Pending receive not found.");
+            return null;
+        }
+        if (preBill.getBackwardReferenceBill() == null) {
+            JsfUtil.addErrorMessage("Cannot find the associated issued bill.");
+            return null;
+        }
+        issuedBill = billFacade.find(preBill.getBackwardReferenceBill().getId());
+        if (issuedBill == null) {
+            JsfUtil.addErrorMessage("Issued bill not found.");
+            return null;
+        }
+        receivedBillId = preBillId;
+        printPreview = false;
+        printDto = null;
+        comments = null;
+        boolean byPurchaseRate = configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Transfer is by Purchase Rate", false);
+        boolean byCostRate = configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Transfer is by Cost Rate", false);
+        itemRowList = transferReceiveNativeSqlService.loadIssuedItemsForReceive(
+                issuedBill.getId(), byPurchaseRate, byCostRate);
+        resolveAmpItemIds(itemRowList);
+        return "/pharmacy/pharmacy_transfer_receive_native_with_approval?faces-redirect=true";
+    }
+
+    public String loadPendingReceiveForApprove(Long preBillId) {
+        if (preBillId == null) {
+            JsfUtil.addErrorMessage("No pending receive selected.");
+            return null;
+        }
+        Bill preBill = billFacade.find(preBillId);
+        if (preBill == null || preBill.isRetired()) {
+            JsfUtil.addErrorMessage("Pending receive not found.");
+            return null;
+        }
+        if (preBill.getBackwardReferenceBill() == null) {
+            JsfUtil.addErrorMessage("Cannot find the associated issued bill.");
+            return null;
+        }
+        issuedBill = billFacade.find(preBill.getBackwardReferenceBill().getId());
+        if (issuedBill == null) {
+            JsfUtil.addErrorMessage("Issued bill not found.");
+            return null;
+        }
+        receivedBillId = preBillId;
+        printPreview = false;
+        printDto = null;
+        comments = null;
+        boolean byPurchaseRate = configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Transfer is by Purchase Rate", false);
+        boolean byCostRate = configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Transfer is by Cost Rate", false);
+        itemRowList = transferReceiveNativeSqlService.loadIssuedItemsForReceive(
+                issuedBill.getId(), byPurchaseRate, byCostRate);
+        resolveAmpItemIds(itemRowList);
+        return "/pharmacy/pharmacy_transfer_receive_native_approval?faces-redirect=true";
+    }
+
+    public String cancelPendingReceive(Long preBillId) {
+        if (preBillId == null) {
+            JsfUtil.addErrorMessage("No pending receive selected.");
+            return null;
+        }
+        Bill preBill = billFacade.find(preBillId);
+        if (preBill == null || preBill.isRetired()) {
+            JsfUtil.addErrorMessage("Pending receive not found.");
+            return null;
+        }
+        preBill.setRetired(true);
+        preBill.setRetireComments("Pending receive cancelled by " + sessionController.getLoggedUser().getWebUserPerson().getName());
+        billFacade.edit(preBill);
+        if (preBill.getBackwardReferenceBill() != null) {
+            Bill issued = billFacade.find(preBill.getBackwardReferenceBill().getId());
+            if (issued != null) {
+                issued.getForwardReferenceBills().remove(preBill);
+                billFacade.edit(issued);
+            }
+        }
+        JsfUtil.addSuccessMessage("Pending receive cancelled.");
+        return "/pharmacy/pharmacy_transfer_issued_list?faces-redirect=true";
+    }
+
+    private Bill findActivePre(long issuedBillId) {
+        String jpql = "SELECT b FROM Bill b "
+                + "WHERE b.retired = false "
+                + "AND b.cancelled = false "
+                + "AND b.billTypeAtomic = :btp "
+                + "AND b.backwardReferenceBill.id = :issueId";
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillTypeAtomic.PHARMACY_RECEIVE_PRE);
+        params.put("issueId", issuedBillId);
+        List<Bill> results = billFacade.findByJpql(jpql, params);
+        return results != null && !results.isEmpty() ? results.get(0) : null;
     }
 
     public String viewByBillId(Long billId) {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -506,6 +506,8 @@ public enum Privileges {
     PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
     PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
     PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
     // Pharmacy Inpatient medication management
     InpatientMedicationManagementMenue("Inpatient Medication Management Menu"),
     PharmacyDirectIssueToBht("Pharmacy Direct Issue to BHT"),
@@ -943,6 +945,8 @@ public enum Privileges {
             case PharmacyIssueForRequestSave:
             case PharmacyIssueForRequestFinalize:
             case PharmacyIssueForRequestApprove:
+            case PharmacyReceiveFinalize:
+            case PharmacyReceiveApprove:
 
             // Retail Transactions
             case PharmacyRetailTransaction:

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssuedListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssuedListDTO.java
@@ -20,6 +20,8 @@ public class PharmacyTransferIssuedListDTO implements Serializable {
     private String cancelledByName;
     private Date cancelledAt;
     private List<PharmacyTransferReceivedListDTO> receivedBills = new ArrayList<>();
+    private Long pendingReceiveBillId;
+    private Boolean pendingReceiveIsFinalized;
 
     public PharmacyTransferIssuedListDTO() {
     }
@@ -139,5 +141,21 @@ public class PharmacyTransferIssuedListDTO implements Serializable {
 
     public void setReceivedBills(List<PharmacyTransferReceivedListDTO> receivedBills) {
         this.receivedBills = receivedBills;
+    }
+
+    public Long getPendingReceiveBillId() {
+        return pendingReceiveBillId;
+    }
+
+    public void setPendingReceiveBillId(Long pendingReceiveBillId) {
+        this.pendingReceiveBillId = pendingReceiveBillId;
+    }
+
+    public Boolean getPendingReceiveIsFinalized() {
+        return pendingReceiveIsFinalized != null && pendingReceiveIsFinalized;
+    }
+
+    public void setPendingReceiveIsFinalized(Boolean pendingReceiveIsFinalized) {
+        this.pendingReceiveIsFinalized = pendingReceiveIsFinalized;
     }
 }

--- a/src/main/webapp/pharmacy/disbursement_index.xhtml
+++ b/src/main/webapp/pharmacy/disbursement_index.xhtml
@@ -100,6 +100,22 @@
                                     class="ui-button-success w-100"
                                     icon="fas fa-truck-loading"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRecieve')}" />
+                                <p:commandButton
+                                    value="Finalize Receives"
+                                    ajax="false"
+                                    action="#{searchController.navigateToReceiveListToFinalize()}"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    class="ui-button-warning w-100"
+                                    icon="fas fa-tasks"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyReceiveFinalize')}" />
+                                <p:commandButton
+                                    value="Approve Receives"
+                                    ajax="false"
+                                    action="#{searchController.navigateToReceiveListToApprove()}"
+                                    actionListener="#{searchController.makeListNull()}"
+                                    class="ui-button-info w-100"
+                                    icon="fas fa-check-circle"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyReceiveApprove')}" />
                             </p:panelGrid>
                         </p:tab>
                         <p:tab title="Reports" >

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/pharmacy/disbursement_index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="subcontent">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyReceiveApprove')}">You are NOT authorized</h:panelGroup>
+        <h:panelGroup id="gpReceiveApprove" rendered="#{webUserController.hasPrivilege('PharmacyReceiveApprove')}">
+            <h:form>
+                <p:panel styleClass="shadow-sm border-0">
+                    <f:facet name="header">
+                        <div class="d-flex align-items-center">
+                            <i class="fas fa-check-circle text-success me-2"></i>
+                            <h:outputText value="Transfer Receives — List to Approve" styleClass="mb-0 text-success" style="font-size: 1.5rem; font-weight: 600;"/>
+                        </div>
+                    </f:facet>
+                    <div class="row g-3">
+                        <div class="col-lg-3 col-md-4">
+                            <p:panel header="Search Filters" styleClass="h-100 shadow-sm">
+                                <div class="mb-3">
+                                    <h:panelGroup styleClass="form-label fw-bold text-secondary d-block">
+                                        <i class="fas fa-calendar-alt me-1"></i>
+                                        <h:outputText value="From Date"/>
+                                    </h:panelGroup>
+                                    <p:calendar
+                                        id="fromDate"
+                                        class="w-100"
+                                        inputStyleClass="form-control"
+                                        value="#{searchController.fromDate}"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:panelGroup styleClass="form-label fw-bold text-secondary d-block">
+                                        <i class="fas fa-calendar-alt me-1"></i>
+                                        <h:outputText value="To Date"/>
+                                    </h:panelGroup>
+                                    <p:calendar
+                                        id="toDate"
+                                        class="w-100"
+                                        inputStyleClass="form-control"
+                                        value="#{searchController.toDate}"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </div>
+                                <p:commandButton
+                                    id="btnSearch"
+                                    class="ui-button-success w-100"
+                                    icon="fas fa-search"
+                                    ajax="false"
+                                    value="Search Receives to Approve"
+                                    action="#{searchController.createReceiveTableToApprove}"
+                                    style="min-height: 45px;"/>
+                            </p:panel>
+                        </div>
+                        <div class="col-lg-9 col-md-8">
+                            <p:panel header="Receives Pending Approval" styleClass="shadow-sm">
+                                <p:dataTable
+                                    id="tblReceiveApprove"
+                                    value="#{searchController.bills}"
+                                    var="g"
+                                    paginator="true"
+                                    rows="10"
+                                    paginatorPosition="bottom"
+                                    paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                    rowsPerPageTemplate="5,10,15,25"
+                                    emptyMessage="No finalized receives found matching your criteria"
+                                    sortMode="multiple"
+                                    resizableColumns="true"
+                                    reflow="true">
+                                    <p:column headerText="Created" width="8em">
+                                        <h:outputLabel value="#{g.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Department" width="8em">
+                                        <h:outputLabel value="#{g.department.name}"/>
+                                    </p:column>
+                                    <p:column headerText="From Dept" width="8em">
+                                        <h:outputLabel value="#{g.fromDepartment.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Created By" width="8em">
+                                        <h:outputLabel value="#{g.creater.webUserPerson.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Finalized By" width="8em">
+                                        <h:outputLabel value="#{g.checkedBy.webUserPerson.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Actions" styleClass="text-center" exportable="false" width="120">
+                                        <p:commandButton
+                                            id="btnApprove"
+                                            class="ui-button-success"
+                                            icon="fas fa-check"
+                                            value="Approve"
+                                            title="Open and Approve Receive #{g.id}"
+                                            ajax="false"
+                                            action="#{transferReceiveNativeSqlController.loadPendingReceiveForApprove(g.id)}"
+                                            style="min-width: 80px;"/>
+                                        <p:commandButton
+                                            id="btnCancel"
+                                            styleClass="ui-button ui-button-danger ms-1"
+                                            icon="fas fa-times"
+                                            value="Cancel"
+                                            title="Cancel this finalized receive"
+                                            ajax="false"
+                                            onclick="if(!confirm('Cancel this finalized receive? This cannot be undone.')) return false;"
+                                            action="#{transferReceiveNativeSqlController.cancelPendingReceive(g.id)}"
+                                            style="min-width: 80px;"/>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
+                        </div>
+                    </div>
+                </p:panel>
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
@@ -8,7 +8,7 @@
     <ui:define name="subcontent">
         <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyReceiveApprove')}">You are NOT authorized</h:panelGroup>
         <h:panelGroup id="gpReceiveApprove" rendered="#{webUserController.hasPrivilege('PharmacyReceiveApprove')}">
-            <h:form>
+            <h:form onkeypress="if (event.key === 'Enter' || event.keyCode === 13) { return false; }">
                 <p:panel styleClass="shadow-sm border-0">
                     <f:facet name="header">
                         <div class="d-flex align-items-center">

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
@@ -16,7 +16,7 @@
                     <h:outputText value="Transfer Receives — List to Finalize" styleClass="mb-0 text-warning"/>
                 </div>
             </f:facet>
-            <h:form>
+            <h:form onkeypress="if (event.key === 'Enter' || event.keyCode === 13) { return false; }">
                 <div class="row g-3">
                     <div class="col-lg-3 col-md-4">
                         <p:panel header="Search Filters" styleClass="h-100 shadow-sm">

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/pharmacy/disbursement_index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="subcontent">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyReceiveFinalize')}">You are NOT authorized</h:panelGroup>
+        <p:panel
+            id="gpReceiveFinalize"
+            rendered="#{webUserController.hasPrivilege('PharmacyReceiveFinalize')}">
+            <f:facet name="header">
+                <div class="d-flex align-items-center">
+                    <i class="fas fa-tasks text-warning me-2"></i>
+                    <h:outputText value="Transfer Receives — List to Finalize" styleClass="mb-0 text-warning"/>
+                </div>
+            </f:facet>
+            <h:form>
+                <div class="row g-3">
+                    <div class="col-lg-3 col-md-4">
+                        <p:panel header="Search Filters" styleClass="h-100 shadow-sm">
+                            <div class="mb-3">
+                                <h:panelGroup styleClass="form-label fw-bold text-secondary d-block">
+                                    <i class="fas fa-calendar-alt me-1"></i>
+                                    <h:outputText value="From Date"/>
+                                </h:panelGroup>
+                                <p:calendar
+                                    id="fromDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.fromDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            </div>
+                            <div class="mb-3">
+                                <h:panelGroup styleClass="form-label fw-bold text-secondary d-block">
+                                    <i class="fas fa-calendar-alt me-1"></i>
+                                    <h:outputText value="To Date"/>
+                                </h:panelGroup>
+                                <p:calendar
+                                    id="toDate"
+                                    class="w-100"
+                                    inputStyleClass="form-control"
+                                    value="#{searchController.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            </div>
+                            <p:commandButton
+                                id="btnSearch"
+                                class="ui-button-warning w-100"
+                                icon="fas fa-search"
+                                ajax="false"
+                                value="Search"
+                                action="#{searchController.createReceiveTableToFinalize}"
+                                style="min-height: 45px;"/>
+                        </p:panel>
+                    </div>
+                    <div class="col-lg-9 col-md-8">
+                        <p:dataTable
+                            id="tblReceiveFinalize"
+                            value="#{searchController.bills}"
+                            var="g"
+                            paginator="true"
+                            rows="15"
+                            paginatorPosition="both"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="10,15,25,50"
+                            emptyMessage="No saved receives found matching your criteria"
+                            sortMode="multiple"
+                            resizableColumns="true"
+                            reflow="true"
+                            size="small"
+                            style="font-size: 0.9em;">
+                            <p:column headerText="Created" width="80px" sortBy="#{g.createdAt}" styleClass="text-center">
+                                <h:outputLabel value="#{g.createdAt}" styleClass="text-muted small">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MM/yy"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Department" width="110px" sortBy="#{g.department.name}">
+                                <h:outputLabel value="#{g.department.name}" title="#{g.department.name}" styleClass="text-truncate d-block"/>
+                            </p:column>
+                            <p:column headerText="From Dept" width="110px" sortBy="#{g.fromDepartment.name}">
+                                <h:outputLabel value="#{g.fromDepartment.name}" title="#{g.fromDepartment.name}" styleClass="text-truncate d-block"/>
+                            </p:column>
+                            <p:column headerText="Created By" width="130px" sortBy="#{g.creater.webUserPerson.name}">
+                                <h:outputLabel value="#{g.creater.webUserPerson.name}" styleClass="text-truncate d-block small"/>
+                            </p:column>
+                            <p:column headerText="Action" styleClass="text-center" exportable="false" width="130px">
+                                <p:commandButton
+                                    id="btnFinalize"
+                                    styleClass="ui-button ui-button-warning ui-button-sm"
+                                    icon="fas fa-check-circle"
+                                    value="Finalize"
+                                    title="Open and Finalize Receive #{g.id}"
+                                    ajax="false"
+                                    action="#{transferReceiveNativeSqlController.loadPendingReceiveForFinalize(g.id)}"
+                                    style="font-size: 0.85em; padding: 0.375rem 0.75rem;"/>
+                                <p:commandButton
+                                    id="btnCancel"
+                                    styleClass="ui-button ui-button-danger ui-button-sm ms-1"
+                                    icon="fas fa-times"
+                                    value="Cancel"
+                                    title="Cancel this pending receive"
+                                    ajax="false"
+                                    onclick="if(!confirm('Cancel this pending receive? This cannot be undone.')) return false;"
+                                    action="#{transferReceiveNativeSqlController.cancelPendingReceive(g.id)}"
+                                    style="font-size: 0.85em; padding: 0.375rem 0.75rem;"/>
+                            </p:column>
+                        </p:dataTable>
+                    </div>
+                </div>
+            </h:form>
+        </p:panel>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -122,10 +122,14 @@
                             </p:column>
 
                             <p:column headerText="Action">
-                                <!-- No pending PRE: show Receive / Fast Receive -->
+                                <!-- No pending PRE: show Receive button (native SQL path) -->
                                 <h:panelGroup rendered="#{p.pendingReceiveBillId == null and !p.cancelled and !p.fullyIssued}">
+                                    <!--
+                                    DEPRECATED: old normal-path Receive button (TransferReceiveController).
+                                    Replaced by the native SQL path below. Remove once TransferReceiveController
+                                    is fully retired.
                                     <p:commandButton
-                                        id="btnToReceive"
+                                        id="btnToReceiveOld"
                                         ajax="false"
                                         value="Receive"
                                         title="Receive items from #{p.deptId}"
@@ -133,11 +137,12 @@
                                         action="#{transferReceiveController.navigateToRecieveRequest()}">
                                         <f:setPropertyActionListener target="#{transferReceiveController.issuedBillId}" value="#{p.billId}"/>
                                     </p:commandButton>
+                                    -->
                                     <p:commandButton
-                                        id="btnToReceiveFast"
+                                        id="btnToReceive"
                                         ajax="false"
-                                        value="Fast Receive"
-                                        title="Fast receive items from #{p.deptId}"
+                                        value="Receive"
+                                        title="Receive items from #{p.deptId}"
                                         class="ui-button-success mx-1"
                                         action="#{transferReceiveNativeSqlController.navigateToReceiveRequestNative()}">
                                         <f:setPropertyActionListener target="#{transferReceiveNativeSqlController.issuedBillId}" value="#{p.billId}"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -122,27 +122,67 @@
                             </p:column>
 
                             <p:column headerText="Action">
-                                <p:commandButton
-                                    id="btnToReceive"
-                                    ajax="false"
-                                    value="Receive"
-                                    title="Receive items from #{p.deptId}"
-                                    class="ui-button-warning mx-1"
-                                    action="#{transferReceiveController.navigateToRecieveRequest()}"
-                                    disabled="#{p.cancelled or p.fullyIssued}">
-                                    <f:setPropertyActionListener target="#{transferReceiveController.issuedBillId}" value="#{p.billId}"/>
-                                </p:commandButton>
-
-                                <p:commandButton
-                                    id="btnToReceiveFast"
-                                    ajax="false"
-                                    value="Fast Receive"
-                                    title="Fast receive items from #{p.deptId}"
-                                    class="ui-button-success mx-1"
-                                    action="#{transferReceiveNativeSqlController.navigateToReceiveRequestNative()}"
-                                    disabled="#{p.cancelled or p.fullyIssued}">
-                                    <f:setPropertyActionListener target="#{transferReceiveNativeSqlController.issuedBillId}" value="#{p.billId}"/>
-                                </p:commandButton>
+                                <!-- No pending PRE: show Receive / Fast Receive -->
+                                <h:panelGroup rendered="#{p.pendingReceiveBillId == null and !p.cancelled and !p.fullyIssued}">
+                                    <p:commandButton
+                                        id="btnToReceive"
+                                        ajax="false"
+                                        value="Receive"
+                                        title="Receive items from #{p.deptId}"
+                                        class="ui-button-warning mx-1"
+                                        action="#{transferReceiveController.navigateToRecieveRequest()}">
+                                        <f:setPropertyActionListener target="#{transferReceiveController.issuedBillId}" value="#{p.billId}"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        id="btnToReceiveFast"
+                                        ajax="false"
+                                        value="Fast Receive"
+                                        title="Fast receive items from #{p.deptId}"
+                                        class="ui-button-success mx-1"
+                                        action="#{transferReceiveNativeSqlController.navigateToReceiveRequestNative()}">
+                                        <f:setPropertyActionListener target="#{transferReceiveNativeSqlController.issuedBillId}" value="#{p.billId}"/>
+                                    </p:commandButton>
+                                </h:panelGroup>
+                                <!-- PRE exists, not finalized: Finalize + Cancel -->
+                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and !p.pendingReceiveIsFinalized}">
+                                    <p:commandButton
+                                        id="btnToFinalizeReceive"
+                                        ajax="false"
+                                        value="Finalize"
+                                        title="Finalize pending receive for #{p.deptId}"
+                                        class="ui-button-warning mx-1"
+                                        icon="fas fa-check"
+                                        action="#{transferReceiveNativeSqlController.loadPendingReceiveForFinalize(p.pendingReceiveBillId)}"/>
+                                    <p:commandButton
+                                        id="btnCancelPendingReceive"
+                                        ajax="false"
+                                        value="Cancel"
+                                        title="Cancel pending receive for #{p.deptId}"
+                                        class="ui-button-danger mx-1"
+                                        icon="fas fa-times"
+                                        onclick="if(!confirm('Cancel this pending receive? This cannot be undone.')) return false;"
+                                        action="#{transferReceiveNativeSqlController.cancelPendingReceive(p.pendingReceiveBillId)}"/>
+                                </h:panelGroup>
+                                <!-- PRE finalized, awaiting approval: Approve + Cancel -->
+                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and p.pendingReceiveIsFinalized}">
+                                    <p:commandButton
+                                        id="btnToApproveReceive"
+                                        ajax="false"
+                                        value="Approve"
+                                        title="Approve finalized receive for #{p.deptId}"
+                                        class="ui-button-success mx-1"
+                                        icon="fas fa-check-double"
+                                        action="#{transferReceiveNativeSqlController.loadPendingReceiveForApprove(p.pendingReceiveBillId)}"/>
+                                    <p:commandButton
+                                        id="btnCancelFinalizedReceive"
+                                        ajax="false"
+                                        value="Cancel"
+                                        title="Cancel finalized receive for #{p.deptId}"
+                                        class="ui-button-danger mx-1"
+                                        icon="fas fa-times"
+                                        onclick="if(!confirm('Cancel this finalized receive? This cannot be undone.')) return false;"
+                                        action="#{transferReceiveNativeSqlController.cancelPendingReceive(p.pendingReceiveBillId)}"/>
+                                </h:panelGroup>
                             </p:column>
 
                             <p:column headerText="Received">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -149,7 +149,7 @@
                                     </p:commandButton>
                                 </h:panelGroup>
                                 <!-- PRE exists, not finalized: Finalize + Cancel -->
-                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and !p.pendingReceiveIsFinalized}">
+                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and !p.pendingReceiveIsFinalized and !p.cancelled and !p.fullyIssued and webUserController.hasPrivilege('PharmacyReceiveFinalize')}">
                                     <p:commandButton
                                         id="btnToFinalizeReceive"
                                         ajax="false"
@@ -169,7 +169,7 @@
                                         action="#{transferReceiveNativeSqlController.cancelPendingReceive(p.pendingReceiveBillId)}"/>
                                 </h:panelGroup>
                                 <!-- PRE finalized, awaiting approval: Approve + Cancel -->
-                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and p.pendingReceiveIsFinalized}">
+                                <h:panelGroup rendered="#{p.pendingReceiveBillId != null and p.pendingReceiveIsFinalized and !p.cancelled and !p.fullyIssued and webUserController.hasPrivilege('PharmacyReceiveApprove')}">
                                     <p:commandButton
                                         id="btnToApproveReceive"
                                         ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -1,4 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' ?>
+<!--
+  DEPRECATED: Old normal-path Transfer Receive page (TransferReceiveController).
+  Replaced by pharmacy_transfer_receive_native_with_approval.xhtml (native SQL path).
+  Do NOT delete — retained for reference until TransferReceiveController is fully retired.
+-->
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/pharmacy/disbursement_index.xhtml"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -1,4 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' ?>
+<!--
+  DEPRECATED: Old normal-path Transfer Receive Approval page (TransferReceiveController).
+  Replaced by pharmacy_transfer_receive_native_approval.xhtml (native SQL path).
+  Do NOT delete — retained for reference until TransferReceiveController is fully retired.
+-->
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/pharmacy/disbursement_index.xhtml"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
@@ -92,7 +92,7 @@
                                     <p:ajax
                                         event="keyup"
                                         process="@this"
-                                        update="value :#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
+                                        update="value :#{p:resolveFirstComponentWithId('gpReceivingNetTotal',view).clientId}"
                                         listener="#{transferReceiveNativeSqlController.onQuantityChangeForTransferReceive(item)}"/>
                                 </p:inputText>
                             </p:column>
@@ -119,9 +119,11 @@
                         </h:outputLabel>
 
                         <h:outputLabel value="Receiving Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
-                        <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
-                            <f:convertNumber pattern="#,##0.00"/>
-                        </h:outputLabel>
+                        <h:panelGroup id="gpReceivingNetTotal">
+                            <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </h:panelGroup>
 
                         <h:outputLabel value="Comments" />
                         <p:inputTextarea class="w-100" rows="3" value="#{transferReceiveNativeSqlController.comments}" />

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
@@ -92,15 +92,37 @@
                                     <p:ajax
                                         event="keyup"
                                         process="@this"
-                                        update=":#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
+                                        update="value :#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
                                         listener="#{transferReceiveNativeSqlController.onQuantityChangeForTransferReceive(item)}"/>
                                 </p:inputText>
+                            </p:column>
+
+                            <p:column headerText="Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" style="width:25px!important;">
+                                <h:outputText id="value" value="#{item.value}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
                             </p:column>
 
                         </p:dataTable>
                     </p:panel>
 
                     <p:panelGrid columns="2" class="mt-2">
+                        <h:outputLabel value="Issued From" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.fromDepartment.name}" />
+
+                        <h:outputLabel value="Issued To" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.toDepartment.name}" />
+
+                        <h:outputLabel value="Issued Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.absoluteNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputLabel>
+
+                        <h:outputLabel value="Receiving Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                        <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputLabel>
+
                         <h:outputLabel value="Comments" />
                         <p:inputTextarea class="w-100" rows="3" value="#{transferReceiveNativeSqlController.comments}" />
                     </p:panelGrid>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
@@ -26,6 +26,16 @@
                             value="Back to Receive List">
                         </p:commandButton>
                         <p:commandButton
+                            value="Cancel"
+                            action="#{transferReceiveNativeSqlController.cancelPendingReceive(transferReceiveNativeSqlController.receivedBillId)}"
+                            class="ui-button-danger mx-1"
+                            icon="fas fa-times"
+                            ajax="false"
+                            style="float: right;"
+                            rendered="#{transferReceiveNativeSqlController.receivedBillId != null}"
+                            onclick="if(!confirm('Cancel this pending receive? This cannot be undone.')) return false;">
+                        </p:commandButton>
+                        <p:commandButton
                             value="Finalize"
                             action="#{transferReceiveNativeSqlController.finalizeRequest()}"
                             class="ui-button-warning mx-1"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
@@ -98,15 +98,37 @@
                                     <p:ajax
                                         event="keyup"
                                         process="@this"
-                                        update=":#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
+                                        update="value :#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
                                         listener="#{transferReceiveNativeSqlController.onQuantityChangeForTransferReceive(item)}"/>
                                 </p:inputText>
+                            </p:column>
+
+                            <p:column headerText="Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" style="width:25px!important;">
+                                <h:outputText id="value" value="#{item.value}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
                             </p:column>
 
                         </p:dataTable>
                     </p:panel>
 
                     <p:panelGrid columns="2" class="mt-2">
+                        <h:outputLabel value="Issued From" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.fromDepartment.name}" />
+
+                        <h:outputLabel value="Issued To" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.toDepartment.name}" />
+
+                        <h:outputLabel value="Issued Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                        <h:outputLabel value="#{transferReceiveNativeSqlController.issuedBill.absoluteNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputLabel>
+
+                        <h:outputLabel value="Receiving Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
+                        <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputLabel>
+
                         <h:outputLabel value="Comments" />
                         <p:inputTextarea class="w-100" rows="3" value="#{transferReceiveNativeSqlController.comments}" />
                     </p:panelGrid>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
@@ -26,6 +26,7 @@
                             value="Back to Receive List">
                         </p:commandButton>
                         <p:commandButton
+                            id="btnCancelPendingReceive"
                             value="Cancel"
                             action="#{transferReceiveNativeSqlController.cancelPendingReceive(transferReceiveNativeSqlController.receivedBillId)}"
                             class="ui-button-danger mx-1"
@@ -108,7 +109,7 @@
                                     <p:ajax
                                         event="keyup"
                                         process="@this"
-                                        update="value :#{p:resolveFirstComponentWithId('txtReceivingNetTotal',view).clientId}"
+                                        update="value :#{p:resolveFirstComponentWithId('gpReceivingNetTotal',view).clientId}"
                                         listener="#{transferReceiveNativeSqlController.onQuantityChangeForTransferReceive(item)}"/>
                                 </p:inputText>
                             </p:column>
@@ -135,9 +136,11 @@
                         </h:outputLabel>
 
                         <h:outputLabel value="Receiving Value" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}" />
-                        <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
-                            <f:convertNumber pattern="#,##0.00"/>
-                        </h:outputLabel>
+                        <h:panelGroup id="gpReceivingNetTotal">
+                            <h:outputLabel id="txtReceivingNetTotal" value="#{transferReceiveNativeSqlController.displayReceivedNetTotal}" rendered="#{webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </h:panelGroup>
 
                         <h:outputLabel value="Comments" />
                         <p:inputTextarea class="w-100" rows="3" value="#{transferReceiveNativeSqlController.comments}" />

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -1,4 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' ?>
+<!--
+  DEPRECATED: Old normal-path Transfer Receive with Approval page (TransferReceiveController).
+  Replaced by pharmacy_transfer_receive_native_with_approval.xhtml (native SQL path).
+  Do NOT delete — retained for reference until TransferReceiveController is fully retired.
+-->
 <!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
                 template="/pharmacy/disbursement_index.xhtml"


### PR DESCRIPTION
## Summary

- Adds a **Save → Finalize → Approve** three-step workflow for pharmacy Transfer Receive, controlled by the config flag `Use Save Finalize Approve Workflow for Transfer Receive` (default false).
- Creates a `PHARMACY_RECEIVE_PRE` draft/lock bill on Save; sets `checkedBy` on Finalize; retires PRE and creates the final `PHARMACY_RECEIVE` bill on Approve (Settle).
- Enforces an **exclusive per-issue lock**: a second user cannot start a new receive on the same issued bill while a PRE is active.
- After **Finalize**, the page automatically switches to print preview — hiding Save and Finalize buttons to prevent double-finalization.
- Adds a **Cancel** button on the receive page to retire the PRE and release the lock.
- Old normal-path Transfer Receive buttons removed from the issued list; `TransferReceiveController.navigateToRecieveRequest()` now delegates to the native SQL path when the config flag is on; deprecated pages retain their XHTML with a comment header.
- Adds `PharmacyReceiveFinalize` and `PharmacyReceiveApprove` privilege enum values with UI tree nodes.
- New pages: `pharmacy_transfer_receive_native_with_approval.xhtml` (Save/Finalize step), `pharmacy_transfer_receive_native_approval.xhtml` (Approve/Settle step), `pharmacy_receive_list_to_finalize.xhtml`, `pharmacy_receive_list_to_approve.xhtml`.

## Test plan

- [ ] Enable config flag `Use Save Finalize Approve Workflow for Transfer Receive`
- [ ] Open Transfer Issued List → click Receive → Save quantities → Finalize → verify page switches to print preview (Save/Finalize hidden)
- [ ] From issued list, click Approve on the finalized row → Settle → verify stock updated
- [ ] Verify Cancel retires the PRE and re-enables Receive on the issued list row
- [ ] Verify a second Receive attempt on an in-progress row is blocked with an error
- [ ] With config flag off, verify normal Receive path is unchanged
- [ ] Check `PharmacyReceiveFinalize` and `PharmacyReceiveApprove` privileges appear in admin UI

Closes #21337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated pages to finalize and approve pharmacy receives with date-based filtering
  * New "Finalize Receives" and "Approve Receives" navigation options in pharmacy disbursement
  * Enhanced issued items list to display pending receive status and contextual workflow actions
  * New permission controls for receive finalization and approval functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->