### PR TITLE
feat(inward): final bill doctor specialty (#21387) and A4 header with patient NIC (#21388)

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -288,10 +288,10 @@
 
                                                                     <td style="text-align: left;font-size: 10px!important;">
                                                                         <h:panelGroup>
-                                                                            #{fe.staff.person.nameWithTitle}
+                                                                            #{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/>
                                                                         </h:panelGroup>
                                                                     </td>
-                                                                    <td  style="text-align: right;font-size: 10px!important;">
+                                                                    <td  style="text-align: right;font-size: 10px!important; padding-left: 25px;">
                                                                         <h:panelGroup>
                                                                             <h:outputLabel value="#{fe.feeAdjusted}">
                                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -701,9 +701,9 @@
                                                                     <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
                                                                         <tr>
                                                                             <td style="text-align: left; font-size: 10px!important;">
-                                                                                <h:panelGroup>#{fe.staff.person.nameWithTitle}</h:panelGroup>
+                                                                                <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
                                                                             </td>
-                                                                            <td style="text-align: right; font-size: 10px!important;">
+                                                                            <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
                                                                                 <h:outputLabel value="#{fe.feeAdjusted}">
                                                                                     <f:convertNumber pattern="#,##0.00" />
                                                                                 </h:outputLabel>
@@ -744,7 +744,7 @@
                                                                     <h:panelGroup  rendered="#{fe.feeAdjusted gt 0 or fe.feeValue gt 0}">
                                                                         <tr>
                                                                             <td style="text-align: left; font-size: 10px!important;">
-                                                                                <h:panelGroup>#{fe.staff.person.nameWithTitle}</h:panelGroup>
+                                                                                <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
                                                                             </td>
                                                                             <td>&emsp;</td>
                                                                             <td style="text-align: right; font-size: 10px!important;">

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -81,172 +81,129 @@
                     </table>
 
 
-                    <div style=" font-size: 13px; margin-left: 1cm; height: " class="mt-2 mb-4 justify-content-center">
+                    <!-- ===== A4 Bill Header (BHT, Name, ...) - auto-wrapping 2-column grid ===== -->
+                    <div style="font-size: 13px; width: 90%; margin-left: 5%; margin-right: 5%" class="mt-4 mb-4">
+                        <div class="row gx-0">
 
-                        <div class="row">
-                            <div class="row col-6 d-flex justify-content-between">
-                                <div class="col-5 d-flex justify-content-between">
-                                    <h:outputLabel value="BHT NO" />
-                                    <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                </div>
-                                <div class="col-7" >
+                            <!-- BHT No -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">BHT No</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
                                     <h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" />
-                                </div>
+                                </span>
                             </div>
-                            <div class="col-6 W-100 ">
-                                <div class="col-6 d-flex justify-content-between">
-                                    <div class="col-5 w-100 d-flex justify-content-between">
-                                        <h:outputLabel value="Bill No" />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7 d-flex w-100">
-                                        <h:outputLabel value="#{cc.attrs.bill.deptId}" />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
 
-                        <div class="row">
-                            <div class="row col-6 d-flex justify-content-between">
-                                <div class="col-5 d-flex justify-content-between">
-                                    <h:outputLabel value="Patient Name" />
-                                    <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                </div>
-                                <div class="col-7" >
+                            <!-- Bill No -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">Bill No</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.deptId}" />
+                                </span>
+                            </div>
+
+                            <!-- Patient Name -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">Patient Name</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
                                     <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"/>
-                                </div>
+                                </span>
                             </div>
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Address on Final Bill',true)}">
-                                <div class="col-6 W-100 ">
-                                    <div class="col-6 d-flex justify-content-between">
-                                        <div class="col-5 w-100 d-flex justify-content-between">
-                                            <h:outputLabel value="Address" />
-                                            <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                        </div>
-                                        <div class="col-7 d-flex w-100">
-                                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.address}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Gender/Age on Final Bill',false)}">
-                                <div class="row col-6 d-flex justify-content-between">
-                                    <div class="col-5 d-flex justify-content-between">
-                                        <h:outputLabel value="Patient Age/Sex" />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7" >
-                                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.ageAsShortString} / #{cc.attrs.bill.patientEncounter.patient.person.sex}"/>
-                                    </div>
-                                </div>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient NIC on Final Bill',false)
-                                           or (cc.attrs.bill.patientEncounter.patient.person.nic ne null and !cc.attrs.bill.patientEncounter.patient.person.nic.equals(''))}">
-                                <div class="col-6 W-100 ">
-                                    <div class="col-6 d-flex justify-content-between">
-                                        <div class="col-5 w-100 d-flex justify-content-between">
-                                            <h:outputLabel value="NIC No" />
-                                            <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                        </div>
-                                        <div class="col-7 d-flex w-100">
-                                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nic ne null and !cc.attrs.bill.patientEncounter.patient.person.nic.equals('') ? cc.attrs.bill.patientEncounter.patient.person.nic : cc.attrs.bill.patientEncounter.guardian.nic}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Phone Number on Final Bill',false)}">
-                                <div class="row col-6 d-flex justify-content-between">
-                                    <div class="col-5 d-flex justify-content-between">
-                                        <h:outputLabel value="Phone No" />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7" >
-                                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.phone}"/>
-                                    </div>
-                                </div>
-                            </h:panelGroup>
-                        </div>
 
