### PR TITLE
fix(notifications): real-time bell updates via OmniFaces o:socket

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -41,6 +41,13 @@ The HMIS login + landing flow has a fixed shape:
    *last* department, so a fresh login often pre-fills it — still click through
    the **Select Department** screen to reach an inner page.
 
+**Do not navigate directly to an inner page URL before selecting a department.**
+`sessionController.department` is null until department selection completes.
+The template wraps `<ez:menu />` in `rendered="#{sessionController.department ne null}"`,
+so the entire menu — including the notification bell, websocket, and remoteCommand —
+is absent from the page. Any Playwright check for these components will fail silently.
+Always go through the department-selection screen first.
+
 **A redeploy invalidates the session.** Every time the WAR is redeployed you are
 logged out and must log in again. Plan test runs so you are not mid-flow when a
 deploy lands.

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,13 @@
             <type>jar</type>
         </dependency>
 
+        <!-- OmniFaces — 3.x targets JSF 2.3 (javax.faces); used for o:socket reliable push -->
+        <dependency>
+            <groupId>org.omnifaces</groupId>
+            <artifactId>omnifaces</artifactId>
+            <version>3.14.6</version>
+        </dependency>
+
         <!-- JFreeChart -->
         <dependency>
             <groupId>org.jfree</groupId>

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -90,7 +90,29 @@ public class UserNotificationController implements Serializable {
     private boolean canceldRequests;
 
     public String navigateToRecivedNotification() {
-        return "/Notification/user_notifications";
+        fillLoggedUserNotifications();
+        return "/Notification/user_notifications?faces-redirect=true";
+    }
+
+    public int getUnseenCount() {
+        if (sessionController == null || sessionController.getLoggedUser() == null) {
+            return 0;
+        }
+        try {
+            String jpql = "select count(un) "
+                    + " from UserNotification un "
+                    + " where un.webUser=:wu "
+                    + " and un.retired=:ret "
+                    + " and un.seen=:seen";
+            Map m = new HashMap();
+            m.put("ret", false);
+            m.put("seen", false);
+            m.put("wu", sessionController.getLoggedUser());
+            long count = getFacade().findLongByJpql(jpql, m);
+            return count > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) count;
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     public String navigateToSentNotification() {
@@ -347,7 +369,8 @@ public class UserNotificationController implements Serializable {
             String jpql = "select un "
                     + " from UserNotification un "
                     + " where un.webUser=:wu "
-                    + " and un.retired=:ret";
+                    + " and un.retired=:ret "
+                    + " order by un.id desc";
             Map m = new HashMap();
             m.put("ret", false);
             m.put("wu", sessionController.getLoggedUser());

--- a/src/main/java/com/divudi/service/NotificationPushService.java
+++ b/src/main/java/com/divudi/service/NotificationPushService.java
@@ -2,8 +2,8 @@ package com.divudi.service;
 
 import java.io.Serializable;
 import javax.enterprise.context.ApplicationScoped;
-import javax.faces.push.Push;
-import javax.faces.push.PushContext;
+import org.omnifaces.cdi.Push;
+import org.omnifaces.cdi.PushContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -89,7 +89,7 @@
     </error-page>
     
     <context-param>
-        <param-name>javax.faces.ENABLE_WEBSOCKET_ENDPOINT</param-name>
+        <param-name>org.omnifaces.SOCKET_ENDPOINT_ENABLED</param-name>
         <param-value>true</param-value>
     </context-param>
     <context-param>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -4,19 +4,58 @@
       xmlns:cc="http://xmlns.jcp.org/jsf/composite"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:o="http://omnifaces.org/ui">
     <!-- INTERFACE -->
     <cc:interface>
     </cc:interface>
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <h:form >
-            <style>
-                .ui-menu .ui-icon, .ui-menu .fa, .ui-menu .pi {
-                    font-size: 18px !important;
-                }
-            </style>
+        <style>
+            .ui-menu .ui-icon, .ui-menu .fa, .ui-menu .pi {
+                font-size: 18px !important;
+            }
+            #notifFloatBar {
+                position: fixed;
+                top: 6px;
+                right: 60px;
+                z-index: 9999;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+        </style>
 
+        <h:form id="notificationPushForm">
+            <!-- o:socket evaluates user= at render time — no view-build-time null problem -->
+            <o:socket channel="notifications"
+                      user="#{sessionController.loggedUser.id}"
+                      onmessage="onNotificationPush"
+                      rendered="#{sessionController.loggedUser != null}" />
+            <script type="text/javascript">
+                function onNotificationPush(message, channel, event) {
+                    refreshNotifications();
+                }
+            </script>
+            <p:remoteCommand name="refreshNotifications"
+                             update="notCount notificationGrowl"
+                             action="#{userNotificationController.onPushRefreshNotifications}" />
+            <p:growl id="notificationGrowl" life="6000" showDetail="true" />
+            <div id="notifFloatBar">
+                <h:panelGroup id="notCount">
+                    <p:badge id="bdgeNotiCount"
+                             severity="danger"
+                             value="#{userNotificationController.unseenCount}">
+                        <p:commandButton id="btnNot"
+                                         ajax="false"
+                                         icon="pi pi-bell"
+                                         action="#{userNotificationController.navigateToRecivedNotification()}" />
+                    </p:badge>
+                </h:panelGroup>
+            </div>
+        </h:form>
+
+        <h:form id="menuForm">
             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Displaying the message provided to system users',false)}" style="background-color: #{configOptionApplicationController.getColorValueByKey('Message background color')}">
                 <div class="card">
                     <div class="d-flex justify-content-center shadow-4 p-2" style="background-color: #{configOptionApplicationController.getColorValueByKey('Message background color')}; font-weight: 700; font-size: 18px;">
@@ -2019,33 +2058,6 @@
                                              ajax="false"
                                              action="#{financialTransactionController.refreshCashNetTotalForMenu()}" />
                         </h:panelGroup>
-                        <f:websocket channel="notifications"
-                                     user="#{sessionController.loggedUser.id}"
-                                     onmessage="onNotificationPush"
-                                     connected="#{sessionController.loggedUser != null}" />
-                        <p:remoteCommand name="refreshNotifications"
-                                         update="notCount notificationGrowl"
-                                         action="#{userNotificationController.onPushRefreshNotifications}" />
-                        <p:growl id="notificationGrowl" life="6000" showDetail="true" />
-                        <script type="text/javascript">
-                            function onNotificationPush(message) {
-                                refreshNotifications();
-                            }
-                        </script>
-                        <div class="mx-4">
-                            <h:panelGroup id="notCount">
-                                <p:badge id="bdgeNotiCount"
-                                         severity="danger"
-                                         value="#{userNotificationController.items != null ? userNotificationController.items.size() : 0}">
-                                    <p:commandButton id="btnNot"
-                                                     ajax="false"
-                                                     icon="pi pi-bell"
-                                                     action="#{userNotificationController.navigateToRecivedNotification()}" />
-                                </p:badge>
-                            </h:panelGroup>
-                        </div>
-
-
                         <p:commandButton id="btnLogout" ajax="false" icon="pi pi-sign-out" action="#{sessionController.logout}" />
                     </div>
 


### PR DESCRIPTION
## Summary
- Notification rows were correctly created on patient discharge, but the bell badge never updated in real time — only after a manual page reload.
- Root cause: `f:websocket`'s `user=` attribute is evaluated at view-build time, before session-scoped beans (`sessionController.loggedUser`) are populated, so the channel always registered as broadcast-only and the targeted push never reached the browser.
- Additionally, `f:websocket`/`p:remoteCommand`/`p:growl` placed inside `<f:facet name="options">` of `p:menubar` were not encoded into the DOM at all by PrimeFaces.

## Changes
- Replace `f:websocket` with OmniFaces `<o:socket>` (`user=` evaluated at render time), backed by `org.omnifaces.cdi.PushContext` in `NotificationPushService`.
- Move the notification bell/badge/growl/remoteCommand into their own form (`notificationPushForm`), positioned with fixed CSS (`#notifFloatBar`), out of the menubar's options facet.
- Fix `UserNotificationController.getUnseenCount()` to query unseen, non-retired `UserNotification` rows directly via JPQL (`findLongByJpql`) instead of relying on a possibly-stale/empty in-memory list — this also resolves the `unseenCount` PropertyNotFoundException seen previously.
- `navigateToRecivedNotification()` now refreshes the list (`fillLoggedUserNotifications()`) and redirects.
- Add OmniFaces 3.14.6 dependency (JSF 2.3 / Payara 5 compatible) and `org.omnifaces.SOCKET_ENDPOINT_ENABLED` context param; remove the now-unused `javax.faces.ENABLE_WEBSOCKET_ENDPOINT` param.
- Document a Playwright testing constraint: the entire `<ez:menu />` (including the notification bell) is absent until department selection completes.

## Test plan
- [x] Verified locally: logged in as one user, performed a patient discharge from a second user's session, confirmed the bell badge updates without a manual page refresh.
- [x] Verified delete/remove and clear-notification actions still work from `user_notifications.xhtml`.
- [ ] Confirm on staging across multiple concurrent users/sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added workflow prerequisites and clarification for testing notification features

* **Improvements**
  * Notification lists now automatically refresh when you navigate to your notifications
  * Unseen notification count badge displays with improved accuracy
  * Enhanced real-time notification delivery mechanism for better performance and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->