### PR TITLE
Improve stock movement timeline filtering and tooltips

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockMovementAnalyticsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockMovementAnalyticsController.java
@@ -67,6 +67,8 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
     private Date fromDate;
     private Date toDate;
     private Item item;
+    private String batchNumberFilter;
+    private Long itemBatchIdFilter;
 
     // Each of the three graphs is scoped by either a Department or a Staff.
     // Scope type: "department" or "staff".
@@ -115,6 +117,8 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         "rgb(173, 216, 230)"
     };
     private static final String TOTAL_LINE_COLOR = "rgb(0, 0, 0)";
+    private static final String TOOLTIP_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static final String TOOLTIP_DATE_FORMAT = "yyyy-MM-dd";
 
     public PharmacyStockMovementAnalyticsController() {
     }
@@ -146,6 +150,8 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         markers1 = null;
         markers2 = null;
         markers3 = null;
+        batchNumberFilter = null;
+        itemBatchIdFilter = null;
         processed = false;
         return "/pharmacy/pharmacy_stock_movement_timeline?faces-redirect=true";
     }
@@ -163,6 +169,14 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         if (fromDate.after(toDate)) {
             JsfUtil.addErrorMessage("From date must be before to date");
             return;
+        }
+        if (!isAnyScopeSelected()) {
+            JsfUtil.addErrorMessage("Please select at least one department or staff scope");
+            return;
+        }
+        if (batchNumberFilter != null && batchNumberFilter.trim().isEmpty()) {
+            batchNumberFilter = null;
+            itemBatchIdFilter = null;
         }
 
         ScopeResult r1 = buildScope(scopeType1, department1, staff1);
@@ -182,6 +196,20 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         scopeLabel3 = r3.label;
 
         processed = true;
