### PR TITLE
Fix XML entity encoding in pharmacy item details config key

### DIFF
--- a/src/main/webapp/resources/pharmacy/history.xhtml
+++ b/src/main/webapp/resources/pharmacy/history.xhtml
@@ -957,7 +957,7 @@
                         <p:tab
                             id="itemDetailsTabDepartmentSaleIssue"
                             title="Dept. Sale &amp; Issue"
-                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Sale & Issue Tab', true)}">
+                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Item Details Section - Display Department Sale &amp; Issue Tab', true)}">
                             <h:panelGroup rendered="#{empty pharmacyController.departmentSaleIssueDtos}">
                                 <div class="alert alert-info text-center" style="margin: 20px 0; padding: 15px;">
                                     <i class="fas fa-info-circle" style="margin-right: 8px;"></i>


### PR DESCRIPTION
## Summary
Fixed XML entity encoding in a configuration key string used in the pharmacy item details XHTML template. The ampersand character in the config key was not properly escaped as an XML entity.

## Changes
- Updated the `getBooleanValueByKey()` configuration key from `'Pharmacy Item Details Section - Display Department Sale & Issue Tab'` to `'Pharmacy Item Details Section - Display Department Sale &amp; Issue Tab'`
- This ensures the ampersand is properly encoded as `&amp;` in the XHTML context, preventing potential XML parsing issues

## Details
This is a JSF/XHTML-only change with no Java code modifications. The fix ensures that the configuration key string is correctly interpreted by the XML parser when the XHTML template is processed.

https://claude.ai/code/session_013eURigTFnS1aFMZbMUUJZL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment to pharmacy history interface configuration with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->