### PR TITLE
feat(pharmacy): DTO-based Movement Out with Stock report (By Item) with last supplier (#21369)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -10,6 +10,7 @@ import com.divudi.bean.channel.ChannelSearchController;
 import com.divudi.bean.channel.analytics.ReportTemplateController;
 import com.divudi.core.data.dto.PharmacyIncomeBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillItemDTO;
+import com.divudi.core.data.dto.PharmacyMovementOutByItemDTO;
 import com.divudi.core.data.reports.SummaryReports;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
@@ -794,8 +795,7 @@ public class PharmacySummaryReportController implements Serializable {
                     processMovementOutWithStockReportByBillType();
                     break;
                 case BY_ITEM:
-                    processMovementOutWithStockReportByItem();
-                    addCurrentItemStock(pharmacyBundle);
+                    processMovementOutWithStockReportByItemDto();
                     break;
                 default:
                     JsfUtil.addErrorMessage("Unsupported report view type: " + reportViewType.getLabel());
@@ -1854,6 +1854,55 @@ public class PharmacySummaryReportController implements Serializable {
             pharmacyBundle = new PharmacyBundle(pbis);
             pharmacyBundle.groupSaleDetailsByItems();
         }, SummaryReports.PHARMACY_MOVEMENT_OUT_REPORT, sessionController.getLoggedUser());
+    }
+
+    /**
+     * DTO-based BY_ITEM movement-out report. Aggregates per item in the database,
+     * then fills current stock and the last supplier in one batched query each
+     * (no per-item N+1).
+     */
+    public void processMovementOutWithStockReportByItemDto() {
+        reportTimerController.trackReportExecution(() -> {
+            List<BillTypeAtomic> billTypeAtomics = getPharmacyMovementOutBillTypes();
+            List<PharmacyMovementOutByItemDTO> dtos = billService.fetchPharmacyMovementOutByItemDTOs(
+                    fromDate, toDate, institution, site, department, webUser, billTypeAtomics, admissionType, paymentScheme);
+            pharmacyBundle = new PharmacyBundle(dtos);
+            addCurrentStockAndSuppliers(pharmacyBundle);
+            pharmacyBundle.summarizeMovementOutByItem();
+        }, SummaryReports.PHARMACY_MOVEMENT_OUT_REPORT, sessionController.getLoggedUser());
+    }
+
+    /**
+     * Fills each row's current stock and last supplier using one batched query
+     * each, keyed by item id (no per-item N+1).
+     */
+    private void addCurrentStockAndSuppliers(PharmacyBundle bundle) {
+        if (bundle == null || bundle.getRows() == null || bundle.getRows().isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (PharmacyRow pr : bundle.getRows()) {
+            if (pr.getItem() != null && pr.getItem().getId() != null) {
+                itemIds.add(pr.getItem().getId());
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> stockByItem = billService.fetchCurrentStockByItemIds(itemIds, institution, site, department);
+        Map<Long, String> lastSupplierByItem = billService.fetchLastSupplierByItemIds(itemIds);
+
+        for (PharmacyRow pr : bundle.getRows()) {
+            if (pr.getItem() == null || pr.getItem().getId() == null) {
+                continue;
+            }
+            Long itemId = pr.getItem().getId();
+            Double stock = stockByItem.get(itemId);
+            pr.setStockQty(stock != null ? stock : 0.0);
+            String supplier = lastSupplierByItem.get(itemId);
+            pr.setSuppliers(supplier != null ? supplier : "");
+        }
     }
 
     public void processPharmacyIncomeAndCostReportByBill() {

--- a/src/main/java/com/divudi/core/data/PharmacyBundle.java
+++ b/src/main/java/com/divudi/core/data/PharmacyBundle.java
@@ -293,6 +293,15 @@ public class PharmacyBundle implements Serializable {
                         rows.add(ir);
                     }
                 }
+            } else if (firstElement instanceof com.divudi.core.data.dto.PharmacyMovementOutByItemDTO) {
+                // Process list as movement-out-by-item DTOs (already aggregated per item in DB)
+                for (Object obj : entries) {
+                    if (obj instanceof com.divudi.core.data.dto.PharmacyMovementOutByItemDTO) {
+                        com.divudi.core.data.dto.PharmacyMovementOutByItemDTO dto
+                                = (com.divudi.core.data.dto.PharmacyMovementOutByItemDTO) obj;
+                        rows.add(new PharmacyRow(dto));
+                    }
+                }
             } else if (firstElement instanceof PharmacyRow) {
                 // Process list as PharmacyRows
                 for (Object obj : entries) {
@@ -568,6 +577,45 @@ public class PharmacyBundle implements Serializable {
         List<PharmacyRow> grouped = new ArrayList<>(itemRowMap.values());
         grouped.sort(Comparator.comparing(r -> r.getItem().getName(), Comparator.nullsLast(String::compareToIgnoreCase)));
         setRows(grouped);
+        summaryRow = new PharmacyRow();
+        summaryRow.setGrossSaleValue(grossSaleValue);
+        summaryRow.setMarginValue(marginValue);
+        summaryRow.setDiscountValue(discountValue);
+        summaryRow.setNetSaleValue(netSaleValue);
+        summaryRow.setQuantity(quantity);
+    }
+
+    /**
+     * Builds the summary (footer) row for the BY_ITEM movement-out view when
+     * the rows are already aggregated per item by the database (DTO path).
+     * Rows are NOT regrouped here; we only total them and build the summary row,
+     * matching the footer values produced by {@code groupSaleDetailsByItems()}.
+     */
+    public void summarizeMovementOutByItem() {
+        grossSaleValue = BigDecimal.ZERO;
+        marginValue = BigDecimal.ZERO;
+        discountValue = BigDecimal.ZERO;
+        netSaleValue = BigDecimal.ZERO;
+        quantity = 0.0;
+
+        for (PharmacyRow r : getRows()) {
+            if (r.getQuantity() != null) {
+                quantity += r.getQuantity();
+            }
+            if (r.getGrossSaleValue() != null) {
+                grossSaleValue = grossSaleValue.add(r.getGrossSaleValue());
+            }
+            if (r.getMarginValue() != null) {
+                marginValue = marginValue.add(r.getMarginValue());
+            }
+            if (r.getDiscountValue() != null) {
+                discountValue = discountValue.add(r.getDiscountValue());
+            }
+            if (r.getNetSaleValue() != null) {
+                netSaleValue = netSaleValue.add(r.getNetSaleValue());
+            }
+        }
+
         summaryRow = new PharmacyRow();
         summaryRow.setGrossSaleValue(grossSaleValue);
         summaryRow.setMarginValue(marginValue);

--- a/src/main/java/com/divudi/core/data/PharmacyRow.java
+++ b/src/main/java/com/divudi/core/data/PharmacyRow.java
@@ -23,6 +23,7 @@ import com.divudi.core.entity.lab.PatientInvestigation;
 import com.divudi.core.entity.pharmacy.ItemBatch;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import com.divudi.core.data.dto.PharmacyMovementOutByItemDTO;
 import com.divudi.core.light.common.BillLight;
 
 import java.util.ArrayList;
@@ -199,6 +200,8 @@ public class PharmacyRow implements Serializable {
     private double consumptionCostValue;
     private double consumptionRetailValue;
 
+    private String suppliers;
+
     private BigDecimal grossSaleRate = BigDecimal.ZERO;
     private BigDecimal discountRate = BigDecimal.ZERO;
     private BigDecimal marginRate = BigDecimal.ZERO;
@@ -214,6 +217,34 @@ public class PharmacyRow implements Serializable {
 
     public PharmacyRow(StockHistory stockHistory) {
         this.stockHistory = stockHistory;
+    }
+
+    /**
+     * Builds a row for the BY_ITEM movement-out report from a database-aggregated
+     * DTO. Mirrors the shape produced by {@code groupSaleDetailsByItems()} so the
+     * existing JSF table bindings (item.name, quantity, grossSaleValue,
+     * discountValue, marginValue, netSaleValue) keep working unchanged.
+     * Current stock and suppliers are filled in afterwards via batched queries.
+     */
+    public PharmacyRow(PharmacyMovementOutByItemDTO dto) {
+        this();
+        if (dto == null) {
+            return;
+        }
+        this.item = new Item();
+        this.item.setId(dto.getItemId());
+        this.item.setName(dto.getItemName());
+        this.item.setCode(dto.getItemCode());
+        Category cat = new Category();
+        cat.setName(dto.getCategoryName());
+        this.item.setCategory(cat);
+
+        this.quantity = dto.getQuantity() != null ? dto.getQuantity() : 0.0;
+        this.grossSaleValue = dto.getGrossValue() != null ? BigDecimal.valueOf(dto.getGrossValue()) : BigDecimal.ZERO;
+        this.discountValue = dto.getDiscountValue() != null ? BigDecimal.valueOf(dto.getDiscountValue()) : BigDecimal.ZERO;
+        this.marginValue = dto.getMarginValue() != null ? BigDecimal.valueOf(dto.getMarginValue()) : BigDecimal.ZERO;
+        this.netSaleValue = dto.getNetValue() != null ? BigDecimal.valueOf(dto.getNetValue()) : BigDecimal.ZERO;
+        this.rowType = "PharmacyMovementOutByItemDTO";
     }
 
     public PharmacyRow(Long id) {
@@ -1790,5 +1821,13 @@ public class PharmacyRow implements Serializable {
 
     public void setConsumptionRetailValue(double consumptionRetailValue) {
         this.consumptionRetailValue = consumptionRetailValue;
+    }
+
+    public String getSuppliers() {
+        return suppliers;
+    }
+
+    public void setSuppliers(String suppliers) {
+        this.suppliers = suppliers;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyMovementOutByItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyMovementOutByItemDTO.java
@@ -1,0 +1,124 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * DTO for the "Pharmacy Movement Out with Stock" report, BY_ITEM view.
+ *
+ * Carries item identity plus database-aggregated movement-out values for a
+ * single item, so the report can be built without loading full
+ * {@code PharmaceuticalBillItem} entities and grouping them in memory.
+ *
+ * Current stock and supplier names are NOT part of this DTO; they are added in
+ * a single batched query each, keyed by item id, after the rows are built.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public class PharmacyMovementOutByItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long itemId;
+    private String itemName;
+    private String itemCode;
+    private String categoryName;
+
+    private Double quantity;
+    private Double grossValue;
+    private Double discountValue;
+    private Double marginValue;
+    private Double netValue;
+
+    public PharmacyMovementOutByItemDTO(
+            Long itemId,
+            String itemName,
+            String itemCode,
+            String categoryName,
+            Double quantity,
+            Double grossValue,
+            Double discountValue,
+            Double marginValue,
+            Double netValue) {
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.categoryName = categoryName;
+        this.quantity = quantity != null ? quantity : 0.0;
+        this.grossValue = grossValue != null ? grossValue : 0.0;
+        this.discountValue = discountValue != null ? discountValue : 0.0;
+        this.marginValue = marginValue != null ? marginValue : 0.0;
+        this.netValue = netValue != null ? netValue : 0.0;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    public Double getGrossValue() {
+        return grossValue;
+    }
+
+    public void setGrossValue(Double grossValue) {
+        this.grossValue = grossValue;
+    }
+
+    public Double getDiscountValue() {
+        return discountValue;
+    }
+
+    public void setDiscountValue(Double discountValue) {
+        this.discountValue = discountValue;
+    }
+
+    public Double getMarginValue() {
+        return marginValue;
+    }
+
+    public void setMarginValue(Double marginValue) {
+        this.marginValue = marginValue;
+    }
+
+    public Double getNetValue() {
+        return netValue;
+    }
+
+    public void setNetValue(Double netValue) {
+        this.netValue = netValue;
+    }
+}

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -36,6 +36,7 @@ import com.divudi.core.data.dto.LabIncomeReportDTO;
 import com.divudi.core.data.dto.OpdSaleSummaryDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillDTO;
 import com.divudi.core.data.dto.PharmacyIncomeBillItemDTO;
+import com.divudi.core.data.dto.PharmacyMovementOutByItemDTO;
 import com.divudi.core.data.dto.OpdIncomeReportDTO;
 import com.divudi.core.data.dto.OpdRevenueDashboardDTO;
 import com.divudi.core.data.dto.HospitalDoctorFeeReportDTO;
@@ -81,6 +82,7 @@ import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.light.common.BillLight;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import javax.annotation.security.PermitAll;
 import javax.ejb.EJB;
@@ -2714,6 +2716,186 @@ public class BillService {
         jpql += " order by b.createdAt desc  ";
         List<PharmaceuticalBillItem> fetchedPharmaceuticalBillItems = pharmaceuticalBillItemFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
         return fetchedPharmaceuticalBillItems;
+    }
+
+    /**
+     * DTO-based replacement for the BY_ITEM movement-out view. Aggregates
+     * movement-out values per item directly in the database (no full
+     * {@code PharmaceuticalBillItem} entity loading, no in-memory grouping).
+     *
+     * Values are summed signed exactly as the legacy in-memory grouping did
+     * (raw {@code BillItem} gross/margin/discount/net), so cancellation and
+     * refund bills net themselves out the same way.
+     */
+    public List<PharmacyMovementOutByItemDTO> fetchPharmacyMovementOutByItemDTOs(Date fromDate,
+            Date toDate,
+            Institution institution,
+            Institution site,
+            Department department,
+            WebUser webUser,
+            List<BillTypeAtomic> billTypeAtomics,
+            AdmissionType admissionType,
+            PaymentScheme paymentScheme) {
+
+        String jpql;
+        Map<String, Object> params = new HashMap<>();
+
+        jpql = "select new com.divudi.core.data.dto.PharmacyMovementOutByItemDTO( "
+                + " it.id, "
+                + " coalesce(it.name, 'N/A'), "
+                + " it.code, "
+                + " coalesce(cat.name, 'N/A'), "
+                + " coalesce(sum(bi.qty), 0.0), "
+                + " coalesce(sum(bi.grossValue), 0.0), "
+                + " coalesce(sum(bi.discount), 0.0), "
+                + " coalesce(sum(bi.marginValue), 0.0), "
+                + " coalesce(sum(bi.netValue), 0.0) ) "
+                + " from PharmaceuticalBillItem pbi "
+                + " join pbi.billItem bi "
+                + " join bi.bill b "
+                + " join bi.item it "
+                + " left join it.category cat "
+                + " where (b.retired = false or b.retired is null) "
+                + " and (bi.retired = false or bi.retired is null) "
+                + " and b.billTypeAtomic in :billTypesAtomics "
+                + " and b.createdAt between :fromDate and :toDate ";
+
+        params.put("billTypesAtomics", billTypeAtomics);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (institution != null) {
+            jpql += " and b.institution=:ins ";
+            params.put("ins", institution);
+        }
+        if (webUser != null) {
+            jpql += " and b.creater=:user ";
+            params.put("user", webUser);
+        }
+        if (department != null) {
+            jpql += " and b.department=:dep ";
+            params.put("dep", department);
+        }
+        if (site != null) {
+            jpql += " and b.department.site=:site ";
+            params.put("site", site);
+        }
+        if (admissionType != null) {
+            jpql += " and b.patientEncounter.admissionType=:admissionType ";
+            params.put("admissionType", admissionType);
+        }
+        if (paymentScheme != null) {
+            jpql += " and b.paymentScheme=:paymentScheme ";
+            params.put("paymentScheme", paymentScheme);
+        }
+
+        jpql += " group by it.id, it.name, it.code, cat.name "
+                + " order by it.name ";
+
+        return (List<PharmacyMovementOutByItemDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    /**
+     * Batched current-stock lookup for a set of item ids. Returns a map of
+     * itemId -> summed current stock, scoped by department/site/institution
+     * exactly like {@code StockController.findStock(...)}. One query for all
+     * items instead of one per item (avoids N+1).
+     */
+    public Map<Long, Double> fetchCurrentStockByItemIds(List<Long> itemIds,
+            Institution institution,
+            Institution site,
+            Department department) {
+        Map<Long, Double> result = new HashMap<>();
+        if (itemIds == null || itemIds.isEmpty()) {
+            return result;
+        }
+
+        String jpql = "select s.itemBatch.item.id, sum(s.stock) "
+                + " from Stock s "
+                + " where s.retired=false "
+                + " and s.itemBatch.item.id in :itemIds ";
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+
+        if (department != null) {
+            jpql += " and s.department=:dep ";
+            params.put("dep", department);
+        } else if (institution != null && site != null) {
+            jpql += " and s.department.site=:site and s.department.institution=:ins ";
+            params.put("site", site);
+            params.put("ins", institution);
+        } else if (institution != null) {
+            jpql += " and s.department.institution=:ins ";
+            params.put("ins", institution);
+        } else if (site != null) {
+            jpql += " and s.department.site=:site ";
+            params.put("site", site);
+        }
+
+        jpql += " group by s.itemBatch.item.id ";
+
+        List<Object[]> rows = (List) billItemFacade.findObjectByJpql(jpql, params, TemporalType.TIMESTAMP);
+        if (rows != null) {
+            for (Object[] row : rows) {
+                Long itemId = (Long) row[0];
+                Double stock = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+                result.put(itemId, stock);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Batched last-supplier lookup for a set of item ids. For each item, returns
+     * the supplier institution name of the most recent GRN / Direct Purchase
+     * bill (by bill {@code createdAt}). Supplier = {@code bill.fromInstitution}.
+     *
+     * One scalar query (no entity loading): rows are returned ordered by item id
+     * then bill date descending, and Java keeps the first row seen per item (the
+     * most recent purchase). This avoids a per-item correlated subquery while
+     * still yielding only the latest supplier.
+     */
+    public Map<Long, String> fetchLastSupplierByItemIds(List<Long> itemIds) {
+        Map<Long, String> result = new HashMap<>();
+        if (itemIds == null || itemIds.isEmpty()) {
+            return result;
+        }
+
+        List<BillTypeAtomic> purchaseBillTypes = Arrays.asList(
+                BillTypeAtomic.PHARMACY_GRN,
+                BillTypeAtomic.PHARMACY_GRN_PRE,
+                BillTypeAtomic.PHARMACY_GRN_WHOLESALE,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE
+        );
+
+        String jpql = "select bi.item.id, ins.name "
+                + " from BillItem bi "
+                + " join bi.bill b "
+                + " join b.fromInstitution ins "
+                + " where (b.retired=false or b.retired is null) "
+                + " and (bi.retired=false or bi.retired is null) "
+                + " and bi.item.id in :itemIds "
+                + " and b.billTypeAtomic in :purchaseTypes "
+                + " order by bi.item.id, b.createdAt desc ";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("purchaseTypes", purchaseBillTypes);
+
+        List<Object[]> rows = (List) billItemFacade.findObjectByJpql(jpql, params, TemporalType.TIMESTAMP);
+        if (rows != null) {
+            for (Object[] row : rows) {
+                Long itemId = (Long) row[0];
+                String supplierName = (String) row[1];
+                if (itemId == null || supplierName == null) {
+                    continue;
+                }
+                // First row per item is the most recent purchase (ordered date desc).
+                result.putIfAbsent(itemId, supplierName);
+            }
+        }
+        return result;
     }
 // Method from 13937-all-item-movement-summary-hotfix
 

--- a/src/main/webapp/pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml
@@ -196,13 +196,27 @@
 
                         </h:panelGrid>
 
-                        <p:commandButton 
-                            value="Process" 
+                        <p:commandButton
+                            value="Process"
                             ajax="false"
-                            action="#{pharmacySummaryReportController.processMovementOutBySaleIssueAndConsumptionWithCurrentStockReport()}" 
-                            styleClass="ui-button-success m-1" 
+                            action="#{pharmacySummaryReportController.processMovementOutBySaleIssueAndConsumptionWithCurrentStockReport()}"
+                            styleClass="ui-button-success m-1"
                             icon="pi pi-cog">
                         </p:commandButton>
+
+                        <!-- Read-only display of the pharmacy bill types (atomics) counted as "movement out" -->
+                        <p:fieldset id="includedBillTypesPanel"
+                                    legend="Included Pharmacy Bill Types"
+                                    toggleable="true"
+                                    collapsed="true"
+                                    styleClass="my-2">
+                            <p:dataList value="#{pharmacySummaryReportController.pharmacyMovementOutBillTypes}"
+                                        var="bta"
+                                        type="ordered"
+                                        styleClass="mb-0">
+                                <h:outputText value="#{bta.label}" />
+                            </p:dataList>
+                        </p:fieldset>
 
                         <h:panelGroup rendered="#{pharmacySummaryReportController.reportViewType eq 'BY_BILL'}" >
 
@@ -400,15 +414,16 @@
 
                         <h:panelGroup rendered="#{pharmacySummaryReportController.reportViewType eq 'BY_ITEM'}">
 
-                            <p:commandButton 
-                                value="Download" 
+                            <p:commandButton
+                                value="Download"
                                 ajax="false"
                                 styleClass="ui-button-info m-1"
                                 icon="pi pi-download">
-                                <p:dataExporter 
-                                    type="xlsx" 
+                                <p:dataExporter
+                                    type="xlsx"
                                     target="tblItem"
-                                    fileName="pharmacy_movement_out_by_item_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}" />
+                                    fileName="pharmacy_movement_out_by_item_#{pharmacySummaryReportController.fromDate}_to_#{pharmacySummaryReportController.toDate}"
+                                    postProcessor="#{pharmacySummaryReportController.postProcessExcel}" />
                             </p:commandButton>
 
                             <p:commandButton 
@@ -488,6 +503,10 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </f:facet>
+                                </p:column>
+
+                                <p:column headerText="Last Supplier">
+                                    <h:outputText value="#{rowi.suppliers}" />
                                 </p:column>
 
                             </p:dataTable>

--- a/src/main/webapp/pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml
@@ -197,6 +197,7 @@
                         </h:panelGrid>
 
                         <p:commandButton
+                            id="btnProcessMovementOut"
                             value="Process"
                             ajax="false"
                             action="#{pharmacySummaryReportController.processMovementOutBySaleIssueAndConsumptionWithCurrentStockReport()}"
@@ -415,6 +416,7 @@
                         <h:panelGroup rendered="#{pharmacySummaryReportController.reportViewType eq 'BY_ITEM'}">
 
                             <p:commandButton
+                                id="btnDownloadMovementOutByItem"
                                 value="Download"
                                 ajax="false"
                                 styleClass="ui-button-info m-1"


### PR DESCRIPTION
## Summary

Improves the **Pharmacy Movement Out with Stock** report (`pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml`), **By Item** view, per issue #21369.

## Changes

1. **DTO-based** — new `PharmacyMovementOutByItemDTO` + `BillService.fetchPharmacyMovementOutByItemDTOs(...)` aggregates per item **directly in the database** (item id/name/code/category + summed qty, gross, discount, margin, net), replacing full `PharmaceuticalBillItem` entity loading and in-memory grouping. Values are summed signed exactly as the old grouping did, so cancellations/refunds net out the same.
2. **Current stock in one batched query** — `fetchCurrentStockByItemIds(...)` replaces the per-item `stockController.findStock` N+1 loop.
3. **Last Supplier column** — new column showing the most recent **GRN / Direct Purchase** supplier per item (`fetchLastSupplierByItemIds`), one scalar query ordered by item + bill date desc, Java keeps the latest per item. (Scope chosen during review: last supplier rather than all-time list, for usefulness + performance.)
4. **All filters in the Excel download** — wired `postProcessor="#{...postProcessExcel}"` on the By Item export so the workbook header carries From/To, Institution, Site, Department, Admission Type, Discount Scheme, Report Type.
5. **Included bill types visible** — read-only collapsible "Included Pharmacy Bill Types" panel listing every atomic from `getPharmacyMovementOutBillTypes()` (stays in sync automatically).

All new queries select **scalars only** — no entity hydration anywhere in this path.

## Performance

Measured on local ruhunu (303K `BILLITEM` rows), 1-month range, 124 items: aggregate query ~0.13s, current-stock trivial, last-supplier ~0.57s. The previous entity-based By Item path is replaced; per-item N+1 stock lookups are eliminated.

## Testing

- By Item processes and renders correctly; footer totals unchanged vs. the previous By Item view for the same range (regression check).
- "Last Supplier" column shows the most recent purchase supplier.
- "Included Pharmacy Bill Types" panel lists the counted atomics.
- Excel download contains the filter header block.
- Confirmed working by the developer on local Payara.

Closes #21369

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BY_ITEM movement-out report now shows current stock and "Last Supplier" per item and includes a summary row of aggregated totals.
  * XLSX export for BY_ITEM reports supports extended post-processing for richer exports.
  * Report UI adds a toggleable, read-only section listing included pharmacy bill types for clearer filtering context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->