+    }
+
+    public void applyBatchFilter(Long itemBatchId, String batchNo) {
+        itemBatchIdFilter = itemBatchId;
+        batchNumberFilter = batchNo;
+        process();
+    }
+
+    public void clearBatchFilter() {
+        batchNumberFilter = null;
+        itemBatchIdFilter = null;
+        if (processed) {
+            process();
+        }
     }
 
     private ScopeResult buildScope(String scopeType, Department dep, Staff stf) {
@@ -217,13 +245,18 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
                 .append("ib.id, ib.batchNo, ")
                 .append("s.stockQty, s.stockPurchaseValue, s.stockSaleValue, ")
                 .append("s.itemStock, s.itemStockValueAtPurchaseRate, s.itemStockValueAtSaleRate, ")
-                .append("bill.id, bill.deptId, bill.billTypeAtomic, ")
+                .append("bill.id, bill.deptId, bill.billDate, bill.billTypeAtomic, ")
+                .append("fromDept.name, toDept.name, porterPerson.name, ")
                 .append("pbi.qty, pbi.freeQty, bifd.quantityByUnits) ")
                 .append("from StockHistory s ")
                 .append("left join s.itemBatch ib ")
                 .append("left join s.pbItem pbi ")
                 .append("left join pbi.billItem bi ")
                 .append("left join bi.bill bill ")
+                .append("left join bill.fromDepartment fromDept ")
+                .append("left join bill.toDepartment toDept ")
+                .append("left join bill.toStaff porter ")
+                .append("left join porter.person porterPerson ")
                 .append("left join bi.billItemFinanceDetails bifd ")
                 .append("where s.retired=false ")
                 .append("and s.item=:i ")
@@ -233,6 +266,14 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
                 // nulls from the left join.
                 .append("and s.pbItem is not null ")
                 .append("and s.createdAt between :fd and :td ");
+
+        if (itemBatchIdFilter != null) {
+            jpql.append("and ib.id=:itemBatchId ");
+            m.put("itemBatchId", itemBatchIdFilter);
+        } else if (batchNumberFilter != null && !batchNumberFilter.trim().isEmpty()) {
+            jpql.append("and lower(ib.batchNo)=:batchNo ");
+            m.put("batchNo", batchNumberFilter.trim().toLowerCase());
+        }
 
         if (staffScope) {
             if (stf == null) {
@@ -346,9 +387,13 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
     private List<BillMarker> buildMarkers(List<StockMovementTimelineDTO> rows) {
         List<BillMarker> list = new ArrayList<>();
         for (StockMovementTimelineDTO r : rows) {
+            if (r.getMovementAt() == null) {
+                continue;
+            }
             BillMarker bm = new BillMarker();
             bm.setStockHistoryId(r.getStockHistoryId());
             bm.setMovementAt(r.getMovementAt());
+            bm.setItemBatchId(r.getItemBatchId());
             bm.setBatchNo(batchLabel(r));
             bm.setStockQty(r.getStockQty());
             bm.setItemStock(r.getItemStock());
@@ -358,6 +403,11 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
             bm.setBillId(r.getBillId());
             bm.setDeptBillNo(r.getDeptBillNo());
             bm.setBillType(r.getBillType());
+            bm.setBillTypeAtomic(r.getBillTypeAtomicName());
+            bm.setBillDate(r.getBillDate());
+            bm.setFromDepartmentName(r.getFromDepartmentName());
+            bm.setToDepartmentName(r.getToDepartmentName());
+            bm.setPorterName(r.getPorterName());
             list.add(bm);
         }
         return list;
@@ -419,6 +469,102 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         return list;
     }
 
+    private boolean scopeHasSelection(String scopeType, Department dep, Staff stf) {
+        return "staff".equals(scopeType) ? stf != null : dep != null;
+    }
+
+    private String buildTooltipDataJson(List<BillMarker> markers) {
+        if (markers == null || markers.isEmpty()) {
+            return "[]";
+        }
+        SimpleDateFormat dateTimeFormat = new SimpleDateFormat(TOOLTIP_DATE_TIME_FORMAT);
+        SimpleDateFormat dateFormat = new SimpleDateFormat(TOOLTIP_DATE_FORMAT);
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < markers.size(); i++) {
+            BillMarker m = markers.get(i);
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append('{');
+            appendJsonField(sb, "movementAt", m.getMovementAt() == null ? null : dateTimeFormat.format(m.getMovementAt()), true);
+            appendJsonField(sb, "billNo", m.getDeptBillNo(), false);
+            appendJsonField(sb, "billDate", m.getBillDate() == null ? null : dateFormat.format(m.getBillDate()), false);
+            appendJsonField(sb, "billTypeAtomic", m.getBillTypeAtomic(), false);
+            appendJsonField(sb, "fromDepartment", m.getFromDepartmentName(), false);
+            appendJsonField(sb, "toDepartment", m.getToDepartmentName(), false);
+            appendJsonField(sb, "porter", m.getPorterName(), false);
+            appendJsonField(sb, "batch", m.getBatchNo(), false);
+            appendJsonField(sb, "batchStock", String.valueOf(m.getStockQty()), false);
+            appendJsonField(sb, "itemStock", m.getItemStock() == null ? null : String.valueOf(m.getItemStock()), false);
+            sb.append('}');
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    private void appendJsonField(StringBuilder sb, String name, String value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        appendJsonString(sb, name);
+        sb.append(':');
+        appendJsonString(sb, value);
+    }
+
+    private void appendJsonString(StringBuilder sb, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            sb.append("\"\"");
+            return;
+        }
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '<':
+                    sb.append("\\u003c");
+                    break;
+                case '>':
+                    sb.append("\\u003e");
+                    break;
+                case '&':
+                    sb.append("\\u0026");
+                    break;
+                case '\'':
+                    sb.append("\\u0027");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                    break;
+            }
+        }
+        sb.append('"');
+    }
+
     // <editor-fold defaultstate="collapsed" desc="Inner classes">
     private static class ScopeResult {
         LineChartModel model;
@@ -431,8 +577,14 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         private static final long serialVersionUID = 1L;
         private Long stockHistoryId;
         private Long billId;
+        private Long itemBatchId;
         private String deptBillNo;
         private String billType;
+        private String billTypeAtomic;
+        private Date billDate;
+        private String fromDepartmentName;
+        private String toDepartmentName;
+        private String porterName;
         private Date movementAt;
         private String batchNo;
         private double stockQty;
@@ -457,6 +609,14 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
             this.billId = billId;
         }
 
+        public Long getItemBatchId() {
+            return itemBatchId;
+        }
+
+        public void setItemBatchId(Long itemBatchId) {
+            this.itemBatchId = itemBatchId;
+        }
+
         public String getDeptBillNo() {
             return deptBillNo;
         }
@@ -471,6 +631,46 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
 
         public void setBillType(String billType) {
             this.billType = billType;
+        }
+
+        public String getBillTypeAtomic() {
+            return billTypeAtomic;
+        }
+
+        public void setBillTypeAtomic(String billTypeAtomic) {
+            this.billTypeAtomic = billTypeAtomic;
+        }
+
+        public Date getBillDate() {
+            return billDate;
+        }
+
+        public void setBillDate(Date billDate) {
+            this.billDate = billDate;
+        }
+
+        public String getFromDepartmentName() {
+            return fromDepartmentName;
+        }
+
+        public void setFromDepartmentName(String fromDepartmentName) {
+            this.fromDepartmentName = fromDepartmentName;
+        }
+
+        public String getToDepartmentName() {
+            return toDepartmentName;
+        }
+
+        public void setToDepartmentName(String toDepartmentName) {
+            this.toDepartmentName = toDepartmentName;
+        }
+
+        public String getPorterName() {
+            return porterName;
+        }
+
+        public void setPorterName(String porterName) {
+            this.porterName = porterName;
         }
 
         public Date getMovementAt() {
@@ -560,6 +760,15 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
 
     public void setItem(Item item) {
         this.item = item;
+    }
+
+    public String getBatchNumberFilter() {
+        return batchNumberFilter;
+    }
+
+    public void setBatchNumberFilter(String batchNumberFilter) {
+        this.batchNumberFilter = batchNumberFilter;
+        this.itemBatchIdFilter = null;
     }
 
     public String getScopeType1() {
@@ -654,6 +863,18 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         return chart3;
     }
 
+    public String getTooltipData1() {
+        return buildTooltipDataJson(markers1);
+    }
+
+    public String getTooltipData2() {
+        return buildTooltipDataJson(markers2);
+    }
+
+    public String getTooltipData3() {
+        return buildTooltipDataJson(markers3);
+    }
+
     public List<BillMarker> getMarkers1() {
         return markers1;
     }
@@ -680,6 +901,22 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
 
     public boolean isProcessed() {
         return processed;
+    }
+
+    public boolean isScope1Selected() {
+        return scopeHasSelection(scopeType1, department1, staff1);
+    }
+
+    public boolean isScope2Selected() {
+        return scopeHasSelection(scopeType2, department2, staff2);
+    }
+
+    public boolean isScope3Selected() {
+        return scopeHasSelection(scopeType3, department3, staff3);
+    }
+
+    public boolean isAnyScopeSelected() {
+        return isScope1Selected() || isScope2Selected() || isScope3Selected();
     }
 
     public SessionController getSessionController() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockMovementAnalyticsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockMovementAnalyticsController.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import javax.ejb.EJB;
 import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
@@ -119,6 +120,7 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
     private static final String TOTAL_LINE_COLOR = "rgb(0, 0, 0)";
     private static final String TOOLTIP_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
     private static final String TOOLTIP_DATE_FORMAT = "yyyy-MM-dd";
+    private static final TimeZone COLOMBO_TIME_ZONE = TimeZone.getTimeZone("Asia/Colombo");
 
     public PharmacyStockMovementAnalyticsController() {
     }
@@ -307,6 +309,7 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         // Seconds are included in the label so distinct same-minute movements
         // remain visually distinguishable.
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        sdf.setTimeZone(COLOMBO_TIME_ZONE);
         List<StockMovementTimelineDTO> plottedRows = new ArrayList<>();
         List<String> labels = new ArrayList<>();
         for (StockMovementTimelineDTO r : rows) {
@@ -394,7 +397,8 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
             bm.setStockHistoryId(r.getStockHistoryId());
             bm.setMovementAt(r.getMovementAt());
             bm.setItemBatchId(r.getItemBatchId());
-            bm.setBatchNo(batchLabel(r));
+            bm.setBatchNo(r.getBatchNo());
+            bm.setBatchLabel(batchLabel(r));
             bm.setStockQty(r.getStockQty());
             bm.setItemStock(r.getItemStock());
             bm.setPbiQty(r.getPbiQty());
@@ -479,6 +483,8 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         }
         SimpleDateFormat dateTimeFormat = new SimpleDateFormat(TOOLTIP_DATE_TIME_FORMAT);
         SimpleDateFormat dateFormat = new SimpleDateFormat(TOOLTIP_DATE_FORMAT);
+        dateTimeFormat.setTimeZone(COLOMBO_TIME_ZONE);
+        dateFormat.setTimeZone(COLOMBO_TIME_ZONE);
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < markers.size(); i++) {
             BillMarker m = markers.get(i);
@@ -493,7 +499,7 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
             appendJsonField(sb, "fromDepartment", m.getFromDepartmentName(), false);
             appendJsonField(sb, "toDepartment", m.getToDepartmentName(), false);
             appendJsonField(sb, "porter", m.getPorterName(), false);
-            appendJsonField(sb, "batch", m.getBatchNo(), false);
+            appendJsonField(sb, "batch", m.getBatchLabel(), false);
             appendJsonField(sb, "batchStock", String.valueOf(m.getStockQty()), false);
             appendJsonField(sb, "itemStock", m.getItemStock() == null ? null : String.valueOf(m.getItemStock()), false);
             sb.append('}');
@@ -587,6 +593,7 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
         private String porterName;
         private Date movementAt;
         private String batchNo;
+        private String batchLabel;
         private double stockQty;
         private Double itemStock;
         private double pbiQty;
@@ -687,6 +694,14 @@ public class PharmacyStockMovementAnalyticsController implements Serializable {
 
         public void setBatchNo(String batchNo) {
             this.batchNo = batchNo;
+        }
+
+        public String getBatchLabel() {
+            return batchLabel;
+        }
+
+        public void setBatchLabel(String batchLabel) {
+            this.batchLabel = batchLabel;
         }
 
         public double getStockQty() {

--- a/src/main/java/com/divudi/core/data/dto/StockMovementTimelineDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StockMovementTimelineDTO.java
@@ -46,6 +46,10 @@ public class StockMovementTimelineDTO implements Serializable {
     private Long billId;
     private String deptBillNo;
     private BillTypeAtomic billTypeAtomic;
+    private Date billDate;
+    private String fromDepartmentName;
+    private String toDepartmentName;
+    private String porterName;
 
     // Transaction quantities
     private double pbiQty;
@@ -89,6 +93,40 @@ public class StockMovementTimelineDTO implements Serializable {
         this.pbiQty = pbiQty;
         this.pbiFreeQty = pbiFreeQty;
         this.bifdQty = bifdQty;
+    }
+
+    /**
+     * Extended constructor for graph tooltips. Keep the original constructor
+     * unchanged for compatibility with any older projections.
+     */
+    public StockMovementTimelineDTO(
+            Long stockHistoryId,
+            Date movementAt,
+            Long itemBatchId,
+            String batchNo,
+            double stockQty,
+            double stockPurchaseValue,
+            double stockSaleValue,
+            Double itemStock,
+            Double itemStockValueAtPurchaseRate,
+            Double itemStockValueAtSaleRate,
+            Long billId,
+            String deptBillNo,
+            Date billDate,
+            BillTypeAtomic billTypeAtomic,
+            String fromDepartmentName,
+            String toDepartmentName,
+            String porterName,
+            double pbiQty,
+            double pbiFreeQty,
+            BigDecimal bifdQty) {
+        this(stockHistoryId, movementAt, itemBatchId, batchNo, stockQty, stockPurchaseValue,
+                stockSaleValue, itemStock, itemStockValueAtPurchaseRate, itemStockValueAtSaleRate,
+                billId, deptBillNo, billTypeAtomic, pbiQty, pbiFreeQty, bifdQty);
+        this.billDate = billDate;
+        this.fromDepartmentName = fromDepartmentName;
+        this.toDepartmentName = toDepartmentName;
+        this.porterName = porterName;
     }
 
     public StockMovementTimelineDTO() {
@@ -198,9 +236,45 @@ public class StockMovementTimelineDTO implements Serializable {
         this.billTypeAtomic = billTypeAtomic;
     }
 
+    public Date getBillDate() {
+        return billDate;
+    }
+
+    public void setBillDate(Date billDate) {
+        this.billDate = billDate;
+    }
+
+    public String getFromDepartmentName() {
+        return fromDepartmentName;
+    }
+
+    public void setFromDepartmentName(String fromDepartmentName) {
+        this.fromDepartmentName = fromDepartmentName;
+    }
+
+    public String getToDepartmentName() {
+        return toDepartmentName;
+    }
+
+    public void setToDepartmentName(String toDepartmentName) {
+        this.toDepartmentName = toDepartmentName;
+    }
+
+    public String getPorterName() {
+        return porterName;
+    }
+
+    public void setPorterName(String porterName) {
+        this.porterName = porterName;
+    }
+
     /** Human-readable bill type label for the marker table. */
     public String getBillType() {
         return billTypeAtomic == null ? null : billTypeAtomic.getLabel();
+    }
+
+    public String getBillTypeAtomicName() {
+        return billTypeAtomic == null ? null : billTypeAtomic.name();
     }
 
     public double getPbiQty() {

--- a/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline.xhtml
@@ -59,7 +59,8 @@
                                                  value="#{pharmacyStockMovementAnalyticsController.batchNumberFilter}"
                                                  styleClass="w-100"
                                                  placeholder="All batches"/>
-                                    <p:commandButton icon="fa fa-times"
+                                    <p:commandButton id="clearBatchFilterBtn"
+                                                     icon="fa fa-times"
                                                      title="Clear batch filter"
                                                      styleClass="ui-button-secondary"
                                                      action="#{pharmacyStockMovementAnalyticsController.clearBatchFilter()}"

--- a/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline.xhtml
@@ -12,10 +12,12 @@
                 <h:form id="stockMovementForm"
                         onkeydown="if (event.key === 'Enter' &amp;&amp; event.target.tagName !== 'TEXTAREA') { event.preventDefault(); return false; }">
 
+                    <p:growl id="msg" showDetail="true" life="5000"/>
+
                     <!-- Filters -->
                     <p:panel header="Stock Movement Timeline - Filters" styleClass="mb-3">
                         <div class="row g-3">
-                            <div class="col-md-3">
+                            <div class="col-md-2">
                                 <p:outputLabel value="From Date" styleClass="d-block mb-1"/>
                                 <p:datePicker id="fromDate"
                                               value="#{pharmacyStockMovementAnalyticsController.fromDate}"
@@ -25,7 +27,7 @@
                                               inputStyleClass="w-100 form-control"
                                               pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-2">
                                 <p:outputLabel value="To Date" styleClass="d-block mb-1"/>
                                 <p:datePicker id="toDate"
                                               value="#{pharmacyStockMovementAnalyticsController.toDate}"
@@ -49,6 +51,21 @@
                                                 forceSelection="true"
                                                 styleClass="w-100"
                                                 inputStyleClass="w-100 form-control"/>
+                            </div>
+                            <div class="col-md-2">
+                                <p:outputLabel value="Batch No" for="batchNumberFilter" styleClass="d-block mb-1"/>
+                                <h:panelGroup id="batchFilter" layout="block" styleClass="d-flex gap-1">
+                                    <p:inputText id="batchNumberFilter"
+                                                 value="#{pharmacyStockMovementAnalyticsController.batchNumberFilter}"
+                                                 styleClass="w-100"
+                                                 placeholder="All batches"/>
+                                    <p:commandButton icon="fa fa-times"
+                                                     title="Clear batch filter"
+                                                     styleClass="ui-button-secondary"
+                                                     action="#{pharmacyStockMovementAnalyticsController.clearBatchFilter()}"
+                                                     process="@this"
+                                                     update="batchFilter msg resultsPanel"/>
+                                </h:panelGroup>
                             </div>
                             <div class="col-md-2">
                                 <p:outputLabel value="Y-Axis Metric" styleClass="d-block mb-1"/>
@@ -161,7 +178,7 @@
                                              icon="fas fa-chart-line"
                                              styleClass="ui-button-success"
                                              action="#{pharmacyStockMovementAnalyticsController.process()}"
-                                             update="resultsPanel"/>
+                                             update="msg resultsPanel"/>
                         </div>
                     </p:panel>
 
@@ -169,26 +186,35 @@
                     <h:panelGroup id="resultsPanel" layout="block">
                         <h:panelGroup rendered="#{pharmacyStockMovementAnalyticsController.processed}">
 
-                            <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
-                                <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart1}"/>
-                                <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers1}"/>
-                                <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel1}"/>
-                                <ui:param name="graphNo" value="1"/>
-                            </ui:include>
+                            <h:panelGroup rendered="#{pharmacyStockMovementAnalyticsController.scope1Selected}">
+                                <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
+                                    <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart1}"/>
+                                    <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers1}"/>
+                                    <ui:param name="tooltipData" value="#{pharmacyStockMovementAnalyticsController.tooltipData1}"/>
+                                    <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel1}"/>
+                                    <ui:param name="graphNo" value="1"/>
+                                </ui:include>
+                            </h:panelGroup>
 
-                            <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
-                                <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart2}"/>
-                                <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers2}"/>
-                                <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel2}"/>
-                                <ui:param name="graphNo" value="2"/>
-                            </ui:include>
+                            <h:panelGroup rendered="#{pharmacyStockMovementAnalyticsController.scope2Selected}">
+                                <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
+                                    <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart2}"/>
+                                    <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers2}"/>
+                                    <ui:param name="tooltipData" value="#{pharmacyStockMovementAnalyticsController.tooltipData2}"/>
+                                    <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel2}"/>
+                                    <ui:param name="graphNo" value="2"/>
+                                </ui:include>
+                            </h:panelGroup>
 
