### PR TITLE
fix(pharmacy): stop stale-entity writes clobbering settled disposal returns (#21396)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -388,6 +388,61 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveDirectPurchaseReturn")) {
             return;
@@ -413,9 +468,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -1833,6 +1898,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -1877,8 +1948,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -1965,6 +2041,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -1989,7 +2069,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -413,6 +413,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             }
             BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
             if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: finalized data for \"" + itemName
+                        + "\" could not be reloaded. The return must be corrected and re-finalized.");
+                allMatch = false;
                 continue;
             }
             BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
@@ -1806,6 +1810,15 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
     // Validation method called during quantity changes (similar to legacy onEdit pattern)
     public boolean validateReturnQuantities(BillItem billItem) {
+        return validateReturnQuantities(billItem, true);
+    }
+
+    /**
+     * @param allowAutoCorrect when false (approval stage), quantities are
+     * never rewritten - a violation fails validation instead of being
+     * silently reduced to the remaining/available amount (#21266 RC4).
+     */
+    public boolean validateReturnQuantities(BillItem billItem, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getBillItemFinanceDetails() == null || billItem.getReferanceBillItem() == null) {
             return false;
         }
@@ -1819,7 +1832,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         double remainingFreeQty = getRemainingFreeQtyToReturn(billItem.getReferanceBillItem());
 
         // Validate stock availability - critical check
-        if (!validateStockAvailability(billItem, true)) {
+        if (!validateStockAvailability(billItem, true, allowAutoCorrect)) {
             isValid = false;
         }
 
@@ -1843,10 +1856,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             // Allow exact match (>=) instead of just (>)
             if (currentTotalQtyInUnits > remainingTotalQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
-                fd.setFreeQuantity(BigDecimal.ZERO);
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
+                    fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                    fd.setFreeQuantity(BigDecimal.ZERO);
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingTotalQty / unitsPerPack) + " packs" : remainingTotalQty + " units"));
                 isValid = false;
@@ -1862,17 +1877,21 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             // Allow exact match (>=) instead of just (>)
             if (currentQtyInUnits > remainingQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
+                    fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingQty / unitsPerPack) + " packs" : remainingQty + " units"));
                 isValid = false;
             }
             if (currentFreeQtyInUnits > remainingFreeQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
-                fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
+                    fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining free quantity. Remaining: "
                         + (isAmppItem ? (remainingFreeQty / unitsPerPack) + " packs" : remainingFreeQty + " units"));
                 isValid = false;
