### PR TITLE
fix(pharmacy): stop phantom transfer receives bound to issuing dept stock (#21266 RC2)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
@@ -288,6 +289,14 @@ public class TransferReceiveController implements Serializable {
             newlyCreatedReceivedBillItem.invertValue();
             newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().invertValue();
 
+            // The copy above inherits the ISSUE line's stock binding, which is the
+            // ISSUING department's stock row. A receive must only ever touch the
+            // porter's in-transit stock (deducted) and the receiving department's
+            // stock (added; bound after addToStock() in settle). A receive line that
+            // keeps the sender's stock reference and slips past the stock loop is
+            // recorded as received without moving any stock (#21266 phantom receives).
+            newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().setStock(null);
+
             // Adjust quantity to remaining amount
             double unitsPerPack = 1.0;
             Item item = newlyCreatedReceivedBillItem.getItem();
@@ -475,6 +484,81 @@ public class TransferReceiveController implements Serializable {
         }
     }
 
+    /**
+     * Converts a bill item's user-entered receive quantity (packs) to units.
+     */
+    private double receiveQtyInUnits(BillItem i) {
+        double qtyInPacks = 0.0;
+        if (i.getBillItemFinanceDetails() != null && i.getBillItemFinanceDetails().getQuantity() != null) {
+            qtyInPacks = i.getBillItemFinanceDetails().getQuantity().doubleValue();
+        }
+        double unitsPerPack = 1.0;
+        Item item = i.getItem();
+        if (item instanceof Ampp || item instanceof Vmpp) {
+            unitsPerPack = item.getDblValue() > 0 ? item.getDblValue() : 1.0;
+        }
+        return qtyInPacks * unitsPerPack;
+    }
+
+    /**
+     * Validates that the porter (carrier) holds enough in-transit stock to cover
+     * EVERY line being received, before any data is written. Quantities are
+     * aggregated per item batch (several receive lines can draw from the same
+     * batch) and compared against the porter's live stock read fresh from the
+     * database.
+     *
+     * On a receive, stock must move porter -> receiving department. Previously,
+     * lines that could not be covered were silently skipped or zeroed mid-settle,
+     * and the skipped lines were later cascade-persisted still carrying the
+     * issuing department's stock binding with no stock movement — the #21266
+     * phantom-receive corruption. Failing the whole settle up front with explicit
+     * messages prevents both the corruption and the silent partial receive.
+     *
+     * @return true if every line is covered; false (with user-facing error
+     * messages) otherwise.
+     */
+    private boolean porterStockCoversAllLines() {
+        Staff porter = getIssuedBill() == null ? null : getIssuedBill().getToStaff();
+        if (porter == null) {
+            JsfUtil.addErrorMessage("This transfer issue has no carrying staff (porter) recorded - cannot receive. Please contact the issuing department.");
+            return false;
+        }
+        Map<Long, Double> requiredUnitsByBatch = new HashMap<>();
+        Map<Long, ItemBatch> batchById = new HashMap<>();
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            double units = receiveQtyInUnits(i);
+            if (units <= 0.0) {
+                continue;
+            }
+            ItemBatch batch = i.getPharmaceuticalBillItem() == null ? null : i.getPharmaceuticalBillItem().getItemBatch();
+            if (batch == null || batch.getId() == null) {
+                JsfUtil.addErrorMessage("Item " + (i.getItem() != null ? i.getItem().getName() : "?") + " has no batch - cannot receive.");
+                return false;
+            }
+            requiredUnitsByBatch.merge(batch.getId(), units, Double::sum);
+            batchById.put(batch.getId(), batch);
+        }
+        boolean allCovered = true;
+        for (Map.Entry<Long, Double> e : requiredUnitsByBatch.entrySet()) {
+            ItemBatch batch = batchById.get(e.getKey());
+            HashMap<String, Object> params = new HashMap<>();
+            String jpql = "select s from Stock s where s.itemBatch=:bc and s.staff=:stf";
+            params.put("bc", batch);
+            params.put("stf", porter);
+            Stock porterStock = getStockFacade().findFirstByJpql(jpql, params, true);
+            double available = porterStock == null ? 0.0 : porterStock.getStock();
+            if (available + 0.0001 < e.getValue()) {
+                String itemName = (batch.getItem() != null && batch.getItem().getName() != null)
+                        ? batch.getItem().getName() : ("Batch " + batch.getId());
+                JsfUtil.addErrorMessage("Insufficient in-transit (porter) stock for " + itemName
+                        + ": receiving " + e.getValue() + " but porter holds " + available
+                        + ". Nothing was received.");
+                allCovered = false;
+            }
+        }
+        return allCovered;
+    }
+
     private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