-                            <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
-                                <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart3}"/>
-                                <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers3}"/>
-                                <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel3}"/>
-                                <ui:param name="graphNo" value="3"/>
-                            </ui:include>
+                            <h:panelGroup rendered="#{pharmacyStockMovementAnalyticsController.scope3Selected}">
+                                <ui:include src="/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml">
+                                    <ui:param name="chartModel" value="#{pharmacyStockMovementAnalyticsController.chart3}"/>
+                                    <ui:param name="markers" value="#{pharmacyStockMovementAnalyticsController.markers3}"/>
+                                    <ui:param name="tooltipData" value="#{pharmacyStockMovementAnalyticsController.tooltipData3}"/>
+                                    <ui:param name="scopeLabel" value="#{pharmacyStockMovementAnalyticsController.scopeLabel3}"/>
+                                    <ui:param name="graphNo" value="3"/>
+                                </ui:include>
+                            </h:panelGroup>
 
                         </h:panelGroup>
                     </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml
@@ -144,8 +144,9 @@
             </p:column>
             <p:column headerText="Batch">
                 <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1">
-                    <h:outputText value="#{m.batchNo}"/>
-                    <p:commandButton icon="fa fa-filter"
+                    <h:outputText value="#{m.batchLabel}"/>
+                    <p:commandButton id="applyBatchFilterBtn"
+                                     icon="fa fa-filter"
                                      title="Filter all charts by this batch"
                                      styleClass="ui-button-secondary ui-button-flat"
                                      rendered="#{not empty m.itemBatchId}"

