### PR TITLE
fix(pharmacy): optional procurement approval workflows + direct purchase stock-link and return validation fixes

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -381,6 +381,21 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
+
+            // When approval is not required, complete (approve) the return
+            // immediately after finalization instead of leaving it pending
+            // for a separate approval step (#21404).
+            if (!configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return - Approval Required", true)) {
+                if (!validateAllItemsStockAvailability(true, false)) {
+                    JsfUtil.addErrorMessage("Cannot finalize: insufficient stock for the return quantities.");
+                    return;
+                }
+                if (validateApproval()) {
+                    completeApproval("Direct Purchase Return Request Finalized and Approved Successfully");
+                }
+                return;
+            }
+
             // Ensure the bill items are properly associated with the current bill for print preview
             ensureBillItemsForPreview();
             printPreview = true;
@@ -489,64 +504,79 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         if (validateApproval()) {
-            // Process zero quantity items before approval
-            processZeroQuantityItems();
-
-            // Mark the current bill as completed (approved)
-            currentBill.setCompleted(true);
-            currentBill.setCompletedBy(sessionController.getLoggedUser());
-            currentBill.setCompletedAt(new Date());
-            currentBill.setApproveAt(new Date());
-            currentBill.setApproveUser(sessionController.getLoggedUser());
-
-            // Save the bill with completed status
-            try {
-                billFacade.edit(currentBill);
-            } catch (Exception e) {
-                JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
-                return;
-            }
-
-            updateStock();  // Stock handling happens only at approval stage
-
-            // Create payment for the return - ALL payment methods require payment records for healthcare compliance
-            // Payment validation was performed at method start, so we can proceed with confidence
-            if (currentBill.getPaymentMethod() != null) {
-                try {
-                    List<Payment> returnPayments = paymentService.createPayment(currentBill, getPaymentMethodData());
-                    if (returnPayments != null && !returnPayments.isEmpty()) {
-                        JsfUtil.addSuccessMessage("Payment created successfully for Direct Purchase return.");
-                    } else {
-                        // This should not happen since validation was done upfront, but handle defensively
-                        String errorMsg = "Unexpected payment creation failure - no payments were created for "
-                                + currentBill.getPaymentMethod().getLabel();
-                        JsfUtil.addErrorMessage(errorMsg);
-                        LOGGER.log(Level.SEVERE, errorMsg + " for bill: " + currentBill.getInsId()
-                                + " - This should not occur after successful validation");
-                    }
-                } catch (Exception e) {
-                    // This should not happen since validation was done upfront, but handle defensively
-                    String errorMsg = "Unexpected error creating payment for Direct Purchase return: " + e.getMessage();
-                    JsfUtil.addErrorMessage(errorMsg);
-                    LOGGER.log(Level.SEVERE, errorMsg + " - This should not occur after successful validation", e);
-                }
-            }
-
-            // Check if the original Direct Purchase is fully returned and mark it as fullReturned
-            Bill originalDirectPurchaseBill = currentBill.getReferenceBill();
-            if (originalDirectPurchaseBill != null && isDirectPurchaseFullyReturned(originalDirectPurchaseBill)) {
-                originalDirectPurchaseBill.setFullReturned(true);
-                originalDirectPurchaseBill.setFullReturnedBy(sessionController.getLoggedUser());
-                originalDirectPurchaseBill.setFullReturnedAt(new Date());
-                billFacade.edit(originalDirectPurchaseBill);
-                JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
-            }
-
-            // Ensure bill items are properly associated for print preview
-            ensureBillItemsForPreview();
-            printPreview = true;
-            JsfUtil.addSuccessMessage("Direct Purchase Return Approved Successfully");
+            completeApproval("Direct Purchase Return Approved Successfully");
         }