@@ -490,6 +574,12 @@ public class TransferReceiveController implements Serializable {
         // Validate that current receive quantities don't exceed remaining quantities
         if (wouldCauseOverReceiving()) {
             JsfUtil.addErrorMessage("Cannot receive - quantities exceed remaining amounts!");
+            return;
+        }
+
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
             return;
         }
 
@@ -552,6 +642,13 @@ public class TransferReceiveController implements Serializable {
                 getBillItemFacade().edit(i);
             }
         }
+
+        // Drop lines that were never persisted (zero quantity or failed checks)
+        // from the in-memory bill. Bill.billItems cascades ALL, so the later
+        // edit(getReceivedBill()) merges would otherwise INSERT these skipped
+        // lines - still carrying the issue line's data with no stock movement -
+        // which is exactly the #21266 phantom-receive corruption.
+        getReceivedBill().getBillItems().removeIf(bi -> bi.getId() == null);
 
         // Handle Department ID generation (independent)
         String deptId;
@@ -891,6 +988,12 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
+            return;
+        }
+
         getReceivedBill().setApproveAt(new Date());
         getReceivedBill().setApproveUser(getSessionController().getLoggedUser());
 
@@ -959,6 +1062,12 @@ public class TransferReceiveController implements Serializable {
                 Stock addedStock = getPharmacyBean().addToStock(tmpPh, Math.abs(qty), getSessionController().getDepartment());
                 tmpPh.setStock(addedStock);
             } else {
+                // No stock was moved - never leave the line bound to the stock
+                // reference inherited from the issue line (the issuing
+                // department's stock), or it records a phantom receive (#21266).
+                tmpPh.setStock(null);
+                tmpPh.setQty(0);
+                i.setQty(0.0);
                 i.setTmpQty(0);
                 getBillItemFacade().edit(i);
             }

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -90,7 +90,7 @@
                                     </p:column>  
 
                                     <p:column headerText="Expiration Date"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
-                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                         </h:outputText>
                                     </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -81,7 +81,7 @@
                             </p:column>
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -89,7 +89,7 @@
                             </p:column> 
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">  
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>  


### PR DESCRIPTION
## Summary

Port of the QA-tested Ruhunu production hotfix (`e72a1c37ed` on `pharmacy-stock-fixes-hotfix`) for the phantom transfer-receive corruption — issue #21266, root cause RC2 of the Ruhunu stock-discrepancy investigation (12 bills / 75 lines / ~LKR 201,620 recorded-but-never-moved).

The legacy `TransferReceiveController` is still the active receive path when the "Use Save Finalize Approve Workflow for Transfer Receive" option is off, so development needs the same guard.

## Root cause

`generateBillComponent()` clones each issue line **including `pbi.stock` — the issuing department's stock row**. Lines skipped in the settle loop (zero qty, or porter stock insufficient in `errorCheck`) were never explicitly persisted but stayed in the in-memory `billItems` list; the later `edit(receivedBill)` merge (`CascadeType.ALL`) cascade-INSERTed them still bound to the sender's stock with **no StockHistory** — recorded as received, no stock moved. Detection signature in data: receive lines with `stock.department_id = bill.fromDepartment_id` and zero stockhistory (75/75 affected lines match).

## Fix

- `generateBillComponent()`: clear the inherited stock binding; a receive line is bound only to the receiving department's stock after `addToStock()` succeeds
- `settle()` / `settleApprove()`: **all-or-nothing porter-stock pre-check** — every line must be coverable from the porter's in-transit stock (aggregated per batch, read fresh from DB) before anything is written; explicit per-item error messages instead of silent skipping/zeroing
- `doSettle()`: remove unpersisted (skipped) lines before the final merges so the cascade can never insert them
- `settleApprove()`: on deduct failure, unbind the inherited stock and zero quantities (covers PRE bills saved before this fix)
- Receive pages (3): expiry column reads `pbi.itemBatch.dateOfExpire` instead of `pbi.stock.itemBatch.dateOfExpire` (stock is unbound until settle)

## Testing

- Full QA on the Ruhunu production hotfix build (transfer issue → receive cycles, insufficient-porter-stock rejection, no new lines matching the phantom detection signature)
- Compiles cleanly on `development`

Refs #21266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential data corruption in pharmacy transfer receives by enforcing mandatory stock validation before processing
  * Corrected expiry date display in pharmacy transfer receive pages to show accurate batch information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->