@@ -2159,8 +2178,9 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            // Re-validate quantities at approval stage (additional security check)
-            if (!validateReturnQuantities(bi)) {
+            // Re-validate quantities at approval stage (additional security check).
+            // allowAutoCorrect=false: approval must never rewrite finalized quantities (#21266 RC4).
+            if (!validateReturnQuantities(bi, false)) {
                 isValid = false;
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
@@ -341,29 +341,47 @@ public class DisposalReturnWorkflowController implements Serializable {
      * @param returnBillToClose The return bill to close
      */
     public void closeDisposalReturn(Bill returnBillToClose) {
-        if (returnBillToClose == null) {
+        if (returnBillToClose == null || returnBillToClose.getId() == null) {
             JsfUtil.addErrorMessage("No disposal return selected to close");
             return;
         }
 
+        // The row passed in comes from a list loaded earlier in the session and can
+        // be STALE - the return may have been settled after the list was loaded.
+        // Validating and merging the stale entity reverted settled bills back to
+        // drafts (completed/completedAt/deptId/insId cleared) while their items and
+        // stock movements remained - the #21266 RC5 orphan-return corruption
+        // (Ruhunu bills 4336218 / 4337297, 2026-03-25). Always validate and edit
+        // the CURRENT row, bypassing the L2 cache (another app server may have
+        // written it under dual-version operation).
+        Bill freshBill = billFacade.findWithoutCache(returnBillToClose.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Disposal return not found");
+            return;
+        }
+
         // Verify the bill is not already completed
-        if (returnBillToClose.isCompleted()) {
+        if (freshBill.isCompleted()) {
             JsfUtil.addErrorMessage("Cannot close a completed disposal return");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         // Verify the bill is not already closed
-        if (returnBillToClose.isBillClosed()) {
+        if (freshBill.isBillClosed()) {
             JsfUtil.addErrorMessage("This disposal return is already closed");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         try {
             // Mark the bill as closed
-            returnBillToClose.setBillClosed(true);
+            freshBill.setBillClosed(true);
 
             // Save the changes
-            billFacade.edit(returnBillToClose);
+            billFacade.edit(freshBill);
 
             // Refresh the lists
             fillDisposalReturnsToFinalize();

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -662,6 +662,61 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveGrnReturn")) {
             return;
@@ -687,9 +742,19 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -2276,6 +2341,12 @@ public class GrnReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -2320,8 +2391,13 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -2417,6 +2493,10 @@ public class GrnReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2441,7 +2521,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -687,6 +687,10 @@ public class GrnReturnWorkflowController implements Serializable {
             }
             BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
             if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: finalized data for \"" + itemName
+                        + "\" could not be reloaded. The return must be corrected and re-finalized.");
+                allMatch = false;
                 continue;
             }
             BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
@@ -2234,6 +2238,15 @@ public class GrnReturnWorkflowController implements Serializable {
 
     // Validation method called during quantity changes (similar to legacy onEdit pattern)
     public boolean validateReturnQuantities(BillItem billItem) {
+        return validateReturnQuantities(billItem, true);
+    }
+
+    /**
+     * @param allowAutoCorrect when false (approval stage), quantities are
+     * never rewritten - a violation fails validation instead of being
+     * silently reduced to the remaining/available amount (#21266 RC4).
+     */
+    public boolean validateReturnQuantities(BillItem billItem, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getBillItemFinanceDetails() == null || billItem.getReferanceBillItem() == null) {
             return false;
         }
@@ -2257,7 +2270,7 @@ public class GrnReturnWorkflowController implements Serializable {
         BigDecimal savedTotalQuantity = fd.getTotalQuantity();
 
         // Validate stock availability - critical check
-        if (!validateStockAvailability(billItem, true)) {
+        if (!validateStockAvailability(billItem, true, allowAutoCorrect)) {
             // Restore original quantities to prevent JPA auto-flush from
             // persisting the reset values (which would corrupt the entity)
             fd.setQuantity(savedQuantity);
@@ -2289,10 +2302,12 @@ public class GrnReturnWorkflowController implements Serializable {
 
             // Allow exact match (>=) instead of just (>)
             if (currentTotalQtyInUnits > remainingTotalQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
-                fd.setFreeQuantity(BigDecimal.ZERO);
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
+                    fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                    fd.setFreeQuantity(BigDecimal.ZERO);
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingTotalQty / unitsPerPack) + " packs" : remainingTotalQty + " units"));
                 isValid = false;
@@ -2308,17 +2323,21 @@ public class GrnReturnWorkflowController implements Serializable {
 
             // Allow exact match (>=) instead of just (>)
             if (currentQtyInUnits > remainingQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
+                    fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingQty / unitsPerPack) + " packs" : remainingQty + " units"));
                 isValid = false;
             }
             if (currentFreeQtyInUnits > remainingFreeQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
-                double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
-                fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
+                if (allowAutoCorrect) {
+                    // Convert back to packs for AMPP items when setting the corrected value
+                    double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
+                    fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
+                }
                 JsfUtil.addErrorMessage("Cannot return more than remaining free quantity. Remaining: "
                         + (isAmppItem ? (remainingFreeQty / unitsPerPack) + " packs" : remainingFreeQty + " units"));
                 isValid = false;
@@ -2611,8 +2630,9 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            // Re-validate quantities at approval stage (additional security check)
-            if (!validateReturnQuantities(bi)) {
+            // Re-validate quantities at approval stage (additional security check).
+            // allowAutoCorrect=false: approval must never rewrite finalized quantities (#21266 RC4).
+            if (!validateReturnQuantities(bi, false)) {
                 isValid = false;
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -280,6 +280,7 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setChecked(true);
         getReturnBill().setCheckeAt(new Date());
         getReturnBill().setCheckedBy(sessionController.getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         // Refresh the bill and reload bill items for print preview
@@ -324,12 +325,14 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setCompleted(true);
         getReturnBill().setCompletedAt(new Date());
         getReturnBill().setCompletedBy(getSessionController().getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         getOriginalBill().setRefundedBill(getReturnBill());
         getOriginalBill().setRefunded(true);
         getOriginalBill().getRefundBills().add(getReturnBill());
 
+        getOriginalBill().setBillItems(null);
         getBillFacade().edit(getOriginalBill());
 
         printPreview = true;
@@ -498,6 +501,10 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
+            // Null out the billItems collection before merge so EclipseLink does not treat
+            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
+            // Bill items are managed independently by saveBillComponents() / billItemFacade.
+            getReturnBill().setBillItems(null);
             getBillFacade().edit(getReturnBill());
         }
     }
@@ -560,6 +567,7 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
+        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -797,8 +805,10 @@ public class IssueReturnController implements Serializable {
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
+            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
     }
@@ -846,6 +856,7 @@ public class IssueReturnController implements Serializable {
 
         bill.setTotal(total);
         bill.setNetTotal(netTotal);
+        bill.setBillItems(null);
         getBillFacade().edit(bill);
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -210,7 +210,49 @@ public class IssueReturnController implements Serializable {
         pageMetadataRegistry.registerPage(metadata);
     }
 
+    /**
+     * Guards every write entry point (save / finalize / settle) against acting
+     * on a bill whose CURRENT database state is already completed or closed.
+     *
+     * The @SessionScoped bean (and the browser page) can hold a STALE copy of
+     * the return bill - e.g. the bill was settled, then Save/Finalize/Settle is
+     * clicked again from an old screen or list row. Merging that stale copy
+     * reverts the settled bill to a draft (completed/deptId/insId cleared)
+     * while its items and stock movements remain - the #21266 RC5 orphan-return
+     * corruption (Ruhunu bills 4336218 / 4337297, 2026-03-25). Reads bypass the
+     * L2 cache because another app server may have written the bill under
+     * dual-version operation.
+     *
+     * @return true if processing must stop (with a user-facing message).
+     */
+    private boolean disposalReturnAlreadyProcessed() {
+        if (getReturnBill() == null || getReturnBill().getId() == null) {
+            return false; // new, never-persisted draft - nothing to clobber
+        }
+        Bill fresh = getBillFacade().findWithoutCache(getReturnBill().getId());
+        if (fresh == null) {
+            return false;
+        }
+        if (fresh.isCompleted()) {
+            JsfUtil.addErrorMessage("This disposal return (" + (fresh.getDeptId() != null ? fresh.getDeptId() : fresh.getId())
+                    + ") has already been settled. Reload the page before continuing.");
+            return true;
+        }
+        if (fresh.isBillClosed()) {
+            JsfUtil.addErrorMessage("This disposal return has been closed. Create a new return instead.");
+            return true;
+        }
+        if (fresh.isCancelled() || fresh.isRetired()) {
+            JsfUtil.addErrorMessage("This disposal return is cancelled or retired and can no longer be processed.");
+            return true;
+        }
+        return false;
+    }
+
     public void saveDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // No validation required for saving drafts - users can save incomplete data
         saveBill();
         saveBillComponents();
@@ -218,6 +260,9 @@ public class IssueReturnController implements Serializable {
     }
 
     public void finalizeDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // Validate return comment is provided
         if (returnBill.getComments() == null || returnBill.getComments().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return Comment is required. Please provide a reason for the return.");
@@ -248,6 +293,12 @@ public class IssueReturnController implements Serializable {
     }
 
     public void settleDisposalIssueReturnBill() {
+        // Re-settling an already-settled bill (double-click, stale screen, stale
+        // list row) would write a second set of items and stock movements and
+        // then clobber the bill header (#21266 RC5).
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         if (getReturnBill().getCheckedBy() == null) {
             JsfUtil.addErrorMessage("Pleace Finalise Bill First. Can not Return");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -785,6 +785,16 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
         for (BillItem bi : getBillItems()) {
+            // Single source of truth for the issued quantity (#21266 RC6): the
+            // user-entered qty lives in BillItemFinanceDetails.quantity, but the
+            // stock movement below uses pbi.qty - which still holds the REQUESTED
+            // qty from item generation if a UI edit did not sync it. Stock then
+            // moved by the requested qty while updateBillItemRateAndValue()
+            // rewrote the persisted line to the user-entered qty AFTER the stock
+            // ops (pbi 4912145, 2026-05-20: stock moved 2, line said 1). Sync
+            // pbi/billItem qty from the user-entered value BEFORE validating or
+            // moving any stock, keeping the positive pre-settle sign convention.
+            syncStockQtyFromUserEnteredQty(bi);
             if (bi.getPharmaceuticalBillItem().getItemBatch() != null) {
                 if (bi.getPharmaceuticalBillItem().getStock().getStock() < bi.getPharmaceuticalBillItem().getQty()) {
                     JsfUtil.addErrorMessage("Available quantity is less than issued quantity in " + bi.getPharmaceuticalBillItem().getItemBatch().getItem().getName());
@@ -1005,6 +1015,31 @@ public class TransferIssueForRequestsController implements Serializable {
 
     }
 
+    /**
+     * Copies the user-entered quantity (BillItemFinanceDetails.quantity, in
+     * packs) onto the fields the settle stock operations read - pbi.qty (units),
+     * pbi.qtyPacks and billItem.qty (packs) - so the quantity that moves stock
+     * is always the quantity that gets persisted (#21266 RC6). Values are set
+     * POSITIVE to match the pre-settle convention expected by the validation
+     * and zero-removal checks; settle() negates them later. Lines without
+     * finance details or a quantity are left untouched (conservative fallback).
+     */
+    private void syncStockQtyFromUserEnteredQty(BillItem bi) {
+        if (bi == null || bi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+        if (f == null || f.getQuantity() == null) {
+            return;
+        }
+        double packs = Math.abs(f.getQuantity().doubleValue());
+        double unitsPerPack = (f.getUnitsPerPack() != null && f.getUnitsPerPack().compareTo(BigDecimal.ZERO) > 0)
+                ? f.getUnitsPerPack().doubleValue() : 1.0;
+        bi.getPharmaceuticalBillItem().setQty(packs * unitsPerPack);
+        bi.getPharmaceuticalBillItem().setQtyPacks(packs);
+        bi.setQty(packs);
+    }
+
     private void updateBillItemRateAndValue(BillItem b) {
         BillItemFinanceDetails f = b.getBillItemFinanceDetails();
         double rate = b.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
@@ -1057,6 +1092,14 @@ public class TransferIssueForRequestsController implements Serializable {
             if (f.getPurchaseRate() == null) {
                 f.setPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()));
             }
+            // Recompute valuation fields from the user-entered quantity. They are
+            // set at item-generation time from the REQUESTED qty and were never
+            // updated when the user changed the issuing qty (#21266 RC6:
+            // valueAtPurchaseRate stayed 990 = 2 x 495 while the line qty became
+            // 1). Positive sign, matching the generation-time convention.
+            f.setValueAtPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(qtyInUnits));
+            f.setValueAtRetailRate(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(qtyInUnits));
+            f.setValueAtCostRate(costRate.multiply(qtyInUnits));
         } else {
             f.setLineCostRate(BigDecimal.ZERO);
             f.setLineCost(BigDecimal.ZERO);

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -89,7 +89,7 @@
                                             value="Save"
                                             title="Save return bill as draft"
                                             action="#{issueReturnController.saveDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -99,7 +99,7 @@
                                             onclick="return confirm('Are you sure you want to finalize this disposal issue? This action cannot be undone.');"
                                             title="Finalize return bill"
                                             action="#{issueReturnController.finalizeDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -109,7 +109,7 @@
                                             onclick="return confirm('Are you sure you want to approve this disposal issue? This action cannot be undone.');"
                                             title="Approve and process the return"
                                             action="#{issueReturnController.settleDisposalIssueReturnBill}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and not issueReturnController.returnBill.billClosed and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                     </div>
@@ -130,6 +130,50 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
                                     <h:outputText value=" by #{issueReturnController.originalBill.fullReturnedBy.webUserPerson.nameWithTitle}. No further returns are allowed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return already approved (settled) - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-success d-flex align-items-center">
+                                <i class="fas fa-check-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.completedAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.completedAt}" rendered="#{issueReturnController.returnBill.completedAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" by #{issueReturnController.returnBill.completedBy.webUserPerson.nameWithTitle}" rendered="#{issueReturnController.returnBill.completedBy ne null}"/>
+                                    <h:outputText value=". No further changes are possible." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return closed - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.billClosed and not issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-warning d-flex align-items-center">
+                                <i class="fas fa-ban me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return has been closed. It can no longer be saved, finalized or approved - create a new return for this disposal issue if needed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: finalized, awaiting approval - explains why Save/Finalize are hidden, and why Approve is hidden when the privilege is missing -->
+                        <p:panel rendered="#{issueReturnController.returnBill.checkedBy ne null and not issueReturnController.returnBill.completed and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-info d-flex align-items-center">
+                                <i class="fas fa-info-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This return was finalized by #{issueReturnController.returnBill.checkedBy.webUserPerson.nameWithTitle}" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.checkeAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.checkeAt}" rendered="#{issueReturnController.returnBill.checkeAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" and is awaiting approval. Items can no longer be edited." styleClass="fw-bold"/>
+                                    <h:outputText value=" You do not have the Approve Disposal Return privilege - please ask an authorized user to approve it."
+                                                  rendered="#{!webUserController.hasPrivilege('ApproveDisposalReturn')}"
+                                                  styleClass="fw-bold text-danger ms-1"/>
                                 </div>
                             </div>
                         </p:panel>


### PR DESCRIPTION
## Summary

Port of the QA-tested ruhunu-prod hotfix `1e57825ce4` (branch `pharmacy-stock-fixes-hotfix`). Fixes #21396; part of the #21266 RC5 remediation.

Clean cherry-pick — both files were byte-identical between `development` and the pre-fix hotfix branch, so the same defect is live here.

## Root cause (proven on the Ruhunu production copy)

Disposal returns 4336218 / 4337297 (2026-03-25) were settled successfully — their bill numbers (`R/DIS/RHD/LBK/26/000017`, `000020`) were consumed and items + StockHistory written — then the user clicked **Close** on a stale "returns to approve" list row. `closeDisposalReturn()` validated `isCompleted()` on the **stale in-memory entity** (false → guard passed) and `billFacade.edit(staleEntity)` merged the whole pre-settle image over the live row: `completed`/`completedAt`/`deptId`/`insId` reverted to NULL, `billClosed=1`. (`billedBill` survived because it is LAZY and was never fetched — merges ignore un-instantiated lazy refs.) Result: stock movement with no completed bill → inflated system stock → COGS variance.

## Fix

- `DisposalReturnWorkflowController.closeDisposalReturn()`: reload the bill with `findWithoutCache` (L2 bypass — another server can write under dual-version operation), validate and edit the **current** row, never the stale list entity
- `IssueReturnController`: guard `save`/`finalize`/`settle` with `disposalReturnAlreadyProcessed()` — fresh-state check refusing already completed/closed/cancelled bills; also blocks double-click re-settles that would duplicate items and stock movements

## Testing

- Full QA on the Ruhunu production hotfix build (warning correctly shown; settled bills keep number + completed state)
- Compiles cleanly on `development`
- ⚠️ The disposal-return flow differs in development — please run the dev-flow QA checklist on #21396 before merging. The guards are purely additive (they only refuse writes that would clobber data), so the happy path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent acting on stale or already-processed disposal/return bills with stricter validation, reloads, and clearer messages.
  * Block edits/approvals on settled/closed/retired returns; avoid unintended persistence side-effects by clearing transient item state before saving.
  * Ensure settlement uses user-entered quantities and recompute valuation fields for consistent totals.
  * Approval now verifies finalized quantities and disables silent auto-correction during approval.

* **New Features**
  * UI: status/alert panels explain why action buttons are hidden and button visibility tightened based on return state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->