### PR TITLE
fix: BioRadD10 analyzer image handling and routing for Southern Lanka production

### DIFF
--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -323,8 +323,16 @@ public class LimsMiddlewareController {
 
                     if (isImageValue
                             && priv.getInvestigationItem().getIxItemType() == InvestigationItemType.ReportImage) {
+                        byte[] imageBytes;
+                        try {
+                            imageBytes = base64TextToByteArray(observationValueStr);
+                        } catch (IllegalArgumentException e) {
+                            return Response.status(Response.Status.BAD_REQUEST)
+                                    .entity("Invalid image observation value: " + observationValueCode)
+                                    .build();
+                        }
                         priv.setLobValue(observationValueStr);
-                        priv.setBaImage(base64TextToByteArray(observationValueStr));
+                        priv.setBaImage(imageBytes);
                         String fileType = extractImageTypeFromResult(observationValueStr);
                         priv.setFileType(fileType);
                         priv.setFileName(observationValueCode + "_" + sampleId + "." + fileType.toLowerCase());

--- a/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java
@@ -163,18 +163,20 @@ public class LimsMiddlewareController {
         String observationUnitCode = observation.optString("observationUnitCode");
         String observationValueStr = observation.optString("observationValue");
         Double observationValueDbl = null;
+        boolean isImageValue = observationValueStr != null && observationValueStr.startsWith("^Image^");
         String issuedDate = observation.optString("issuedDate");
         String password = observation.optString("password");
         String username = observation.optString("username");
 
-        // Convert observationValueStr to Double
-        try {
-            observationValueDbl = Double.valueOf(observationValueStr);
-        } catch (NumberFormatException e) {
-            // // System.out.println("Invalid observation value: " + observationValueStr);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Invalid observation value: " + observationValueStr)
-                    .build();
+        // Convert observationValueStr to Double (skip for image values)
+        if (!isImageValue) {
+            try {
+                observationValueDbl = Double.valueOf(observationValueStr);
+            } catch (NumberFormatException e) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("Invalid observation value: " + observationValueStr)
+                        .build();
+            }
         }
 
         Long sampleIdLong;
@@ -311,13 +313,28 @@ public class LimsMiddlewareController {
                 // // System.out.println("tpr = " + tpr);
 
                 for (PatientReportItemValue priv : tpr.getPatientReportItemValues()) {
-                    // // System.out.println("priv = " + priv);
-                    // // System.out.println("priv.getInvestigationItem().getValueCodeSystem() = " + priv.getInvestigationItem());
-                    if (priv.getInvestigationItem() != null
-                            && priv.getInvestigationItem().getValueCodeSystem() != null
-                            && priv.getInvestigationItem().getValueCodeSystem().equals(observationValueCodingSystem)
-                            && priv.getInvestigationItem().getValueCode() != null
-                            && priv.getInvestigationItem().getValueCode().equals(observationValueCode)) {
+                    if (priv.getInvestigationItem() == null
+                            || priv.getInvestigationItem().getValueCodeSystem() == null
+                            || !priv.getInvestigationItem().getValueCodeSystem().equals(observationValueCodingSystem)
+                            || priv.getInvestigationItem().getValueCode() == null
+                            || !priv.getInvestigationItem().getValueCode().equals(observationValueCode)) {
+                        continue;
+                    }
+
+                    if (isImageValue
+                            && priv.getInvestigationItem().getIxItemType() == InvestigationItemType.ReportImage) {
+                        priv.setLobValue(observationValueStr);
+                        priv.setBaImage(base64TextToByteArray(observationValueStr));
+                        String fileType = extractImageTypeFromResult(observationValueStr);
+                        priv.setFileType(fileType);
+                        priv.setFileName(observationValueCode + "_" + sampleId + "." + fileType.toLowerCase());
+                        if (priv.getId() == null) {
+                            patientReportItemValueFacade.create(priv);
+                        } else {
+                            patientReportItemValueFacade.edit(priv);
+                        }
+                        resultAdded = true;
+                    } else if (!isImageValue) {
                         priv.setStrValue(observationValueStr);
                         priv.setDoubleValue(observationValueDbl);
                         resultAdded = true;

--- a/src/main/java/com/divudi/ws/lims/MiddlewareController.java
+++ b/src/main/java/com/divudi/ws/lims/MiddlewareController.java
@@ -157,10 +157,6 @@ public class MiddlewareController {
                 Analyzer analyzer = Analyzer.valueOf(analyzerDetails.getAnalyzerName().replace(" ", "_")); // Ensuring enum compatibility
                 System.out.println("analyzer = " + analyzer);
                 switch (analyzer) {
-                    case BioRadD10:
-                        return processBioRadD10(dataBundle);
-
-
                     case Dimension_Clinical_Chemistry_System:
                         return processDimensionClinicalChemistrySystem(dataBundle);
                     case Gallery_Indiko:
@@ -171,6 +167,7 @@ public class MiddlewareController {
                         return processBA400(dataBundle);
                     case Sysmex_XS_Series:
 //                         return processSysmexXSSeries(dataBundle);
+                    case BioRadD10:
                     case MaglumiX3HL7:
                     case MindrayBC5150:
                     case IndikoPlus:


### PR DESCRIPTION
## Summary

Brings the **Bio-Rad D10 analyzer image handling** to **Southern Lanka production**, matching what was already hotfixed into coop production (PR #20791 / originally #20788).

These changes let the LIMS middleware accept and store analyzer images (e.g. HbA1c chromatogram images) coming from the Bio-Rad D10, and fix the BioRadD10 routing that previously dropped all results.

## Changes (cherry-picked from coop-prod hotfix, `-x` traceability)

| Commit | Change |
|--------|--------|
| `5c5c2e7` | `processD10Observation` now accepts and stores `ReportImage` data — skips `Double` parsing when the value starts with `^Image^`, decodes base64, and persists `baImage`/`fileType`/`fileName`. |
| `aeeca12` | Route `BioRadD10` to `processResultsCommon` instead of the no-op stub that returned success without saving any results. |
| `eb6807f` | Return **400 BAD_REQUEST** for malformed image payloads instead of letting `IllegalArgumentException` bubble up as a 500. |

## Files

- `src/main/java/com/divudi/ws/lims/LimsMiddlewareController.java`
- `src/main/java/com/divudi/ws/lims/MiddlewareController.java`

## Notes

- Target branch: `southernlanka-prod` (production hotfix; branch name ends with `-hotfix` per CI merge validation).
- All three commits cherry-picked cleanly with no conflicts.
- Verified the target methods/routing already exist on `southernlanka-prod`; only Java files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
