### PR TITLE
fix(admin): require bank name before saving in manage_banks

### DIFF
--- a/src/main/webapp/admin/institutions/manage_banks.xhtml
+++ b/src/main/webapp/admin/institutions/manage_banks.xhtml
@@ -36,7 +36,8 @@
                             <p:panel id="gpDetail" class="w-100" header="Details of the Bank">
                                 <h:panelGrid id="gpDetailText" columns="2" class="w-100">
                                     <h:outputText value="Name"/>
-                                    <p:inputText autocomplete="off" value="#{bankController.current.name}" class="w-100 p-1"/>
+                                    <p:inputText id="txtName" autocomplete="off" value="#{bankController.current.name}" class="w-100 p-1"
+                                                 required="true" requiredMessage="Bank name is required."/>
                                 </h:panelGrid>
                                 <p:commandButton id="btnSave" value="Save"
                                                  icon="fas fa-save"


### PR DESCRIPTION
## Summary
- Added `required="true"` and `requiredMessage="Bank name is required."` to the Name field in `manage_banks.xhtml`
- Clicking Save with an empty name now shows a validation error via the existing `p:growl` and blocks the save action
- Valid saves continue to work normally

Closes #20972

## Test plan
- [ ] Click **Add New**, leave Name empty, click **Save** → growl shows "Bank name is required." and nothing is saved
- [ ] Click **Add New**, enter a name, click **Save** → saves successfully and appears in the list
- [ ] Select an existing bank, clear the name, click **Save** → validation fires, record is not updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bank name field now requires input with a validation message, ensuring data integrity in the bank management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->