### PR TITLE
fix(inward): error page when cancelling professional bill (hotfix #21376)

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -937,57 +937,61 @@
                                         value="#{bhtSummeryController.profesionallFee}" 
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
+                                        
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
+                                        
                                         <p:column headerText="Fee Value" >
                                             <h:outputLabel value="#{pf.feeValue}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
-
                                             <p:badge class="mx-2" value="Free Of Charge" rendered="#{pf.freeOfCharge}" severity="warning"></p:badge>
                                         </p:column>
+                                        
                                         <p:column headerText="Fee At">
                                             <h:outputLabel value="#{pf.feeAt}">
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>
                                             </h:outputLabel>
                                         </p:column>
+                                        
                                         <p:column headerText="Added Time">
                                             <h:outputLabel value="#{pf.createdAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                             <br/>
-                                            <h:panelGroup rendered="#{pf.bill.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{pf.bill.cancelled}"
-                                                               value="#{pf.bill.cancelledBill.createdAt}" >
+                                            <h:panelGroup rendered="#{pf.bill.cancelled}" class="d-flex gap-2" >
+                                                <h:outputLabel style="color: red;" value="Cancelled at" />
+                                                <h:outputLabel style="color: red;" value="#{pf.bill.cancelledBill.createdAt}" >
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        
                                         <p:column headerText="Added User">
-                                            <h:outputLabel value="#{pf.bill.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{pf.bill.creater.webUserPerson.nameWithTitle}"/>
                                             <br/>
-                                            <h:panelGroup rendered="#{pf.bill.cancelled}" >
+                                            <h:panelGroup rendered="#{pf.bill.cancelled}" class="d-flex gap-2" >
                                                 <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel style="color: red;" rendered="#{pf.bill.cancelled}"
-                                                               value="#{pf.bill.cancelledBill.creater.webUserPerson.name}" >
-                                                </h:outputLabel>
+                                                <h:outputLabel style="color: red;" value="#{pf.bill.cancelledBill.creater.webUserPerson.nameWithTitle}" ></h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{pf.bill.checkeAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column>
-                                            <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View " >
+                                        
+                                        <p:column headerText="Action" width="6em;">
+                                            <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
+                                        
                                     </p:dataTable>
                                 </p:tab>
 
@@ -998,55 +1002,61 @@
                                         value="#{bhtSummeryController.doctorAndNurseFee}"
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
+                                        
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
+                                        
                                         <p:column headerText="Fee Value" >
                                             <h:outputLabel value="#{pf.feeValue}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>
+                                        
                                         <p:column headerText="Fee At">
                                             <h:outputLabel value="#{pf.feeAt}">
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>
                                             </h:outputLabel>
                                         </p:column>
+                                        
                                         <p:column headerText="Added Time">
                                             <h:outputLabel value="#{pf.createdAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                             <br/>
-                                            <h:panelGroup rendered="#{pf.bill.cancelled}" >
+                                            <h:panelGroup rendered="#{pf.bill.cancelled}" class="d-flex gap-2" >
                                                 <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{pf.bill.cancelled}"
-                                                               value="#{pf.bill.cancelledBill.createdAt}" >
+                                                <h:outputLabel style="color: red;"  value="#{pf.bill.cancelledBill.createdAt}" >
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
                                         <p:column headerText="Added User">
-                                            <h:outputLabel value="#{pf.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{pf.creater.webUserPerson.nameWithTitle}"/>
                                             <br/>
-                                            <h:panelGroup rendered="#{pf.bill.cancelled}" >
+                                            <h:panelGroup rendered="#{pf.bill.cancelled}" class="d-flex gap-2" >
                                                 <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel style="color: red;" rendered="#{pf.bill.cancelled}"
-                                                               value="#{pf.bill.cancelledBill.creater.webUserPerson.name}" >
+                                                <h:outputLabel style="color: red;" value="#{pf.bill.cancelledBill.creater.webUserPerson.nameWithTitle}" >
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
+                                        
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{pf.bill.checkeAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column>
+                                        
+                                        <p:column headerText="Action" width="6em;">
                                             <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
+                                        
                                     </p:dataTable>
                                 </p:tab>
 
@@ -1068,39 +1078,42 @@
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                             <br/>
-                                            <h:panelGroup rendered="#{p.cancelled}" >
+                                            <h:panelGroup rendered="#{p.cancelled}" class="d-flex gap-2">
                                                 <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{p.cancelled}"
-                                                               value="#{p.cancelledBill.createdAt}" >
+                                                <h:outputLabel style="color: red;" value="#{p.cancelledBill.createdAt}" >
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        
                                         <p:column headerText="Added User">
-                                            <h:outputLabel value="#{p.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{p.creater.webUserPerson.nameWithTitle}"/>
                                             <br/>
-                                            <h:panelGroup rendered="#{p.cancelled}" >
+                                            <h:panelGroup rendered="#{p.cancelled}" class="d-flex gap-2">
                                                 <h:outputLabel style="color: red;" value="Cancelled By " />
                                                 <h:outputLabel 
-                                                    style="color: red;" rendered="#{p.cancelled}"
-                                                    value="#{p.cancelledBill.creater.webUserPerson.name}" >
+                                                    style="color: red;" value="#{p.cancelledBill.creater.webUserPerson.nameWithTitle}" >
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        
                                         <p:column headerText="Value" >
                                             <h:outputLabel  value="#{p.netTotal}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>
+                                        
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.name}"/>
+                                            <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
+                                        
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{p.checkeAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column>
+                                        
+                                        <p:column headerText="Action" width="6em;">
                                             <p:commandButton ajax="false" action="inward_reprint_bill_payment?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{p}" target="#{inwardSearch.bill}"/>
                                             </p:commandButton>

--- a/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
@@ -25,6 +25,7 @@
                                         ajax="false" value="To Cancel"
                                         icon="fa fa-cancel"
                                         class="ui-button-danger mx-1"
+                                        rendered="#{inwardSearch.bill.billClass ne 'class com.divudi.core.entity.CancelledBill'}"
                                         action="inward_cancel_bill_professional"  
                                         disabled="#{inwardSearch.bill.cancelled}"  >                           
                                     </p:commandButton>


### PR DESCRIPTION
## Summary

Hotfix for **RMH production** addressing [#21376](https://github.com/hmislk/hmis/issues/21376) — a system error page was displayed when users attempted to cancel a professional bill.

### Root cause
On the professional bill reprint page, the **To Cancel** button stayed visible even for bills that were already cancelled. Clicking it ran `InwardSearch.cancelProfessional()`, which cast the already-existing `CancelledBill` to a `BilledBill`, throwing a `ClassCastException` (InwardSearch.java:1544) and rendering the error page instead of completing the action.

### Changes

1. **`inward_reprint_bill_professional.xhtml`** — Guard the *To Cancel* button with a `rendered` condition (`billClass ne CancelledBill`) so an already-cancelled bill can no longer be re-cancelled. This eliminates the ClassCastException.

2. **`inward_bill_intrim.xhtml`** — Correct cancelled-bill metadata display on the interim summary tabs:
   - Use `nameWithTitle` for added / checked / cancelled users.
   - Lay out the *Cancelled at* / *Cancelled By* labels with `d-flex gap-2`.
   - Remove redundant `rendered` attributes on the inner labels.
   - Label the action columns and *View Bill* buttons clearly.

### Testing
- JSF/XHTML-only change — no Java recompilation required.
- After the fix, the *To Cancel* button is hidden for cancelled professional bills; cancelling an open professional bill completes normally without the error page.

### Notes
- `persistence.xml` intentionally left unchanged (local dev JNDI not committed).

Fixes #21376
