### PR TITLE
fix(pharmacy): guard Enter key on direct purchase entry fields against defaultCommand race

### DIFF
--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -128,6 +128,7 @@
                                             id="acItem"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.item}"
                                             forceSelection="true"
+                                            onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                             completeMethod="#{pharmacyDirectPurchaseController.completeItemsFilteredByDepartmentType}"
                                             var="vt"
                                             maxResults="20"
@@ -157,6 +158,8 @@
                                             id="txtQty"
                                             class="w-100 m-1 text-end"
                                             autocomplete="off"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.quantity}">
                                             <p:ajax
                                                 event="blur"
@@ -176,6 +179,8 @@
                                             autocomplete="off"
                                             id="txtFreeQty"
                                             class="w-100 m-1 text-end"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.freeQuantity}">
                                             <!--<f:convertNumber integerOnly="#{!pharmacyDirectPurchaseController.currentBillItem.item.allowFractions}" />-->
                                             <p:ajax
@@ -195,6 +200,8 @@
                                             id="txtPrate"
                                             autocomplete="off"
                                             class="w-100 m-1 text-end"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.lineGrossRate}">
                                             <p:ajax 
                                                 event="blur"
@@ -220,6 +227,8 @@
                                             autocomplete="off"
                                             onfocus="this.select()"
                                             class="w-100 m-1 text-end"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.lineDiscountRate}">
                                             <p:ajax 
                                                 event="blur"
@@ -243,6 +252,8 @@
                                             id="txtRetailRate"
                                             onfocus="this.select()"
                                             class="w-100 m-1 text-end"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.billItemFinanceDetails.retailSaleRate}">
                                             <f:convertNumber pattern="#,##0.00" />
                                             <p:ajax 
@@ -278,6 +289,8 @@
                                             autocomplete="off"
                                             class="w-100 m-1"
                                             id="tmp"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); var addBtnId = '#{p:resolveFirstComponentWithId('btnAdd',view).clientId}'; this.blur(); setTimeout(function () { document.getElementById(addBtnId).click(); }, 350); }"
                                             value="#{pharmacyDirectPurchaseController.currentBillItem.pharmaceuticalBillItem.stringValue}"  />
                                     </div>
 
@@ -654,6 +667,7 @@
                                                 inputStyleClass="w-100"
                                                 value="#{pharmacyDirectPurchaseController.currentExpense.item}"
                                                 forceSelection="true"
+                                                onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                                 minQueryLength="3" queryDelay="300" completeMethod="#{itemController.completeExpenseItem}"
                                                 var="ex"
                                                 itemLabel="#{ex.name}"
@@ -675,15 +689,19 @@
                                                 class="w-100 m-1 text-end"
                                                 onfocus="this.select()"
                                                 styleClass="numericTxt"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); document.getElementById('#{p:resolveFirstComponentWithId('btnAddExpense',view).clientId}').click(); }"
                                                 value="#{pharmacyDirectPurchaseController.currentExpense.rate}" />
                                         </div>
                                         <div class="col-3">
                                             <h:outputLabel 
                                                 class="w-100 m-1"
                                                 value="Description"/><br/>
-                                            <p:inputText 
+                                            <p:inputText
                                                 class="w-100 m-1"
-                                                maxlength="250" 
+                                                maxlength="250"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); document.getElementById('#{p:resolveFirstComponentWithId('btnAddExpense',view).clientId}').click(); }"
                                                 value="#{pharmacyDirectPurchaseController.currentExpense.descreption}" />
                                         </div>
                                         <div class="col-2">
@@ -785,6 +803,7 @@
                                         converter="deal"
                                         value="#{pharmacyDirectPurchaseController.bill.fromInstitution}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         completeMethod="#{dealerController.completeActiveDealor}"
                                         var="vt"
                                         maxResults="10"
@@ -797,6 +816,7 @@
                                         value="#{pharmacyDirectPurchaseController.bill.referenceInstitution}"
                                         completeMethod="#{institutionController.completeCompany}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         var="vt"
                                         itemLabel="#{vt.name}"
                                         itemValue="#{vt}" />


### PR DESCRIPTION
## Summary

Fixes #21415 — on `pharmacy/direct_purchase.xhtml`, the page-level `<p:defaultCommand target="btnAdd"/>` made **Enter anywhere in the form fire the item Add button**, causing two problems:

1. **Autocomplete race**: pressing Enter to pick a suggestion in the item autocomplete could fire Add *before* the `itemSelect` AJAX committed the selection server-side (with `forceSelection="true"` the input text is cosmetic). Result: `"Please select an item"` even though the item was visibly selected. Reproduced both by hand and by an E2E automation session.
2. **Silent value loss**: the qty/rate/discount fields recalculate on `blur` AJAX, which `defaultCommand` bypasses — Enter mid-edit added the line using the stale, pre-edit values and the typed value was overwritten by the AJAX update.

## Fix

Applies the Enter-guard pattern already established on `pharmacy_transfer_request.xhtml` (live-tested 2026-06-06):

| Control(s) | Enter now does |
|---|---|
| Item autocomplete (`acItem`), expense autocomplete (`acExpense`), distributor, reference company | Swallowed unless the suggestion panel is open; when open, PrimeFaces handles selection only — never reaches `defaultCommand` |
| `txtQty`, `txtFreeQty`, `txtPrate`, `txtLineDiscountRate`, `txtRetailRate`, batch no | Blurs the field first (committing the blur-AJAX recalculation), then clicks **Add** after 350 ms |
| Expense value / description | Clicks **Add Expense** (its full-submit processing has no blur race) instead of the unrelated item Add button |

`p:defaultCommand` itself is retained for the remaining benign cases.

XHTML-only change — no Java, no compilation impact.

## Test plan

- Type an item name in the autocomplete, press Enter while the suggestion panel is open → suggestion selected, **no** "Please select an item", no item added prematurely.
- Press Enter in the autocomplete with the panel closed → nothing happens.
- Select item, type quantity, press Enter → blur recalculation runs, then the line is added with the typed quantity.
- Type a purchase/retail/discount rate and press Enter → line added with the **typed** value, not the previous one.
- In Bill Expenses: pick an expense, type a value, press Enter → expense row added via Add Expense; no item-row side effects.
- Distributor / reference company autocompletes: Enter selects from the open panel only; no Add-button errors.

Closes #21415

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Enter key handling in the pharmacy purchase form. Pressing Enter while entering data in "Add New Item", "Bill Expenses", and "Purchasing Details" sections now automatically submits the input without requiring an additional button click, enabling faster data entry workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->