### PR TITLE
fix(inward): Patient Deposit payment ComponentNotFoundException and missing deposit details (#21408)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -774,6 +774,7 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
                     }
                     PatientDeposit pd = patientDepositService.getDepositOfThePatient(patient, sessionController.getDepartment());
                     paymentMethodData.getPatient_deposit().setPatientDepost(pd);
+                    paymentMethodData.getPatient_deposit().setTotalValue(0.0);
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -453,6 +453,7 @@ public class InwardSearch implements Serializable {
         PatientEncounter pe = inwardPaymentController.getCurrent().getPatientEncounter();
         inwardPaymentController.makeNull();
         inwardPaymentController.getCurrent().setPatientEncounter(pe);
+        inwardPaymentController.setPatient(pe.getPatient());
         if (sessionController.getPaymentManagementAfterShiftStart()) {
             financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
             if (financialTransactionController.getNonClosedShiftStartFundBill() != null) {

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -155,6 +155,7 @@
                                     <div class="col-md-2">
                                         <h:outputLabel value="Payment Mode" class="mt-2"/>
                                     </div>
+                                    
                                     <div class="col-md-3">
                                         <p:selectOneMenu 
                                             class="w-100" 

--- a/src/main/webapp/resources/paymentMethod/patient_deposit_with_paid_value.xhtml
+++ b/src/main/webapp/resources/paymentMethod/patient_deposit_with_paid_value.xhtml
@@ -40,7 +40,6 @@
                             required="true"
                             requiredMessage="Amount is required">
                             <f:convertNumber pattern="#,##0.00" />
-                            <p:ajax event="keyup" process="txtMpPd" update=":#{p:resolveFirstComponentWithId('balanceDisplay',view).clientId}" listener="#{cc.attrs.controller.calculatRemainForMultiplePaymentTotal()}" />
                         </p:inputText>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Fixes the **Inward Bill Payment → Patient Deposit** payment flow, which threw an exception and failed to display patient/deposit details.

Closes #21408

## Problem

On `inward/inward_bill_payment.xhtml`, selecting **Patient Deposit** from the *Payment Mode* dropdown caused:

1. **`ComponentNotFoundException`** in the Payara log while rendering the deposit amount field (`txtMpPd`).
2. **"Patient not selected"** — the deposit balance was never shown.
3. A **stale deposit amount** carried over instead of starting at 0.

## Root cause

- The single-payment composite `patient_deposit_with_paid_value.xhtml` carried a `<p:ajax>` copied from the multi-payment variant. Its `update` targeted `balanceDisplay` via `p:resolveFirstComponentWithId('balanceDisplay', view)`, but that component only exists inside `multiple_payment_methods.xhtml`. On the inward page the lookup returned `null`, the `update` expression collapsed to `":"`, and PrimeFaces failed. The `listener` also referenced a `controller` attribute the inward callers never pass.
- The patient was never set on `InwardPaymentController` during navigation to the payment page.
- The deposit `totalValue` was not reset when the deposit was loaded.

## Changes

**Commit 1 — `fix(inward): remove broken p:ajax causing ComponentNotFoundException on Patient Deposit`**
- Removed the offending `<p:ajax>` from `patient_deposit_with_paid_value.xhtml`. The amount still commits via the non-ajax Pay button submit (matching the Cash field on the same page).
- Minor whitespace in `inward_bill_payment.xhtml`.

**Commit 2 — `fix(inward): set patient and reset deposit amount for Patient Deposit payment`**
- `InwardSearch.navigateDoctorPayment()` now sets the patient from the encounter so the deposit balance is available.
- `InwardPaymentController.setPatient()` now resets the deposit `totalValue` to `0.0` on load.

## Testing

- JSF/XHTML change verified by inspection; the `balanceDisplay` reference is confirmed to exist only in the multi-payment context.
- Java changes wire the patient into the payment page and zero the amount.

Manual verification: open Inward Bill Payment, select **Patient Deposit** — the panel renders with the patient's deposit balance, the amount starts at 0.00, and no `ComponentNotFoundException` appears in the Payara log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed patient deposit payment initialization to ensure accurate data handling.
  * Corrected patient data propagation to payment functionality.

* **Changes**
  * Removed real-time balance recalculation from the deposit amount input field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->