### PR TITLE
feat(notifications): manage trigger subscriptions via REST API + AI chat (#21358)

### DIFF
--- a/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
+++ b/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
@@ -47,18 +47,22 @@ public class TriggerSubscriptionController implements Serializable {
     private Department department;
     private List<Department> departments;
     private WebUser user;
-    private boolean institutionWide;
+    // Application-wide (department IS NULL) subscription. Named "application-wide"
+    // rather than "institution-wide" because one HMIS application instance can host
+    // multiple institutions; a null department matches every department across the
+    // whole application.
+    private boolean applicationWide;
 
     public List<WebUser> fillSubscribedUsersByDepartment(TriggerType tt,Department dept) {
         List<WebUser> us = new ArrayList<>();
         if (tt == null) {
             return us;
         }
-        // Returns subscribers matching the given department PLUS institution-wide
+        // Returns subscribers matching the given department PLUS application-wide
         // subscribers (department IS NULL), so hospital-wide roles (e.g. Guest
         // Relations Officer) can subscribe once instead of per department.
         // DISTINCT avoids duplicate UserNotifications when a user holds both a
-        // department-specific and an institution-wide subscription for the trigger.
+        // department-specific and an application-wide subscription for the trigger.
         Map m = new HashMap();
         String jpql = "SELECT DISTINCT i.webUser "
                 + " FROM TriggerSubscription i "
@@ -78,17 +82,17 @@ public class TriggerSubscriptionController implements Serializable {
             JsfUtil.addErrorMessage("Select Subscription");
             return;
         }
-        if (department == null && !institutionWide) {
-            JsfUtil.addErrorMessage("Select a Department or mark the subscription Institution-wide");
+        if (department == null && !applicationWide) {
+            JsfUtil.addErrorMessage("Select a Department or mark the subscription Application-wide");
             return;
         }
         if (user == null) {
             JsfUtil.addErrorMessage("Program Error. Cannot have this page without a user. Create an issue in GitHub");
             return;
         }
-        // Institution-wide subscriptions are stored with a null department so they
+        // Application-wide subscriptions are stored with a null department so they
         // match every department in fillSubscribedUsersByDepartment.
-        Department subscriptionDepartment = institutionWide ? null : department;
+        Department subscriptionDepartment = applicationWide ? null : department;
         double newOrder = getTriggerSubscriptions().size() + 1;
         TriggerSubscription existingTS = findUserSubscriptionByOrder(newOrder);
 
@@ -325,12 +329,12 @@ public class TriggerSubscriptionController implements Serializable {
         this.department = department;
     }
 
-    public boolean isInstitutionWide() {
-        return institutionWide;
+    public boolean isApplicationWide() {
+        return applicationWide;
     }
 
-    public void setInstitutionWide(boolean institutionWide) {
-        this.institutionWide = institutionWide;
+    public void setApplicationWide(boolean applicationWide) {
+        this.applicationWide = applicationWide;
     }
 
     public List<Department> getDepartments() {

--- a/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
+++ b/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
@@ -335,6 +335,9 @@ public class TriggerSubscriptionController implements Serializable {
 
     public void setApplicationWide(boolean applicationWide) {
         this.applicationWide = applicationWide;
+        if (applicationWide) {
+            department = null;
+        }
     }
 
     public List<Department> getDepartments() {

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1507,8 +1507,12 @@ public class AnthropicApiService implements Serializable {
                         urlBuilder.append(first ? "?" : "&").append("departmentId=").append(URLEncoder.encode(departmentId, StandardCharsets.UTF_8));
                         first = false;
                     }
-                    if ("true".equalsIgnoreCase(applicationWide)) {
-                        urlBuilder.append(first ? "?" : "&").append("applicationWide=true");
+                    if (applicationWide != null && !applicationWide.trim().isEmpty()) {
+                        String normalizedAw = applicationWide.trim().toLowerCase();
+                        if (!"true".equals(normalizedAw) && !"false".equals(normalizedAw)) {
+                            return "Error: applicationWide must be 'true' or 'false'.";
+                        }
+                        urlBuilder.append(first ? "?" : "&").append("applicationWide=").append(normalizedAw);
                         first = false;
                     }
                     url = urlBuilder.toString();
@@ -1518,6 +1522,14 @@ public class AnthropicApiService implements Serializable {
                 case "POST": {
                     url = base;
                     httpMethod = "POST";
+                    boolean hasDepartmentId = departmentId != null && !departmentId.trim().isEmpty();
+                    boolean isApplicationWide = "true".equalsIgnoreCase(applicationWide);
+                    if (hasDepartmentId && isApplicationWide) {
+                        return "Error: provide exactly one of departmentId or applicationWide=true, not both.";
+                    }
+                    if (!hasDepartmentId && !isApplicationWide) {
+                        return "Error: provide either departmentId or applicationWide=true.";
+                    }
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
                     if (triggerType != null && !triggerType.isEmpty()) bodyBuilder.add("triggerType", triggerType);
                     if (userId != null && !userId.isEmpty()) {
@@ -1527,9 +1539,9 @@ public class AnthropicApiService implements Serializable {
                             return "Error: userId must be numeric.";
                         }
                     }
-                    if ("true".equalsIgnoreCase(applicationWide)) {
+                    if (isApplicationWide) {
                         bodyBuilder.add("applicationWide", true);
-                    } else if (departmentId != null && !departmentId.isEmpty()) {
+                    } else {
                         try {
                             bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
                         } catch (NumberFormatException e) {
@@ -2834,7 +2846,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have eleven tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, and notification subscriptions:\n\n");
+        sb.append("You have twelve tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, and notification subscriptions:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -912,6 +912,44 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("resource_type").add("method")))
                 .build();
 
+        JsonObject manageSubscriptionsTool = Json.createObjectBuilder()
+                .add("name", "manage_subscriptions")
+                .add("description",
+                        "Manage notification trigger subscriptions: who receives which notification, in which department. "
+                        + "A subscription links a user to a TriggerType for a department, or — when application-wide — for the whole "
+                        + "application (matches every department; useful for hospital-wide roles such as a Guest Relations Officer).\n\n"
+                        + "method: LIST | LIST_TRIGGER_TYPES | POST | DELETE\n\n"
+                        + "LIST_TRIGGER_TYPES: returns all available TriggerType values (name, label, medium, parent). "
+                        + "Call this first to discover valid triggerType names.\n"
+                        + "LIST: list subscriptions; optional filters triggerType, userId, departmentId, applicationWide.\n"
+                        + "POST: create a subscription. Requires userId, triggerType, and EITHER departmentId OR applicationWide=true. "
+                        + "Returns already_exists when an identical non-retired subscription exists.\n"
+                        + "DELETE: soft-retire the subscription with the given id.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("LIST_TRIGGER_TYPES").add("POST").add("DELETE"))
+                                        .add("description", "Operation to perform"))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Subscription ID — required for DELETE"))
+                                .add("triggerType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "TriggerType enum name (e.g. INWARD_PATIENT_DISCHARGED). Required for POST; optional filter for LIST"))
+                                .add("userId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "WebUser ID. Required for POST; optional filter for LIST"))
+                                .add("departmentId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Department ID. For POST, provide this OR applicationWide (not both)"))
+                                .add("applicationWide", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' to make the subscription apply across every department (null department)")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         return Json.createArrayBuilder()
                 .add(searchCodeTool)
                 .add(fetchFileTool)
@@ -924,6 +962,7 @@ public class AnthropicApiService implements Serializable {
                 .add(manageInvestigationsTool)
                 .add(manageInvestigationFormatTool)
                 .add(manageFormsTool)
+                .add(manageSubscriptionsTool)
                 .build();
     }
 
@@ -1151,6 +1190,16 @@ public class AnthropicApiService implements Serializable {
                             name, description, formCssClass, cpt, cdt, orderNo, required,
                             placeholder, minValue, maxValue, stepSize, maxRating,
                             onLabel, offLabel, editHtml, viewHtml, label, value,
+                            hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_subscriptions": {
+                    String method          = toolInput.getString("method", "LIST");
+                    String id              = toolInput.containsKey("id")              ? toolInput.getString("id", "")              : "";
+                    String triggerType     = toolInput.containsKey("triggerType")     ? toolInput.getString("triggerType", "")     : "";
+                    String userId          = toolInput.containsKey("userId")          ? toolInput.getString("userId", "")          : "";
+                    String departmentId    = toolInput.containsKey("departmentId")    ? toolInput.getString("departmentId", "")    : "";
+                    String applicationWide = toolInput.containsKey("applicationWide") ? toolInput.getString("applicationWide", "") : "";
+                    return callSubscriptionApi(method, id, triggerType, userId, departmentId, applicationWide,
                             hmisBaseUrl, hmisApiKey);
                 }
                 default:
@@ -1415,6 +1464,113 @@ public class AnthropicApiService implements Serializable {
             return "Clinical metadata API call interrupted.";
         } catch (Exception e) {
             return "Clinical metadata API error: " + e.getMessage();
+        }
+    }
+
+    private String callSubscriptionApi(String method, String id, String triggerType, String userId,
+            String departmentId, String applicationWide, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured. Cannot call subscription API.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String base = hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/subscriptions";
+            String url;
+            String requestBody = null;
+            String httpMethod;
+
+            switch (method.toUpperCase()) {
+                case "LIST_TRIGGER_TYPES": {
+                    url = base + "/trigger-types";
+                    httpMethod = "GET";
+                    break;
+                }
+                case "LIST":
+                case "GET": {
+                    StringBuilder urlBuilder = new StringBuilder(base);
+                    boolean first = true;
+                    if (triggerType != null && !triggerType.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("triggerType=").append(URLEncoder.encode(triggerType, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (userId != null && !userId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("userId=").append(URLEncoder.encode(userId, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if (departmentId != null && !departmentId.isEmpty()) {
+                        urlBuilder.append(first ? "?" : "&").append("departmentId=").append(URLEncoder.encode(departmentId, StandardCharsets.UTF_8));
+                        first = false;
+                    }
+                    if ("true".equalsIgnoreCase(applicationWide)) {
+                        urlBuilder.append(first ? "?" : "&").append("applicationWide=true");
+                        first = false;
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "POST": {
+                    url = base;
+                    httpMethod = "POST";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (triggerType != null && !triggerType.isEmpty()) bodyBuilder.add("triggerType", triggerType);
+                    if (userId != null && !userId.isEmpty()) {
+                        try {
+                            bodyBuilder.add("userId", Long.parseLong(userId.trim()));
+                        } catch (NumberFormatException e) {
+                            return "Error: userId must be numeric.";
+                        }
+                    }
+                    if ("true".equalsIgnoreCase(applicationWide)) {
+                        bodyBuilder.add("applicationWide", true);
+                    } else if (departmentId != null && !departmentId.isEmpty()) {
+                        try {
+                            bodyBuilder.add("departmentId", Long.parseLong(departmentId.trim()));
+                        } catch (NumberFormatException e) {
+                            return "Error: departmentId must be numeric.";
+                        }
+                    }
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                case "DELETE": {
+                    if (id == null || id.trim().isEmpty()) return "Error: id is required for DELETE.";
+                    url = base + "/" + id.trim();
+                    httpMethod = "DELETE";
+                    break;
+                }
+                default:
+                    return "Error: Unknown method: " + method;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .header("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                reqBuilder.method(httpMethod, HttpRequest.BodyPublishers.ofString(requestBody));
+            } else if ("DELETE".equals(httpMethod)) {
+                reqBuilder.DELETE();
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Subscription API call interrupted.";
+        } catch (Exception e) {
+            return "Subscription API error: " + e.getMessage();
         }
     }
 
@@ -2678,7 +2834,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have ten tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, and dynamic clinical form templates:\n\n");
+        sb.append("You have eleven tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, and notification subscriptions:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");
@@ -2767,6 +2923,16 @@ public class AnthropicApiService implements Serializable {
           .append("  </div>\n")
           .append("When generating viewHtml, use {{LABEL}} and {{VALUE}} (the formatted stored value).\n")
           .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
+        sb.append("### manage_subscriptions\n");
+        sb.append("Manage notification trigger subscriptions — who receives which notification, in which department. ")
+          .append("method: LIST | LIST_TRIGGER_TYPES | POST | DELETE. ")
+          .append("Use LIST_TRIGGER_TYPES first to discover valid TriggerType names. ")
+          .append("Use LIST to see existing subscriptions (filter by triggerType, userId, departmentId, or applicationWide). ")
+          .append("Use POST to subscribe a user (userId + triggerType + EITHER departmentId OR applicationWide=true); ")
+          .append("an application-wide subscription has a null department and matches every department, which suits hospital-wide roles such as a Guest Relations Officer. ")
+          .append("POST returns 'already_exists' with the existing id when an identical non-retired subscription exists. ")
+          .append("Use DELETE to soft-retire a subscription by id. ")
+          .append("Always confirm with the user before POST or DELETE — these changes affect who receives live notifications.\n\n");
 
         sb.append("## How to Use the Tools\n");
         sb.append("- When a user describes a problem or asks why something behaves a certain way, search the source code first.\n");
@@ -2956,6 +3122,17 @@ public class AnthropicApiService implements Serializable {
                     {"DELETE", "/user-roles/{id}",                "Retire a role"},
                     {"GET",    "/user-roles/{id}/privileges",     "List privileges assigned to a role"},
                     {"POST",   "/user-roles/{id}/privileges",     "Assign a privilege to a role"}
+                });
+
+        appendModule(sb, "Subscriptions", "/subscriptions",
+                "Manage notification trigger subscriptions (who receives which notification, in which department). "
+                + "An application-wide subscription (null department) matches every department across the whole application.",
+                null,
+                new String[][]{
+                    {"GET",    "/subscriptions",                "List subscriptions (filters: triggerType, userId, departmentId, applicationWide)"},
+                    {"GET",    "/subscriptions/trigger-types",  "List all available TriggerType values (name, label, medium, parent)"},
+                    {"POST",   "/subscriptions",                "Create a subscription (userId, triggerType, and departmentId OR applicationWide). Returns already_exists on duplicate"},
+                    {"DELETE", "/subscriptions/{id}",           "Soft-retire a subscription by ID"}
                 });
 
         // ── Finance ───────────────────────────────────────────────────────────

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -45,6 +45,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.common.CapabilityStatementResource.class);
         resources.add(com.divudi.ws.common.ConfigResource.class);
         resources.add(com.divudi.ws.common.LoginHistoryApi.class);
+        resources.add(com.divudi.ws.common.SubscriptionApi.class);
         resources.add(com.divudi.ws.common.UserManagementApi.class);
         resources.add(com.divudi.ws.common.UserRoleApi.class);
         resources.add(com.divudi.ws.fhir.Fhir.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -265,6 +265,16 @@ public class CapabilityStatementResource {
                         "User role CRUD and role-level privilege assignment with optional department scope.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Subscriptions", "/api/subscriptions",
+                        "Manage notification trigger subscriptions (who receives which notification, in which department). "
+                        + "GET /subscriptions lists subscriptions (filters: triggerType, userId, departmentId, applicationWide=true). "
+                        + "GET /subscriptions/trigger-types lists all available TriggerType values (name, label, medium, parent). "
+                        + "POST /subscriptions creates a subscription (body: userId, triggerType, and EITHER departmentId OR applicationWide:true); "
+                        + "returns already_exists when an identical non-retired subscription exists. "
+                        + "DELETE /subscriptions/{id} soft-retires a subscription. "
+                        + "An application-wide subscription (null department) matches every department across the whole application.",
+                        "API Key",
+                        "GET", "POST", "DELETE"))
                                 .add(resource("Investigations", "/api/investigations",
                         "Investigation master management including search, create, update, and activate/deactivate for item import workflows",
                         "API Key",

--- a/src/main/java/com/divudi/ws/common/SubscriptionApi.java
+++ b/src/main/java/com/divudi/ws/common/SubscriptionApi.java
@@ -109,7 +109,7 @@ public class SubscriptionApi {
 
             Map<String, Object> params = new HashMap<>();
             StringBuilder jpql = new StringBuilder(
-                    "select i from TriggerSubscription i where i.retired=false");
+                    "select i from TriggerSubscription i where i.retired=false and i.webUser is not null");
 
             String triggerTypeStr = param("triggerType");
             if (triggerTypeStr != null && !triggerTypeStr.trim().isEmpty()) {
@@ -241,13 +241,16 @@ public class SubscriptionApi {
             TriggerSubscription existing = triggerSubscriptionFacade.findFirstByJpql(dupJpql, dupParams);
             if (existing != null) {
                 Map<String, Object> found = new LinkedHashMap<>();
-                found.put("status", "already_exists");
                 found.put("id", existing.getId());
                 found.put("triggerType", existing.getTriggerType() != null ? existing.getTriggerType().name() : null);
                 found.put("userId", existing.getWebUser() != null ? existing.getWebUser().getId() : null);
                 found.put("departmentId", existing.getDepartment() != null ? existing.getDepartment().getId() : null);
                 found.put("applicationWide", existing.getDepartment() == null);
-                return Response.ok(gson.toJson(found)).build();
+                Map<String, Object> alreadyExists = new LinkedHashMap<>();
+                alreadyExists.put("status", "already_exists");
+                alreadyExists.put("code", 200);
+                alreadyExists.put("data", found);
+                return Response.ok(gson.toJson(alreadyExists)).build();
             }
 
             // Next order number for this user within the same department scope.
@@ -290,6 +293,9 @@ public class SubscriptionApi {
             if (ts == null || ts.isRetired()) {
                 return errorResponse("Subscription not found with id: " + id, 404);
             }
+            if (ts.getWebUser() == null) {
+                return errorResponse("Subscription " + id + " is a role-based subscription and cannot be managed through this API", 400);
+            }
             ts.setRetired(true);
             ts.setRetiredAt(new Date());
             ts.setRetirer(apiUser.getId() != null ? apiUser : null);
@@ -317,7 +323,13 @@ public class SubscriptionApi {
             params.put("dep", department);
         }
         List<TriggerSubscription> existing = triggerSubscriptionFacade.findByJpql(jpql, params);
-        return existing == null ? 1.0 : existing.size() + 1.0;
+        double maxOrder = 0.0;
+        if (existing != null) {
+            for (TriggerSubscription subscription : existing) {
+                maxOrder = Math.max(maxOrder, subscription.getOrderNumber());
+            }
+        }
+        return maxOrder + 1.0;
     }
 
     private TriggerType resolveTriggerType(String name) {
@@ -358,9 +370,14 @@ public class SubscriptionApi {
     }
 
     // Gson parses JSON numbers as Double; accept Number or numeric string.
+    // Reject fractional values (e.g. 12.9) instead of silently truncating to 12.
     private Long asLong(Object value) {
         if (value == null) return null;
         if (value instanceof Number) {
+            double d = ((Number) value).doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d) || d % 1 != 0) {
+                return null;
+            }
             return ((Number) value).longValue();
         }
         return parseLong(value.toString());

--- a/src/main/java/com/divudi/ws/common/SubscriptionApi.java
+++ b/src/main/java/com/divudi/ws/common/SubscriptionApi.java
@@ -1,0 +1,407 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.common;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.ApiKeyType;
+import com.divudi.core.data.TriggerType;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.TriggerSubscription;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.TriggerSubscriptionFacade;
+import com.divudi.core.facade.WebUserFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.*;
+
+/**
+ * REST API for managing notification trigger subscriptions
+ * ({@link TriggerSubscription}).
+ *
+ * Mirrors the JSF page {@code admin/users/user_subscription.xhtml}: a
+ * subscription links a {@link WebUser} to a {@link TriggerType} for a given
+ * {@link Department}, or — when the department is {@code null} —
+ * <b>application-wide</b> (matches every department across the whole
+ * application; one HMIS application instance can host multiple institutions).
+ *
+ * All operations require a valid Finance API key header.
+ */
+@Path("subscriptions")
+@RequestScoped
+public class SubscriptionApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private TriggerSubscriptionFacade triggerSubscriptionFacade;
+
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    @EJB
+    private DepartmentFacade departmentFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    // -------------------------------------------------------------------------
+    // GET /api/subscriptions/trigger-types
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Path("/trigger-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listTriggerTypes() {
+        try {
+            if (validateApiKey(requestContext.getHeader("Finance")) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            List<Map<String, Object>> result = new ArrayList<>();
+            for (TriggerType tt : TriggerType.getAlphabeticallySortedValues()) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("name", tt.name());
+                m.put("label", tt.getLabel());
+                m.put("medium", tt.getMedium() != null ? tt.getMedium().name() : null);
+                m.put("parent", tt.getParent() != null ? tt.getParent().name() : null);
+                result.add(m);
+            }
+            return successResponse(result);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/subscriptions[?triggerType=X&userId=N&departmentId=N&applicationWide=true]
+    // -------------------------------------------------------------------------
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        try {
+            if (validateApiKey(requestContext.getHeader("Finance")) == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            StringBuilder jpql = new StringBuilder(
+                    "select i from TriggerSubscription i where i.retired=false");
+
+            String triggerTypeStr = param("triggerType");
+            if (triggerTypeStr != null && !triggerTypeStr.trim().isEmpty()) {
+                TriggerType tt = resolveTriggerType(triggerTypeStr);
+                if (tt == null) {
+                    return errorResponse("Unknown triggerType: " + triggerTypeStr, 400);
+                }
+                jpql.append(" and i.triggerType=:tt");
+                params.put("tt", tt);
+            }
+
+            String userIdStr = param("userId");
+            if (userIdStr != null && !userIdStr.trim().isEmpty()) {
+                Long userId = parseLong(userIdStr);
+                if (userId == null) {
+                    return errorResponse("Invalid userId", 400);
+                }
+                WebUser u = webUserFacade.find(userId);
+                if (u == null) {
+                    return errorResponse("User not found with id: " + userId, 404);
+                }
+                jpql.append(" and i.webUser=:u");
+                params.put("u", u);
+            }
+
+            boolean applicationWide = "true".equalsIgnoreCase(param("applicationWide"));
+            String departmentIdStr = param("departmentId");
+            if (applicationWide) {
+                jpql.append(" and i.department is null");
+            } else if (departmentIdStr != null && !departmentIdStr.trim().isEmpty()) {
+                Long deptId = parseLong(departmentIdStr);
+                if (deptId == null) {
+                    return errorResponse("Invalid departmentId", 400);
+                }
+                Department dept = departmentFacade.find(deptId);
+                if (dept == null) {
+                    return errorResponse("Department not found with id: " + deptId, 404);
+                }
+                jpql.append(" and i.department=:dep");
+                params.put("dep", dept);
+            }
+
+            jpql.append(" order by i.orderNumber");
+
+            List<TriggerSubscription> subs = triggerSubscriptionFacade.findByJpql(jpql.toString(), params);
+            List<Map<String, Object>> result = new ArrayList<>();
+            for (TriggerSubscription s : subs) {
+                result.add(toMap(s));
+            }
+            return successResponse(result);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/subscriptions
+    // body: {userId, triggerType, departmentId?, applicationWide?}
+    // -------------------------------------------------------------------------
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            WebUser apiUser = validateApiKey(requestContext.getHeader("Finance"));
+            if (apiUser == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Map<String, Object> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            // triggerType (required)
+            String triggerTypeStr = asString(body.get("triggerType"));
+            if (triggerTypeStr == null || triggerTypeStr.trim().isEmpty()) {
+                return errorResponse("triggerType is required", 400);
+            }
+            TriggerType tt = resolveTriggerType(triggerTypeStr);
+            if (tt == null) {
+                return errorResponse("Unknown triggerType: " + triggerTypeStr, 400);
+            }
+
+            // userId (required)
+            Long userId = asLong(body.get("userId"));
+            if (userId == null) {
+                return errorResponse("userId is required", 400);
+            }
+            WebUser user = webUserFacade.find(userId);
+            if (user == null || user.isRetired()) {
+                return errorResponse("User not found with id: " + userId, 404);
+            }
+
+            // exactly one of departmentId / applicationWide
+            boolean applicationWide = asBoolean(body.get("applicationWide"));
+            Long departmentId = asLong(body.get("departmentId"));
+            if (applicationWide && departmentId != null) {
+                return errorResponse("Provide either departmentId or applicationWide, not both", 400);
+            }
+            if (!applicationWide && departmentId == null) {
+                return errorResponse("Provide either departmentId or applicationWide:true", 400);
+            }
+
+            Department department = null;
+            if (!applicationWide) {
+                department = departmentFacade.find(departmentId);
+                if (department == null) {
+                    return errorResponse("Department not found with id: " + departmentId, 404);
+                }
+            }
+
+            // Duplicate detection: same user + trigger + department (or both null).
+            Map<String, Object> dupParams = new HashMap<>();
+            dupParams.put("u", user);
+            dupParams.put("tt", tt);
+            String dupJpql = "select i from TriggerSubscription i where i.retired=false"
+                    + " and i.webUser=:u and i.triggerType=:tt"
+                    + (department == null ? " and i.department is null" : " and i.department=:dep");
+            if (department != null) {
+                dupParams.put("dep", department);
+            }
+            TriggerSubscription existing = triggerSubscriptionFacade.findFirstByJpql(dupJpql, dupParams);
+            if (existing != null) {
+                Map<String, Object> found = new LinkedHashMap<>();
+                found.put("status", "already_exists");
+                found.put("id", existing.getId());
+                found.put("triggerType", existing.getTriggerType() != null ? existing.getTriggerType().name() : null);
+                found.put("userId", existing.getWebUser() != null ? existing.getWebUser().getId() : null);
+                found.put("departmentId", existing.getDepartment() != null ? existing.getDepartment().getId() : null);
+                found.put("applicationWide", existing.getDepartment() == null);
+                return Response.ok(gson.toJson(found)).build();
+            }
+
+            // Next order number for this user within the same department scope.
+            double nextOrder = nextOrderNumber(user, department);
+
+            TriggerSubscription ts = new TriggerSubscription();
+            ts.setWebUser(user);
+            ts.setTriggerType(tt);
+            ts.setDepartment(department);
+            ts.setOrderNumber(nextOrder);
+            ts.setCreatedAt(new Date());
+            ts.setCreater(apiUser.getId() != null ? apiUser : null);
+            triggerSubscriptionFacade.create(ts);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "success");
+            response.put("code", 201);
+            response.put("data", toMap(ts));
+            return Response.status(201).entity(gson.toJson(response)).build();
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /api/subscriptions/{id}
+    // -------------------------------------------------------------------------
+
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response delete(@PathParam("id") Long id) {
+        try {
+            WebUser apiUser = validateApiKey(requestContext.getHeader("Finance"));
+            if (apiUser == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            TriggerSubscription ts = triggerSubscriptionFacade.find(id);
+            if (ts == null || ts.isRetired()) {
+                return errorResponse("Subscription not found with id: " + id, 404);
+            }
+            ts.setRetired(true);
+            ts.setRetiredAt(new Date());
+            ts.setRetirer(apiUser.getId() != null ? apiUser : null);
+            triggerSubscriptionFacade.edit(ts);
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("id", ts.getId());
+            result.put("deleted", true);
+            return successResponse(result);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private double nextOrderNumber(WebUser user, Department department) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("u", user);
+        String jpql = "select i from TriggerSubscription i where i.retired=false and i.webUser=:u"
+                + (department == null ? " and i.department is null" : " and i.department=:dep");
+        if (department != null) {
+            params.put("dep", department);
+        }
+        List<TriggerSubscription> existing = triggerSubscriptionFacade.findByJpql(jpql, params);
+        return existing == null ? 1.0 : existing.size() + 1.0;
+    }
+
+    private TriggerType resolveTriggerType(String name) {
+        if (name == null) return null;
+        for (TriggerType tt : TriggerType.values()) {
+            if (tt.name().equalsIgnoreCase(name.trim())) {
+                return tt;
+            }
+        }
+        return null;
+    }
+
+    private Map<String, Object> toMap(TriggerSubscription s) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", s.getId());
+        m.put("triggerType", s.getTriggerType() != null ? s.getTriggerType().name() : null);
+        m.put("triggerLabel", s.getTriggerType() != null ? s.getTriggerType().getLabel() : null);
+        m.put("userId", s.getWebUser() != null ? s.getWebUser().getId() : null);
+        m.put("userName", s.getWebUser() != null ? s.getWebUser().getName() : null);
+        m.put("departmentId", s.getDepartment() != null ? s.getDepartment().getId() : null);
+        m.put("departmentName", s.getDepartment() != null ? s.getDepartment().getName() : null);
+        m.put("applicationWide", s.getDepartment() == null);
+        m.put("orderNumber", s.getOrderNumber());
+        return m;
+    }
+
+    private String param(String key) {
+        return uriInfo.getQueryParameters().getFirst(key);
+    }
+
+    private Long parseLong(String value) {
+        if (value == null) return null;
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // Gson parses JSON numbers as Double; accept Number or numeric string.
+    private Long asLong(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return parseLong(value.toString());
+    }
+
+    private String asString(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    // Accept a JSON boolean true or the string "true" (case-insensitive).
+    private boolean asBoolean(Object value) {
+        if (value == null) return false;
+        if (value instanceof Boolean) return (Boolean) value;
+        return "true".equalsIgnoreCase(value.toString().trim());
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        if (apiKey.isRetired()) return null;
+        if (apiKey.getKeyType() == ApiKeyType.Config) return new WebUser();
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.status(200).entity(gson.toJson(response)).build();
+    }
+}

--- a/src/main/java/com/divudi/ws/common/SubscriptionApi.java
+++ b/src/main/java/com/divudi/ws/common/SubscriptionApi.java
@@ -135,21 +135,28 @@ public class SubscriptionApi {
                 params.put("u", u);
             }
 
-            boolean applicationWide = "true".equalsIgnoreCase(param("applicationWide"));
+            String applicationWideParam = param("applicationWide");
+            boolean applicationWideTrue = "true".equalsIgnoreCase(applicationWideParam);
+            boolean applicationWideFalse = "false".equalsIgnoreCase(applicationWideParam);
             String departmentIdStr = param("departmentId");
-            if (applicationWide) {
+            if (applicationWideTrue) {
                 jpql.append(" and i.department is null");
-            } else if (departmentIdStr != null && !departmentIdStr.trim().isEmpty()) {
-                Long deptId = parseLong(departmentIdStr);
-                if (deptId == null) {
-                    return errorResponse("Invalid departmentId", 400);
+            } else {
+                if (applicationWideFalse) {
+                    jpql.append(" and i.department is not null");
                 }
-                Department dept = departmentFacade.find(deptId);
-                if (dept == null) {
-                    return errorResponse("Department not found with id: " + deptId, 404);
+                if (departmentIdStr != null && !departmentIdStr.trim().isEmpty()) {
+                    Long deptId = parseLong(departmentIdStr);
+                    if (deptId == null) {
+                        return errorResponse("Invalid departmentId", 400);
+                    }
+                    Department dept = departmentFacade.find(deptId);
+                    if (dept == null) {
+                        return errorResponse("Department not found with id: " + deptId, 404);
+                    }
+                    jpql.append(" and i.department=:dep");
+                    params.put("dep", dept);
                 }
-                jpql.append(" and i.department=:dep");
-                params.put("dep", dept);
             }
 
             jpql.append(" order by i.orderNumber");

--- a/src/main/webapp/admin/users/user_subscription.xhtml
+++ b/src/main/webapp/admin/users/user_subscription.xhtml
@@ -28,7 +28,7 @@
                         placeholder="Department"
                         value="#{triggerSubscriptionController.department}"
                         class="w-100"
-                        disabled="#{triggerSubscriptionController.institutionWide}"
+                        disabled="#{triggerSubscriptionController.applicationWide}"
                         filter="true">
                         <f:selectItem itemLabel="Select" ></f:selectItem>
                         <f:selectItems
@@ -50,10 +50,10 @@
                         >
                     </p:commandButton>
 
-                    <p:outputLabel value="Institution-wide" ></p:outputLabel>
+                    <p:outputLabel value="Application-wide" ></p:outputLabel>
                     <p:selectBooleanCheckbox
-                        id="chkInstitutionWide"
-                        value="#{triggerSubscriptionController.institutionWide}">
+                        id="chkApplicationWide"
+                        value="#{triggerSubscriptionController.applicationWide}">
                         <p:ajax update="cmbDepartment" />
                     </p:selectBooleanCheckbox>
                     <h:outputText


### PR DESCRIPTION
## Summary

Adds a **Subscription Management REST API** over `TriggerSubscription` and exposes it to the in-page AI chat, so notification trigger subscriptions can be configured programmatically (and via natural language) instead of only through `admin/users/user_subscription.xhtml`.

Closes #21358.

## What changed

### 1. Rename Institution-wide → Application-wide
One HMIS application instance can host multiple institutions, so a `null`-department subscription is **application-wide** (matches every department), not institution-wide.
- `TriggerSubscriptionController`: `institutionWide` → `applicationWide` (field + getter/setter + validation message). Persisted semantics unchanged (`department = null`).
- `user_subscription.xhtml`: label → "Application-wide", checkbox id → `chkApplicationWide`.

### 2. New `SubscriptionApi` (`/api/subscriptions`)
Thin CRUD over a single entity, `Finance` header, standard success/error envelope, facades injected directly (no service layer).

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/subscriptions` | List (filters: `triggerType`, `userId`, `departmentId`, `applicationWide`) |
| `GET` | `/subscriptions/trigger-types` | List all `TriggerType` values (name/label/medium/parent) |
| `POST` | `/subscriptions` | Create — `userId` + `triggerType` + **exactly one** of `departmentId`/`applicationWide`; `already_exists` on duplicate; HTTP 201 |
| `DELETE` | `/subscriptions/{id}` | Soft-retire |

### 3. Registered in all 4 mandatory touch-points
`ApplicationConfig`, `CapabilityStatementResource`, `AnthropicApiService` system-prompt module listing + `manage_subscriptions` tool description (tool count ten → eleven), and the `manage_subscriptions` tool itself (`buildToolsArray` + `executeToolCall` + `callSubscriptionApi`).

## Testing

Verified live against a running deployment (`/rh`) — the API is deployed and working:
- `GET /trigger-types` → returns the 3 discharge stages (+ all others)
- `GET /users?query=` → user lookup
- `POST /subscriptions` (application-wide) → created 3 discharge subscriptions, all HTTP 201
- `GET /subscriptions?userId=` → confirms all 3 persisted with `applicationWide: true`

## Notes
- No `TriggerType` ordinals changed; no constructor signatures modified.
- Reordering (`orderNumber` up/down) and role-based (`webUserRole`) subscriptions remain out of scope (per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription management REST API for listing trigger types, querying, creating, and deleting subscriptions (requires API key)
  * API supports an "application-wide" subscription scope in addition to department-scoped subscriptions

* **UI**
  * “Application-wide” subscription option replaces the previous institution-wide toggle; department selector disables when application-wide is enabled

* **Documentation**
  * Capability statement updated to document the Subscriptions API, its endpoint and authentication requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->