### PR TITLE
Ruhunu hotfix: pharmacy stock-integrity fixes (#21266 family — all 6 root causes)

### DIFF
--- a/developer_docs/database/dual-version-id-allocator-separation.md
+++ b/developer_docs/database/dual-version-id-allocator-separation.md
@@ -1,0 +1,134 @@
+# Dual-Version ID Allocator Separation (Temporary)
+
+**Status:** TEMPORARY measure — remove once every production deployment that shares a
+database with a newer build has been upgraded to `GenerationType.IDENTITY`.
+
+**Added for:** Ruhunu, June 2026. The Ruhunu production build and the development
+build run side by side against the same main and audit databases.
+
+## Symptom
+
+```
+Internal Exception: java.sql.SQLIntegrityConstraintViolationException:
+Duplicate entry '18251' for key 'REPORTLOG.PRIMARY'
+Error Code: 1062
+Call: INSERT INTO REPORTLOG (ID, CREATEDAT, ...) VALUES (?, ?, ...)
+```
+
+The INSERT lists the `ID` column explicitly — that identifies the **old build**
+(`GenerationType.AUTO`) as the failing side. `REPORTLOG` lives in the **audit
+database** (`ReportLogFacade` uses `hmisAuditPU` on both branches), so both
+databases are affected, not just the main one.
+
+## Root cause: two independent ID allocators on one table
+
+| Build | Strategy | Allocator |
+|---|---|---|
+| Old production (e.g. `ruhunu-prod`, 189 entities) | `GenerationType.AUTO` | EclipseLink table sequencing: one global `SEQ_GEN` row in the `SEQUENCE` table, preallocated in blocks of 50, ID sent explicitly on INSERT |
+| Development build (198 entities) | `GenerationType.IDENTITY` | MySQL `AUTO_INCREMENT` on each table |
+
+Neither allocator sees the other's reservations. InnoDB's auto_increment counter
+always chases the highest inserted ID, which makes the collision *immediate*, not
+occasional:
+
+1. Old build preallocates sequence block `[18251..18300]`, inserts `18251`.
+2. The table's auto_increment counter jumps to `18252`.
+3. New build inserts → takes `18252`.
+4. Old build inserts its next preallocated value → `18252` → **duplicate key**.
+
+## Why a plain sequence bump cannot fix it
+
+Bumping `SEQ_COUNT` to any value N just moves the same race to N: as soon as the
+old build inserts at the new range, the auto_increment counter follows it, and the
+new build's next insert lands exactly on the old build's next preallocated value.
+The gap size is irrelevant.
+
+## The fix: disjoint ranges
+
+`IdAllocatorSeparation.separate(Connection)` (package
+`com.divudi.core.facade`) runs per schema:
+
+1. **Inventory** every table with a `BIGINT` primary key named `ID` (case detected
+   via `INFORMATION_SCHEMA`, per the cross-deployment case-sensitivity rule) and
+   find the **global max ID** across all of them.
+2. **Raise every `SEQUENCE` row** to `globalMax + 10,000`
+   (`SEQUENCE_SAFETY_MARGIN`). The old build stops re-issuing IDs the new build
+   has already used. The margin absorbs new-build inserts that happen between the
+   scan and step 3.
+3. **Push every table's `AUTO_INCREMENT` counter** to `globalMax + 1,000,000,000`
+   (`AUTO_INCREMENT_OFFSET`). The new build now allocates in a band the old
+   build's sequence would need a billion allocations to reach.
+
+The bands stay disjoint because InnoDB only moves an auto_increment counter
+*upward*, and only when an insert is **at or above** it — the old build's explicit
+low-range IDs never touch the high counters.
+
+```
+IDs:  [1 .. globalMax]   (globalMax+10k ...→]            [globalMax+1e9 ...→
+       existing rows      old build (SEQUENCE, explicit)   new build (AUTO_INCREMENT)
+```
+
+Both builds may still share the `SEQUENCE` table itself (the dev build's one
+remaining `AUTO` entity, `ShiftStaffRequirement`, also draws from `SEQ_GEN`) —
+that is safe: table sequencing uses row-locked `UPDATE`s, so concurrent processes
+get disjoint blocks.
+
+## Where the code lives
+
+| Piece | Location |
+|---|---|
+| Core logic (shared) | `src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java` |
+| Main DB entry point | `DatabaseMigrationFacade.separateIdAllocatorsForDualVersionOperation()` |
+| Audit DB entry point | `AuditDatabaseFacade.separateIdAllocatorsForDualVersionOperation()` |
+| Controller action | `DataAdministrationController.separateIdAllocatorsForDualVersionOperation()` |
+| UI | `admin_functions.xhtml` → tab **"ID Generation — Dual Version Operation"** |
+
+The facade methods run on a raw JDBC connection outside JTA
+(`TransactionAttributeType.NOT_SUPPORTED`, `autoCommit=true`) because
+`ALTER TABLE` triggers MySQL implicit commits that desync the JTA transaction
+manager — same pattern as `executeDdlNative` / `applyAutoIncrementToAllEntityTables`.
+
+## Runbook
+
+1. Deploy the development build containing this function.
+2. Log in as a user with the **Admin** privilege.
+3. Admin → Data Administration → **Admin Functions** → tab
+   **"ID Generation — Dual Version Operation"** → **Separate ID Allocators**
+   (confirm dialog). The output column reports, per database: tables scanned,
+   global max ID, old sequence values, the new sequence target, and how many
+   tables had their counters moved.
+4. **Immediately restart the old-version Payara.** It still holds a preallocated
+   sequence block in memory and keeps colliding until it re-reads the bumped
+   `SEQUENCE` row. The new build needs no restart.
+
+### Verification (read-only, either DB)
+
+```sql
+SELECT SEQ_NAME, SEQ_COUNT FROM SEQUENCE;            -- ≈ global max + 10,000
+SELECT MAX(ID) FROM REPORTLOG;                        -- old-build rows: low range
+SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
+ WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'REPORTLOG';  -- ≈ global max + 1e9
+```
+
+After the restart, old-build inserts continue in the low range and new-build rows
+appear above one billion.
+
+## Side effects & safety
+
+- New-build rows get IDs above ~1,000,000,000. Harmless: every ID is `BIGINT`,
+  and IDs are surrogate keys (bill numbers etc. are generated separately).
+- Re-running is safe (idempotent in effect): max IDs only grow, `SEQUENCE` rows
+  below the target are raised, `ALTER ... AUTO_INCREMENT` to a value below a
+  counter that is already higher is ignored by InnoDB.
+- Empty tables are included deliberately — the new build must allocate high
+  everywhere, including tables it has not written yet.
+- No row data is modified; only the `SEQUENCE` counters and table metadata.
+
+## Permanent fix / removal
+
+Upgrade the old production branch to `GenerationType.IDENTITY` for all entities
+(as already done for Coop), with migration `v2.9.0` restoring `AUTO_INCREMENT`
+on any ID primary key missing it. IDENTITY then simply continues from wherever
+the counters stand — the billion-offset rows need no cleanup. After that
+upgrade, remove the admin tab, the controller method, the two facade methods,
+and `IdAllocatorSeparation`.

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -31,6 +31,7 @@ import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BillNumberFacade;
 import com.divudi.core.facade.AuditDatabaseFacade;
 import com.divudi.core.facade.CategoryFacade;
+import com.divudi.core.facade.DatabaseMigrationFacade;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.ItemBatchFacade;
@@ -234,6 +235,8 @@ public class DataAdministrationController implements Serializable {
     @EJB
     AuditDatabaseFacade auditDatabaseFacade;
     @EJB
+    DatabaseMigrationFacade databaseMigrationFacade;
+    @EJB
     CategoryFacade categoryFacade;
     @EJB
     ItemBatchFacade itemBatchFacade;
@@ -363,6 +366,37 @@ public class DataAdministrationController implements Serializable {
             return "Unknown exception";
         }
         return throwable.getMessage() != null ? throwable.getMessage() : throwable.getClass().getName();
+    }
+
+    /**
+     * TEMPORARY admin function for dual-version operation at Ruhunu: this
+     * production build uses GenerationType.AUTO (EclipseLink SEQUENCE table)
+     * while the newer development build uses GenerationType.IDENTITY
+     * (AUTO_INCREMENT), and both write to the same main and audit databases,
+     * so their independent ID allocators collide (Duplicate entry ... for key
+     * 'REPORTLOG.PRIMARY'). This raises the SEQUENCE rows above every existing
+     * ID and pushes all AUTO_INCREMENT counters one billion higher, giving
+     * each build its own range. THIS application server must be restarted
+     * after running. Remove once this build is upgraded to IDENTITY ID
+     * generation. See developer_docs/database/dual-version-id-allocator-separation.md
+     */
+    public void separateIdAllocatorsForDualVersionOperation() {
+        StringBuilder feedback = new StringBuilder();
+        feedback.append("=== Main Database ===<br/>");
+        try {
+            feedback.append(String.join("<br/>", databaseMigrationFacade.separateIdAllocatorsForDualVersionOperation()));
+        } catch (Exception e) {
+            feedback.append("Error: ").append(getExceptionMessage(e));
+        }
+        feedback.append("<br/><br/>=== Audit Database ===<br/>");
+        try {
+            feedback.append(String.join("<br/>", auditDatabaseFacade.separateIdAllocatorsForDualVersionOperation()));
+        } catch (Exception e) {
+            feedback.append("Error: ").append(getExceptionMessage(e));
+        }
+        feedback.append("<br/><br/>IMPORTANT: Restart THIS application server now. ")
+                .append("It still holds a preallocated ID block in memory and will keep colliding until restarted.");
+        executionFeedback = feedback.toString();
     }
 
     public void refresh() {

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -388,6 +388,61 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveDirectPurchaseReturn")) {
             return;
@@ -413,9 +468,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -1833,6 +1898,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -1877,8 +1948,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -1965,6 +2041,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -1989,7 +2069,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
@@ -341,29 +341,47 @@ public class DisposalReturnWorkflowController implements Serializable {
      * @param returnBillToClose The return bill to close
      */
     public void closeDisposalReturn(Bill returnBillToClose) {
-        if (returnBillToClose == null) {
+        if (returnBillToClose == null || returnBillToClose.getId() == null) {
             JsfUtil.addErrorMessage("No disposal return selected to close");
             return;
         }
 
+        // The row passed in comes from a list loaded earlier in the session and can
+        // be STALE - the return may have been settled after the list was loaded.
+        // Validating and merging the stale entity reverted settled bills back to
+        // drafts (completed/completedAt/deptId/insId cleared) while their items and
+        // stock movements remained - the #21266 RC5 orphan-return corruption
+        // (Ruhunu bills 4336218 / 4337297, 2026-03-25). Always validate and edit
+        // the CURRENT row, bypassing the L2 cache (another app server may have
+        // written it under dual-version operation).
+        Bill freshBill = billFacade.findWithoutCache(returnBillToClose.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Disposal return not found");
+            return;
+        }
+
         // Verify the bill is not already completed
-        if (returnBillToClose.isCompleted()) {
+        if (freshBill.isCompleted()) {
             JsfUtil.addErrorMessage("Cannot close a completed disposal return");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         // Verify the bill is not already closed
-        if (returnBillToClose.isBillClosed()) {
+        if (freshBill.isBillClosed()) {
             JsfUtil.addErrorMessage("This disposal return is already closed");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         try {
             // Mark the bill as closed
-            returnBillToClose.setBillClosed(true);
+            freshBill.setBillClosed(true);
 
             // Save the changes
-            billFacade.edit(returnBillToClose);
+            billFacade.edit(freshBill);
 
             // Refresh the lists
             fillDisposalReturnsToFinalize();

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -30,6 +30,8 @@ import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.BillService;
 import com.divudi.core.data.PaymentMethod;
@@ -83,6 +85,8 @@ public class GrnReturnWorkflowController implements Serializable {
     private BillItemFacade billItemFacade;
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private StockFacade stockFacade;
     @EJB
     private PharmacyBean pharmacyBean;
     @EJB
@@ -968,6 +972,52 @@ public class GrnReturnWorkflowController implements Serializable {
 
     // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
     private boolean updateStock() {
+        // Phase 1: pre-deduction availability check — reads fresh DB stock for every
+        // item and accumulates total requested qty per stock record.  No mutations are
+        // made here, so a failure leaves the database completely unchanged.
+        Map<Long, Double> requestedByStockId = new HashMap<>();
+        Map<Long, String> itemNameByStockId = new HashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.isRetired()) {
+                continue;
+            }
+            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
+            if (phi == null || phi.getStock() == null || phi.getStock().getId() == null) {
+                continue;
+            }
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
+            if (absQty == 0) {
+                continue;
+            }
+            Long stockId = phi.getStock().getId();
+            requestedByStockId.merge(stockId, absQty, Double::sum);
+            itemNameByStockId.putIfAbsent(stockId,
+                    bi.getItem() != null ? bi.getItem().getName() : "Unknown");
+        }
+
+        boolean preCheckPassed = true;
+        for (Map.Entry<Long, Double> entry : requestedByStockId.entrySet()) {
+            Long stockId = entry.getKey();
+            double totalRequested = entry.getValue();
+            Stock freshStock = stockFacade.find(stockId);
+            double available = (freshStock != null && freshStock.getStock() != null)
+                    ? freshStock.getStock() : 0.0;
+            if (available < totalRequested) {
+                String itemName = itemNameByStockId.getOrDefault(stockId, "Unknown");
+                LOGGER.log(Level.WARNING,
+                        "Pre-deduction stock check failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, totalRequested});
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \""
+                        + itemName + "\". Available: " + String.format("%.2f", available)
+                        + ", Requested: " + String.format("%.2f", totalRequested) + ".");
+                preCheckPassed = false;
+            }
+        }
+        if (!preCheckPassed) {
+            return false;
+        }
+
+        // Phase 2: all items passed the pre-check — proceed with deductions.
         for (BillItem bi : billItems) {
             if (bi.isRetired()) {
                 continue;
@@ -992,9 +1042,12 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
+                // Pre-check passed but deductFromStock still failed — concurrent transaction
+                // drained the stock between our check and this deduction.
                 String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
                 double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
-                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                LOGGER.log(Level.WARNING,
+                        "Stock deduction failed after pre-check for item: {0}, available: {1}, requested: {2}",
                         new Object[]{itemName, available, absQty});
                 phi.setQty(Math.abs(phi.getQty()));
                 phi.setFreeQty(Math.abs(phi.getFreeQty()));
@@ -1009,7 +1062,6 @@ public class GrnReturnWorkflowController implements Serializable {
         if (currentBill != null && currentBill.getBillFinanceDetails() != null) {
             BillFinanceDetails bfd = currentBill.getBillFinanceDetails();
 
-            // Negate the purchase, cost, and retail values at bill level
             if (bfd.getTotalPurchaseValue() != null) {
                 bfd.setTotalPurchaseValue(bfd.getTotalPurchaseValue().abs().negate());
             }
@@ -1020,7 +1072,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 bfd.setTotalRetailSaleValue(bfd.getTotalRetailSaleValue().abs().negate());
             }
 
-            // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
         return true;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -708,7 +708,16 @@ public class GrnReturnWorkflowController implements Serializable {
                 return;
             }
 
-            updateStock();  // Stock handling happens only at approval stage
+            if (!updateStock()) {
+                // Roll back completed status — stock deduction failed for one or more items
+                currentBill.setCompleted(false);
+                currentBill.setCompletedBy(null);
+                currentBill.setCompletedAt(null);
+                currentBill.setApproveAt(null);
+                currentBill.setApproveUser(null);
+                billFacade.edit(currentBill);
+                return;
+            }
 
             // Create payment for the return - ALL payment methods require payment records for healthcare compliance
             // Payment validation was performed at method start, so we can proceed with confidence
@@ -847,6 +856,9 @@ public class GrnReturnWorkflowController implements Serializable {
             currentBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
             currentBill.setInstitution(sessionController.getInstitution());
             currentBill.setDepartment(sessionController.getDepartment());
+            if (sessionController.getDepartment() != null) {
+                currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            }
             currentBill.setCreater(sessionController.getLoggedUser());
             currentBill.setCreatedAt(new Date());
 
@@ -954,31 +966,24 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
-    // Stock handling - only at approval stage
-    private void updateStock() {
+    // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
+    private boolean updateStock() {
         for (BillItem bi : billItems) {
-            // Skip only retired items or items with truly zero quantities
             if (bi.isRetired()) {
                 continue;
             }
 
             PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-            double totalQty = phi.getQty() + phi.getFreeQty();
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
 
-            // Skip stock processing for zero quantity items (no stock impact)
-            if (totalQty == 0) {
+            if (absQty == 0) {
                 continue;
             }
 
-            // For returns: make quantities negative before saving, use absolute value for stock deduction
-            double absQty = Math.abs(totalQty);
             phi.setQty(-Math.abs(phi.getQty()));
             phi.setFreeQty(-Math.abs(phi.getFreeQty()));
-
-            // Save the pharmaceutical bill item with negative quantities
             pharmaceuticalBillItemFacade.edit(phi);
 
-            // Deduct from stock for return (use absolute value)
             boolean returnFlag = pharmacyBean.deductFromStock(
                     phi.getStock(),
                     absQty,
@@ -987,11 +992,16 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
-                LOGGER.log(Level.WARNING, "Unable to deduct stock for item: {0}", bi.getItem().getName());
-                // Reset quantities if stock deduction failed
-                phi.setQty(0);
-                phi.setFreeQty(0);
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
+                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, absQty});
+                phi.setQty(Math.abs(phi.getQty()));
+                phi.setFreeQty(Math.abs(phi.getFreeQty()));
                 pharmaceuticalBillItemFacade.edit(phi);
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \"" + itemName
+                        + "\". Available: " + available + ", Requested: " + absQty + ".");
+                return false;
             }
         }
 
@@ -1013,6 +1023,7 @@ public class GrnReturnWorkflowController implements Serializable {
             // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
+        return true;
     }
 
     // Validation methods
@@ -1921,6 +1932,9 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        if (sessionController.getDepartment() != null) {
+            currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        }
 
         //Copy Payment Method Details from GRN to GRN Return
         currentBill.setPaymentMethod(originalGrn.getPaymentMethod());

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -662,6 +662,61 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveGrnReturn")) {
             return;
@@ -687,9 +742,19 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -2197,6 +2262,12 @@ public class GrnReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -2241,8 +2312,13 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -2329,6 +2405,10 @@ public class GrnReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2353,7 +2433,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -280,6 +280,7 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setChecked(true);
         getReturnBill().setCheckeAt(new Date());
         getReturnBill().setCheckedBy(sessionController.getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         // Refresh the bill and reload bill items for print preview
@@ -324,12 +325,14 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setCompleted(true);
         getReturnBill().setCompletedAt(new Date());
         getReturnBill().setCompletedBy(getSessionController().getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         getOriginalBill().setRefundedBill(getReturnBill());
         getOriginalBill().setRefunded(true);
         getOriginalBill().getRefundBills().add(getReturnBill());
 
+        getOriginalBill().setBillItems(null);
         getBillFacade().edit(getOriginalBill());
 
         printPreview = true;
@@ -498,6 +501,10 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
+            // Null out the billItems collection before merge so EclipseLink does not treat
+            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
+            // Bill items are managed independently by saveBillComponents() / billItemFacade.
+            getReturnBill().setBillItems(null);
             getBillFacade().edit(getReturnBill());
         }
     }
@@ -560,6 +567,7 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
+        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -797,8 +805,10 @@ public class IssueReturnController implements Serializable {
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
+            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
     }
@@ -846,6 +856,7 @@ public class IssueReturnController implements Serializable {
 
         bill.setTotal(total);
         bill.setNetTotal(netTotal);
+        bill.setBillItems(null);
         getBillFacade().edit(bill);
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -210,7 +210,49 @@ public class IssueReturnController implements Serializable {
         pageMetadataRegistry.registerPage(metadata);
     }
 
+    /**
+     * Guards every write entry point (save / finalize / settle) against acting
+     * on a bill whose CURRENT database state is already completed or closed.
+     *
+     * The @SessionScoped bean (and the browser page) can hold a STALE copy of
+     * the return bill - e.g. the bill was settled, then Save/Finalize/Settle is
+     * clicked again from an old screen or list row. Merging that stale copy
+     * reverts the settled bill to a draft (completed/deptId/insId cleared)
+     * while its items and stock movements remain - the #21266 RC5 orphan-return
+     * corruption (Ruhunu bills 4336218 / 4337297, 2026-03-25). Reads bypass the
+     * L2 cache because another app server may have written the bill under
+     * dual-version operation.
+     *
+     * @return true if processing must stop (with a user-facing message).
+     */
+    private boolean disposalReturnAlreadyProcessed() {
+        if (getReturnBill() == null || getReturnBill().getId() == null) {
+            return false; // new, never-persisted draft - nothing to clobber
+        }
+        Bill fresh = getBillFacade().findWithoutCache(getReturnBill().getId());
+        if (fresh == null) {
+            return false;
+        }
+        if (fresh.isCompleted()) {
+            JsfUtil.addErrorMessage("This disposal return (" + (fresh.getDeptId() != null ? fresh.getDeptId() : fresh.getId())
+                    + ") has already been settled. Reload the page before continuing.");
+            return true;
+        }
+        if (fresh.isBillClosed()) {
+            JsfUtil.addErrorMessage("This disposal return has been closed. Create a new return instead.");
+            return true;
+        }
+        if (fresh.isCancelled() || fresh.isRetired()) {
+            JsfUtil.addErrorMessage("This disposal return is cancelled or retired and can no longer be processed.");
+            return true;
+        }
+        return false;
+    }
+
     public void saveDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // No validation required for saving drafts - users can save incomplete data
         saveBill();
         saveBillComponents();
@@ -218,6 +260,9 @@ public class IssueReturnController implements Serializable {
     }
 
     public void finalizeDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // Validate return comment is provided
         if (returnBill.getComments() == null || returnBill.getComments().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return Comment is required. Please provide a reason for the return.");
@@ -248,6 +293,12 @@ public class IssueReturnController implements Serializable {
     }
 
     public void settleDisposalIssueReturnBill() {
+        // Re-settling an already-settled bill (double-click, stale screen, stale
+        // list row) would write a second set of items and stock movements and
+        // then clobber the bill header (#21266 RC5).
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         if (getReturnBill().getCheckedBy() == null) {
             JsfUtil.addErrorMessage("Pleace Finalise Bill First. Can not Return");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3827,6 +3827,50 @@ public class PharmacyController implements Serializable {
         }
     }
 
+    /**
+     * Multiplier to convert a stored {@code valueAt*Rate} into consumption-direction value.
+     *
+     * <p>Stored {@code billItemFinanceDetails.valueAt*Rate} (and the matching
+     * {@code billFinanceDetails.total*Value}) use a stock-direction sign: negative when
+     * stock leaves the source department, positive when it comes back. Consumption
+     * accounting is the inverse — an issue adds to consumption, a return/cancel subtracts.
+     * For every disposal-issue bill in this convention the contribution to consumption
+     * value is therefore {@code -valueAt*Rate}.</p>
+     *
+     * <p>See {@code DataAdministrationController.isFinanceValueNegative} for the canonical
+     * sign rules.</p>
+     */
+    private static double consumptionValueSign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE:
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+    /**
+     * Multiplier to convert a stored {@code billItem.qty} into consumption-direction qty.
+     * Issues add to consumption (+1); returns and cancellations subtract (-1).
+     */
+    private static double consumptionQtySign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
     public void generateConsumptionReportTableByBill(List<BillTypeAtomic> billTypeAtomics) {
         try {
             bills = new ArrayList<>();
@@ -3897,10 +3941,26 @@ public class PharmacyController implements Serializable {
                 PharmacyRow row = new PharmacyRow();
                 row.setBill(b);
 
-                // Simply aggregate the values displayed in the columns without manipulation
-                totalPurchase += b.getBillFinanceDetails().getTotalPurchaseValue() != null ? b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
-                totalCostValue += b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
-                totalRetailValue += b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
+                if (b.getBillFinanceDetails() != null) {
+                    double sign = consumptionValueSign(b.getBillTypeAtomic());
+
+                    double rowPurchase = b.getBillFinanceDetails().getTotalPurchaseValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
+                    double rowCost = b.getBillFinanceDetails().getTotalCostValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
+                    double rowRetail = b.getBillFinanceDetails().getTotalRetailSaleValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
+                }
 
                 pharmacyRows.add(row);
 
@@ -4083,23 +4143,32 @@ public class PharmacyController implements Serializable {
             totalRetailValue = 0.0;
 
             for (PharmacyRow row : pharmacyRows) {
-                // Simply aggregate the values displayed in the columns without manipulation
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
                 if (row.getBillItem() != null && row.getBillItem().getBillItemFinanceDetails() != null) {
                     BigDecimal valueAtPurchase = row.getBillItem().getBillItemFinanceDetails().getValueAtPurchaseRate();
                     BigDecimal valueAtCost = row.getBillItem().getBillItemFinanceDetails().getValueAtCostRate();
                     BigDecimal valueAtRetail = row.getBillItem().getBillItemFinanceDetails().getValueAtRetailRate();
 
-                    if (valueAtPurchase != null) {
-                        totalPurchase += valueAtPurchase.doubleValue();
-                    }
+                    BillTypeAtomic bta = row.getBillItem().getBill() != null
+                            ? row.getBillItem().getBill().getBillTypeAtomic()
+                            : null;
+                    double valueSign = consumptionValueSign(bta);
+                    double qtySign = consumptionQtySign(bta);
 
-                    if (valueAtCost != null) {
-                        totalCostValue += valueAtCost.doubleValue();
-                    }
+                    double rowPurchase = valueAtPurchase != null ? valueSign * valueAtPurchase.doubleValue() : 0.0;
+                    double rowCost = valueAtCost != null ? valueSign * valueAtCost.doubleValue() : 0.0;
+                    double rowRetail = valueAtRetail != null ? valueSign * valueAtRetail.doubleValue() : 0.0;
+                    double rowQty = qtySign * (row.getBillItem().getQty() != null ? row.getBillItem().getQty() : 0.0);
 
-                    if (valueAtRetail != null) {
-                        totalRetailValue += valueAtRetail.doubleValue();
-                    }
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+                    row.setConsumptionQty(rowQty);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
                 }
             }
 
@@ -4489,17 +4558,23 @@ public class PharmacyController implements Serializable {
             try {
                 List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
 
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025). netTotal is
+                // already stored with the correct sign, so it does not need flipping.
+                double valueSign = consumptionValueSign(billType);
+                double qtySign = consumptionQtySign(billType);
+
                 // Convert Object[] to DepartmentCategoryWiseItems
                 for (Object[] row : results) {
                     Department mainDept = (Department) row[0];
                     Department consumptionDept = (Department) row[1];
                     Item item = (Item) row[2];
                     Category category = (item != null) ? item.getCategory() : null;
-                    Double purchaseValue = row[3] != null ? ((Number) row[3]).doubleValue() : 0.0;
-                    Double costValue = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
-                    Double retailValue = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
+                    Double purchaseValue = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
+                    Double costValue = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double retailValue = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
                     Double netTotal = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
-                    Double qty = row[7] != null ? ((Number) row[7]).doubleValue() : 0.0;
+                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
 
                     DepartmentCategoryWiseItems dtoItem = new DepartmentCategoryWiseItems(
                             mainDept, consumptionDept, item, category,
@@ -12294,20 +12369,17 @@ public class PharmacyController implements Serializable {
                     table.addCell(new PdfPCell(new Phrase(bill.getInvoiceNumber() != null ? bill.getInvoiceNumber() : "", normalFont)));
 
                     PdfPCell purchaseCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalPurchaseValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalPurchaseValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionPurchaseValue()), normalFont));
                     purchaseCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(purchaseCell);
 
                     PdfPCell costCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalCostValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalCostValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionCostValue()), normalFont));
                     costCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(costCell);
 
                     PdfPCell retailCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalRetailSaleValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalRetailSaleValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionRetailValue()), normalFont));
                     retailCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(retailCell);
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4164,33 +4164,6 @@ public class PharmacyController implements Serializable {
         billTableCostTotal = 0.0;
     }
 
-    private static double consumptionValueSign(BillTypeAtomic bta) {
-        if (bta == null) {
-            return 1.0;
-        }
-        switch (bta) {
-            case PHARMACY_DISPOSAL_ISSUE:
-            case PHARMACY_DISPOSAL_ISSUE_RETURN:
-            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
-                return -1.0;
-            default:
-                return 1.0;
-        }
-    }
-
-    private static double consumptionQtySign(BillTypeAtomic bta) {
-        if (bta == null) {
-            return 1.0;
-        }
-        switch (bta) {
-            case PHARMACY_DISPOSAL_ISSUE_RETURN:
-            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
-                return -1.0;
-            default:
-                return 1.0;
-        }
-    }
-
         public void generateConsumptionReportTableByBill(BillType billType) {
         try {
             bills = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -722,6 +722,7 @@ public class PurchaseOrderRequestController implements Serializable {
     public void saveBillComponent() {
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             if (b.getId() == null) {
                 getBillItemFacade().create(b);
             } else {
@@ -730,10 +731,32 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
+    // A duplicate-line removal can leave the surviving BillItem with a lazily
+    // created all-zero PharmaceuticalBillItem while its BillItemFinanceDetails
+    // still holds the real quantities; downstream approval/GRN reads the PBI,
+    // so rebuild it from the finance details before persisting (issue #21417)
+    private void resyncPharmaceuticalBillItemIfEmpty(BillItem b) {
+        if (b == null || b.isRetired() || b.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbi = b.getPharmaceuticalBillItem();
+        if (pbi.getQty() != 0 || pbi.getFreeQty() != 0) {
+            return;
+        }
+        BigDecimal qtyByUnits = b.getBillItemFinanceDetails().getQuantityByUnits();
+        BigDecimal freeQtyByUnits = b.getBillItemFinanceDetails().getFreeQuantityByUnits();
+        boolean financeDetailsHaveQty = (qtyByUnits != null && qtyByUnits.compareTo(BigDecimal.ZERO) > 0)
+                || (freeQtyByUnits != null && freeQtyByUnits.compareTo(BigDecimal.ZERO) > 0);
+        if (financeDetailsHaveQty) {
+            calculateLineValues(b);
+        }
+    }
+
     public void finalizeBillComponent() {
         getBillItems().removeIf(BillItem::isRetired);
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             BigDecimal qUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getQuantityByUnits() != null)
                     ? b.getBillItemFinanceDetails().getQuantityByUnits() : BigDecimal.ZERO;
             BigDecimal fqUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getFreeQuantityByUnits() != null)
@@ -797,7 +820,11 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
-    private boolean saveRequestWithoutMessage() {
+    // synchronized: concurrent saves from the same session (Enter-key defaultCommand
+    // racing a button click) both saw billItem.id == null and persisted the same
+    // in-memory BillItem twice, creating duplicate rows sharing one
+    // BillItemFinanceDetails (issue #21417)
+    private synchronized boolean saveRequestWithoutMessage() {
         if (getCurrentBill().isChecked()) {
             JsfUtil.addErrorMessage("Cannot save a finalized bill");
             return false;
@@ -866,7 +893,7 @@ public class PurchaseOrderRequestController implements Serializable {
         return allItems;
     }
 
-    public void finalizeRequest() {
+    public synchronized void finalizeRequest() {
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -417,6 +417,16 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
         for (BillItem bi : getBillItems()) {
+            // Single source of truth for the issued quantity (#21266 RC6): the
+            // user-entered qty lives in BillItemFinanceDetails.quantity, but the
+            // stock movement below uses pbi.qty - which still holds the REQUESTED
+            // qty from item generation if a UI edit did not sync it. Stock then
+            // moved by the requested qty while updateBillItemRateAndValue()
+            // rewrote the persisted line to the user-entered qty AFTER the stock
+            // ops (pbi 4912145, 2026-05-20: stock moved 2, line said 1). Sync
+            // pbi/billItem qty from the user-entered value BEFORE validating or
+            // moving any stock, keeping the positive pre-settle sign convention.
+            syncStockQtyFromUserEnteredQty(bi);
             if (bi.getPharmaceuticalBillItem().getItemBatch() != null) {
                 if (bi.getPharmaceuticalBillItem().getStock().getStock() < bi.getPharmaceuticalBillItem().getQty()) {
                     JsfUtil.addErrorMessage("Available quantity is less than issued quantity in " + bi.getPharmaceuticalBillItem().getItemBatch().getItem().getName());
@@ -637,6 +647,31 @@ public class TransferIssueForRequestsController implements Serializable {
 
     }
 
+    /**
+     * Copies the user-entered quantity (BillItemFinanceDetails.quantity, in
+     * packs) onto the fields the settle stock operations read - pbi.qty (units),
+     * pbi.qtyPacks and billItem.qty (packs) - so the quantity that moves stock
+     * is always the quantity that gets persisted (#21266 RC6). Values are set
+     * POSITIVE to match the pre-settle convention expected by the validation
+     * and zero-removal checks; settle() negates them later. Lines without
+     * finance details or a quantity are left untouched (conservative fallback).
+     */
+    private void syncStockQtyFromUserEnteredQty(BillItem bi) {
+        if (bi == null || bi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+        if (f == null || f.getQuantity() == null) {
+            return;
+        }
+        double packs = Math.abs(f.getQuantity().doubleValue());
+        double unitsPerPack = (f.getUnitsPerPack() != null && f.getUnitsPerPack().compareTo(BigDecimal.ZERO) > 0)
+                ? f.getUnitsPerPack().doubleValue() : 1.0;
+        bi.getPharmaceuticalBillItem().setQty(packs * unitsPerPack);
+        bi.getPharmaceuticalBillItem().setQtyPacks(packs);
+        bi.setQty(packs);
+    }
+
     private void updateBillItemRateAndValue(BillItem b) {
         BillItemFinanceDetails f = b.getBillItemFinanceDetails();
         double rate = b.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
@@ -689,6 +724,14 @@ public class TransferIssueForRequestsController implements Serializable {
             if (f.getPurchaseRate() == null) {
                 f.setPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()));
             }
+            // Recompute valuation fields from the user-entered quantity. They are
+            // set at item-generation time from the REQUESTED qty and were never
+            // updated when the user changed the issuing qty (#21266 RC6:
+            // valueAtPurchaseRate stayed 990 = 2 x 495 while the line qty became
+            // 1). Positive sign, matching the generation-time convention.
+            f.setValueAtPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(qtyInUnits));
+            f.setValueAtRetailRate(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(qtyInUnits));
+            f.setValueAtCostRate(costRate.multiply(qtyInUnits));
         } else {
             f.setLineCostRate(BigDecimal.ZERO);
             f.setLineCost(BigDecimal.ZERO);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -558,7 +558,6 @@ public class TransferReceiveController implements Serializable {
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
-        getBillFacade().edit(getReceivedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
         if (getIssuedBill() != null && !getIssuedBill().isFullyIssued()) {
@@ -970,7 +969,12 @@ public class TransferReceiveController implements Serializable {
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());
+            // Detach billItems before create() to prevent CascadeType.ALL from inserting
+            // them here — settle() creates each BillItem explicitly after stock validation.
+            List<BillItem> items = getReceivedBill().getBillItems();
+            getReceivedBill().setBillItems(new ArrayList<>());
             getBillFacade().create(getReceivedBill());
+            getReceivedBill().setBillItems(items);
         } else {
             getBillFacade().edit(getReceivedBill());
         }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
@@ -262,6 +263,14 @@ public class TransferReceiveController implements Serializable {
             newlyCreatedReceivedBillItem.invertValue();
             newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().invertValue();
 
+            // The copy above inherits the ISSUE line's stock binding, which is the
+            // ISSUING department's stock row. A receive must only ever touch the
+            // porter's in-transit stock (deducted) and the receiving department's
+            // stock (added; bound after addToStock() in settle). A receive line that
+            // keeps the sender's stock reference and slips past the stock loop is
+            // recorded as received without moving any stock (#21266 phantom receives).
+            newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().setStock(null);
+
             // Adjust quantity to remaining amount
             double unitsPerPack = 1.0;
             Item item = newlyCreatedReceivedBillItem.getItem();
@@ -449,6 +458,81 @@ public class TransferReceiveController implements Serializable {
         }
     }
 
+    /**
+     * Converts a bill item's user-entered receive quantity (packs) to units.
+     */
+    private double receiveQtyInUnits(BillItem i) {
+        double qtyInPacks = 0.0;
+        if (i.getBillItemFinanceDetails() != null && i.getBillItemFinanceDetails().getQuantity() != null) {
+            qtyInPacks = i.getBillItemFinanceDetails().getQuantity().doubleValue();
+        }
+        double unitsPerPack = 1.0;
+        Item item = i.getItem();
+        if (item instanceof Ampp || item instanceof Vmpp) {
+            unitsPerPack = item.getDblValue() > 0 ? item.getDblValue() : 1.0;
+        }
+        return qtyInPacks * unitsPerPack;
+    }
+
+    /**
+     * Validates that the porter (carrier) holds enough in-transit stock to cover
+     * EVERY line being received, before any data is written. Quantities are
+     * aggregated per item batch (several receive lines can draw from the same
+     * batch) and compared against the porter's live stock read fresh from the
+     * database.
+     *
+     * On a receive, stock must move porter -> receiving department. Previously,
+     * lines that could not be covered were silently skipped or zeroed mid-settle,
+     * and the skipped lines were later cascade-persisted still carrying the
+     * issuing department's stock binding with no stock movement — the #21266
+     * phantom-receive corruption. Failing the whole settle up front with explicit
+     * messages prevents both the corruption and the silent partial receive.
+     *
+     * @return true if every line is covered; false (with user-facing error
+     * messages) otherwise.
+     */
+    private boolean porterStockCoversAllLines() {
+        Staff porter = getIssuedBill() == null ? null : getIssuedBill().getToStaff();
+        if (porter == null) {
+            JsfUtil.addErrorMessage("This transfer issue has no carrying staff (porter) recorded - cannot receive. Please contact the issuing department.");
+            return false;
+        }
+        Map<Long, Double> requiredUnitsByBatch = new HashMap<>();
+        Map<Long, ItemBatch> batchById = new HashMap<>();
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            double units = receiveQtyInUnits(i);
+            if (units <= 0.0) {
+                continue;
+            }
+            ItemBatch batch = i.getPharmaceuticalBillItem() == null ? null : i.getPharmaceuticalBillItem().getItemBatch();
+            if (batch == null || batch.getId() == null) {
+                JsfUtil.addErrorMessage("Item " + (i.getItem() != null ? i.getItem().getName() : "?") + " has no batch - cannot receive.");
+                return false;
+            }
+            requiredUnitsByBatch.merge(batch.getId(), units, Double::sum);
+            batchById.put(batch.getId(), batch);
+        }
+        boolean allCovered = true;
+        for (Map.Entry<Long, Double> e : requiredUnitsByBatch.entrySet()) {
+            ItemBatch batch = batchById.get(e.getKey());
+            HashMap<String, Object> params = new HashMap<>();
+            String jpql = "select s from Stock s where s.itemBatch=:bc and s.staff=:stf";
+            params.put("bc", batch);
+            params.put("stf", porter);
+            Stock porterStock = getStockFacade().findFirstByJpql(jpql, params, true);
+            double available = porterStock == null ? 0.0 : porterStock.getStock();
+            if (available + 0.0001 < e.getValue()) {
+                String itemName = (batch.getItem() != null && batch.getItem().getName() != null)
+                        ? batch.getItem().getName() : ("Batch " + batch.getId());
+                JsfUtil.addErrorMessage("Insufficient in-transit (porter) stock for " + itemName
+                        + ": receiving " + e.getValue() + " but porter holds " + available
+                        + ". Nothing was received.");
+                allCovered = false;
+            }
+        }
+        return allCovered;
+    }
+
     private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
@@ -464,6 +548,12 @@ public class TransferReceiveController implements Serializable {
         // Validate that current receive quantities don't exceed remaining quantities
         if (wouldCauseOverReceiving()) {
             JsfUtil.addErrorMessage("Cannot receive - quantities exceed remaining amounts!");
+            return;
+        }
+
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
             return;
         }
 
@@ -526,6 +616,13 @@ public class TransferReceiveController implements Serializable {
                 getBillItemFacade().edit(i);
             }
         }
+
+        // Drop lines that were never persisted (zero quantity or failed checks)
+        // from the in-memory bill. Bill.billItems cascades ALL, so the later
+        // edit(getReceivedBill()) merges would otherwise INSERT these skipped
+        // lines - still carrying the issue line's data with no stock movement -
+        // which is exactly the #21266 phantom-receive corruption.
+        getReceivedBill().getBillItems().removeIf(bi -> bi.getId() == null);
 
         // Handle Department ID generation (independent)
         String deptId;
@@ -864,6 +961,12 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
+            return;
+        }
+
         getReceivedBill().setApproveAt(new Date());
         getReceivedBill().setApproveUser(getSessionController().getLoggedUser());
 
@@ -932,6 +1035,12 @@ public class TransferReceiveController implements Serializable {
                 Stock addedStock = getPharmacyBean().addToStock(tmpPh, Math.abs(qty), getSessionController().getDepartment());
                 tmpPh.setStock(addedStock);
             } else {
+                // No stock was moved - never leave the line bound to the stock
+                // reference inherited from the issue line (the issuing
+                // department's stock), or it records a phantom receive (#21266).
+                tmpPh.setStock(null);
+                tmpPh.setQty(0);
+                i.setQty(0.0);
                 i.setTmpQty(0);
                 getBillItemFacade().edit(i);
             }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -112,6 +112,9 @@ public class TransferReceiveController implements Serializable {
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
     private BillItem selectedBillItem;
+    // Re-entrancy guard: blocks a second settle() (e.g. rapid double-click on the
+    // non-AJAX Receive button) from processing the same transfer twice.
+    private boolean settling;
 
     public static class ConfigOptionInfo {
 
@@ -433,6 +436,20 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void settle() {
+        // Re-entrancy guard: a second near-simultaneous submit (rapid double-click
+        // on the non-AJAX Receive button) is ignored until the first completes.
+        if (settling) {
+            return;
+        }
+        settling = true;
+        try {
+            doSettle();
+        } finally {
+            settling = false;
+        }
+    }
+
+    private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
             return;
@@ -557,6 +574,11 @@ public class TransferReceiveController implements Serializable {
 
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
+        // Persist the received bill again after fillData() recalculates its
+        // net/grand/total and BillFinanceDetails value fields. Safe here: the
+        // BillItems were already created (have IDs) in the settle() loop above,
+        // so this merge updates totals without re-inserting them.
+        getBillFacade().edit(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
@@ -973,8 +995,13 @@ public class TransferReceiveController implements Serializable {
             // them here — settle() creates each BillItem explicitly after stock validation.
             List<BillItem> items = getReceivedBill().getBillItems();
             getReceivedBill().setBillItems(new ArrayList<>());
-            getBillFacade().create(getReceivedBill());
-            getReceivedBill().setBillItems(items);
+            try {
+                getBillFacade().create(getReceivedBill());
+            } finally {
+                // Always restore the in-memory items, even if create() throws,
+                // so the @SessionScoped bean does not lose the receive rows on retry.
+                getReceivedBill().setBillItems(items);
+            }
         } else {
             getBillFacade().edit(getReceivedBill());
         }
@@ -1477,6 +1504,10 @@ public class TransferReceiveController implements Serializable {
 
     public void setSelectedBillItem(BillItem selectedBillItem) {
         this.selectedBillItem = selectedBillItem;
+    }
+
+    public boolean isSettling() {
+        return settling;
     }
 
     @Deprecated

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13511,6 +13511,12 @@ public class PharmacyReportController implements Serializable {
             List<BillType> billTypes = new ArrayList<>();
             billTypes.add(BillType.PharmacyAdjustmentDepartmentSingleStock);
             billTypes.add(BillType.PharmacyAdjustmentDepartmentStock);
+            // Stock-take adjustment bills (PHARMACY_STOCK_ADJUSTMENT_BILL) move stock too;
+            // omitting them left their stock movements uncounted on the calculated side and
+            // produced a COGS variance equal to the adjustment value on every stock-take day.
+            // pbi.qty on these bills is the adjustment delta, so the existing qty<0/qty>0
+            // split places them in the Issue/Receive rows correctly. See issue #21266.
+            billTypes.add(BillType.PharmacyStockAdjustmentBill);
 
             // Query for Stock Adjustment Issues (negative quantities)
             Map<String, Object> paramsIssue = new HashMap<>();

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11832,7 +11832,21 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Filter by the actual STOCK-MOVEMENT date, not bill creation, so the
+                    // movement rows align with the stock side (StockHistory is written when
+                    // stock physically moves). Stock moves on approval, but which timestamp
+                    // marks approval differs by workflow:
+                    //   - GRN / GRN-return / direct purchase: stock moves at completedAt.
+                    //   - Draft transfer issue: completedAt is set at draft *finalization*
+                    //     (finalizeDraftIssue), while stock is deducted later at *approval*
+                    //     (approveDraftIssue), which sets checkeAt.
+                    // GREATEST(createdAt, completedAt, checkeAt) picks the latest of the three,
+                    // which is the moment stock actually moved in every workflow, and falls
+                    // back to createdAt when the approval timestamps are null (non-approval
+                    // flows). Using createdAt alone mis-dated approval-gated movements (e.g. a
+                    // GRN return created one day, approved another) and produced a spurious COGS
+                    // variance. See issue #21266 (and Codex review on PR #21348 re: draft transfers).
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             params.put("ret", false);
             params.put("btas", billTypeAtomics);
@@ -11879,13 +11893,22 @@ public class PharmacyReportController implements Serializable {
             List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN);
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
+            // FIX (variance double-count): GRN/Direct-Purchase CANCELLED bills must NOT be
+            // summed here. They are already counted (with their negative values) in the
+            // "Purchase Return" row via calculatePurchaseReturn(). Counting them again in the
+            // GRN Cash/Credit row subtracted the cancellation value twice on the calculated
+            // side while actual stock only dropped once, producing a variance equal to the
+            // cancelled bill's value (e.g. GSKGRNCAN/1 -> -1,350 variance in Ruhunu).
+            // These two lines were added on 2025-10-07 (commit 7ddc2781087) and duplicate the
+            // cancellation handling that has lived in calculatePurchaseReturn() since 2025-08-04.
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
 
             StringBuilder jpql = new StringBuilder("SELECT bi.bill.paymentMethod, SUM(bi.billItemFinanceDetails.valueAtPurchaseRate), SUM(bi.billItemFinanceDetails.valueAtCostRate), SUM(bi.billItemFinanceDetails.valueAtRetailRate) FROM BillItem bi ")
                     .append("WHERE bi.retired = false ")
                     .append("AND bi.bill.billTypeAtomic IN :bType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.bill.paymentMethod IN (:cash, :credit) ");
 
             Map<String, Object> params = new HashMap<>();
@@ -11972,7 +11995,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("btas", btas);
@@ -12030,7 +12057,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -12084,7 +12115,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12145,7 +12180,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12205,7 +12244,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic = :preAddToStockType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             preAddParams.put("ret", false);
             preAddParams.put("preAddToStockType", BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_ADD_TO_STOCK);
@@ -12266,7 +12309,11 @@ public class PharmacyReportController implements Serializable {
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
                     .append("AND (rb IS NULL OR rb.createdAt > :td) ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -12389,7 +12436,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13376,7 +13427,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13467,7 +13522,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty < 0.0 ");
 
             paramsIssue.put("ret", false);
@@ -13493,7 +13549,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty > 0.0 ");
 
             paramsReceive.put("ret", false);
@@ -13601,8 +13658,13 @@ public class PharmacyReportController implements Serializable {
 
     private void calculateSaleWithoutCreditPaymentMethod() {
         try {
+            // FIX (variance double-count): the "Sale Credit" row (calculateSaleCreditValue())
+            // owns BOTH Credit AND Staff payment methods. This "Sale" row must therefore
+            // exclude Staff as well as Credit, otherwise a Staff-paid retail sale is summed
+            // in both rows and double-counted on the calculated side. (Latent in Ruhunu today
+            // since there are no Staff/Credit retail sales, but a correctness bug regardless.)
             List<PaymentMethod> nonCreditPaymentMethods = Arrays.stream(PaymentMethod.values())
-                    .filter(pm -> pm != PaymentMethod.Credit)
+                    .filter(pm -> pm != PaymentMethod.Credit && pm != PaymentMethod.Staff)
                     .collect(Collectors.toList());
 
             List<BillTypeAtomic> billTypes = Arrays.asList(

--- a/src/main/java/com/divudi/core/data/PharmacyRow.java
+++ b/src/main/java/com/divudi/core/data/PharmacyRow.java
@@ -194,6 +194,11 @@ public class PharmacyRow implements Serializable {
     private BigDecimal valueOfStocksAtPurchaseRate = BigDecimal.ZERO;
     private BigDecimal valueOfStocksAtRetailSaleRate = BigDecimal.ZERO;
 
+    private double consumptionQty;
+    private double consumptionPurchaseValue;
+    private double consumptionCostValue;
+    private double consumptionRetailValue;
+
     private BigDecimal grossSaleRate = BigDecimal.ZERO;
     private BigDecimal discountRate = BigDecimal.ZERO;
     private BigDecimal marginRate = BigDecimal.ZERO;
@@ -1753,5 +1758,37 @@ public class PharmacyRow implements Serializable {
 
     public void setValueOfStocksAtRetailSaleRate(BigDecimal valueOfStocksAtRetailSaleRate) {
         this.valueOfStocksAtRetailSaleRate = valueOfStocksAtRetailSaleRate;
+    }
+
+    public double getConsumptionQty() {
+        return consumptionQty;
+    }
+
+    public void setConsumptionQty(double consumptionQty) {
+        this.consumptionQty = consumptionQty;
+    }
+
+    public double getConsumptionPurchaseValue() {
+        return consumptionPurchaseValue;
+    }
+
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) {
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+    }
+
+    public double getConsumptionCostValue() {
+        return consumptionCostValue;
+    }
+
+    public void setConsumptionCostValue(double consumptionCostValue) {
+        this.consumptionCostValue = consumptionCostValue;
+    }
+
+    public double getConsumptionRetailValue() {
+        return consumptionRetailValue;
+    }
+
+    public void setConsumptionRetailValue(double consumptionRetailValue) {
+        this.consumptionRetailValue = consumptionRetailValue;
     }
 }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -707,7 +707,49 @@ public enum Privileges {
     DeleteData("Delete Data"),
     BillCancel("Bill Cancel"),
     BillRefund("Bill Refund"), //</editor-fold>
-    AiChat("AI Chat")
+    AiChat("AI Chat"),
+    // Inward
+    InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
+    InwardDocumentUpload("Inward Document Upload"),
+    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    // Pharmacy workflow
+    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
+    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
+    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
+    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
+    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
+    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
+    // Cashier / petty cash
+    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
+    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    CashierHandoverStatusReport("Cashier Handover Status Report"),
+    SettleHandoverProofMissing("Settle Handover Proof Missing"),
+    SettleNonCashPayments("Settle Non-Cash Payments"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
+    // Clinical
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
+    // Admin
+    AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
+    // Fund transfer
+    RequestFundTransfer("Request Float Transfer"),
+    IssueFundTransfer("Issue Float Transfer"),
+    ReceiveFundTransfer("Receive Float Transfer"),
+    DeclineFundTransfer("Decline Float Transfer"),
+    ProcessFundTransferRequest("Process Float Transfer Request"),
+    CancelOwnFundTransfer("Cancel Own Float Transfer"),
+    CancelOthersFundTransfer("Cancel Others Float Transfer"),
+    ViewFundTransferReports("View Float Transfer Reports")
     ;
 
     private final String label;
@@ -1013,6 +1055,10 @@ public enum Privileges {
             case InwardAppointmentUpdate:
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
+            case InpatientClinicalDischarge:
+            case InwardFormTemplateAdmin:
+            case InwardFormFill:
+            case InwardDocumentUpload:
                 return "Inward";
 
             default:

--- a/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
+++ b/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
@@ -5,9 +5,17 @@
 package com.divudi.core.facade;
 
 import com.divudi.core.entity.Item;
+import java.sql.Connection;
+import java.util.List;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.JNDIConnector;
+import org.eclipse.persistence.sessions.server.ServerSession;
 
 /**
  * Facade for audit database operations including schema management.
@@ -29,5 +37,41 @@ public class AuditDatabaseFacade extends AbstractFacade<Item> {
 
     public AuditDatabaseFacade() {
         super(Item.class);
+    }
+
+    /**
+     * Temporary measure while this GenerationType.AUTO build (sequence-table
+     * IDs) and the newer GenerationType.IDENTITY build (AUTO_INCREMENT IDs)
+     * share the audit database (REPORTLOG, AUDITEVENT, ...). Separates the two
+     * allocators into disjoint ID ranges so they stop colliding on the same
+     * primary keys. THIS application server must be restarted after running —
+     * it holds a preallocated sequence block in memory. See {@link IdAllocatorSeparation}.
+     *
+     * @return human-readable report of what was changed
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> separateIdAllocatorsForDualVersionOperation() throws Exception {
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            return IdAllocatorSeparation.separate(conn);
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+    }
+
+    /**
+     * Obtain a raw JDBC connection from EclipseLink's JNDI datasource,
+     * completely outside JTA. ALTER TABLE causes MySQL implicit commits that
+     * desync the JTA transaction manager, so DDL must bypass it. Caller is
+     * responsible for closing the connection.
+     */
+    private Connection getRawJdbcConnection() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        ServerSession serverSession = emImpl.getServerSession();
+        DataSource ds = ((JNDIConnector) serverSession.getLogin().getConnector()).getDataSource();
+        return ds.getConnection();
     }
 }

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -6,12 +6,19 @@ package com.divudi.core.facade;
 
 import com.divudi.core.entity.DatabaseMigration;
 import com.divudi.core.data.MigrationStatus;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.JNDIConnector;
+import org.eclipse.persistence.sessions.server.ServerSession;
 
 /**
  * Facade for DatabaseMigration entity operations
@@ -31,6 +38,42 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
 
     public DatabaseMigrationFacade() {
         super(DatabaseMigration.class);
+    }
+
+    /**
+     * Temporary measure while this GenerationType.AUTO build (sequence-table
+     * IDs) and the newer GenerationType.IDENTITY build (AUTO_INCREMENT IDs)
+     * share the main database. Separates the two allocators into disjoint ID
+     * ranges so they stop colliding on the same primary keys. THIS application
+     * server must be restarted after running — it holds a preallocated
+     * sequence block in memory. See {@link IdAllocatorSeparation}.
+     *
+     * @return human-readable report of what was changed
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> separateIdAllocatorsForDualVersionOperation() throws Exception {
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            return IdAllocatorSeparation.separate(conn);
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+    }
+
+    /**
+     * Obtain a raw JDBC connection from EclipseLink's JNDI datasource,
+     * completely outside JTA. ALTER TABLE causes MySQL implicit commits that
+     * desync the JTA transaction manager, so DDL must bypass it. Caller is
+     * responsible for closing the connection.
+     */
+    private Connection getRawJdbcConnection() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        ServerSession serverSession = emImpl.getServerSession();
+        DataSource ds = ((JNDIConnector) serverSession.getLogin().getConnector()).getDataSource();
+        return ds.getConnection();
     }
 
     /**

--- a/src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java
+++ b/src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java
@@ -1,0 +1,175 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Temporary remedy for running two application builds against the same
+ * database when they use different ID generation strategies:
+ *
+ * <ul>
+ * <li>an old production build with {@code GenerationType.AUTO} — EclipseLink
+ * table sequencing, which allocates IDs from the {@code SEQUENCE} table and
+ * sends them explicitly on INSERT, and</li>
+ * <li>a new build with {@code GenerationType.IDENTITY} — MySQL
+ * {@code AUTO_INCREMENT}.</li>
+ * </ul>
+ *
+ * The two allocators are independent, and MySQL's auto_increment counter
+ * always chases the highest inserted ID, so the IDENTITY build's next insert
+ * lands exactly on the AUTO build's next preallocated sequence value —
+ * a guaranteed duplicate-primary-key collision (e.g. REPORTLOG at Ruhunu).
+ * Simply bumping the sequence cannot fix this; the two allocators must be
+ * separated into disjoint ranges:
+ *
+ * <ol>
+ * <li>every {@code SEQUENCE} row is raised just above the highest existing ID,
+ * so the AUTO build stops re-issuing IDs the IDENTITY build already used;</li>
+ * <li>every table's {@code AUTO_INCREMENT} counter is pushed
+ * {@link #AUTO_INCREMENT_OFFSET} above the highest existing ID, so the
+ * IDENTITY build allocates in a high band the sequence will not reach.
+ * Explicit inserts below an auto_increment counter never move it, so the
+ * bands stay disjoint.</li>
+ * </ol>
+ *
+ * The AUTO build's servers must be restarted after this runs — they hold a
+ * preallocated sequence block in memory and keep using it until restarted.
+ *
+ * Full background, runbook and removal plan:
+ * developer_docs/database/dual-version-id-allocator-separation.md
+ */
+final class IdAllocatorSeparation {
+
+    /**
+     * SEQUENCE rows are raised to global max ID + this margin. The margin
+     * absorbs IDENTITY-build inserts that happen between scanning the max and
+     * applying the AUTO_INCREMENT offsets below.
+     */
+    static final long SEQUENCE_SAFETY_MARGIN = 10_000L;
+
+    /**
+     * AUTO_INCREMENT counters jump to global max ID + this offset. The AUTO
+     * build's sequence would need to allocate this many IDs to catch up —
+     * far beyond the temporary dual-version window.
+     */
+    static final long AUTO_INCREMENT_OFFSET = 1_000_000_000L;
+
+    private IdAllocatorSeparation() {
+    }
+
+    /**
+     * Runs the separation on the schema of the given connection. The caller
+     * must supply a raw, autoCommit=true connection outside JTA (ALTER TABLE
+     * causes implicit commits) and is responsible for closing it.
+     *
+     * @return human-readable report of what was scanned and changed
+     */
+    static List<String> separate(Connection conn) throws SQLException {
+        List<String> report = new ArrayList<>();
+
+        // Step 1: inventory entity tables — BIGINT primary key named ID.
+        // The stored case of both table and column names varies between
+        // deployments (lower_case_table_names), so take them verbatim from
+        // INFORMATION_SCHEMA instead of hardcoding either case.
+        Map<String, String> idColumnByTable = new LinkedHashMap<>();
+        String tableQuery = "SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS "
+                + "WHERE TABLE_SCHEMA = DATABASE() "
+                + "AND UPPER(COLUMN_NAME) = 'ID' "
+                + "AND COLUMN_KEY = 'PRI' "
+                + "AND DATA_TYPE = 'bigint' "
+                + "ORDER BY TABLE_NAME";
+        try (PreparedStatement ps = conn.prepareStatement(tableQuery);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                idColumnByTable.put(rs.getString(1), rs.getString(2));
+            }
+        }
+        if (idColumnByTable.isEmpty()) {
+            report.add("No tables with a BIGINT ID primary key found — nothing to do.");
+            return report;
+        }
+
+        // Step 2: global max ID across every table. Both targets below are
+        // derived from one shared maximum so the sequence band and the
+        // auto_increment band are disjoint across ALL tables, not per table.
+        // MAX(primary key) is an index-end lookup — cheap even on BILL/BILLITEM.
+        long globalMaxId = 0;
+        for (Map.Entry<String, String> e : idColumnByTable.entrySet()) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery(
+                         "SELECT MAX(`" + e.getValue() + "`) FROM `" + e.getKey() + "`")) {
+                if (rs.next()) {
+                    globalMaxId = Math.max(globalMaxId, rs.getLong(1));
+                }
+            }
+        }
+        report.add("Scanned " + idColumnByTable.size() + " tables; highest existing ID = " + globalMaxId + ".");
+
+        // Step 3: raise every SEQUENCE row (not just SEQ_GEN — custom
+        // generators would collide the same way) above every existing ID.
+        // Rows already at or beyond the target are left alone, so re-running
+        // never rewinds a sequence.
+        String sequenceTable = findSequenceTableName(conn);
+        if (sequenceTable == null) {
+            report.add("No SEQUENCE table in this schema — sequence bump skipped.");
+        } else {
+            long sequenceTarget = globalMaxId + SEQUENCE_SAFETY_MARGIN;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT SEQ_NAME, SEQ_COUNT FROM `" + sequenceTable + "`")) {
+                while (rs.next()) {
+                    report.add("Sequence " + rs.getString(1) + " was at " + rs.getLong(2) + ".");
+                }
+            }
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "UPDATE `" + sequenceTable + "` SET SEQ_COUNT = ? WHERE SEQ_COUNT < ?")) {
+                ps.setLong(1, sequenceTarget);
+                ps.setLong(2, sequenceTarget);
+                int updated = ps.executeUpdate();
+                report.add("Raised " + updated + " sequence row(s) to " + sequenceTarget + ".");
+            }
+        }
+
+        // Step 4: move every table's AUTO_INCREMENT counter into the high
+        // band — including empty tables, because the IDENTITY build must
+        // allocate high everywhere, even in tables it has not written yet.
+        // ALTER ... AUTO_INCREMENT is a metadata-only change (no row rewrite),
+        // and InnoDB ignores a target below the current counter, so re-running
+        // is harmless. Failures are collected per table rather than aborting:
+        // a partial separation still protects every table that was altered.
+        long autoIncrementTarget = globalMaxId + AUTO_INCREMENT_OFFSET;
+        int altered = 0;
+        List<String> failures = new ArrayList<>();
+        for (String tableName : idColumnByTable.keySet()) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("ALTER TABLE `" + tableName + "` AUTO_INCREMENT = " + autoIncrementTarget);
+                altered++;
+            } catch (SQLException e) {
+                failures.add("Could not set AUTO_INCREMENT on `" + tableName + "`: " + e.getMessage());
+            }
+        }
+        report.add("Set AUTO_INCREMENT to " + autoIncrementTarget + " on " + altered + " of "
+                + idColumnByTable.size() + " table(s).");
+        report.addAll(failures);
+        return report;
+    }
+
+    private static String findSequenceTableName(Connection conn) throws SQLException {
+        String query = "SELECT TABLE_NAME FROM information_schema.TABLES "
+                + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'SEQUENCE'";
+        try (PreparedStatement ps = conn.prepareStatement(query);
+             ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+}

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -981,6 +981,48 @@
                             </div>
                         </p:tab>
 
+                        <p:tab id="tabIdGeneration" title="ID Generation — Dual Version Operation">
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 15%;">Name</th>
+                                        <th style="width: 30%;">Description</th>
+                                        <th style="width: 10%;">Action</th>
+                                        <th style="width: 45%;">Output</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>Separate ID Allocators</strong></td>
+                                        <td>
+                                            Temporary fix for running this production build (sequence-table ID
+                                            generation, GenerationType.AUTO) and the newer development build
+                                            (AUTO_INCREMENT, GenerationType.IDENTITY) against the same database — the
+                                            two independent allocators collide, e.g. Duplicate entry for key
+                                            REPORTLOG.PRIMARY. Raises every SEQUENCE row just above the highest
+                                            existing ID and pushes all table AUTO_INCREMENT counters one billion above
+                                            it, so the two builds allocate from non-overlapping ranges. Applies to both
+                                            the main and audit databases. Restart THIS application server immediately
+                                            after running — it keeps a preallocated ID block in memory until restarted.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                id="btnSeparateIdAllocators"
+                                                action="#{dataAdministrationController.separateIdAllocatorsForDualVersionOperation()}"
+                                                ajax="false"
+                                                value="Separate ID Allocators"
+                                                styleClass="ui-button-danger m-1"
+                                                icon="pi pi-sort-numeric-up"
+                                                rendered="#{webUserController.hasPrivilege('Admin')}"
+                                                onclick="return confirm('This will raise the SEQUENCE table and move the AUTO_INCREMENT counters of ALL tables in the main and audit databases. Restart this application server afterwards. Proceed?');" />
+                                        </td>
+                                        <td>
+                                            <h:outputText value="#{dataAdministrationController.executionFeedback}" escape="false" />
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </p:tab>
 
                     </p:accordionPanel>
                 </h:form>

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -89,7 +89,7 @@
                                             value="Save"
                                             title="Save return bill as draft"
                                             action="#{issueReturnController.saveDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -99,7 +99,7 @@
                                             onclick="return confirm('Are you sure you want to finalize this disposal issue? This action cannot be undone.');"
                                             title="Finalize return bill"
                                             action="#{issueReturnController.finalizeDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -109,7 +109,7 @@
                                             onclick="return confirm('Are you sure you want to approve this disposal issue? This action cannot be undone.');"
                                             title="Approve and process the return"
                                             action="#{issueReturnController.settleDisposalIssueReturnBill}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and not issueReturnController.returnBill.billClosed and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                     </div>
@@ -130,6 +130,50 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
                                     <h:outputText value=" by #{issueReturnController.originalBill.fullReturnedBy.webUserPerson.nameWithTitle}. No further returns are allowed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return already approved (settled) - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-success d-flex align-items-center">
+                                <i class="fas fa-check-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.completedAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.completedAt}" rendered="#{issueReturnController.returnBill.completedAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" by #{issueReturnController.returnBill.completedBy.webUserPerson.nameWithTitle}" rendered="#{issueReturnController.returnBill.completedBy ne null}"/>
+                                    <h:outputText value=". No further changes are possible." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return closed - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.billClosed and not issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-warning d-flex align-items-center">
+                                <i class="fas fa-ban me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return has been closed. It can no longer be saved, finalized or approved - create a new return for this disposal issue if needed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: finalized, awaiting approval - explains why Save/Finalize are hidden, and why Approve is hidden when the privilege is missing -->
+                        <p:panel rendered="#{issueReturnController.returnBill.checkedBy ne null and not issueReturnController.returnBill.completed and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-info d-flex align-items-center">
+                                <i class="fas fa-info-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This return was finalized by #{issueReturnController.returnBill.checkedBy.webUserPerson.nameWithTitle}" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.checkeAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.checkeAt}" rendered="#{issueReturnController.returnBill.checkeAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" and is awaiting approval. Items can no longer be edited." styleClass="fw-bold"/>
+                                    <h:outputText value=" You do not have the Approve Disposal Return privilege - please ask an authorized user to approve it."
+                                                  rendered="#{!webUserController.hasPrivilege('ApproveDisposalReturn')}"
+                                                  styleClass="fw-bold text-danger ms-1"/>
                                 </div>
                             </div>
                         </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -265,6 +265,7 @@
                                                 title="Create a GRN for Selected Approved PO with costing"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
                                                 action="#{grnCostingController.navigateToResiveCostingWithSaveApprove()}"
+                                                onclick="return confirm('Are you sure you want to create a GRN for this Purchase Order?');"
                                                 disabled="#{p.cancelled or p.billClosed or p.fullyIssued}">
                                                 <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                             </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -86,14 +86,16 @@
                                         width="6em"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off"  
-                                            id="qty" 
-                                            value="#{bi.billItemFinanceDetails.quantity}" 
-                                            style="padding: 0;" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="qty"
+                                            value="#{bi.billItemFinanceDetails.quantity}"
+                                            style="padding: 0;"
                                             label="Qty"
                                             class="text-end w-100"
-                                            onfocus="this.select()">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            onfocus="this.select()">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <p:ajax 
                                                 event="blur" 
@@ -108,14 +110,16 @@
                                         headerText="Free Qty"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off" 
-                                            id="freeQty" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="freeQty"
                                             onfocus="this.select()"
                                             class="text-end w-100"
-                                            value="#{bi.billItemFinanceDetails.freeQuantity}" 
-                                            style="padding: 0;" 
-                                            label="Qty">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                            style="padding: 0;"
+                                            label="Qty">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <f:ajax 
                                                 event="blur" 
@@ -135,9 +139,11 @@
                                             <p:inputText
                                                 id="txtRetailRate"
                                                 onfocus="this.select()"
-                                                autocomplete="off" 
-                                                style="padding: 0;" 
-                                                value="#{bi.billItemFinanceDetails.lineGrossRate}" 
+                                                autocomplete="off"
+                                                style="padding: 0;"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                                 class="w-100 text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                                 <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
@@ -220,11 +226,12 @@
                                     <p:outputLabel value="Supplier"
                                                    class="form-label"
                                                    for="acSupplier"></p:outputLabel>
-                                    <p:autoComplete 
+                                    <p:autoComplete
                                         id="acSupplier"
-                                        converter="deal" 
-                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"  
+                                        converter="deal"
+                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-100"
                                         inputStyleClass="w-100"
                                         completeMethod="#{dealerController.completeActiveDealor}"
@@ -388,6 +395,7 @@
                                         id="exItem"
                                         value="#{purchaseOrderRequestController.currentBillItem.item}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-75"
                                         maxResults="50"
                                         scrollHeight="600"

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
@@ -101,17 +101,22 @@
                                         rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
                                     </p:commandButton>
 
+                                    <!-- Cashier sale bill cancellation temporarily disabled (#21419 COGS remediation).
+                                         Cancelling this bill causes the COGS report to show incorrect figures.
+                                         Re-enable once the COGS variance is fixed. -->
+                                    <!--
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Accept Sale for Cashier Bill can be Cancelled', true)}">
-                                        <p:commandButton 
-                                            ajax="false" 
+                                        <p:commandButton
+                                            ajax="false"
                                             value="To Cancel"
                                             icon="fa fa-cancel"
                                             class="ui-button-danger m-1"
-                                            action="pharmacy_cancel_bill_retail?faces-redirect=true" 
+                                            action="pharmacy_cancel_bill_retail?faces-redirect=true"
                                             disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded}"
-                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
+                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">
                                         </p:commandButton>
                                     </h:panelGroup>
+                                    -->
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
@@ -22,9 +22,14 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
 
                             </p:commandButton>
+                            <!-- GRN Return cancellation temporarily disabled (#21266 stock remediation).
+                                 Cancelling a GRN Return has caused stock data errors in production.
+                                 Re-enable only after all stock discrepancy issues are settled. -->
+                            <!--
                             <p:commandButton value="Cancel" ajax="false"
-                                             action="pharmacy_cancel_grn_return" 
+                                             action="pharmacy_cancel_grn_return"
                                              disabled="#{pharmacyBillSearch.bill.cancelled}"/>
+                            -->
 
 
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
@@ -32,6 +32,10 @@
                                     ajax="false" >
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
+                                <!-- Transfer Receive cancellation temporarily disabled (#21419 COGS remediation).
+                                     Cancelling a Transfer Receive bill causes the COGS report to show
+                                     incorrect figures. Re-enable once the COGS variance is fixed. -->
+                                <!--
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receives can be Cancelled', true)}" >
                                     <p:commandButton
                                         id="btnToCancel"
@@ -45,6 +49,7 @@
                                         <f:setPropertyActionListener target="#{transferReceiveCancellationController.originalReceiveBillId}" value="#{pharmacyBillSearch.bill.id}" />
                                     </p:commandButton>
                                 </h:panelGroup>
+                                -->
                                 <p:commandButton
                                     value="Back"
                                     icon="fas fa-arrow-left"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -85,7 +85,7 @@
                                     </p:column>  
 
                                     <p:column headerText="Expiration Date"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
-                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                         </h:outputText>
                                     </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -28,14 +28,15 @@
                 <p:panel>
                     <f:facet name="header" >                                  
 
-                        <p:commandButton  
+                        <p:commandButton
                             id="btnSettleReceive"
-                            value="Receive" 
+                            value="Receive"
                             icon="fas fa-check"
                             style="float: right;"
                             class="ui-button-success mx-2"
-                            action="#{transferReceiveController.settle}" 
-                            ajax="false" >
+                            action="#{transferReceiveController.settle}"
+                            ajax="false"
+                            onclick="return confirm('Are you sure you want to receive this transfer?');" >
                         </p:commandButton>
                         <h:panelGroup rendered="#{transferReceiveController.issuedBill.comments ne null and not empty transferReceiveController.issuedBill.comments}">
                             <p:outputLabel class="mx-4 text-break" value="Note :  #{transferReceiveController.issuedBill.comments}" />
@@ -61,6 +62,7 @@
                                             icon="pi pi-search"
                                             id="btnViewSelectedItemDetails"
                                             title="View Item Details"
+                                            ariaLabel="View Item Details"
                                             action="#{transferReceiveController.displayItemDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
                                             process="@this"
@@ -69,6 +71,7 @@
                                             icon="pi pi-info-circle"
                                             id="btnViewBatchDetails"
                                             title="View Batch Details"
+                                            ariaLabel="View Batch Details"
                                             actionListener="#{transferReceiveController.prepareBatchDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('batchDetailsForm',view).clientId}"
                                             oncomplete="PF('batchDetailsDialog').show();"
@@ -308,7 +311,7 @@
                                 </div>
                                 <div class="card-body">
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4"
                                             value="#{pharmacyConfigController.transferReceiveA4}" />
                                         <p:outputLabel for="transferReceiveA4" value="A4 Receipt Format" class="ms-2" />
@@ -316,15 +319,15 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveTemplate"
                                             value="#{pharmacyConfigController.transferReceiveTemplate}" />
                                         <p:outputLabel for="transferReceiveTemplate" value="Template Bill Format" class="ms-2" />
                                         <small class="form-text text-muted d-block">Template-based receipt format for transfer receive bills</small>
                                     </div>
-                                    
+
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveCustom1"
                                             value="#{pharmacyConfigController.transferReceiveCustom1}" />
                                         <p:outputLabel for="transferReceiveCustom1" value="Letter Paper Format Custom 1" class="ms-2" />
@@ -332,7 +335,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Detailed"
                                             value="#{pharmacyConfigController.transferReceiveA4Detailed}" />
                                         <p:outputLabel for="transferReceiveA4Detailed" value="A4 Detailed Receipt" class="ms-2" />
@@ -340,7 +343,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom1"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom1}" />
                                         <p:outputLabel for="transferReceiveA4Custom1" value="A4 Custom Format 1" class="ms-2" />
@@ -348,7 +351,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom2"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom2}" />
                                         <p:outputLabel for="transferReceiveA4Custom2" value="A4 Custom Format 2" class="ms-2" />

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -76,7 +76,7 @@
                             </p:column>
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -84,7 +84,7 @@
                             </p:column> 
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">  
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>  

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -518,8 +518,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalPurchaseValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalPurchaseValue}">
+                                    sortBy="#{b.consumptionPurchaseValue}">
+                                    <h:outputText value="#{b.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -533,8 +533,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalCostValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalCostValue}">
+                                    sortBy="#{b.consumptionCostValue}">
+                                    <h:outputText value="#{b.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -548,8 +548,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
+                                    sortBy="#{b.consumptionRetailValue}">
+                                    <h:outputText value="#{b.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -658,9 +658,9 @@
                                     width="4em"
                                     style="text-align: right; padding-right: 20px;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.qty}"
-                                    filterBy="#{i.billItem.qty}">
-                                    <p:outputLabel value="#{i.billItem.qty}"/>
+                                    sortBy="#{i.consumptionQty}"
+                                    filterBy="#{i.consumptionQty}">
+                                    <p:outputLabel value="#{i.consumptionQty}"/>
                                 </p:column>
 
                                 <p:column headerText="Status/Links" width="10em" exportable="false">
@@ -732,9 +732,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
-                                    <p:outputLabel
-                                        value="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
+                                    sortBy="#{i.consumptionPurchaseValue}">
+                                    <p:outputLabel value="#{i.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -759,8 +758,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
+                                    sortBy="#{i.consumptionRetailValue}">
+                                    <p:outputLabel value="#{i.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -785,8 +784,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
+                                    sortBy="#{i.consumptionCostValue}">
+                                    <p:outputLabel value="#{i.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -115,7 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3"/>
+                                <p:outputLabel value="Department" class="mx-3" for="phmDept"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -29,13 +29,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="From Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="From Date" class="mx-3" for="fromDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="fromDate"
+                                ariaLabel="From Date"
                                 value="#{pharmacyReportController.fromDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -43,13 +43,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="To Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="To Date" class="mx-3" for="toDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="toDate"
+                                ariaLabel="To Date"
                                 value="#{pharmacyReportController.toDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -82,12 +82,12 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-university ml-3" />
-                                <p:outputLabel value="Institution" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="Institution" class="mx-3" for="phmIns"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmIns"
                                 class="w-100"
+                                ariaLabel="Institution"
                                 value="#{pharmacyReportController.institution}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Institutions"/>
@@ -98,12 +98,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-map-marker-alt ml-3" />
-                                <p:outputLabel value="Site" class="mx-3"></p:outputLabel>
+                                <p:outputLabel value="Site" class="mx-3" for="phmSite"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmSite"
                                 class="w-100"
                                 styleClass="w-100"
+                                ariaLabel="Site"
                                 value="#{pharmacyReportController.site}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Sites"/>
@@ -114,8 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Department" class="mx-3"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 
@@ -123,6 +123,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -137,6 +138,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -151,6 +153,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -165,6 +168,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -178,13 +182,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-pills ml-3" />
-                                <p:outputLabel value="Item" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Item" class="mx-3" for="phmItem"/>
                             </h:panelGroup>
                             <p:autoComplete
                                 id="phmItem"
                                 class="w-100"
                                 inputStyleClass="w-100"
+                                ariaLabel="Item"
                                 value="#{pharmacyReportController.item}"
                                 completeMethod="#{itemController.completeItem}"
                                 var="itm"

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1413,8 +1413,11 @@
                 </p:submenu>
 
                 <!--            Store Section-->
-                <p:submenu   
-                    id="smStore"  icon="fa fa-fw fa-store"  rendered="#{webUserController.hasPrivilege('Store')}">                                                           
+                <!-- Stores menu temporarily hidden for production hotfix (#21423).
+                     Forced to not render regardless of privilege; remove this override
+                     once a configuration toggle for hiding the Stores menu is in place. -->
+                <p:submenu
+                    id="smStore"  icon="fa fa-fw fa-store"  rendered="false">
                     <p:submenu label="BHT Issue" icon="fas fa-procedures" rendered="#{webUserController.hasPrivilege('StoreIssueInwardBilling')}">
                         <p:menuitem ajax="false" action="/store/store_retail_sale_bht?faces-redirect=true"  value="Inward Billing"
                                     rendered="#{webUserController.hasPrivilege('StoreIssueInwardBilling')}"


### PR DESCRIPTION
## Summary

Production hotfix for the Ruhunu stock-discrepancy incident (issue #21266, also #21396). Closes out the **code side of all six root causes** identified in the COGS-variance investigation, plus supporting fixes. Every fix is **QA-verified on the Ruhunu production build** (localhost rhprod deployment against a fresh production restore).

## Root-cause fixes

| RC | Fix | Commits |
|---|---|---|
| RC1 | Duplicate BillItems on transfer receive (cascade re-insert in settle) | `de9e1d9092`, `aeab690b94` |
| RC2 | Phantom receives bound to issuing dept's stock (12 bills / 75 lines): null inherited stock binding, all-or-nothing porter-stock pre-check, drop unpersisted lines before cascade merges | `e72a1c37ed` |
| RC3 | COGS report dated movements by createdAt instead of stock-move date + 2 double-count fixes (port of dev PR #21348) | `c21bb8fa2e` |
| RC4 | Return approval could silently issue less than finalized: validation no longer mutates quantities at approval; approve() compares per-item quantities against the finalized DB state and blocks on mismatch — **GRN returns and Direct Purchase returns** | `226fd98bd5`, `937214319e`, `4d8df44b61` |
| RC5 | Stale-list Close clobbered settled disposal returns (reverted completed/deptId while stock movement remained): closeDisposalReturn reloads fresh (L2 bypass); save/finalize/settle guarded against already-processed bills | `1e57825ce4` |
| RC6 | Transfer issue moved stock by stale requested qty while persisting the user-edited qty: qty synced from user input BEFORE stock ops; valuation fields recomputed | `4c0ec6140d` |

## Supporting fixes

- Pre-deduction stock check in updateStock() — all-or-nothing approval (`911b0e75f0`)
- Orphan-removal guard: setBillItems(null) before bill merges in IssueReturnController — stops FK-blocked mass deletes (`1eb7d7211a`)
- Disposal-return page: status panels explaining why action buttons are hidden (approved/closed/awaiting approval/missing privilege) (`c7eb8e470a`)
- COGS/consumption report fixes, compile fix for duplicated helpers (`8bb498ce4f`, `3a8083cbdc`)
- Separate ID allocators for dual-version operation (`375f1336a2`)
- 36 missing Privileges enum constants (General Stores login) (`523bfe33c7`)

## Deployment notes

- **Deploy BEFORE running the data-correction runbook** (`production_correction_runbook.md`) — the corrections assume these bugs can no longer recreate the corruption.
- Restart Payara after deploy (L2 cache).
- Post-deploy detection sweeps (expect 0 rows): duplicate-receive scan; phantom-receive scan (`stock.department_id = bill.fromDepartment_id` on PHARMACY_RECEIVE).

All fixes are ported to `development` (PRs #21394, #21397 + already-merged #21297/#21348).

🤖 Generated with [Claude Code](https://claude.com/claude-code)