-                        <div class="row">
-                            <div class="row col-6 d-flex justify-content-between">
-                                <div class="col-5 d-flex justify-content-between">
-                                    <h:outputLabel value="Admission At"/>
-                                    <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                </div>
-                                <div class="col-7" >
+                            <!-- Address -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Address on Final Bill',true)}">
+                                <span style="width: 130px;">Address</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.address}"/>
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- Patient Age/Sex -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Gender/Age on Final Bill',false)}">
+                                <span style="width: 130px;">Patient Age/Sex</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.ageAsShortString} / #{cc.attrs.bill.patientEncounter.patient.person.sex}"/>
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- NIC No -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient NIC on Final Bill',false) or (cc.attrs.bill.patientEncounter.patient.person.nic ne null and !cc.attrs.bill.patientEncounter.patient.person.nic.equals(''))}">
+                                <span style="width: 130px;">NIC No</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nic ne null and !cc.attrs.bill.patientEncounter.patient.person.nic.equals('') ? cc.attrs.bill.patientEncounter.patient.person.nic : 'N/A'}"/>
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- Phone No -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Patient Phone Number on Final Bill',false)}">
+                                <span style="width: 130px;">Phone No</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.phone}"/>
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- Admission At -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">Admission At</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
                                     <h:outputLabel value="#{cc.attrs.bill.patientEncounter.printingAdmissionTime ne null and !cc.attrs.bill.patientEncounter.printingAdmissionTime.equals('') ? cc.attrs.bill.patientEncounter.printingAdmissionTime : cc.attrs.bill.patientEncounter.dateOfAdmission}">
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                     </h:outputLabel>
-                                </div>
+                                </span>
                             </div>
-                            <div class="col-6 W-100 ">
-                                <div class="col-6 d-flex justify-content-between">
-                                    <div class="col-5 w-100 d-flex justify-content-between">
-                                        <h:outputLabel value="Discharged At"/>
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7 d-flex w-100">
-                                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.printingDischargeTime ne null and !cc.attrs.bill.patientEncounter.printingDischargeTime.equals('') ? cc.attrs.bill.patientEncounter.printingDischargeTime : cc.attrs.bill.patientEncounter.dateOfDischarge}">
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                        </h:outputLabel>
-                                    </div>
-                                </div>
+
+                            <!-- Discharged At -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">Discharged At</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.printingDischargeTime ne null and !cc.attrs.bill.patientEncounter.printingDischargeTime.equals('') ? cc.attrs.bill.patientEncounter.printingDischargeTime : cc.attrs.bill.patientEncounter.dateOfDischarge}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                    </h:outputLabel>
+                                </span>
                             </div>
+
+                            <!-- Guardian -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Guardian on Final Bill',true)}">
+                                <span style="width: 130px;">Guardian</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.guardian.nameWithTitle}" />
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- Room -->
+                            <div class="col-6 d-flex mb-1">
+                                <span style="width: 130px;">Room</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" />
+                                </span>
+                            </div>
+
+                            <!-- Credit Company -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{cc.attrs.bill.creditCompany ne null and cc.attrs.bill.paymentMethod eq 'Credit'}">
+                                <span style="width: 130px;">Credit Company</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.creditCompany.name}" />
+                                </span>
+                            </h:panelGroup>
+
                         </div>
