### PR TITLE
fix(inward): inward deposit payment due fails to update and shows zero (#21332)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -123,12 +123,17 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
             JsfUtil.addErrorMessage("Select BHT");
             return;
         }
+        
+        paymentListener();
+
+    }
+    
+    public void paymentListener(){
         due = getFinalBillDue();
         finalBillTotal = getFinalBillNetTotal();
         patient = current.getPatientEncounter().getPatient();
         paymentMethod = null;
         paymentMethodData = new PaymentMethodData();
-
     }
 
     /** Navigate to the inward patient co-payment collection page, requiring an active shift. */

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -454,6 +454,9 @@ public class InwardSearch implements Serializable {
         inwardPaymentController.makeNull();
         inwardPaymentController.getCurrent().setPatientEncounter(pe);
         inwardPaymentController.setPatient(pe.getPatient());
+        
+        inwardPaymentController.paymentListener();
+        
         if (sessionController.getPaymentManagementAfterShiftStart()) {
             financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
             if (financialTransactionController.getNonClosedShiftStartFundBill() != null) {


### PR DESCRIPTION
## Summary

Fixes the critical inward deposit **Payment Due** bug where, after collecting a couple of payments for a patient, the system stopped deducting the paid amounts from the total due and the Payment Due field broke and incorrectly showed **zero**.

Root cause: when the inward deposit payment screen was (re)entered for an encounter, the due / final-bill-total values were not recalculated, so the displayed Payment Due went stale and collapsed to zero after multiple payment rounds.

The fix recomputes the payment due on entry to the screen:

1. **`InwardPaymentController`** — extracted the recalculation logic (`due = getFinalBillDue()`, `finalBillTotal = getFinalBillNetTotal()`, patient and payment-method reset) into a dedicated, reusable `paymentListener()` method.
2. **`InwardSearch`** — calls `inwardPaymentController.paymentListener()` while navigating to the inward deposit payment page, so the Payment Due and final bill total are freshly computed for the selected encounter every time the screen is opened.

## Issue #21332 — Inward deposit payment due fails to update and shows zero after multiple payments rounds

**Describe the bug**
Payment Due field does not update correctly. After a user collects a couple of payments for a patient, the system fails to deduct the paid amounts from the total due. Instead of reducing the remaining balance accurately, the payment due field completely breaks and incorrectly shows as zero (0).

## Changes

- `src/main/java/com/divudi/bean/inward/InwardPaymentController.java` — add `paymentListener()` and invoke it from the selection handler.
- `src/main/java/com/divudi/bean/inward/InwardSearch.java` — invoke `paymentListener()` on navigation to the payment screen.

## Testing

- Collect multiple inward deposit payments for the same BHT and confirm each payment is deducted and the Payment Due reflects the correct remaining balance (no longer drops to zero).

Closes #21332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined payment initialization logic to enhance code maintainability and reusability across payment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->