+    }
+
+    /**
+     * Performs the actual approval completion: marks the bill completed,
+     * deducts stock, creates payment, and updates the original Direct
+     * Purchase's full-returned status. Shared by approve() and by
+     * finalizeRequest() when the "Direct Purchase Return - Approval
+     * Required" config is disabled (#21404).
+     *
+     * Callers must have already run validateApproval() (and, for the
+     * finalize-without-approval path, saveBill(true) so getCheckedBy() is
+     * set, since validateApproval() requires the request to be finalized).
+     */
+    private void completeApproval(String successMessage) {
+        // Process zero quantity items before approval
+        processZeroQuantityItems();
+
+        // Mark the current bill as completed (approved)
+        currentBill.setCompleted(true);
+        currentBill.setCompletedBy(sessionController.getLoggedUser());
+        currentBill.setCompletedAt(new Date());
+        currentBill.setApproveAt(new Date());
+        currentBill.setApproveUser(sessionController.getLoggedUser());
+
+        // Save the bill with completed status
+        try {
+            billFacade.edit(currentBill);
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
+            return;
+        }
+
+        updateStock();  // Stock handling happens only at approval stage
+
+        // Create payment for the return - ALL payment methods require payment records for healthcare compliance
+        // Payment validation was performed at method start, so we can proceed with confidence
+        if (currentBill.getPaymentMethod() != null) {
+            try {
+                List<Payment> returnPayments = paymentService.createPayment(currentBill, getPaymentMethodData());
+                if (returnPayments != null && !returnPayments.isEmpty()) {
+                    JsfUtil.addSuccessMessage("Payment created successfully for Direct Purchase return.");
+                } else {
+                    // This should not happen since validation was done upfront, but handle defensively
+                    String errorMsg = "Unexpected payment creation failure - no payments were created for "
+                            + currentBill.getPaymentMethod().getLabel();
+                    JsfUtil.addErrorMessage(errorMsg);
+                    LOGGER.log(Level.SEVERE, errorMsg + " for bill: " + currentBill.getInsId()
+                            + " - This should not occur after successful validation");
+                }
+            } catch (Exception e) {
+                // This should not happen since validation was done upfront, but handle defensively
+                String errorMsg = "Unexpected error creating payment for Direct Purchase return: " + e.getMessage();
+                JsfUtil.addErrorMessage(errorMsg);
+                LOGGER.log(Level.SEVERE, errorMsg + " - This should not occur after successful validation", e);
+            }
+        }
+
+        // Check if the original Direct Purchase is fully returned and mark it as fullReturned
+        Bill originalDirectPurchaseBill = currentBill.getReferenceBill();
+        if (originalDirectPurchaseBill != null && isDirectPurchaseFullyReturned(originalDirectPurchaseBill)) {
+            originalDirectPurchaseBill.setFullReturned(true);
+            originalDirectPurchaseBill.setFullReturnedBy(sessionController.getLoggedUser());
+            originalDirectPurchaseBill.setFullReturnedAt(new Date());
+            billFacade.edit(originalDirectPurchaseBill);
+            JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
+        }
+
+        // Ensure bill items are properly associated for print preview
+        ensureBillItemsForPreview();
+        printPreview = true;
+        JsfUtil.addSuccessMessage(successMessage);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -1953,8 +1953,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
     }
 
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
-        if (billItem == null || billItem.getPharmaceuticalBillItem() == null
-                || billItem.getPharmaceuticalBillItem().getStock() == null) {
+        if (billItem == null || billItem.getPharmaceuticalBillItem() == null) {
             if (showMessages) {
                 JsfUtil.addErrorMessage("Stock information not available for item: "
                         + (billItem != null && billItem.getItem() != null ? billItem.getItem().getName() : "Unknown"));
@@ -1964,6 +1963,24 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
         PharmaceuticalBillItem phi = billItem.getPharmaceuticalBillItem();
         BillItemFinanceDetails fd = billItem.getBillItemFinanceDetails();
+
+        if (phi.getStock() == null) {
+            // The original purchase line had zero quantity, so no Stock record
+            // was ever created for it (see PharmacyDirectPurchaseController's
+            // settle/approve loops, which skip qty+freeQty==0 lines). Such a
+            // line carries forward into the return bill with qty 0 and has
+            // nothing to return, so it should not block the whole return.
+            double requestedQty = fd != null && fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
+            double requestedFreeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            if (requestedQty == 0.0 && requestedFreeQty == 0.0) {
+                return true;
+            }
+            if (showMessages) {
+                JsfUtil.addErrorMessage("Stock information not available for item: "
+                        + (billItem.getItem() != null ? billItem.getItem().getName() : "Unknown"));
+            }
+            return false;
+        }
 
         if (fd == null) {
             return true; // No quantities to validate
@@ -2014,6 +2031,16 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                     fd.setQuantity(BigDecimal.valueOf(availableForThisItem));
                     fd.setFreeQuantity(BigDecimal.ZERO);
                 }
+
+                // Keep PharmaceuticalBillItem.qty/freeQty (always stored in units,
+                // see syncQuantitiesAfterQuantityChange) in sync with the
+                // auto-corrected fd quantities. updateStock() at approval reads
+                // phi.getQty()/getFreeQty(), not fd - if these are left at their
+                // stale pre-correction values, a re-finalize after auto-correction
+                // approves the OLD (too-large) quantity instead of the corrected
+                // one (#21266 RC-followup).
+                phi.setQty(availableForThisItem);
+                phi.setFreeQty(0.0);
             }
             return false;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -2395,8 +2395,7 @@ public class GrnReturnWorkflowController implements Serializable {
     }
 
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
-        if (billItem == null || billItem.getPharmaceuticalBillItem() == null
-                || billItem.getPharmaceuticalBillItem().getStock() == null) {
+        if (billItem == null || billItem.getPharmaceuticalBillItem() == null) {
             if (showMessages) {
                 JsfUtil.addErrorMessage("Stock information not available for item: "
                         + (billItem != null && billItem.getItem() != null ? billItem.getItem().getName() : "Unknown"));
@@ -2406,6 +2405,24 @@ public class GrnReturnWorkflowController implements Serializable {
 
         PharmaceuticalBillItem phi = billItem.getPharmaceuticalBillItem();
         BillItemFinanceDetails fd = billItem.getBillItemFinanceDetails();
+
+        if (phi.getStock() == null) {
+            // The original GRN line had zero quantity, so no Stock record was
+            // ever created for it (the receive loop skips qty+freeQty==0
+            // lines). Such a line carries forward into the return bill with
+            // qty 0 and has nothing to return, so it should not block the
+            // whole return.
+            double requestedQty = fd != null && fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
+            double requestedFreeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            if (requestedQty == 0.0 && requestedFreeQty == 0.0) {
+                return true;
+            }
+            if (showMessages) {
+                JsfUtil.addErrorMessage("Stock information not available for item: "
+                        + (billItem.getItem() != null ? billItem.getItem().getName() : "Unknown"));
+            }
+            return false;
+        }
 
         if (fd == null) {
             return true; // No quantities to validate
@@ -2465,6 +2482,16 @@ public class GrnReturnWorkflowController implements Serializable {
                     fd.setTotalQuantityByUnits(BigDecimal.valueOf(availableForThisItem).negate());
                     fd.setTotalQuantity(BigDecimal.valueOf(availableForThisItem).negate());
                 }
+
+                // Keep PharmaceuticalBillItem.qty/freeQty (always stored in units,
+                // see syncQuantitiesAfterQuantityChange) in sync with the
+                // auto-corrected fd quantities. updateStock() at approval reads
+                // phi.getQty()/getFreeQty(), not fd - if these are left at their
+                // stale pre-correction values, a re-finalize after auto-correction
+                // approves the OLD (too-large) quantity instead of the corrected
+                // one (#21266 RC-followup).
+                phi.setQty(availableForThisItem);
+                phi.setFreeQty(0.0);
             }
             return false;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -655,6 +655,21 @@ public class GrnReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
+
+            // When approval is not required, complete (approve) the return
+            // immediately after finalization instead of leaving it pending
+            // for a separate approval step (#21404).
+            if (!configOptionApplicationController.getBooleanValueByKey("GRN Return - Approval Required", true)) {
+                if (!validateAllItemsStockAvailability(true, false)) {
+                    JsfUtil.addErrorMessage("Cannot finalize: insufficient stock for the return quantities.");
+                    return;
+                }
+                if (validateApproval()) {
+                    completeApproval("GRN Return Request Finalized and Approved Successfully");
+                }
+                return;
+            }
+
             // Ensure the bill items are properly associated with the current bill for print preview
             ensureBillItemsForPreview();
             printPreview = true;
@@ -763,86 +778,100 @@ public class GrnReturnWorkflowController implements Serializable {
         }
 
         if (validateApproval()) {
-            // Process zero quantity items before approval
-            processZeroQuantityItems();
-
-            // Approve re-submits the same form, so JSF rebinds fd.quantity / fd.freeQuantity
-            // to the positive number shown in the inputs. Re-apply the stock-out sign and
-            // persist each line so the approved bill keeps the correct sign. (hmislk/hmis#21052)
-            normalizeReturnFinanceSigns();
-            if (billItems != null) {
-                for (BillItem bi : billItems) {
-                    if (bi == null || bi.isRetired() || bi.getId() == null) {
-                        continue;
-                    }
-                    billItemFacade.edit(bi);
-                }
-            }
-
-            // Mark the current bill as completed (approved)
-            currentBill.setCompleted(true);
-            currentBill.setCompletedBy(sessionController.getLoggedUser());
-            currentBill.setCompletedAt(new Date());
-            currentBill.setApproveAt(new Date());
-            currentBill.setApproveUser(sessionController.getLoggedUser());
-
-            // Save the bill with completed status
-            try {
-                billFacade.edit(currentBill);
-            } catch (Exception e) {
-                JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
-                return;
-            }
-
-            if (!updateStock()) {
-                // Roll back completed status — stock deduction failed for one or more items
-                currentBill.setCompleted(false);
-                currentBill.setCompletedBy(null);
-                currentBill.setCompletedAt(null);
-                currentBill.setApproveAt(null);
-                currentBill.setApproveUser(null);
-                billFacade.edit(currentBill);
-                return;
-            }
-
-            // Create payment for the return - ALL payment methods require payment records for healthcare compliance
-            // Payment validation was performed at method start, so we can proceed with confidence
-            if (currentBill.getPaymentMethod() != null) {
-                try {
-                    List<Payment> returnPayments = paymentService.createPayment(currentBill, getPaymentMethodData());
-                    if (returnPayments != null && !returnPayments.isEmpty()) {
-                        JsfUtil.addSuccessMessage("Payment created successfully for GRN return.");
-                    } else {
-                        // This should not happen since validation was done upfront, but handle defensively
-                        String errorMsg = "Unexpected payment creation failure - no payments were created for "
-                                + currentBill.getPaymentMethod().getLabel();
-                        JsfUtil.addErrorMessage(errorMsg);
-                        LOGGER.log(Level.SEVERE, errorMsg + " for bill: " + currentBill.getInsId()
-                                + " - This should not occur after successful validation");
-                    }
-                } catch (Exception e) {
-                    // This should not happen since validation was done upfront, but handle defensively
-                    String errorMsg = "Unexpected error creating payment for GRN return: " + e.getMessage();
-                    JsfUtil.addErrorMessage(errorMsg);
-                    LOGGER.log(Level.SEVERE, errorMsg + " - This should not occur after successful validation", e);
-                }
-            }
-
-            // Check if the original GRN is fully returned and mark it as fullReturned
-            Bill originalGrnBill = currentBill.getReferenceBill();
-            if (originalGrnBill != null && isGrnFullyReturned(originalGrnBill)) {
-                originalGrnBill.setFullReturned(true);
-                originalGrnBill.setFullReturnedBy(sessionController.getLoggedUser());
-                originalGrnBill.setFullReturnedAt(new Date());
-                billFacade.edit(originalGrnBill);
-                JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
-            }
-
-            // Ensure bill items are properly associated for print preview
-            ensureBillItemsForPreview();
-            printPreview = true;
-            JsfUtil.addSuccessMessage("GRN Return Approved Successfully");
+            completeApproval("GRN Return Approved Successfully");
         }
+    }
+
+    /**
+     * Performs the actual approval completion: marks the bill completed,
+     * deducts stock, creates payment, and updates the original GRN's
+     * full-returned status. Shared by approve() and by finalizeRequest()
+     * when the "GRN Return - Approval Required" config is disabled (#21404).
+     *
+     * Callers must have already run validateApproval() (and, for the
+     * finalize-without-approval path, saveBill(true) so getCheckedBy() is
+     * set, since validateApproval() requires the request to be finalized).
+     */
+    private void completeApproval(String successMessage) {
+        // Process zero quantity items before approval
+        processZeroQuantityItems();
+
+        // Approve re-submits the same form, so JSF rebinds fd.quantity / fd.freeQuantity
+        // to the positive number shown in the inputs. Re-apply the stock-out sign and
+        // persist each line so the approved bill keeps the correct sign. (hmislk/hmis#21052)
+        normalizeReturnFinanceSigns();
+        if (billItems != null) {
+            for (BillItem bi : billItems) {
+                if (bi == null || bi.isRetired() || bi.getId() == null) {
+                    continue;
+                }
+                billItemFacade.edit(bi);
+            }
+        }
+
+        // Mark the current bill as completed (approved)
+        currentBill.setCompleted(true);
+        currentBill.setCompletedBy(sessionController.getLoggedUser());
+        currentBill.setCompletedAt(new Date());
+        currentBill.setApproveAt(new Date());
+        currentBill.setApproveUser(sessionController.getLoggedUser());
+
+        // Save the bill with completed status
+        try {
+            billFacade.edit(currentBill);
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
+            return;
+        }
+
+        if (!updateStock()) {
+            // Roll back completed status — stock deduction failed for one or more items
+            currentBill.setCompleted(false);
+            currentBill.setCompletedBy(null);
+            currentBill.setCompletedAt(null);
+            currentBill.setApproveAt(null);
+            currentBill.setApproveUser(null);
+            billFacade.edit(currentBill);
+            return;
+        }
+
+        // Create payment for the return - ALL payment methods require payment records for healthcare compliance
+        // Payment validation was performed at method start, so we can proceed with confidence
+        if (currentBill.getPaymentMethod() != null) {
+            try {
+                List<Payment> returnPayments = paymentService.createPayment(currentBill, getPaymentMethodData());
+                if (returnPayments != null && !returnPayments.isEmpty()) {
+                    JsfUtil.addSuccessMessage("Payment created successfully for GRN return.");
+                } else {
+                    // This should not happen since validation was done upfront, but handle defensively
+                    String errorMsg = "Unexpected payment creation failure - no payments were created for "
+                            + currentBill.getPaymentMethod().getLabel();
+                    JsfUtil.addErrorMessage(errorMsg);
+                    LOGGER.log(Level.SEVERE, errorMsg + " for bill: " + currentBill.getInsId()
+                            + " - This should not occur after successful validation");
+                }
+            } catch (Exception e) {
+                // This should not happen since validation was done upfront, but handle defensively
+                String errorMsg = "Unexpected error creating payment for GRN return: " + e.getMessage();
+                JsfUtil.addErrorMessage(errorMsg);
+                LOGGER.log(Level.SEVERE, errorMsg + " - This should not occur after successful validation", e);
+            }
+        }
+
+        // Check if the original GRN is fully returned and mark it as fullReturned
+        Bill originalGrnBill = currentBill.getReferenceBill();
+        if (originalGrnBill != null && isGrnFullyReturned(originalGrnBill)) {
+            originalGrnBill.setFullReturned(true);
+            originalGrnBill.setFullReturnedBy(sessionController.getLoggedUser());
+            originalGrnBill.setFullReturnedAt(new Date());
+            billFacade.edit(originalGrnBill);
+            JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
+        }
+
+        // Ensure bill items are properly associated for print preview
+        ensureBillItemsForPreview();
+        printPreview = true;
+        JsfUtil.addSuccessMessage(successMessage);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1409,7 +1409,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
         bill = (com.divudi.core.entity.BilledBill) freshBill;
 
         JsfUtil.addSuccessMessage("Direct Purchase finalized. It is now pending approval.");
-        printPreview = false;
+        printPreview = true;
     }
 
     public void approveDirectPurchaseDraft() {
@@ -1503,6 +1503,14 @@ public class PharmacyDirectPurchaseController implements Serializable {
             Stock stock = getPharmacyBean().addToStockForCosting(i, Math.abs(addingQty), getSessionController().getDepartment());
             i.getPharmaceuticalBillItem().setLastPurchaseRate(lastPurchaseRate);
             i.getPharmaceuticalBillItem().setStock(stock);
+            // Persist the stock link explicitly. Unlike the settle path (where
+            // the bill and items are an in-memory graph fully merged at the end),
+            // here the items were reloaded from DB and the detached bill's lazy
+            // billItems collection does not carry this change through the final
+            // bill merge - without this edit, phi.stock stays NULL in the DB and
+            // a later Direct Purchase Return fails with "Stock information not
+            // available for item".
+            getBillItemFacade().edit(i);
             getBill().getBillItems().add(i);
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
@@ -20,6 +20,7 @@ public class PharmacyReturnApprovalConfigController implements Serializable {
 
     private boolean grnReturnApprovalRequired;
     private boolean directPurchaseReturnApprovalRequired;
+    private boolean directPurchaseApprovalRequired;
 
     public PharmacyReturnApprovalConfigController() {
     }
@@ -27,12 +28,14 @@ public class PharmacyReturnApprovalConfigController implements Serializable {
     public void loadCurrentConfig() {
         grnReturnApprovalRequired = configOptionApplicationController.getBooleanValueByKey("GRN Return - Approval Required", true);
         directPurchaseReturnApprovalRequired = configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return - Approval Required", true);
+        directPurchaseApprovalRequired = configOptionApplicationController.getBooleanValueByKey("Use Save Finalize Approve Workflow for Direct Purchase", false);
     }
 
     public void saveConfig() {
         try {
             configOptionApplicationController.setBooleanValueByKey("GRN Return - Approval Required", grnReturnApprovalRequired);
             configOptionApplicationController.setBooleanValueByKey("Direct Purchase Return - Approval Required", directPurchaseReturnApprovalRequired);
+            configOptionApplicationController.setBooleanValueByKey("Use Save Finalize Approve Workflow for Direct Purchase", directPurchaseApprovalRequired);
 
             JsfUtil.addSuccessMessage("Procurement return configuration saved successfully");
 
@@ -56,5 +59,13 @@ public class PharmacyReturnApprovalConfigController implements Serializable {
 
     public void setDirectPurchaseReturnApprovalRequired(boolean directPurchaseReturnApprovalRequired) {
         this.directPurchaseReturnApprovalRequired = directPurchaseReturnApprovalRequired;
+    }
+
+    public boolean isDirectPurchaseApprovalRequired() {
+        return directPurchaseApprovalRequired;
+    }
+
+    public void setDirectPurchaseApprovalRequired(boolean directPurchaseApprovalRequired) {
+        this.directPurchaseApprovalRequired = directPurchaseApprovalRequired;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
@@ -1,0 +1,60 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.util.JsfUtil;
+import javax.inject.Named;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import java.io.Serializable;
+
+/**
+ * Controller for managing approval-requirement settings for pharmacy
+ * GRN and Direct Purchase Returns (#21404).
+ */
+@Named
+@ViewScoped
+public class PharmacyReturnApprovalConfigController implements Serializable {
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    private boolean grnReturnApprovalRequired;
+    private boolean directPurchaseReturnApprovalRequired;
+
+    public PharmacyReturnApprovalConfigController() {
+    }
+
+    public void loadCurrentConfig() {
+        grnReturnApprovalRequired = configOptionApplicationController.getBooleanValueByKey("GRN Return - Approval Required", true);
+        directPurchaseReturnApprovalRequired = configOptionApplicationController.getBooleanValueByKey("Direct Purchase Return - Approval Required", true);
+    }
+
+    public void saveConfig() {
+        try {
+            configOptionApplicationController.setBooleanValueByKey("GRN Return - Approval Required", grnReturnApprovalRequired);
+            configOptionApplicationController.setBooleanValueByKey("Direct Purchase Return - Approval Required", directPurchaseReturnApprovalRequired);
+
+            JsfUtil.addSuccessMessage("Procurement return configuration saved successfully");
+
+            loadCurrentConfig();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving configuration: " + e.getMessage());
+        }
+    }
+
+    public boolean isGrnReturnApprovalRequired() {
+        return grnReturnApprovalRequired;
+    }
+
+    public void setGrnReturnApprovalRequired(boolean grnReturnApprovalRequired) {
+        this.grnReturnApprovalRequired = grnReturnApprovalRequired;
+    }
+
+    public boolean isDirectPurchaseReturnApprovalRequired() {
+        return directPurchaseReturnApprovalRequired;
+    }
+
+    public void setDirectPurchaseReturnApprovalRequired(boolean directPurchaseReturnApprovalRequired) {
+        this.directPurchaseReturnApprovalRequired = directPurchaseReturnApprovalRequired;
+    }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnApprovalConfigController.java
@@ -1,6 +1,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import javax.inject.Named;
 import javax.faces.view.ViewScoped;
@@ -17,6 +18,8 @@ public class PharmacyReturnApprovalConfigController implements Serializable {
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private WebUserController webUserController;
 
     private boolean grnReturnApprovalRequired;
     private boolean directPurchaseReturnApprovalRequired;
@@ -32,6 +35,14 @@ public class PharmacyReturnApprovalConfigController implements Serializable {
     }
 
     public void saveConfig() {
+        // Server-side guard: the Config button is privilege-gated in the UI,
+        // but the dialog form itself is always in the component tree, so the
+        // action is invocable without it. Mirror the button's rendered check.
+        if (!webUserController.hasPrivilege("PharmacyGrnApprove")
+                && !webUserController.hasPrivilege("PharmacyDirectPurchaseApprove")) {
+            JsfUtil.addErrorMessage("You do not have permission to modify procurement return configuration.");
+            return;
+        }
         try {
             configOptionApplicationController.setBooleanValueByKey("GRN Return - Approval Required", grnReturnApprovalRequired);
             configOptionApplicationController.setBooleanValueByKey("Direct Purchase Return - Approval Required", directPurchaseReturnApprovalRequired);

--- a/src/main/webapp/pharmacy/procurement_index.xhtml
+++ b/src/main/webapp/pharmacy/procurement_index.xhtml
@@ -14,6 +14,20 @@
         </div>
 
         <div class="row">
+            <div class="col-12 d-flex justify-content-end">
+                <p:commandButton
+                    id="procurementConfigButton"
+                    value="Config"
+                    icon="fa fa-cog"
+                    title="Procurement Return Configuration"
+                    type="button"
+                    class="ui-button-secondary"
+                    onclick="PF('procurementReturnConfigDialog').show();"
+                    rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove') or webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}" />
+            </div>
+        </div>
+
+        <div class="row">
             <div class="col-2">
                 <h:form>
                     <p:accordionPanel activeIndex="0">
@@ -177,6 +191,73 @@
                 </ui:insert>
             </div>
         </div>
+
+        <p:dialog id="procurementReturnConfigDialog"
+                  header="Procurement Return Configuration"
+                  widgetVar="procurementReturnConfigDialog"
+                  modal="true"
+                  width="600"
+                  height="auto"
+                  resizable="true"
+                  closeOnEscape="true">
+
+            <p:ajax event="open" listener="#{pharmacyReturnApprovalConfigController.loadCurrentConfig}" update="procurementReturnConfigForm" />
+
+            <h:form id="procurementReturnConfigForm">
+
+                <div class="row">
+                    <div class="col-12">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <h6><i class="fas fa-check-circle"></i> Return Approval Settings</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox
+                                        id="grnReturnApprovalRequired"
+                                        value="#{pharmacyReturnApprovalConfigController.grnReturnApprovalRequired}" />
+                                    <p:outputLabel for="grnReturnApprovalRequired" value="GRN Return - Approval Required" class="ms-2" />
+                                    <small class="form-text text-muted d-block">When enabled (default), a GRN Return must be Finalized and then separately Approved before stock and payments are processed. When disabled, Finalize completes the return immediately.</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox
+                                        id="directPurchaseReturnApprovalRequired"
+                                        value="#{pharmacyReturnApprovalConfigController.directPurchaseReturnApprovalRequired}" />
+                                    <p:outputLabel for="directPurchaseReturnApprovalRequired" value="Direct Purchase Return - Approval Required" class="ms-2" />
+                                    <small class="form-text text-muted d-block">When enabled (default), a Direct Purchase Return must be Finalized and then separately Approved before stock and payments are processed. When disabled, Finalize completes the return immediately.</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mt-4">
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-body">
+                                <p:messages id="procurementReturnConfigMessages" showDetail="true" closable="true" />
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Apply &amp; Close"
+                                        icon="fas fa-save"
+                                        class="ui-button-success"
+                                        ajax="false"
+                                        action="#{pharmacyReturnApprovalConfigController.saveConfig}" />
+                                    <p:commandButton
+                                        value="Cancel"
+                                        icon="fas fa-times"
+                                        class="ui-button-secondary"
+                                        onclick="PF('procurementReturnConfigDialog').hide(); return false;"
+                                        type="button" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </h:form>
+        </p:dialog>
 
     </ui:define>
 

--- a/src/main/webapp/pharmacy/procurement_index.xhtml
+++ b/src/main/webapp/pharmacy/procurement_index.xhtml
@@ -13,19 +13,7 @@
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-12 d-flex justify-content-end">
-                <p:commandButton
-                    id="procurementConfigButton"
-                    value="Config"
-                    icon="fa fa-cog"
-                    title="Procurement Return Configuration"
-                    type="button"
-                    class="ui-button-secondary"
-                    onclick="PF('procurementReturnConfigDialog').show();"
-                    rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove') or webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}" />
-            </div>
-        </div>
+
 
         <div class="row">
             <div class="col-2">
@@ -160,6 +148,20 @@
                             </p:panelGrid>
                         </p:tab>
 
+                        <p:tab title="Admin">
+                            <p:panelGrid columns="1">
+                                <p:commandButton
+                                    id="procurementConfigButton"
+                                    value="Config"
+                                    icon="fa fa-cog"
+                                    title="Procurement Return Configuration"
+                                    type="button"
+                                    class="ui-button-secondary w-100"
+                                    onclick="PF('procurementReturnConfigDialog').show();"
+                                    rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove') or webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}" />
+                            </p:panelGrid>
+                        </p:tab>
+
                     </p:accordionPanel>
                 </h:form>
             </div>
@@ -226,6 +228,14 @@
                                         value="#{pharmacyReturnApprovalConfigController.directPurchaseReturnApprovalRequired}" />
                                     <p:outputLabel for="directPurchaseReturnApprovalRequired" value="Direct Purchase Return - Approval Required" class="ms-2" />
                                     <small class="form-text text-muted d-block">When enabled (default), a Direct Purchase Return must be Finalized and then separately Approved before stock and payments are processed. When disabled, Finalize completes the return immediately.</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox
+                                        id="directPurchaseApprovalRequired"
+                                        value="#{pharmacyReturnApprovalConfigController.directPurchaseApprovalRequired}" />
+                                    <p:outputLabel for="directPurchaseApprovalRequired" value="Direct Purchase - Approval Required" class="ms-2" />
+                                    <small class="form-text text-muted d-block">When enabled, a Direct Purchase must be Saved, then Finalized, and then separately Approved before stock and payments are processed (the single-step "Settle" button is hidden). When disabled (default), the "Settle" button completes the purchase immediately in one step.</small>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary

Adds optional approval workflows for procurement and fixes three bugs found while testing them.

### New configuration (Procurement page → Admin tab → Config)

The "Procurement Return Configuration" dialog now has three toggles:

| Toggle | Default | Effect |
|---|---|---|
| GRN Return - Approval Required | ON | GRN Return needs Finalize, then separate Approve |
| Direct Purchase Return - Approval Required | ON | Same two-stage flow for DP Returns |
| Direct Purchase - Approval Required | OFF | DP uses Save Draft → Finalize → Approve; single-step Settle hidden |

The third toggle maps to the existing config key `Use Save Finalize Approve Workflow for Direct Purchase` — no new key introduced.

### Bug fixes

1. **Missing stock link after draft approval** — `approveDirectPurchaseDraft()` set `phi.setStock(stock)` in memory but never persisted it (`StockHistory` creation merges the phi mid-loop, before the stock is set, which is why `ITEMBATCH_ID` was saved but `STOCK_ID` stayed NULL). Any Direct Purchase Return against such a bill failed with *"Stock information not available for item"*. Fixed with an explicit `billItemFacade.edit(i)` after the stock link is set. Verified against local DB: settle-path bills had `STOCK_ID` set, draft-approved bills had NULL.

2. **Auto-correct quantity not synced to phi** — in GRN/DP return `validateStockAvailability()`, the auto-correct path rewrote `fd` quantities but left `phi.qty/freeQty` stale. A re-finalize after auto-correction then approved the old oversized quantity, producing "Cannot approve: insufficient stock... Available: X, Requested: 2X". Both controllers now sync phi with the corrected values.

3. **Zero-quantity lines blocked returns** — purchase/GRN lines with qty 0 never get a Stock record (the receive/settle loops skip them), but the return form still lists them, and validation rejected the whole return. Zero-qty lines with no stock record now pass validation; non-zero requests against a missing stock record still fail correctly.

### Behaviour change

After **Finalize** of a draft Direct Purchase, the page switches to the read-only bill/print preview (no further edits). There is intentionally no Approve button on the preview — approval is done from the **Approve Direct Purchase** list only. Starting a new bill resets the form to edit mode.

## Test plan

- Full Playwright E2E script: `tmp/playwright_test_prompt_grn_dpr_return_approval_config.md` (config dialog, both return toggles ON/OFF, DP draft workflow, regression tests for all three bug fixes, Bin Card + COGS verification)
- DB sanity query used for verification: GRN/DP/DP-Return lines with `STOCK_ID IS NULL` and non-zero qty — zero rows after fix

Part of #21404
Refs #21266

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI to enable/disable approval requirements for pharmacy return workflows (GRN and direct purchase), with server-side privilege check.

* **Improvements**
  * When approval is disabled, returns can complete immediately with stricter stock validation.
  * Stock auto-correction now updates returned item quantities to stay synchronized and avoids stale values.
  * Better handling of lines with no stock info (allows zero-quantity lines, blocks others).
  * Finalized direct purchases now default to print-preview.
  * Ensures stock associations are persisted during draft approvals to prevent later failures.

* **Bug Fixes**
  * Safer completion flow with rollback on stock deduction failures and reliable payment/return state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->