-
-                        <div class="row">
-                            <div class="row col-6 d-flex justify-content-between">
-                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Guardian on Final Bill',true)}">
-                                    <div class="col-5 d-flex justify-content-between">
-                                        <h:outputLabel value="Guardian" />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7" >
-                                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.guardian.nameWithTitle}" />
-                                    </div>
-                                </h:panelGroup>
-                            </div>
-                            <div class="col-6 W-100 ">
-                                <div class="col-6 d-flex justify-content-between">
-                                    <div class="col-5 w-100 d-flex justify-content-between">
-                                        <h:outputLabel value="Room " />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7 d-flex w-100">
-                                        <h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}" />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="row">
-                            <div class="row col-6 d-flex justify-content-between">
-                                <h:panelGroup rendered="#{cc.attrs.bill.creditCompany ne null and cc.attrs.bill.paymentMethod eq 'Credit'}">
-                                    <div class="col-5 d-flex justify-content-between">
-                                        <h:outputLabel value="Credit Company " />
-                                        <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                    </div>
-                                    <div class="col-7" >
-                                        <div class="col-7 d-flex w-100">
-                                            <h:outputLabel value="#{cc.attrs.bill.creditCompany.name}" />
-                                        </div>
-                                    </div>
-                                </h:panelGroup>
-
-                            </div>
-                            <!--                            <div class="col-6 W-100 ">
-                                                            <div class="col-6 d-flex justify-content-between">
-                                                                <div class="col-5 w-100 d-flex justify-content-between">
-                                                                    <h:outputLabel value="Vat Reg. No " />
-                                                                    <h:outputLabel value=":" style="width: 20px; text-align: center;"/>
-                                                                </div>
-                                                                <div class="col-7 d-flex w-100">
-
-                                                                </div>
-                                                            </div>
-                                                        </div>-->
-                        </div>
-
                     </div>
 
                     <div style="width: 90%; margin-left: 5%; margin-right: 5%">


### PR DESCRIPTION
## Summary

This PR addresses two inward final bill issues on the same branch:

- **#21387 — Display doctor specialty next to doctor name.** The doctor's specialty is now shown in parentheses right after the staff name in **all three** Professional Charge breakdown blocks (standard, organized, and "Display All Doctor Chargers as a One" summary). The specialty only renders when the staff member actually has one assigned, so doctors without a specialty are unaffected. Added left padding between the name/specialty cell and the fee amount so the figures stay clearly separated.
- **#21388 — Display patient ID number on the final bill.** On the inward final bill, the "Patient ID" is the patient's **NIC**. The bill header was rebuilt as a clean, auto-wrapping two-column Bootstrap grid sized for A4, and the patient NIC ("Patient ID") is presented in this layout. Each field is a self-contained `col-6` block with an aligned label / colon / value, so optional fields that are hidden no longer leave blank gaps or break the left/right pairing.

## Issue #21387 — Display doctor specialty next to doctor name on the final bill

**Describe the bug**
The final bill does not display the doctor's specialty.

**Expected Behavior**
The doctor's name on the final bill should be formatted to include their specialty in parentheses.

## Issue #21388 — Display patient ID number on the final bill

**Describe the bug**
Add Patient ID number to the final bill layout.

> Note: On the inward final bill, "Patient ID" refers to the patient's **NIC** number. It is presented via the existing `NIC No` field in the restructured header.

## Config Options

The restructured A4 header honours the following existing application configuration options (no new keys are introduced):

| Config Option | Type | Default | Effect |
| --- | --- | --- | --- |
| `Print Patient Address on Final Bill` | Boolean | `true` | Show the patient address row |
| `Print Patient Gender/Age on Final Bill` | Boolean | `false` | Show the patient Age/Sex row |
| `Print Patient NIC on Final Bill` | Boolean | `false` | Force-show the NIC ("Patient ID") row (the row also appears automatically whenever the patient has a NIC) |
| `Print Patient Phone Number on Final Bill` | Boolean | `false` | Show the patient phone row |
| `Print Guardian on Final Bill` | Boolean | `true` | Show the guardian row |

## Changes

- `src/main/webapp/resources/inward/bill/finalBill.xhtml`
  - Rebuilt the bill header (BHT, Bill No, Patient Name, NIC, Admission/Discharge, Guardian, Room, Credit Company) into an auto-wrapping two-column A4 grid.
  - Appended `(<speciality>)` after the doctor name in the three Professional Charge blocks, rendered only when a specialty exists.
  - Added `padding-left` spacing between the doctor name/specialty and the fee amount.

## Testing

JSF/XHTML-only change — no Java changes, so no compilation required. Verified the header renders correctly on an A4-width inward final bill and that the specialty appears next to doctor names in the Professional Charge section.

Closes #21387
Closes #21388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced bill display with additional patient information fields (BHT No, NIC, Phone, Admission/Discharge dates, Guardian, Room, Credit Company)
  * Added staff speciality information throughout bill sections

* **Style**
  * Reorganized bill header layout for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->