--- a/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_movement_timeline_graph.xhtml
@@ -16,6 +16,105 @@
     -->
     <p:panel header="Graph #{graphNo} — #{scopeLabel}" styleClass="mb-4">
 
+        <span id="stockMovementTooltipData#{graphNo}" style="display:none;">
+            <h:outputText value="#{tooltipData}"/>
+        </span>
+        <script type="text/javascript">
+            //<![CDATA[
+            window.stockMovementTimelineTooltips = window.stockMovementTimelineTooltips || {};
+            (function () {
+                var tooltipDataNode = document.getElementById('stockMovementTooltipData#{graphNo}');
+                try {
+                    window.stockMovementTimelineTooltips['#{graphNo}'] = tooltipDataNode
+                            ? JSON.parse(tooltipDataNode.textContent || '[]')
+                            : [];
+                } catch (e) {
+                    window.stockMovementTimelineTooltips['#{graphNo}'] = [];
+                }
+            })();
+
+            window.stockMovementTimelineBuildTooltipCallbacks = window.stockMovementTimelineBuildTooltipCallbacks || function (tooltipRows) {
+                var dataIndex = function (item) {
+                    return item && item.dataIndex !== undefined ? item.dataIndex : item.index;
+                };
+                var datasetLabel = function (item, data) {
+                    if (item && item.dataset && item.dataset.label) {
+                        return item.dataset.label;
+                    }
+                    if (data && data.datasets && data.datasets[item.datasetIndex]) {
+                        return data.datasets[item.datasetIndex].label || '';
+                    }
+                    return '';
+                };
+                var pointValue = function (item) {
+                    if (item && item.formattedValue !== undefined) {
+                        return item.formattedValue;
+                    }
+                    if (item && item.parsed && item.parsed.y !== undefined) {
+                        return item.parsed.y;
+                    }
+                    return item && item.yLabel !== undefined ? item.yLabel : '';
+                };
+                var addLine = function (lines, label, value) {
+                    if (value !== undefined && value !== null && value !== '') {
+                        lines.push(label + ': ' + value);
+                    }
+                };
+
+                return {
+                    title: function (items) {
+                        var item = Array.isArray(items) ? items[0] : items;
+                        var row = tooltipRows[dataIndex(item)] || {};
+                        return row.movementAt || '';
+                    },
+                    label: function (item, data) {
+                        var row = tooltipRows[dataIndex(item)] || {};
+                        var lines = [];
+                        var label = datasetLabel(item, data);
+                        var value = pointValue(item);
+                        if (label || value !== '') {
+                            lines.push((label ? label + ': ' : '') + value);
+                        }
+                        addLine(lines, 'Bill No', row.billNo);
+                        addLine(lines, 'Bill Date', row.billDate);
+                        addLine(lines, 'Bill Type', row.billTypeAtomic);
+                        addLine(lines, 'From Department', row.fromDepartment);
+                        addLine(lines, 'To Department', row.toDepartment);
+                        addLine(lines, 'Porter', row.porter);
+                        addLine(lines, 'Batch', row.batch);
+                        addLine(lines, 'Batch Stock After', row.batchStock);
+                        addLine(lines, 'Item Stock After', row.itemStock);
+                        return lines;
+                    }
+                };
+            };
+
+            (function patchStockMovementTimelineChartRender() {
+                if (!window.PrimeFaces || !PrimeFaces.widget || !PrimeFaces.widget.Chart
+                        || PrimeFaces.widget.Chart.__stockMovementTimelineTooltipPatch) {
+                    return;
+                }
+                var originalRender = PrimeFaces.widget.Chart.prototype._render;
+                PrimeFaces.widget.Chart.prototype._render = function () {
+                    var widgetVar = this.widgetVar || (this.cfg ? this.cfg.widgetVar : '');
+                    if (widgetVar && widgetVar.indexOf('stockMovementChart') === 0 && this.cfg && this.cfg.config) {
+                        var graphKey = widgetVar.replace('stockMovementChart', '');
+                        var tooltipRows = window.stockMovementTimelineTooltips[graphKey] || [];
+                        var options = this.cfg.config.options = this.cfg.config.options || {};
+                        options.plugins = options.plugins || {};
+                        options.plugins.tooltip = options.plugins.tooltip || {};
+                        options.tooltips = options.tooltips || {};
+                        var callbacks = window.stockMovementTimelineBuildTooltipCallbacks(tooltipRows);
+                        options.plugins.tooltip.callbacks = callbacks;
+                        options.tooltips.callbacks = callbacks;
+                    }
+                    return originalRender.apply(this, arguments);
+                };
+                PrimeFaces.widget.Chart.__stockMovementTimelineTooltipPatch = true;
+            })();
+            //]]>
+        </script>
+
         <div style="width:100%; height:400px;">
             <p:lineChart model="#{chartModel}"
                          style="width:100%; height:400px;"
