### PR TITLE
hotfix(pharmacy): coop — PO request PBI fixes + stock-integrity fixes from #21401

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,19 @@ claude-*.jsonl
 
 # Claude Code temporary working directories
 tmpclaude-*
+
+# Playwright MCP session data
+.playwright-mcp/
+
+# Claude Code session state files (YAML artifacts from AI sessions)
+*-auto.yml
+*-pre-process.yml
+*-result.yml
+*-state.yml
+*-autocomplete.yml
+
+# Debug/investigation screenshots at project root
+/*.png
+
+# Test results directory
+/test-results/

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -388,6 +388,61 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveDirectPurchaseReturn")) {
             return;
@@ -413,9 +468,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -1833,6 +1898,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -1877,8 +1948,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -1965,6 +2041,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -1989,7 +2069,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
@@ -341,29 +341,47 @@ public class DisposalReturnWorkflowController implements Serializable {
      * @param returnBillToClose The return bill to close
      */
     public void closeDisposalReturn(Bill returnBillToClose) {
-        if (returnBillToClose == null) {
+        if (returnBillToClose == null || returnBillToClose.getId() == null) {
             JsfUtil.addErrorMessage("No disposal return selected to close");
             return;
         }
 
+        // The row passed in comes from a list loaded earlier in the session and can
+        // be STALE - the return may have been settled after the list was loaded.
+        // Validating and merging the stale entity reverted settled bills back to
+        // drafts (completed/completedAt/deptId/insId cleared) while their items and
+        // stock movements remained - the #21266 RC5 orphan-return corruption
+        // (Ruhunu bills 4336218 / 4337297, 2026-03-25). Always validate and edit
+        // the CURRENT row, bypassing the L2 cache (another app server may have
+        // written it under dual-version operation).
+        Bill freshBill = billFacade.findWithoutCache(returnBillToClose.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Disposal return not found");
+            return;
+        }
+
         // Verify the bill is not already completed
-        if (returnBillToClose.isCompleted()) {
+        if (freshBill.isCompleted()) {
             JsfUtil.addErrorMessage("Cannot close a completed disposal return");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         // Verify the bill is not already closed
-        if (returnBillToClose.isBillClosed()) {
+        if (freshBill.isBillClosed()) {
             JsfUtil.addErrorMessage("This disposal return is already closed");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         try {
             // Mark the bill as closed
-            returnBillToClose.setBillClosed(true);
+            freshBill.setBillClosed(true);
 
             // Save the changes
-            billFacade.edit(returnBillToClose);
+            billFacade.edit(freshBill);
 
             // Refresh the lists
             fillDisposalReturnsToFinalize();

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -30,6 +30,8 @@ import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.BillService;
 import com.divudi.core.data.PaymentMethod;
@@ -83,6 +85,8 @@ public class GrnReturnWorkflowController implements Serializable {
     private BillItemFacade billItemFacade;
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private StockFacade stockFacade;
     @EJB
     private PharmacyBean pharmacyBean;
     @EJB
@@ -1039,6 +1043,52 @@ public class GrnReturnWorkflowController implements Serializable {
 
     // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
     private boolean updateStock() {
+        // Phase 1: pre-deduction availability check — reads fresh DB stock for every
+        // item and accumulates total requested qty per stock record.  No mutations are
+        // made here, so a failure leaves the database completely unchanged.
+        Map<Long, Double> requestedByStockId = new HashMap<>();
+        Map<Long, String> itemNameByStockId = new HashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.isRetired()) {
+                continue;
+            }
+            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
+            if (phi == null || phi.getStock() == null || phi.getStock().getId() == null) {
+                continue;
+            }
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
+            if (absQty == 0) {
+                continue;
+            }
+            Long stockId = phi.getStock().getId();
+            requestedByStockId.merge(stockId, absQty, Double::sum);
+            itemNameByStockId.putIfAbsent(stockId,
+                    bi.getItem() != null ? bi.getItem().getName() : "Unknown");
+        }
+
+        boolean preCheckPassed = true;
+        for (Map.Entry<Long, Double> entry : requestedByStockId.entrySet()) {
+            Long stockId = entry.getKey();
+            double totalRequested = entry.getValue();
+            Stock freshStock = stockFacade.find(stockId);
+            double available = (freshStock != null && freshStock.getStock() != null)
+                    ? freshStock.getStock() : 0.0;
+            if (available < totalRequested) {
+                String itemName = itemNameByStockId.getOrDefault(stockId, "Unknown");
+                LOGGER.log(Level.WARNING,
+                        "Pre-deduction stock check failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, totalRequested});
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \""
+                        + itemName + "\". Available: " + String.format("%.2f", available)
+                        + ", Requested: " + String.format("%.2f", totalRequested) + ".");
+                preCheckPassed = false;
+            }
+        }
+        if (!preCheckPassed) {
+            return false;
+        }
+
+        // Phase 2: all items passed the pre-check — proceed with deductions.
         for (BillItem bi : billItems) {
             if (bi.isRetired()) {
                 continue;
@@ -1063,9 +1113,12 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
+                // Pre-check passed but deductFromStock still failed — concurrent transaction
+                // drained the stock between our check and this deduction.
                 String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
                 double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
-                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                LOGGER.log(Level.WARNING,
+                        "Stock deduction failed after pre-check for item: {0}, available: {1}, requested: {2}",
                         new Object[]{itemName, available, absQty});
                 phi.setQty(Math.abs(phi.getQty()));
                 phi.setFreeQty(Math.abs(phi.getFreeQty()));
@@ -1080,7 +1133,6 @@ public class GrnReturnWorkflowController implements Serializable {
         if (currentBill != null && currentBill.getBillFinanceDetails() != null) {
             BillFinanceDetails bfd = currentBill.getBillFinanceDetails();
 
-            // Negate the purchase, cost, and retail values at bill level
             if (bfd.getTotalPurchaseValue() != null) {
                 bfd.setTotalPurchaseValue(bfd.getTotalPurchaseValue().abs().negate());
             }
@@ -1091,7 +1143,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 bfd.setTotalRetailSaleValue(bfd.getTotalRetailSaleValue().abs().negate());
             }
 
-            // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
         return true;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -658,6 +658,61 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveGrnReturn")) {
             return;
@@ -683,9 +738,19 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -2155,6 +2220,12 @@ public class GrnReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -2199,8 +2270,13 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -2296,6 +2372,10 @@ public class GrnReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2320,7 +2400,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -773,7 +773,16 @@ public class GrnReturnWorkflowController implements Serializable {
                 return;
             }
 
-            updateStock();  // Stock handling happens only at approval stage
+            if (!updateStock()) {
+                // Roll back completed status — stock deduction failed for one or more items
+                currentBill.setCompleted(false);
+                currentBill.setCompletedBy(null);
+                currentBill.setCompletedAt(null);
+                currentBill.setApproveAt(null);
+                currentBill.setApproveUser(null);
+                billFacade.edit(currentBill);
+                return;
+            }
 
             // Create payment for the return - ALL payment methods require payment records for healthcare compliance
             // Payment validation was performed at method start, so we can proceed with confidence
@@ -918,6 +927,9 @@ public class GrnReturnWorkflowController implements Serializable {
             currentBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
             currentBill.setInstitution(sessionController.getInstitution());
             currentBill.setDepartment(sessionController.getDepartment());
+            if (sessionController.getDepartment() != null) {
+                currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            }
             currentBill.setCreater(sessionController.getLoggedUser());
             currentBill.setCreatedAt(new Date());
 
@@ -1025,31 +1037,24 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
-    // Stock handling - only at approval stage
-    private void updateStock() {
+    // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
+    private boolean updateStock() {
         for (BillItem bi : billItems) {
-            // Skip only retired items or items with truly zero quantities
             if (bi.isRetired()) {
                 continue;
             }
 
             PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-            double totalQty = phi.getQty() + phi.getFreeQty();
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
 
-            // Skip stock processing for zero quantity items (no stock impact)
-            if (totalQty == 0) {
+            if (absQty == 0) {
                 continue;
             }
 
-            // For returns: make quantities negative before saving, use absolute value for stock deduction
-            double absQty = Math.abs(totalQty);
             phi.setQty(-Math.abs(phi.getQty()));
             phi.setFreeQty(-Math.abs(phi.getFreeQty()));
-
-            // Save the pharmaceutical bill item with negative quantities
             pharmaceuticalBillItemFacade.edit(phi);
 
-            // Deduct from stock for return (use absolute value)
             boolean returnFlag = pharmacyBean.deductFromStock(
                     phi.getStock(),
                     absQty,
@@ -1058,11 +1063,16 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
-                LOGGER.log(Level.WARNING, "Unable to deduct stock for item: {0}", bi.getItem().getName());
-                // Reset quantities if stock deduction failed
-                phi.setQty(0);
-                phi.setFreeQty(0);
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
+                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, absQty});
+                phi.setQty(Math.abs(phi.getQty()));
+                phi.setFreeQty(Math.abs(phi.getFreeQty()));
                 pharmaceuticalBillItemFacade.edit(phi);
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \"" + itemName
+                        + "\". Available: " + available + ", Requested: " + absQty + ".");
+                return false;
             }
         }
 
@@ -1084,6 +1094,7 @@ public class GrnReturnWorkflowController implements Serializable {
             // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
+        return true;
     }
 
     // Validation methods
@@ -1992,6 +2003,9 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        if (sessionController.getDepartment() != null) {
+            currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        }
 
         //Copy Payment Method Details from GRN to GRN Return
         currentBill.setPaymentMethod(originalGrn.getPaymentMethod());

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -280,6 +280,7 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setChecked(true);
         getReturnBill().setCheckeAt(new Date());
         getReturnBill().setCheckedBy(sessionController.getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         // Refresh the bill and reload bill items for print preview
@@ -324,12 +325,14 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setCompleted(true);
         getReturnBill().setCompletedAt(new Date());
         getReturnBill().setCompletedBy(getSessionController().getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         getOriginalBill().setRefundedBill(getReturnBill());
         getOriginalBill().setRefunded(true);
         getOriginalBill().getRefundBills().add(getReturnBill());
 
+        getOriginalBill().setBillItems(null);
         getBillFacade().edit(getOriginalBill());
 
         printPreview = true;
@@ -498,6 +501,10 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
+            // Null out the billItems collection before merge so EclipseLink does not treat
+            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
+            // Bill items are managed independently by saveBillComponents() / billItemFacade.
+            getReturnBill().setBillItems(null);
             getBillFacade().edit(getReturnBill());
         }
     }
@@ -560,6 +567,7 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
+        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -797,8 +805,10 @@ public class IssueReturnController implements Serializable {
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
+            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
     }
@@ -846,6 +856,7 @@ public class IssueReturnController implements Serializable {
 
         bill.setTotal(total);
         bill.setNetTotal(netTotal);
+        bill.setBillItems(null);
         getBillFacade().edit(bill);
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -210,7 +210,49 @@ public class IssueReturnController implements Serializable {
         pageMetadataRegistry.registerPage(metadata);
     }
 
+    /**
+     * Guards every write entry point (save / finalize / settle) against acting
+     * on a bill whose CURRENT database state is already completed or closed.
+     *
+     * The @SessionScoped bean (and the browser page) can hold a STALE copy of
+     * the return bill - e.g. the bill was settled, then Save/Finalize/Settle is
+     * clicked again from an old screen or list row. Merging that stale copy
+     * reverts the settled bill to a draft (completed/deptId/insId cleared)
+     * while its items and stock movements remain - the #21266 RC5 orphan-return
+     * corruption (Ruhunu bills 4336218 / 4337297, 2026-03-25). Reads bypass the
+     * L2 cache because another app server may have written the bill under
+     * dual-version operation.
+     *
+     * @return true if processing must stop (with a user-facing message).
+     */
+    private boolean disposalReturnAlreadyProcessed() {
+        if (getReturnBill() == null || getReturnBill().getId() == null) {
+            return false; // new, never-persisted draft - nothing to clobber
+        }
+        Bill fresh = getBillFacade().findWithoutCache(getReturnBill().getId());
+        if (fresh == null) {
+            return false;
+        }
+        if (fresh.isCompleted()) {
+            JsfUtil.addErrorMessage("This disposal return (" + (fresh.getDeptId() != null ? fresh.getDeptId() : fresh.getId())
+                    + ") has already been settled. Reload the page before continuing.");
+            return true;
+        }
+        if (fresh.isBillClosed()) {
+            JsfUtil.addErrorMessage("This disposal return has been closed. Create a new return instead.");
+            return true;
+        }
+        if (fresh.isCancelled() || fresh.isRetired()) {
+            JsfUtil.addErrorMessage("This disposal return is cancelled or retired and can no longer be processed.");
+            return true;
+        }
+        return false;
+    }
+
     public void saveDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // No validation required for saving drafts - users can save incomplete data
         saveBill();
         saveBillComponents();
@@ -218,6 +260,9 @@ public class IssueReturnController implements Serializable {
     }
 
     public void finalizeDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // Validate return comment is provided
         if (returnBill.getComments() == null || returnBill.getComments().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return Comment is required. Please provide a reason for the return.");
@@ -248,6 +293,12 @@ public class IssueReturnController implements Serializable {
     }
 
     public void settleDisposalIssueReturnBill() {
+        // Re-settling an already-settled bill (double-click, stale screen, stale
+        // list row) would write a second set of items and stock movements and
+        // then clobber the bill header (#21266 RC5).
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         if (getReturnBill().getCheckedBy() == null) {
             JsfUtil.addErrorMessage("Pleace Finalise Bill First. Can not Return");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3857,6 +3857,50 @@ public class PharmacyController implements Serializable {
         }
     }
 
+    /**
+     * Multiplier to convert a stored {@code valueAt*Rate} into consumption-direction value.
+     *
+     * <p>Stored {@code billItemFinanceDetails.valueAt*Rate} (and the matching
+     * {@code billFinanceDetails.total*Value}) use a stock-direction sign: negative when
+     * stock leaves the source department, positive when it comes back. Consumption
+     * accounting is the inverse — an issue adds to consumption, a return/cancel subtracts.
+     * For every disposal-issue bill in this convention the contribution to consumption
+     * value is therefore {@code -valueAt*Rate}.</p>
+     *
+     * <p>See {@code DataAdministrationController.isFinanceValueNegative} for the canonical
+     * sign rules.</p>
+     */
+    private static double consumptionValueSign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE:
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+    /**
+     * Multiplier to convert a stored {@code billItem.qty} into consumption-direction qty.
+     * Issues add to consumption (+1); returns and cancellations subtract (-1).
+     */
+    private static double consumptionQtySign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
     public void generateConsumptionReportTableByBill(List<BillTypeAtomic> billTypeAtomics) {
         try {
             bills = new ArrayList<>();
@@ -3927,10 +3971,26 @@ public class PharmacyController implements Serializable {
                 PharmacyRow row = new PharmacyRow();
                 row.setBill(b);
 
-                // Simply aggregate the values displayed in the columns without manipulation
-                totalPurchase += b.getBillFinanceDetails().getTotalPurchaseValue() != null ? b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
-                totalCostValue += b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
-                totalRetailValue += b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
+                if (b.getBillFinanceDetails() != null) {
+                    double sign = consumptionValueSign(b.getBillTypeAtomic());
+
+                    double rowPurchase = b.getBillFinanceDetails().getTotalPurchaseValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
+                    double rowCost = b.getBillFinanceDetails().getTotalCostValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
+                    double rowRetail = b.getBillFinanceDetails().getTotalRetailSaleValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
+                }
 
                 pharmacyRows.add(row);
 
@@ -4113,23 +4173,32 @@ public class PharmacyController implements Serializable {
             totalRetailValue = 0.0;
 
             for (PharmacyRow row : pharmacyRows) {
-                // Simply aggregate the values displayed in the columns without manipulation
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
                 if (row.getBillItem() != null && row.getBillItem().getBillItemFinanceDetails() != null) {
                     BigDecimal valueAtPurchase = row.getBillItem().getBillItemFinanceDetails().getValueAtPurchaseRate();
                     BigDecimal valueAtCost = row.getBillItem().getBillItemFinanceDetails().getValueAtCostRate();
                     BigDecimal valueAtRetail = row.getBillItem().getBillItemFinanceDetails().getValueAtRetailRate();
 
-                    if (valueAtPurchase != null) {
-                        totalPurchase += valueAtPurchase.doubleValue();
-                    }
+                    BillTypeAtomic bta = row.getBillItem().getBill() != null
+                            ? row.getBillItem().getBill().getBillTypeAtomic()
+                            : null;
+                    double valueSign = consumptionValueSign(bta);
+                    double qtySign = consumptionQtySign(bta);
 
-                    if (valueAtCost != null) {
-                        totalCostValue += valueAtCost.doubleValue();
-                    }
+                    double rowPurchase = valueAtPurchase != null ? valueSign * valueAtPurchase.doubleValue() : 0.0;
+                    double rowCost = valueAtCost != null ? valueSign * valueAtCost.doubleValue() : 0.0;
+                    double rowRetail = valueAtRetail != null ? valueSign * valueAtRetail.doubleValue() : 0.0;
+                    double rowQty = qtySign * (row.getBillItem().getQty() != null ? row.getBillItem().getQty() : 0.0);
 
-                    if (valueAtRetail != null) {
-                        totalRetailValue += valueAtRetail.doubleValue();
-                    }
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+                    row.setConsumptionQty(rowQty);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
                 }
             }
 
@@ -4519,17 +4588,23 @@ public class PharmacyController implements Serializable {
             try {
                 List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
 
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025). netTotal is
+                // already stored with the correct sign, so it does not need flipping.
+                double valueSign = consumptionValueSign(billType);
+                double qtySign = consumptionQtySign(billType);
+
                 // Convert Object[] to DepartmentCategoryWiseItems
                 for (Object[] row : results) {
                     Department mainDept = (Department) row[0];
                     Department consumptionDept = (Department) row[1];
                     Item item = (Item) row[2];
                     Category category = (item != null) ? item.getCategory() : null;
-                    Double purchaseValue = row[3] != null ? ((Number) row[3]).doubleValue() : 0.0;
-                    Double costValue = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
-                    Double retailValue = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
+                    Double purchaseValue = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
+                    Double costValue = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double retailValue = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
                     Double netTotal = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
-                    Double qty = row[7] != null ? ((Number) row[7]).doubleValue() : 0.0;
+                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
 
                     DepartmentCategoryWiseItems dtoItem = new DepartmentCategoryWiseItems(
                             mainDept, consumptionDept, item, category,
@@ -12678,20 +12753,17 @@ public class PharmacyController implements Serializable {
                     table.addCell(new PdfPCell(new Phrase(bill.getInvoiceNumber() != null ? bill.getInvoiceNumber() : "", normalFont)));
 
                     PdfPCell purchaseCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalPurchaseValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalPurchaseValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionPurchaseValue()), normalFont));
                     purchaseCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(purchaseCell);
 
                     PdfPCell costCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalCostValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalCostValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionCostValue()), normalFont));
                     costCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(costCell);
 
                     PdfPCell retailCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalRetailSaleValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalRetailSaleValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionRetailValue()), normalFont));
                     retailCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(retailCell);
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -722,6 +722,7 @@ public class PurchaseOrderRequestController implements Serializable {
     public void saveBillComponent() {
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             if (b.getId() == null) {
                 getBillItemFacade().create(b);
             } else {
@@ -730,10 +731,32 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
+    // A duplicate-line removal can leave the surviving BillItem with a lazily
+    // created all-zero PharmaceuticalBillItem while its BillItemFinanceDetails
+    // still holds the real quantities; downstream approval/GRN reads the PBI,
+    // so rebuild it from the finance details before persisting (issue #21417)
+    private void resyncPharmaceuticalBillItemIfEmpty(BillItem b) {
+        if (b == null || b.isRetired() || b.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbi = b.getPharmaceuticalBillItem();
+        if (pbi.getQty() != 0 || pbi.getFreeQty() != 0) {
+            return;
+        }
+        BigDecimal qtyByUnits = b.getBillItemFinanceDetails().getQuantityByUnits();
+        BigDecimal freeQtyByUnits = b.getBillItemFinanceDetails().getFreeQuantityByUnits();
+        boolean financeDetailsHaveQty = (qtyByUnits != null && qtyByUnits.compareTo(BigDecimal.ZERO) > 0)
+                || (freeQtyByUnits != null && freeQtyByUnits.compareTo(BigDecimal.ZERO) > 0);
+        if (financeDetailsHaveQty) {
+            calculateLineValues(b);
+        }
+    }
+
     public void finalizeBillComponent() {
         getBillItems().removeIf(BillItem::isRetired);
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             BigDecimal qUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getQuantityByUnits() != null)
                     ? b.getBillItemFinanceDetails().getQuantityByUnits() : BigDecimal.ZERO;
             BigDecimal fqUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getFreeQuantityByUnits() != null)
@@ -797,7 +820,11 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
-    private boolean saveRequestWithoutMessage() {
+    // synchronized: concurrent saves from the same session (Enter-key defaultCommand
+    // racing a button click) both saw billItem.id == null and persisted the same
+    // in-memory BillItem twice, creating duplicate rows sharing one
+    // BillItemFinanceDetails (issue #21417)
+    private synchronized boolean saveRequestWithoutMessage() {
         if (getCurrentBill().isChecked()) {
             JsfUtil.addErrorMessage("Cannot save a finalized bill");
             return false;
@@ -866,7 +893,7 @@ public class PurchaseOrderRequestController implements Serializable {
         return allItems;
     }
 
-    public void finalizeRequest() {
+    public synchronized void finalizeRequest() {
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -421,6 +421,16 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
         for (BillItem bi : getBillItems()) {
+            // Single source of truth for the issued quantity (#21266 RC6): the
+            // user-entered qty lives in BillItemFinanceDetails.quantity, but the
+            // stock movement below uses pbi.qty - which still holds the REQUESTED
+            // qty from item generation if a UI edit did not sync it. Stock then
+            // moved by the requested qty while updateBillItemRateAndValue()
+            // rewrote the persisted line to the user-entered qty AFTER the stock
+            // ops (pbi 4912145, 2026-05-20: stock moved 2, line said 1). Sync
+            // pbi/billItem qty from the user-entered value BEFORE validating or
+            // moving any stock, keeping the positive pre-settle sign convention.
+            syncStockQtyFromUserEnteredQty(bi);
             if (bi.getPharmaceuticalBillItem().getItemBatch() != null) {
                 if (bi.getPharmaceuticalBillItem().getStock().getStock() < bi.getPharmaceuticalBillItem().getQty()) {
                     JsfUtil.addErrorMessage("Available quantity is less than issued quantity in " + bi.getPharmaceuticalBillItem().getItemBatch().getItem().getName());
@@ -637,6 +647,31 @@ public class TransferIssueForRequestsController implements Serializable {
 
     }
 
+    /**
+     * Copies the user-entered quantity (BillItemFinanceDetails.quantity, in
+     * packs) onto the fields the settle stock operations read - pbi.qty (units),
+     * pbi.qtyPacks and billItem.qty (packs) - so the quantity that moves stock
+     * is always the quantity that gets persisted (#21266 RC6). Values are set
+     * POSITIVE to match the pre-settle convention expected by the validation
+     * and zero-removal checks; settle() negates them later. Lines without
+     * finance details or a quantity are left untouched (conservative fallback).
+     */
+    private void syncStockQtyFromUserEnteredQty(BillItem bi) {
+        if (bi == null || bi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+        if (f == null || f.getQuantity() == null) {
+            return;
+        }
+        double packs = Math.abs(f.getQuantity().doubleValue());
+        double unitsPerPack = (f.getUnitsPerPack() != null && f.getUnitsPerPack().compareTo(BigDecimal.ZERO) > 0)
+                ? f.getUnitsPerPack().doubleValue() : 1.0;
+        bi.getPharmaceuticalBillItem().setQty(packs * unitsPerPack);
+        bi.getPharmaceuticalBillItem().setQtyPacks(packs);
+        bi.setQty(packs);
+    }
+
     private void updateBillItemRateAndValue(BillItem b) {
         BillItemFinanceDetails f = b.getBillItemFinanceDetails();
         double rate = b.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
@@ -689,6 +724,14 @@ public class TransferIssueForRequestsController implements Serializable {
             if (f.getPurchaseRate() == null) {
                 f.setPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()));
             }
+            // Recompute valuation fields from the user-entered quantity. They are
+            // set at item-generation time from the REQUESTED qty and were never
+            // updated when the user changed the issuing qty (#21266 RC6:
+            // valueAtPurchaseRate stayed 990 = 2 x 495 while the line qty became
+            // 1). Positive sign, matching the generation-time convention.
+            f.setValueAtPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(qtyInUnits));
+            f.setValueAtRetailRate(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(qtyInUnits));
+            f.setValueAtCostRate(costRate.multiply(qtyInUnits));
         } else {
             f.setLineCostRate(BigDecimal.ZERO);
             f.setLineCost(BigDecimal.ZERO);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
@@ -112,6 +113,9 @@ public class TransferReceiveController implements Serializable {
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
     private BillItem selectedBillItem;
+    // Re-entrancy guard: blocks a second settle() (e.g. rapid double-click on the
+    // non-AJAX Receive button) from processing the same transfer twice.
+    private boolean settling;
 
     public static class ConfigOptionInfo {
 
@@ -258,6 +262,14 @@ public class TransferReceiveController implements Serializable {
             // Invert to turn negative values from the issued bill into positives
             newlyCreatedReceivedBillItem.invertValue();
             newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().invertValue();
+
+            // The copy above inherits the ISSUE line's stock binding, which is the
+            // ISSUING department's stock row. A receive must only ever touch the
+            // porter's in-transit stock (deducted) and the receiving department's
+            // stock (added; bound after addToStock() in settle). A receive line that
+            // keeps the sender's stock reference and slips past the stock loop is
+            // recorded as received without moving any stock (#21266 phantom receives).
+            newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().setStock(null);
 
             // Adjust quantity to remaining amount
             double unitsPerPack = 1.0;
@@ -433,6 +445,95 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void settle() {
+        // Re-entrancy guard: a second near-simultaneous submit (rapid double-click
+        // on the non-AJAX Receive button) is ignored until the first completes.
+        if (settling) {
+            return;
+        }
+        settling = true;
+        try {
+            doSettle();
+        } finally {
+            settling = false;
+        }
+    }
+
+    /**
+     * Converts a bill item's user-entered receive quantity (packs) to units.
+     */
+    private double receiveQtyInUnits(BillItem i) {
+        double qtyInPacks = 0.0;
+        if (i.getBillItemFinanceDetails() != null && i.getBillItemFinanceDetails().getQuantity() != null) {
+            qtyInPacks = i.getBillItemFinanceDetails().getQuantity().doubleValue();
+        }
+        double unitsPerPack = 1.0;
+        Item item = i.getItem();
+        if (item instanceof Ampp || item instanceof Vmpp) {
+            unitsPerPack = item.getDblValue() > 0 ? item.getDblValue() : 1.0;
+        }
+        return qtyInPacks * unitsPerPack;
+    }
+
+    /**
+     * Validates that the porter (carrier) holds enough in-transit stock to cover
+     * EVERY line being received, before any data is written. Quantities are
+     * aggregated per item batch (several receive lines can draw from the same
+     * batch) and compared against the porter's live stock read fresh from the
+     * database.
+     *
+     * On a receive, stock must move porter -> receiving department. Previously,
+     * lines that could not be covered were silently skipped or zeroed mid-settle,
+     * and the skipped lines were later cascade-persisted still carrying the
+     * issuing department's stock binding with no stock movement — the #21266
+     * phantom-receive corruption. Failing the whole settle up front with explicit
+     * messages prevents both the corruption and the silent partial receive.
+     *
+     * @return true if every line is covered; false (with user-facing error
+     * messages) otherwise.
+     */
+    private boolean porterStockCoversAllLines() {
+        Staff porter = getIssuedBill() == null ? null : getIssuedBill().getToStaff();
+        if (porter == null) {
+            JsfUtil.addErrorMessage("This transfer issue has no carrying staff (porter) recorded - cannot receive. Please contact the issuing department.");
+            return false;
+        }
+        Map<Long, Double> requiredUnitsByBatch = new HashMap<>();
+        Map<Long, ItemBatch> batchById = new HashMap<>();
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            double units = receiveQtyInUnits(i);
+            if (units <= 0.0) {
+                continue;
+            }
+            ItemBatch batch = i.getPharmaceuticalBillItem() == null ? null : i.getPharmaceuticalBillItem().getItemBatch();
+            if (batch == null || batch.getId() == null) {
+                JsfUtil.addErrorMessage("Item " + (i.getItem() != null ? i.getItem().getName() : "?") + " has no batch - cannot receive.");
+                return false;
+            }
+            requiredUnitsByBatch.merge(batch.getId(), units, Double::sum);
+            batchById.put(batch.getId(), batch);
+        }
+        boolean allCovered = true;
+        for (Map.Entry<Long, Double> e : requiredUnitsByBatch.entrySet()) {
+            ItemBatch batch = batchById.get(e.getKey());
+            HashMap<String, Object> params = new HashMap<>();
+            String jpql = "select s from Stock s where s.itemBatch=:bc and s.staff=:stf";
+            params.put("bc", batch);
+            params.put("stf", porter);
+            Stock porterStock = getStockFacade().findFirstByJpql(jpql, params, true);
+            double available = porterStock == null ? 0.0 : porterStock.getStock();
+            if (available + 0.0001 < e.getValue()) {
+                String itemName = (batch.getItem() != null && batch.getItem().getName() != null)
+                        ? batch.getItem().getName() : ("Batch " + batch.getId());
+                JsfUtil.addErrorMessage("Insufficient in-transit (porter) stock for " + itemName
+                        + ": receiving " + e.getValue() + " but porter holds " + available
+                        + ". Nothing was received.");
+                allCovered = false;
+            }
+        }
+        return allCovered;
+    }
+
+    private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
             return;
@@ -447,6 +548,12 @@ public class TransferReceiveController implements Serializable {
         // Validate that current receive quantities don't exceed remaining quantities
         if (wouldCauseOverReceiving()) {
             JsfUtil.addErrorMessage("Cannot receive - quantities exceed remaining amounts!");
+            return;
+        }
+
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
             return;
         }
 
@@ -509,6 +616,13 @@ public class TransferReceiveController implements Serializable {
                 getBillItemFacade().edit(i);
             }
         }
+
+        // Drop lines that were never persisted (zero quantity or failed checks)
+        // from the in-memory bill. Bill.billItems cascades ALL, so the later
+        // edit(getReceivedBill()) merges would otherwise INSERT these skipped
+        // lines - still carrying the issue line's data with no stock movement -
+        // which is exactly the #21266 phantom-receive corruption.
+        getReceivedBill().getBillItems().removeIf(bi -> bi.getId() == null);
 
         // Handle Department ID generation (independent)
         String deptId;
@@ -843,6 +957,12 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
+            return;
+        }
+
         getReceivedBill().setApproveAt(new Date());
         getReceivedBill().setApproveUser(getSessionController().getLoggedUser());
 
@@ -911,6 +1031,12 @@ public class TransferReceiveController implements Serializable {
                 Stock addedStock = getPharmacyBean().addToStock(tmpPh, Math.abs(qty), getSessionController().getDepartment());
                 tmpPh.setStock(addedStock);
             } else {
+                // No stock was moved - never leave the line bound to the stock
+                // reference inherited from the issue line (the issuing
+                // department's stock), or it records a phantom receive (#21266).
+                tmpPh.setStock(null);
+                tmpPh.setQty(0);
+                i.setQty(0.0);
                 i.setTmpQty(0);
                 getBillItemFacade().edit(i);
             }
@@ -1473,6 +1599,10 @@ public class TransferReceiveController implements Serializable {
 
     public void setSelectedBillItem(BillItem selectedBillItem) {
         this.selectedBillItem = selectedBillItem;
+    }
+
+    public boolean isSettling() {
+        return settling;
     }
 
     @Deprecated

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -672,7 +672,6 @@ public class TransferReceiveController implements Serializable {
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
-        getBillFacade().edit(getReceivedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
         if (getIssuedBill() != null && !getIssuedBill().isFullyIssued()) {
@@ -1096,7 +1095,12 @@ public class TransferReceiveController implements Serializable {
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());
+            // Detach billItems before create() to prevent CascadeType.ALL from inserting
+            // them here — settle() creates each BillItem explicitly after stock validation.
+            List<BillItem> items = getReceivedBill().getBillItems();
+            getReceivedBill().setBillItems(new ArrayList<>());
             getBillFacade().create(getReceivedBill());
+            getReceivedBill().setBillItems(items);
         } else {
             getBillFacade().edit(getReceivedBill());
         }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -671,6 +671,11 @@ public class TransferReceiveController implements Serializable {
 
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
+        // Persist the received bill again after fillData() recalculates its
+        // net/grand/total and BillFinanceDetails value fields. Safe here: the
+        // BillItems were already created (have IDs) in the settle() loop above,
+        // so this merge updates totals without re-inserting them.
+        getBillFacade().edit(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
@@ -1099,8 +1104,13 @@ public class TransferReceiveController implements Serializable {
             // them here — settle() creates each BillItem explicitly after stock validation.
             List<BillItem> items = getReceivedBill().getBillItems();
             getReceivedBill().setBillItems(new ArrayList<>());
-            getBillFacade().create(getReceivedBill());
-            getReceivedBill().setBillItems(items);
+            try {
+                getBillFacade().create(getReceivedBill());
+            } finally {
+                // Always restore the in-memory items, even if create() throws,
+                // so the @SessionScoped bean does not lose the receive rows on retry.
+                getReceivedBill().setBillItems(items);
+            }
         } else {
             getBillFacade().edit(getReceivedBill());
         }

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11694,7 +11694,21 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Filter by the actual STOCK-MOVEMENT date, not bill creation, so the
+                    // movement rows align with the stock side (StockHistory is written when
+                    // stock physically moves). Stock moves on approval, but which timestamp
+                    // marks approval differs by workflow:
+                    //   - GRN / GRN-return / direct purchase: stock moves at completedAt.
+                    //   - Draft transfer issue: completedAt is set at draft *finalization*
+                    //     (finalizeDraftIssue), while stock is deducted later at *approval*
+                    //     (approveDraftIssue), which sets checkeAt.
+                    // GREATEST(createdAt, completedAt, checkeAt) picks the latest of the three,
+                    // which is the moment stock actually moved in every workflow, and falls
+                    // back to createdAt when the approval timestamps are null (non-approval
+                    // flows). Using createdAt alone mis-dated approval-gated movements (e.g. a
+                    // GRN return created one day, approved another) and produced a spurious COGS
+                    // variance. See issue #21266 (and Codex review on PR #21348 re: draft transfers).
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             params.put("ret", false);
             params.put("btas", billTypeAtomics);
@@ -11741,13 +11755,22 @@ public class PharmacyReportController implements Serializable {
             List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN);
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
+            // FIX (variance double-count): GRN/Direct-Purchase CANCELLED bills must NOT be
+            // summed here. They are already counted (with their negative values) in the
+            // "Purchase Return" row via calculatePurchaseReturn(). Counting them again in the
+            // GRN Cash/Credit row subtracted the cancellation value twice on the calculated
+            // side while actual stock only dropped once, producing a variance equal to the
+            // cancelled bill's value (e.g. GSKGRNCAN/1 -> -1,350 variance in Ruhunu).
+            // These two lines were added on 2025-10-07 (commit 7ddc2781087) and duplicate the
+            // cancellation handling that has lived in calculatePurchaseReturn() since 2025-08-04.
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
 
             StringBuilder jpql = new StringBuilder("SELECT bi.bill.paymentMethod, SUM(bi.billItemFinanceDetails.valueAtPurchaseRate), SUM(bi.billItemFinanceDetails.valueAtCostRate), SUM(bi.billItemFinanceDetails.valueAtRetailRate) FROM BillItem bi ")
                     .append("WHERE bi.retired = false ")
                     .append("AND bi.bill.billTypeAtomic IN :bType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.bill.paymentMethod IN (:cash, :credit) ");
 
             Map<String, Object> params = new HashMap<>();
@@ -11834,7 +11857,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("btas", btas);
@@ -11892,7 +11919,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -11946,7 +11977,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12007,7 +12042,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12067,7 +12106,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic = :preAddToStockType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             preAddParams.put("ret", false);
             preAddParams.put("preAddToStockType", BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_ADD_TO_STOCK);
@@ -12128,7 +12171,11 @@ public class PharmacyReportController implements Serializable {
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
                     .append("AND (rb IS NULL OR rb.createdAt > :td) ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -12251,7 +12298,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13238,7 +13289,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13335,7 +13390,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty < 0.0 ");
 
             paramsIssue.put("ret", false);
@@ -13361,7 +13417,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty > 0.0 ");
 
             paramsReceive.put("ret", false);
@@ -13469,8 +13526,13 @@ public class PharmacyReportController implements Serializable {
 
     private void calculateSaleWithoutCreditPaymentMethod() {
         try {
+            // FIX (variance double-count): the "Sale Credit" row (calculateSaleCreditValue())
+            // owns BOTH Credit AND Staff payment methods. This "Sale" row must therefore
+            // exclude Staff as well as Credit, otherwise a Staff-paid retail sale is summed
+            // in both rows and double-counted on the calculated side. (Latent in Ruhunu today
+            // since there are no Staff/Credit retail sales, but a correctness bug regardless.)
             List<PaymentMethod> nonCreditPaymentMethods = Arrays.stream(PaymentMethod.values())
-                    .filter(pm -> pm != PaymentMethod.Credit)
+                    .filter(pm -> pm != PaymentMethod.Credit && pm != PaymentMethod.Staff)
                     .collect(Collectors.toList());
 
             List<BillTypeAtomic> billTypes = Arrays.asList(

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13318,6 +13318,12 @@ public class PharmacyReportController implements Serializable {
             List<BillType> billTypes = new ArrayList<>();
             billTypes.add(BillType.PharmacyAdjustmentDepartmentSingleStock);
             billTypes.add(BillType.PharmacyAdjustmentDepartmentStock);
+            // Stock-take adjustment bills (PHARMACY_STOCK_ADJUSTMENT_BILL) move stock too;
+            // omitting them left their stock movements uncounted on the calculated side and
+            // produced a COGS variance equal to the adjustment value on every stock-take day.
+            // pbi.qty on these bills is the adjustment delta, so the existing qty<0/qty>0
+            // split places them in the Issue/Receive rows correctly. See issue #21266.
+            billTypes.add(BillType.PharmacyStockAdjustmentBill);
 
             // Query for Stock Adjustment Issues (negative quantities)
             Map<String, Object> paramsIssue = new HashMap<>();

--- a/src/main/java/com/divudi/core/data/PharmacyRow.java
+++ b/src/main/java/com/divudi/core/data/PharmacyRow.java
@@ -194,6 +194,11 @@ public class PharmacyRow implements Serializable {
     private BigDecimal valueOfStocksAtPurchaseRate = BigDecimal.ZERO;
     private BigDecimal valueOfStocksAtRetailSaleRate = BigDecimal.ZERO;
 
+    private double consumptionQty;
+    private double consumptionPurchaseValue;
+    private double consumptionCostValue;
+    private double consumptionRetailValue;
+
     private BigDecimal grossSaleRate = BigDecimal.ZERO;
     private BigDecimal discountRate = BigDecimal.ZERO;
     private BigDecimal marginRate = BigDecimal.ZERO;
@@ -1753,5 +1758,37 @@ public class PharmacyRow implements Serializable {
 
     public void setValueOfStocksAtRetailSaleRate(BigDecimal valueOfStocksAtRetailSaleRate) {
         this.valueOfStocksAtRetailSaleRate = valueOfStocksAtRetailSaleRate;
+    }
+
+    public double getConsumptionQty() {
+        return consumptionQty;
+    }
+
+    public void setConsumptionQty(double consumptionQty) {
+        this.consumptionQty = consumptionQty;
+    }
+
+    public double getConsumptionPurchaseValue() {
+        return consumptionPurchaseValue;
+    }
+
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) {
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+    }
+
+    public double getConsumptionCostValue() {
+        return consumptionCostValue;
+    }
+
+    public void setConsumptionCostValue(double consumptionCostValue) {
+        this.consumptionCostValue = consumptionCostValue;
+    }
+
+    public double getConsumptionRetailValue() {
+        return consumptionRetailValue;
+    }
+
+    public void setConsumptionRetailValue(double consumptionRetailValue) {
+        this.consumptionRetailValue = consumptionRetailValue;
     }
 }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -725,7 +725,6 @@ public enum Privileges {
     InwardFormTemplateAdmin("Inward Form Template Admin"),
     InwardFormFill("Inward Form Fill"),
     InwardDocumentUpload("Inward Document Upload"),
-    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
     // Pharmacy workflow
     PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
     PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
@@ -742,7 +741,6 @@ public enum Privileges {
     ArchiveOldItemBatch("Archive Old ItemBatch Records"),
     // Cashier / petty cash
     PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
-    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
     CashierHandoverStatusReport("Cashier Handover Status Report"),
     SettleHandoverProofMissing("Settle Handover Proof Missing"),
     SettleNonCashPayments("Settle Non-Cash Payments"),
@@ -753,16 +751,7 @@ public enum Privileges {
     // Admin
     AdminPatientRelationships("Manage Patient Relationships"),
     AdminInactivePatients("Manage Inactive Patients"),
-    MergePatients("Merge Patients"),
-    // Fund transfer
-    RequestFundTransfer("Request Float Transfer"),
-    IssueFundTransfer("Issue Float Transfer"),
-    ReceiveFundTransfer("Receive Float Transfer"),
-    DeclineFundTransfer("Decline Float Transfer"),
-    ProcessFundTransferRequest("Process Float Transfer Request"),
-    CancelOwnFundTransfer("Cancel Own Float Transfer"),
-    CancelOthersFundTransfer("Cancel Others Float Transfer"),
-    ViewFundTransferReports("View Float Transfer Reports")
+    MergePatients("Merge Patients")
     ;
 
     private final String label;

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -720,7 +720,49 @@ public enum Privileges {
     DeleteData("Delete Data"),
     BillCancel("Bill Cancel"),
     BillRefund("Bill Refund"), //</editor-fold>
-    AiChat("AI Chat")
+    AiChat("AI Chat"),
+    // Inward
+    InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
+    InwardDocumentUpload("Inward Document Upload"),
+    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    // Pharmacy workflow
+    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
+    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
+    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
+    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
+    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
+    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
+    // Cashier / petty cash
+    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
+    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    CashierHandoverStatusReport("Cashier Handover Status Report"),
+    SettleHandoverProofMissing("Settle Handover Proof Missing"),
+    SettleNonCashPayments("Settle Non-Cash Payments"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
+    // Clinical
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
+    // Admin
+    AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
+    // Fund transfer
+    RequestFundTransfer("Request Float Transfer"),
+    IssueFundTransfer("Issue Float Transfer"),
+    ReceiveFundTransfer("Receive Float Transfer"),
+    DeclineFundTransfer("Decline Float Transfer"),
+    ProcessFundTransferRequest("Process Float Transfer Request"),
+    CancelOwnFundTransfer("Cancel Own Float Transfer"),
+    CancelOthersFundTransfer("Cancel Others Float Transfer"),
+    ViewFundTransferReports("View Float Transfer Reports")
     ;
 
     private final String label;
@@ -1038,6 +1080,9 @@ public enum Privileges {
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
             case InpatientClinicalDischarge:
+            case InwardFormTemplateAdmin:
+            case InwardFormFill:
+            case InwardDocumentUpload:
                 return "Inward";
 
             default:

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -89,7 +89,7 @@
                                             value="Save"
                                             title="Save return bill as draft"
                                             action="#{issueReturnController.saveDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -99,7 +99,7 @@
                                             onclick="return confirm('Are you sure you want to finalize this disposal issue? This action cannot be undone.');"
                                             title="Finalize return bill"
                                             action="#{issueReturnController.finalizeDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -109,7 +109,7 @@
                                             onclick="return confirm('Are you sure you want to approve this disposal issue? This action cannot be undone.');"
                                             title="Approve and process the return"
                                             action="#{issueReturnController.settleDisposalIssueReturnBill}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and not issueReturnController.returnBill.billClosed and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                     </div>
@@ -130,6 +130,50 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
                                     <h:outputText value=" by #{issueReturnController.originalBill.fullReturnedBy.webUserPerson.nameWithTitle}. No further returns are allowed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return already approved (settled) - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-success d-flex align-items-center">
+                                <i class="fas fa-check-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.completedAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.completedAt}" rendered="#{issueReturnController.returnBill.completedAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" by #{issueReturnController.returnBill.completedBy.webUserPerson.nameWithTitle}" rendered="#{issueReturnController.returnBill.completedBy ne null}"/>
+                                    <h:outputText value=". No further changes are possible." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return closed - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.billClosed and not issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-warning d-flex align-items-center">
+                                <i class="fas fa-ban me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return has been closed. It can no longer be saved, finalized or approved - create a new return for this disposal issue if needed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: finalized, awaiting approval - explains why Save/Finalize are hidden, and why Approve is hidden when the privilege is missing -->
+                        <p:panel rendered="#{issueReturnController.returnBill.checkedBy ne null and not issueReturnController.returnBill.completed and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-info d-flex align-items-center">
+                                <i class="fas fa-info-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This return was finalized by #{issueReturnController.returnBill.checkedBy.webUserPerson.nameWithTitle}" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.checkeAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.checkeAt}" rendered="#{issueReturnController.returnBill.checkeAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" and is awaiting approval. Items can no longer be edited." styleClass="fw-bold"/>
+                                    <h:outputText value=" You do not have the Approve Disposal Return privilege - please ask an authorized user to approve it."
+                                                  rendered="#{!webUserController.hasPrivilege('ApproveDisposalReturn')}"
+                                                  styleClass="fw-bold text-danger ms-1"/>
                                 </div>
                             </div>
                         </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -86,14 +86,16 @@
                                         width="6em"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off"  
-                                            id="qty" 
-                                            value="#{bi.billItemFinanceDetails.quantity}" 
-                                            style="padding: 0;" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="qty"
+                                            value="#{bi.billItemFinanceDetails.quantity}"
+                                            style="padding: 0;"
                                             label="Qty"
                                             class="text-end w-100"
-                                            onfocus="this.select()">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            onfocus="this.select()">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <p:ajax 
                                                 event="blur" 
@@ -108,14 +110,16 @@
                                         headerText="Free Qty"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off" 
-                                            id="freeQty" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="freeQty"
                                             onfocus="this.select()"
                                             class="text-end w-100"
-                                            value="#{bi.billItemFinanceDetails.freeQuantity}" 
-                                            style="padding: 0;" 
-                                            label="Qty">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                            style="padding: 0;"
+                                            label="Qty">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <f:ajax 
                                                 event="blur" 
@@ -135,9 +139,11 @@
                                             <p:inputText
                                                 id="txtRetailRate"
                                                 onfocus="this.select()"
-                                                autocomplete="off" 
-                                                style="padding: 0;" 
-                                                value="#{bi.billItemFinanceDetails.lineGrossRate}" 
+                                                autocomplete="off"
+                                                style="padding: 0;"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                                 class="w-100 text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                                 <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
@@ -220,11 +226,12 @@
                                     <p:outputLabel value="Supplier"
                                                    class="form-label"
                                                    for="acSupplier"></p:outputLabel>
-                                    <p:autoComplete 
+                                    <p:autoComplete
                                         id="acSupplier"
-                                        converter="deal" 
-                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"  
+                                        converter="deal"
+                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-100"
                                         inputStyleClass="w-100"
                                         completeMethod="#{dealerController.completeActiveDealor}"
@@ -388,6 +395,7 @@
                                         id="exItem"
                                         value="#{purchaseOrderRequestController.currentBillItem.item}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-75"
                                         maxResults="50"
                                         scrollHeight="600"

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
@@ -101,17 +101,22 @@
                                         rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
                                     </p:commandButton>
 
+                                    <!-- Cashier sale bill cancellation temporarily disabled (#21419 COGS remediation).
+                                         Cancelling this bill causes the COGS report to show incorrect figures.
+                                         Re-enable once the COGS variance is fixed. -->
+                                    <!--
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Accept Sale for Cashier Bill can be Cancelled', true)}">
-                                        <p:commandButton 
-                                            ajax="false" 
+                                        <p:commandButton
+                                            ajax="false"
                                             value="To Cancel"
                                             icon="fa fa-cancel"
                                             class="ui-button-danger m-1"
-                                            action="pharmacy_cancel_bill_retail?faces-redirect=true" 
+                                            action="pharmacy_cancel_bill_retail?faces-redirect=true"
                                             disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded}"
-                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
+                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">
                                         </p:commandButton>
                                     </h:panelGroup>
+                                    -->
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
@@ -22,9 +22,14 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
 
                             </p:commandButton>
+                            <!-- GRN Return cancellation temporarily disabled (#21266 stock remediation).
+                                 Cancelling a GRN Return has caused stock data errors in production.
+                                 Re-enable only after all stock discrepancy issues are settled. -->
+                            <!--
                             <p:commandButton value="Cancel" ajax="false"
-                                             action="pharmacy_cancel_grn_return" 
+                                             action="pharmacy_cancel_grn_return"
                                              disabled="#{pharmacyBillSearch.bill.cancelled}"/>
+                            -->
 
 
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
@@ -32,6 +32,10 @@
                                     ajax="false" >
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
+                                <!-- Transfer Receive cancellation temporarily disabled (#21419 COGS remediation).
+                                     Cancelling a Transfer Receive bill causes the COGS report to show
+                                     incorrect figures. Re-enable once the COGS variance is fixed. -->
+                                <!--
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receives can be Cancelled', true)}" >
                                     <p:commandButton
                                         id="btnToCancel"
@@ -45,6 +49,7 @@
                                         <f:setPropertyActionListener target="#{transferReceiveCancellationController.originalReceiveBillId}" value="#{pharmacyBillSearch.bill.id}" />
                                     </p:commandButton>
                                 </h:panelGroup>
+                                -->
                                 <p:commandButton
                                     value="Back"
                                     icon="fas fa-arrow-left"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -82,7 +82,7 @@
                                     </p:column>  
 
                                     <p:column headerText="Expiration Date"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
-                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                         </h:outputText>
                                     </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -28,14 +28,15 @@
                 <p:panel>
                     <f:facet name="header" >                                  
 
-                        <p:commandButton  
+                        <p:commandButton
                             id="btnSettleReceive"
-                            value="Receive" 
+                            value="Receive"
                             icon="fas fa-check"
                             style="float: right;"
                             class="ui-button-success mx-2"
-                            action="#{transferReceiveController.settle}" 
-                            ajax="false" >
+                            action="#{transferReceiveController.settle}"
+                            ajax="false"
+                            onclick="return confirm('Are you sure you want to receive this transfer?');" >
                         </p:commandButton>
                         <h:panelGroup rendered="#{transferReceiveController.issuedBill.comments ne null and not empty transferReceiveController.issuedBill.comments}">
                             <p:outputLabel class="mx-4 text-break" value="Note :  #{transferReceiveController.issuedBill.comments}" />
@@ -61,6 +62,7 @@
                                             icon="pi pi-search"
                                             id="btnViewSelectedItemDetails"
                                             title="View Item Details"
+                                            ariaLabel="View Item Details"
                                             action="#{transferReceiveController.displayItemDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
                                             process="@this"
@@ -69,6 +71,7 @@
                                             icon="pi pi-info-circle"
                                             id="btnViewBatchDetails"
                                             title="View Batch Details"
+                                            ariaLabel="View Batch Details"
                                             actionListener="#{transferReceiveController.prepareBatchDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('batchDetailsForm',view).clientId}"
                                             oncomplete="PF('batchDetailsDialog').show();"
@@ -308,7 +311,7 @@
                                 </div>
                                 <div class="card-body">
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4"
                                             value="#{pharmacyConfigController.transferReceiveA4}" />
                                         <p:outputLabel for="transferReceiveA4" value="A4 Receipt Format" class="ms-2" />
@@ -316,15 +319,15 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveTemplate"
                                             value="#{pharmacyConfigController.transferReceiveTemplate}" />
                                         <p:outputLabel for="transferReceiveTemplate" value="Template Bill Format" class="ms-2" />
                                         <small class="form-text text-muted d-block">Template-based receipt format for transfer receive bills</small>
                                     </div>
-                                    
+
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveCustom1"
                                             value="#{pharmacyConfigController.transferReceiveCustom1}" />
                                         <p:outputLabel for="transferReceiveCustom1" value="Letter Paper Format Custom 1" class="ms-2" />
@@ -332,7 +335,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Detailed"
                                             value="#{pharmacyConfigController.transferReceiveA4Detailed}" />
                                         <p:outputLabel for="transferReceiveA4Detailed" value="A4 Detailed Receipt" class="ms-2" />
@@ -340,7 +343,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom1"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom1}" />
                                         <p:outputLabel for="transferReceiveA4Custom1" value="A4 Custom Format 1" class="ms-2" />
@@ -348,7 +351,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom2"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom2}" />
                                         <p:outputLabel for="transferReceiveA4Custom2" value="A4 Custom Format 2" class="ms-2" />

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -76,7 +76,7 @@
                             </p:column>
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -84,7 +84,7 @@
                             </p:column> 
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">  
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>  

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -522,8 +522,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalPurchaseValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalPurchaseValue}">
+                                    sortBy="#{b.consumptionPurchaseValue}">
+                                    <h:outputText value="#{b.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -537,8 +537,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalCostValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalCostValue}">
+                                    sortBy="#{b.consumptionCostValue}">
+                                    <h:outputText value="#{b.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -552,8 +552,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
+                                    sortBy="#{b.consumptionRetailValue}">
+                                    <h:outputText value="#{b.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -662,9 +662,9 @@
                                     width="4em"
                                     style="text-align: right; padding-right: 20px;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.qty}"
-                                    filterBy="#{i.billItem.qty}">
-                                    <p:outputLabel value="#{i.billItem.qty}"/>
+                                    sortBy="#{i.consumptionQty}"
+                                    filterBy="#{i.consumptionQty}">
+                                    <p:outputLabel value="#{i.consumptionQty}"/>
                                 </p:column>
 
                                 <p:column headerText="Status/Links" width="10em" exportable="false">
@@ -736,9 +736,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
-                                    <p:outputLabel
-                                        value="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
+                                    sortBy="#{i.consumptionPurchaseValue}">
+                                    <p:outputLabel value="#{i.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -763,8 +762,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
+                                    sortBy="#{i.consumptionRetailValue}">
+                                    <p:outputLabel value="#{i.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -789,8 +788,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
+                                    sortBy="#{i.consumptionCostValue}">
+                                    <p:outputLabel value="#{i.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -115,7 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3"/>
+                                <p:outputLabel value="Department" class="mx-3" for="phmDept"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -29,13 +29,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="From Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="From Date" class="mx-3" for="fromDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="fromDate"
+                                ariaLabel="From Date"
                                 value="#{pharmacyReportController.fromDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -43,13 +43,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="To Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="To Date" class="mx-3" for="toDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="toDate"
+                                ariaLabel="To Date"
                                 value="#{pharmacyReportController.toDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -82,12 +82,12 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-university ml-3" />
-                                <p:outputLabel value="Institution" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="Institution" class="mx-3" for="phmIns"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmIns"
                                 class="w-100"
+                                ariaLabel="Institution"
                                 value="#{pharmacyReportController.institution}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Institutions"/>
@@ -98,12 +98,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-map-marker-alt ml-3" />
-                                <p:outputLabel value="Site" class="mx-3"></p:outputLabel>
+                                <p:outputLabel value="Site" class="mx-3" for="phmSite"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmSite"
                                 class="w-100"
                                 styleClass="w-100"
+                                ariaLabel="Site"
                                 value="#{pharmacyReportController.site}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Sites"/>
@@ -114,8 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Department" class="mx-3"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 
@@ -123,6 +123,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -137,6 +138,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -151,6 +153,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -165,6 +168,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -178,13 +182,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-pills ml-3" />
-                                <p:outputLabel value="Item" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Item" class="mx-3" for="phmItem"/>
                             </h:panelGroup>
                             <p:autoComplete
                                 id="phmItem"
                                 class="w-100"
                                 inputStyleClass="w-100"
+                                ariaLabel="Item"
                                 value="#{pharmacyReportController.item}"
                                 completeMethod="#{itemController.completeItem}"
                                 var="itm"


### PR DESCRIPTION
## Summary

Hotfix for **coop production** combining two fix sets:

1. **PO request duplicate-billitem / zero-qty PBI fix** (issue #21417, merged to `development` via #21420) — the bug that blocked GRN for **POR/COOP/MP/26/000965** (Maxgalin 50mg qty 0; incident record #21418)
2. **Pharmacy stock-integrity fixes from the Ruhunu hotfix #21401** (#21266 family — all 6 root causes), cherry-picked onto `coop-prod`

## Part 1 — PO request fix (cherry-pick of #21420, commit `b544eb2d58`)

- `saveRequestWithoutMessage()` / `finalizeRequest()` synchronized — concurrent saves from one session persisted the same in-memory BillItem twice (duplicate rows sharing one BIFD)
- `resyncPharmaceuticalBillItemIfEmpty()` at save/finalize — rebuilds an all-zero PBI from the finance details so a PO can no longer reach approval/GRN with qty 0
- Enter-key guards on the PO request page (qty/price inputs + autocompletes)

## Part 2 — stock-integrity fixes (cherry-picked from #21401)

| Fix | Commit (this branch) |
|---|---|
| Disposal Consumption Report: net consumption | `21b4f86fc6` |
| Block GRN Return approval when stock insufficient | `8ac5f7b333` |
| Pre-deduction stock check in `updateStock()` | `6eb34746b1` |
| Duplicate BillItems on transfer receive (cascade re-insert) + a11y | `30ca20091e` |
| Transfer receive review fixes (settling guard, edit-after-fillData, try/finally restore) | `9c76b53fc6` |
| COGS report: date by stock-move date, remove double-counts | `2d85c5c26d` |
| Phantom transfer receives bound to issuing dept stock | `388775defb` |
| Stale-list Close clobbering settled disposal returns | `8b7993b077` |
| 36 missing Privileges enum constants (General Stores login) | `df77820070` |
| Transfer issue: move stock by user-entered qty | `7428587104` |
| Orphan-removal guard on disposal return merges | `fa4478ac97` |
| Status panels explaining hidden disposal-return buttons | `8a6ad187a1` |
| GRN return approval: exact finalized quantities only | `0083304f0e` |
| Direct purchase return approval: exact finalized quantities only | `8965b065c6` |
| Count stock-take adjustment bills in COGS | `607934adc9` |
| Temporarily disable GRN Return Cancel on reprint (#21266) | `7e8a3cc16c` |
| Temporarily disable Transfer Receive / cashier sale cancel (#21419) | `93e3e14229` |

**Deliberately NOT cherry-picked:**
- `375f1336a2` (separate ID allocators for dual-version operation) — Ruhunu-specific; the commit itself notes coop is already on IDENTITY ID generation
- `3dffd3449f` (merge) + `3a8083cbdc` (remove duplicate helpers left by that merge) — merge artifacts; this branch took the consumption-report changes via the original commit, so there are no duplicate helpers to remove (verified: single copy of `consumptionValueSign`/`consumptionQtySign`)

## Conflict resolutions & verification

Three conflicts were resolved (TransferReceiveController ×2, Privileges ×1), caused by cherry-pick order and pre-existing coop/ruhunu prod divergence. Verification: every touched file was diffed against `pharmacy-stock-fixes-hotfix` — **TransferReceiveController, all four return/issue workflow controllers, and all pharmacy XHTML pages converge to byte-identical content**; the remaining per-file differences match the pre-existing `coop-prod`↔`ruhunu-prod` divergence exactly (i.e., only Ruhunu-only history, nothing lost, nothing leaked).

The Part 1 fixes were manually tested on a local deployment with DB verification; Part 2 fixes are QA-verified on the Ruhunu production build per #21401. Recommend a compile + smoke test of transfer receive and GRN/direct-purchase return approval on coop staging before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
