### PR TITLE
fix(pharmacy): escape & in EL string in history.xhtml

### DIFF
--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -343,7 +343,7 @@
                             layout="block"
                             class="col-3"
                             id="itemDetailsBlockDepartmentSaleIssue"
-                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Sale & Issue Block', true)}" >
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Sale &amp; Issue Block', true)}" >
                             <p:panel>
                                 <div style="background-color: #337357; padding: 10px; font-weight: bold; color: white; text-align: center;">
                                     Dept. Sale &amp; Issue


### PR DESCRIPTION
https://claude.ai/code/session_01TvJDpaXpvzNHX4X3dgVmGd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration handling in the pharmacy history view to ensure proper display and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->