### PR TITLE
fix(pharmacy): correct movement-out quantity sign (use pharmaceutical bill item qty)

### DIFF
--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2740,12 +2740,18 @@ public class BillService {
         String jpql;
         Map<String, Object> params = new HashMap<>();
 
+        // Quantity sign note: BillItem.qty is stored unsigned (magnitude only), so summing it
+        // makes a sale and its return both add instead of netting out. PharmaceuticalBillItem.qty
+        // is the correctly signed stock delta (negative = stock went out for a sale/issue,
+        // positive = stock came back on a return). For a "movement OUT" report we want the
+        // quantity that went out, so we negate the summed pbi.qty: a sale yields a positive
+        // out-quantity and a return reduces it, matching the signed value columns below.
         jpql = "select new com.divudi.core.data.dto.PharmacyMovementOutByItemDTO( "
                 + " it.id, "
                 + " coalesce(it.name, 'N/A'), "
                 + " it.code, "
                 + " coalesce(cat.name, 'N/A'), "
-                + " coalesce(sum(bi.qty), 0.0), "
+                + " (coalesce(sum(pbi.qty), 0.0) * -1.0), "
                 + " coalesce(sum(bi.grossValue), 0.0), "
                 + " coalesce(sum(bi.discount), 0.0), "
                 + " coalesce(sum(bi.marginValue), 0.0), "


### PR DESCRIPTION
## Summary

Fixes the **quantity sign** in the Pharmacy Movement Out with Stock report (By Item view), introduced by #21371 / merged via that PR.

## Problem

The By Item DTO aggregate summed `BillItem.qty`, which is stored **unsigned** (magnitude only):

- A sale and its return **both add** instead of netting out.
- `PHARMACY_ISSUE` rows came through with the wrong sign.

The value columns (gross/discount/margin/net) were already correctly signed — **only quantity** was wrong. The legacy in-memory grouping (`groupSaleDetailsByItems()`) had the same bug, so this had been latent before the DTO refactor too.

## Fix

`PharmaceuticalBillItem.qty` is the correctly signed **stock delta** (negative = stock went out for a sale/issue, positive = stock returned). For a movement-**out** report we want the quantity that went out, so the aggregate now uses:

```
(coalesce(sum(pbi.qty), 0.0) * -1.0)
```

A sale yields a **positive** out-quantity; a return **reduces** it — now consistent with the signed value columns.

## Verification (local ruhunu DB)

Confirmed across retail-sale, issue, and return families that `-SUM(pbi.qty)` produces the correct signed out-quantity per item, whereas `SUM(bi.qty)` was unsigned/wrong:

| Bill type | `SUM(pbi.qty)` | `-SUM(pbi.qty)` (out) | `SUM(bi.qty)` (old, wrong) |
|---|---|---|---|
| PHARMACY_RETAIL_SALE | −120 | **+120** | +120 |
| PHARMACY_ISSUE | −96,460,824 | **+96,460,824** | +48,352,853 (wrong) |
| RETAIL_SALE_RETURN_ITEMS_ONLY | +789 | **−789** | +789 (wrong) |

Build: `BUILD SUCCESS`.

Closes #21369

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pharmacy movement-out quantity calculations in reports to accurately reflect sales and returns with proper directional indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->