### PR TITLE
fix(inward): keep filter functional after adding pharmacy discount matrix entry (#21262)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
@@ -118,7 +118,7 @@ public class InwardDiscountMatrixController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Discount Scheme");
             return;
         }
-        
+
         if (department == null) {
             JsfUtil.addErrorMessage("Please select a Department");
             return;
@@ -130,13 +130,8 @@ public class InwardDiscountMatrixController implements Serializable {
         }
 
         InwardDiscountMatrix entry = buildEntry();
-        if (entry.getId() == null) {
-            ejbFacade.create(entry);
-            JsfUtil.addSuccessMessage("Saved Successfully");
-        } else {
-            ejbFacade.edit(entry);
-            JsfUtil.addSuccessMessage("Update Successfully");
-        }
+        ejbFacade.create(entry);
+        JsfUtil.addSuccessMessage("Saved Successfully");
 
         loadPharmacy();
         clearInputFields();
@@ -147,7 +142,7 @@ public class InwardDiscountMatrixController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Discount Scheme");
             return;
         }
-        
+
         if (inwardChargeType == null) {
             JsfUtil.addErrorMessage("Please select a Room Charge Type");
             return;

--- a/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
@@ -34,8 +34,8 @@ import javax.inject.Named;
 /**
  * Controller for the Inward Discount Matrix configuration pages.
  *
- * Manages discount percentage entries keyed by department, category,
- * BHT type (paymentMethod), admission type, and discount scheme (paymentScheme).
+ * Manages discount percentage entries keyed by department, category, BHT type
+ * (paymentMethod), admission type, and discount scheme (paymentScheme).
  *
  * @author Dr M H B Ariyaratne
  */
@@ -67,7 +67,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Navigation
     // -------------------------------------------------------------------------
-
     public String navigateToDiscountMatrixServiceInvestigation() {
         prepareAdd();
         return "/inward/inward_discount_matrix_service_investigation?faces-redirect=true";
@@ -86,7 +85,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Lifecycle
     // -------------------------------------------------------------------------
-
     public void prepareAdd() {
         department = null;
         category = null;
@@ -103,7 +101,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Save
     // -------------------------------------------------------------------------
-
     public void saveForServiceInvestigation() {
         if (paymentScheme == null) {
             JsfUtil.addErrorMessage("Please select a Discount Scheme");
@@ -121,9 +118,26 @@ public class InwardDiscountMatrixController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Discount Scheme");
             return;
         }
+        
+        if (department == null) {
+            JsfUtil.addErrorMessage("Please select a Department");
+            return;
+        }
+
+        if (category == null) {
+            JsfUtil.addErrorMessage("Please select a category");
+            return;
+        }
+
         InwardDiscountMatrix entry = buildEntry();
-        ejbFacade.create(entry);
-        JsfUtil.addSuccessMessage("Saved Successfully");
+        if (entry.getId() == null) {
+            ejbFacade.create(entry);
+            JsfUtil.addSuccessMessage("Saved Successfully");
+        } else {
+            ejbFacade.edit(entry);
+            JsfUtil.addSuccessMessage("Update Successfully");
+        }
+
         loadPharmacy();
         clearInputFields();
     }
@@ -133,6 +147,7 @@ public class InwardDiscountMatrixController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Discount Scheme");
             return;
         }
+        
         if (inwardChargeType == null) {
             JsfUtil.addErrorMessage("Please select a Room Charge Type");
             return;
@@ -176,7 +191,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Load / Fill
     // -------------------------------------------------------------------------
-
     public void loadServiceInvestigation() {
         filterItems = null;
         HashMap<String, Object> hm = new HashMap<>();
@@ -219,7 +233,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Edit / Delete
     // -------------------------------------------------------------------------
-
     public void onEdit(PriceMatrix entry) {
         ejbFacade.edit(entry);
         JsfUtil.addSuccessMessage("Updated Successfully");
@@ -242,7 +255,6 @@ public class InwardDiscountMatrixController implements Serializable {
     // -------------------------------------------------------------------------
     // Getters / Setters
     // -------------------------------------------------------------------------
-
     public PriceMatrix getCurrent() {
         return current;
     }

--- a/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_discount_matrix_pharmacy.xhtml
@@ -78,11 +78,12 @@
                                         <p:selectOneMenu
                                             class="w-100"
                                             value="#{inwardDiscountMatrixController.category}">
-                                            <f:selectItem itemLabel="All Categories" itemValue="#{null}"/>
-                                            <f:selectItems value="#{pharmaceuticalItemCategoryController.items}"
-                                                           var="c"
-                                                           itemLabel="#{c.name}"
-                                                           itemValue="#{c}"/>
+                                            <f:selectItem itemLabel="Select Categories" itemValue="#{null}"/>
+                                            <f:selectItems 
+                                                value="#{pharmaceuticalItemCategoryController.items}"
+                                                var="c"
+                                                itemLabel="#{c.name}"
+                                                itemValue="#{c}"/>
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
@@ -96,10 +97,11 @@
                                             class="w-100"
                                             value="#{inwardDiscountMatrixController.admissionType}">
                                             <f:selectItem itemLabel="All Admission Types" itemValue="#{null}"/>
-                                            <f:selectItems value="#{admissionTypeController.items}"
-                                                           var="at"
-                                                           itemValue="#{at}"
-                                                           itemLabel="#{at.name}"/>
+                                            <f:selectItems 
+                                                value="#{admissionTypeController.items}"
+                                                var="at"
+                                                itemValue="#{at}"
+                                                itemLabel="#{at.name}"/>
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
@@ -134,7 +136,10 @@
                                             itemValue="#{cc}"
                                             placeholder="Leave blank to apply to all companies"
                                             maxResults="20"
-                                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
+                                            onkeydown="if (event.key === 'Enter') {
+                                                        event.preventDefault();
+                                                        return false;
+                                                    }">
                                             <p:column headerText="Name">#{cc.name}</p:column>
                                         </p:autoComplete>
                                     </div>
@@ -146,8 +151,9 @@
                                     </div>
                                     <div class="col-4">
                                         <p:inputText
-                                            class="w-100"
+                                            class="w-100 text-end"
                                             autocomplete="off"
+                                            onfocus="this.select()"
                                             value="#{inwardDiscountMatrixController.discountPercent}"/>
                                     </div>
                                 </div>
@@ -236,12 +242,14 @@
                                 </p:column>
 
                                 <p:column headerText="Discount %" style="width: 8em;">
-                                    <h:inputText
+                                    <p:inputText
                                         autocomplete="off"
+                                        class="w-100 text-end"
                                         value="#{a.discountPercent}"
+                                        onfocus="this.select()"
                                         style="width: 5em;">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </p:inputText>
                                 </p:column>
 
                                 <p:column headerText="Action" style="width: 10em;">


### PR DESCRIPTION
## Summary

Fixes the Inward → Pharmacy Discount Matrix page where the Filter/Fill action became unresponsive after adding a discount entry, leaving users unable to refresh the grid and confirm their record was saved.

Closes #21262

## Changes

### Controller — `InwardDiscountMatrixController.saveForPharmacy()`
- Added validation requiring a **Department** and a **Category** to be selected before persisting an entry.
- Added create-vs-edit handling: a new entry (no id) is created, an existing entry is updated, with the appropriate success message.
- The pharmacy grid is reloaded after saving so newly added entries appear immediately.

### View — `inward_discount_matrix_pharmacy.xhtml`
- Changed the Category dropdown placeholder from "All Categories" to **"Select Categories"** to reflect that a category is now required.
- Right-aligned the discount-percentage inputs and made them select their content on focus for faster editing.
- Switched the grid's discount cell from `h:inputText` to `p:inputText` for consistent PrimeFaces styling.

## Testing
- Verified that adding a pharmacy discount entry without a Department or Category now shows a clear validation message instead of failing silently.
- Verified the grid refreshes and displays newly added entries after saving.

## Notes
- `persistence.xml` local JNDI settings were intentionally left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent saving entries when department or category is missing.

* **UI/UX Improvements**
  * Enhanced discount percentage inputs with auto-select on focus, right-aligned text, and disabled autocomplete.
  * Clarified pharmaceutical category dropdown label.
  * Polished form controls and table editable field rendering for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->