@@ -44,7 +143,16 @@
                 <h:outputText value="#{m.billType}"/>
             </p:column>
             <p:column headerText="Batch">
-                <h:outputText value="#{m.batchNo}"/>
+                <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1">
+                    <h:outputText value="#{m.batchNo}"/>
+                    <p:commandButton icon="fa fa-filter"
+                                     title="Filter all charts by this batch"
+                                     styleClass="ui-button-secondary ui-button-flat"
+                                     rendered="#{not empty m.itemBatchId}"
+                                     action="#{pharmacyStockMovementAnalyticsController.applyBatchFilter(m.itemBatchId, m.batchNo)}"
+                                     process="@this"
+                                     update=":stockMovementForm:batchFilter :stockMovementForm:msg :stockMovementForm:resultsPanel"/>
+                </h:panelGroup>
             </p:column>
             <p:column headerText="Bill Qty (pbi)" styleClass="text-end">
                 <h:outputText value="#{m.pbiQty}">


### PR DESCRIPTION
## Summary
- Add a batch number filter to the stock movement timeline report
- Add per-row batch filter buttons that filter all selected charts by the clicked batch
- Fetch bill metadata in the stock movement DTO projection for richer chart point tooltips
- Show bill no, bill date, bill type atomic, from/to department, porter, batch, and stock values in chart tooltips

## Verification
- XHTML parse checks passed for the stock movement timeline pages
- `git diff --check` passed for the changed report files
- Maven build was not run per project instructions

## Notes
- `src/main/resources/META-INF/persistence.xml` has local datasource changes in the working tree and was intentionally excluded from this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch filtering for the stock movement timeline with a dedicated Batch No input and clear action.
  * Quick-apply batch filter from results table and clearer batch labels in the table.
  * Richer chart tooltips showing bill date, bill type, from/to departments, porter and batch details.
  * Per-graph visibility controls so each timeline chart can be shown/hidden independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->