### PR TITLE
feat(clinical): favourite diagnosis API — weight range support, no-filter fallbacks, and channel report summaries

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelReportTempController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportTempController.java
@@ -24,6 +24,7 @@ import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.ServiceSessionLeave;
 import com.divudi.core.entity.Speciality;
 import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.channel.AgentReferenceBook;
 import com.divudi.core.facade.AgentHistoryFacade;
 import com.divudi.core.facade.AgentReferenceBookFacade;
@@ -35,6 +36,7 @@ import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.ServiceSessionLeaveFacade;
 import com.divudi.core.facade.SpecialityFacade;
 import com.divudi.core.facade.StaffFacade;
+import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.util.CommonFunctions;
 import javax.inject.Named;
@@ -81,6 +83,8 @@ public class ChannelReportTempController implements Serializable {
     StaffFacade staffFacade;
     @EJB
     SpecialityFacade specialityFacade;
+    @EJB
+    WebUserFacade webUserFacade;
     //
     @EJB
     ChannelBean channelBean;
@@ -113,6 +117,9 @@ public class ChannelReportTempController implements Serializable {
     boolean sessoinDate;
     boolean paid;
     boolean scan;
+    boolean agency;
+    ChannelTotal channelTotal;
+    List<ChannelSummeryDateRangeOrUserRow> channelSummeryDateRangeOrUserRows = new ArrayList<>();
 
 
     /**
@@ -222,6 +229,487 @@ public class ChannelReportTempController implements Serializable {
             return getBillFacade().findLongByJpql(sql, m, TemporalType.TIMESTAMP);
         } else {
             return getBillFacade().findDoubleByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+
+    }
+
+    public double fetchBillsTotal(BillType[] billTypes, BillType bt, Class[] bills, Class[] nbills, Bill b, Date fd, Date td, Institution billedInstitution, Institution creditCompany, boolean withOutDocFee, boolean count, Staff staff, Speciality sp, WebUser webUser) {
+
+        String sql;
+        Map m = new HashMap();
+        if (count) {
+            sql = " select count(b) ";
+        } else if (withOutDocFee) {
+            sql = " select sum(b.netTotal-b.staffFee) ";
+        } else {
+            sql = " select sum(b.netTotal) ";
+        }
+
+        sql += " from Bill b "
+                + " where b.retired=false ";
+
+        if (b.getClass().equals(BilledBill.class)) {
+            sql += " and b.singleBillSession.sessionDate between :fromDate and :toDate ";
+        }
+        if (b.getClass().equals(CancelledBill.class)) {
+            sql += " and b.createdAt between :fromDate and :toDate ";
+        }
+        if (b.getClass().equals(RefundBill.class)) {
+            sql += " and b.createdAt between :fromDate and :toDate ";
+        }
+
+        if (billTypes != null) {
+            sql += " and b.billType in :bt ";
+            List<BillType> bts = Arrays.asList(billTypes);
+            m.put("bt", bts);
+        }
+        if (bt != null) {
+            sql += " and b.billType=:bt ";
+            m.put("bt", bt);
+        }
+        if (bills != null) {
+            sql += " and type(b) in :class ";
+            List<Class> cs = Arrays.asList(bills);
+            m.put("class", cs);
+        }
+        if (nbills != null) {
+            sql += " and type(b) not in :nclass ";
+            List<Class> ncs = Arrays.asList(nbills);
+            m.put("nclass", ncs);
+        }
+        if (b != null) {
+            sql += " and type(b)=:class ";
+            m.put("class", b.getClass());
+        }
+        if (billedInstitution != null) {
+            sql += " and b.institution=:ins ";
+            m.put("ins", billedInstitution);
+        }
+        if (creditCompany != null) {
+            sql += " and b.creditCompany=:cc ";
+            m.put("cc", creditCompany);
+        }
+        if (staff != null) {
+            sql += " and b.staff=:s ";
+            m.put("s", staff);
+        }
+        if (webUser != null) {
+            sql += " and b.creater=:wu ";
+            m.put("wu", webUser);
+        }
+        if (sp != null) {
+            sql += " and b.staff.speciality=:sp ";
+            m.put("sp", sp);
+        }
+        if (getReportKeyWord().getBillType() != null) {
+            sql += " and b.singleBillSession.serviceSession.originatingSession.forBillType=:fbt ";
+            m.put("fbt", getReportKeyWord().getBillType());
+        }
+
+        m.put("fromDate", fd);
+        m.put("toDate", td);
+        if (count) {
+            return getBillFacade().findLongByJpql(sql, m, TemporalType.TIMESTAMP);
+        } else {
+            return getBillFacade().findDoubleByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+
+    }
+
+    public double fetchBillsTotalSessoin(BillType[] billTypes, BillType bt, Class[] bills, Class[] nbills, Bill b, Date fd, Date td, Institution billedInstitution, Institution creditCompany, boolean withOutDocFee, boolean count, Staff staff, Speciality sp, WebUser webUser) {
+
+        String sql;
+        Map m = new HashMap();
+        if (count) {
+            sql = " select count(b) ";
+        } else if (withOutDocFee) {
+            sql = " select sum(b.netTotal-b.staffFee) ";
+        } else {
+            sql = " select sum(b.netTotal) ";
+        }
+
+        sql += " from Bill b "
+                + " where b.retired=false"
+                + " and b.createdAt between :fromDate and :toDate "
+                + " and b.singleBillSession.sessionDate between :fd and :td ";
+
+        if (billTypes != null) {
+            sql += " and b.billType in :bt ";
+            List<BillType> bts = Arrays.asList(billTypes);
+            m.put("bt", bts);
+        }
+        if (bt != null) {
+            sql += " and b.billType=:bt ";
+            m.put("bt", bt);
+        }
+        if (bills != null) {
+            sql += " and type(b) in :class ";
+            List<Class> cs = Arrays.asList(bills);
+            m.put("class", cs);
+        }
+        if (nbills != null) {
+            sql += " and type(b) not in :nclass ";
+            List<Class> ncs = Arrays.asList(nbills);
+            m.put("nclass", ncs);
+        }
+        if (b != null) {
+            sql += " and type(b)=:class ";
+            m.put("class", b.getClass());
+        }
+        if (billedInstitution != null) {
+            sql += " and b.institution=:ins ";
+            m.put("ins", billedInstitution);
+        }
+        if (creditCompany != null) {
+            sql += " and b.creditCompany=:cc ";
+            m.put("cc", creditCompany);
+        }
+        if (staff != null) {
+            sql += " and b.staff=:s ";
+            m.put("s", staff);
+        }
+        if (webUser != null) {
+            sql += " and b.creater=:wu ";
+            m.put("wu", webUser);
+        }
+        if (sp != null) {
+            sql += " and b.staff.speciality=:sp ";
+            m.put("sp", sp);
+        }
+        if (getReportKeyWord().getBillType() != null) {
+            sql += " and b.singleBillSession.serviceSession.originatingSession.forBillType=:fbt ";
+            m.put("fbt", getReportKeyWord().getBillType());
+        }
+
+        m.put("fromDate", fd);
+        m.put("toDate", td);
+        m.put("fd", getFromDate());
+        m.put("td", getToDate());
+        if (count) {
+            return getBillFacade().findLongByJpql(sql, m, TemporalType.TIMESTAMP);
+        } else {
+            return getBillFacade().findDoubleByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+
+    }
+
+    public List<WebUser> fetchCashiers(BillType[] bts) {
+        List<WebUser> cashiers;
+        String sql;
+        Map m = new HashMap();
+        List<BillType> btys = Arrays.asList(bts);
+        sql = "select us from "
+                + " Bill b "
+                + " join b.creater us "
+                + " where b.retired=false "
+                + " and b.institution=:ins "
+                + " and b.billType in :btp "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " group by us "
+                + " having sum(b.netTotal)!=0 ";
+        m.put("toDate", getToDate());
+        m.put("fromDate", getFromDate());
+        m.put("btp", btys);
+        m.put("ins", sessionController.getInstitution());
+        cashiers = getWebUserFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
+        if (cashiers == null) {
+            cashiers = new ArrayList<>();
+        }
+
+        return cashiers;
+    }
+
+    public List<WebUser> fetchCashiersSession(BillType[] bts) {
+        List<WebUser> cashiers;
+        String sql;
+        Map m = new HashMap();
+        List<BillType> btys = Arrays.asList(bts);
+        sql = "select us from "
+                + " Bill b "
+                + " join b.creater us "
+                + " where b.retired=false "
+                + " and b.institution=:ins "
+                + " and b.billType in :btp "
+                + " and b.singleBillSession.sessionDate between :fromDate and :toDate "
+                + " group by us "
+                + " having sum(b.netTotal)!=0 ";
+        m.put("toDate", getToDate());
+        m.put("fromDate", getFromDate());
+        m.put("btp", btys);
+        m.put("ins", sessionController.getInstitution());
+        cashiers = getWebUserFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
+        if (cashiers == null) {
+            cashiers = new ArrayList<>();
+        }
+
+        return cashiers;
+    }
+
+    public List<ChannelSummeryUserRow> fetchUserRows(Date fDate, Date tDate, BillType[] bts) {
+        List<ChannelSummeryUserRow> userRows = new ArrayList<>();
+        double tbc = 0.0;
+        double tcc = 0.0;
+        double trc = 0.0;
+        double tht = 0.0;
+        double tst = 0.0;
+        for (WebUser webUser : fetchCashiers(bts)) {
+            ChannelSummeryUserRow row = new ChannelSummeryUserRow();
+            row.setUser(webUser);
+            row.setBillCount(fetchBillsTotal(bts, null, null, null, new BilledBill(), fDate, tDate, null, null, false, true, null, null, webUser));
+            row.setCanceledCount(fetchBillsTotal(bts, null, null, null, new CancelledBill(), fDate, tDate, null, null, false, true, null, null, webUser));
+            row.setRefundCount(fetchBillsTotal(bts, null, null, null, new RefundBill(), fDate, tDate, null, null, false, true, null, null, webUser));
+            double netTotal = fetchBillsTotal(bts, null, null, null, new BilledBill(), fDate, tDate, null, null, false, false, null, null, webUser)
+                    + (fetchBillsTotal(bts, null, null, null, new CancelledBill(), fDate, tDate, null, null, false, false, null, null, webUser)
+                    + fetchBillsTotal(bts, null, null, null, new RefundBill(), fDate, tDate, null, null, false, false, null, null, webUser));
+            double hosTotal = fetchBillsTotal(bts, null, null, null, new BilledBill(), fDate, tDate, null, null, true, false, null, null, webUser)
+                    + (fetchBillsTotal(bts, null, null, null, new CancelledBill(), fDate, tDate, null, null, true, false, null, null, webUser)
+                    + fetchBillsTotal(bts, null, null, null, new RefundBill(), fDate, tDate, null, null, true, false, null, null, webUser));
+            row.setTotalHosFee(hosTotal);
+            row.setTotalDocFee(netTotal - hosTotal);
+            row.setBold(false);
+            if (row.getBillCount() != 0.0 || row.getCanceledCount() != 0.0 || row.getRefundCount() != 0.0) {
+                userRows.add(row);
+            }
+
+            tbc += row.getBillCount();
+            tcc += row.getCanceledCount();
+            trc += row.getRefundCount();
+            tht += row.getTotalHosFee();
+            tst += row.getTotalDocFee();
+        }
+
+        ChannelSummeryUserRow row = new ChannelSummeryUserRow();
+        row.setBillCount(tbc);
+        row.setCanceledCount(tcc);
+        row.setRefundCount(trc);
+        row.setTotalHosFee(tht);
+        row.setTotalDocFee(tst);
+        row.setBold(true);
+        userRows.add(row);
+
+        channelTotal.setTotalBillCount(channelTotal.getTotalBillCount() + tbc);
+        channelTotal.setTotalCanceledCount(channelTotal.getTotalCanceledCount() + tcc);
+        channelTotal.setTotalRefundCount(channelTotal.getTotalRefundCount() + trc);
+        channelTotal.setTotalDocFee(channelTotal.getTotalDocFee() + tst);
+        channelTotal.setTotalHosFee(channelTotal.getTotalHosFee() + tht);
+
+        return userRows;
+    }
+
+    public List<ChannelSummeryDateRangeRow> fetchDateRangeRows(Date fDate, Date tDate, WebUser webUser, BillType[] bts) {
+        List<ChannelSummeryDateRangeRow> dateRangeRows = new ArrayList<>();
+        Date nowDate = fDate;
+        double tbc = 0.0;
+        double tcc = 0.0;
+        double trc = 0.0;
+        double tht = 0.0;
+        double tst = 0.0;
+        while (nowDate.before(tDate)) {
+            ChannelSummeryDateRangeRow row = new ChannelSummeryDateRangeRow();
+            String formatedDate;
+            Date fd;
+            Date td;
+            fd = CommonFunctions.getStartOfDay(nowDate);
+            td = CommonFunctions.getEndOfDay(nowDate);
+
+            DateFormat df = new SimpleDateFormat("yyyy MMMM dd");
+            formatedDate = df.format(fd);
+            row.setDate(formatedDate);
+            row.setBillCount(fetchBillsTotal(bts, null, null, null, new BilledBill(), fd, td, null, null, false, true, null, null, webUser));
+            row.setCanceledCount(fetchBillsTotal(bts, null, null, null, new CancelledBill(), fd, td, null, null, false, true, null, null, webUser));
+            row.setRefundCount(fetchBillsTotal(bts, null, null, null, new RefundBill(), fd, td, null, null, false, true, null, null, webUser));
+            double netTotal = fetchBillsTotal(bts, null, null, null, new BilledBill(), fd, td, null, null, false, false, null, null, webUser)
+                    + (fetchBillsTotal(bts, null, null, null, new CancelledBill(), fd, td, null, null, false, false, null, null, webUser)
+                    + fetchBillsTotal(bts, null, null, null, new RefundBill(), fd, td, null, null, false, false, null, null, webUser));
+            double hosTotal = fetchBillsTotal(bts, null, null, null, new BilledBill(), fd, td, null, null, true, false, null, null, webUser)
+                    + (fetchBillsTotal(bts, null, null, null, new CancelledBill(), fd, td, null, null, true, false, null, null, webUser)
+                    + fetchBillsTotal(bts, null, null, null, new RefundBill(), fd, td, null, null, true, false, null, null, webUser));
+            row.setTotalHosFee(hosTotal);
+            row.setTotalDocFee(netTotal - hosTotal);
+            row.setBold(false);
+
+            if (row.getBillCount() != 0.0 || row.getCanceledCount() != 0.0 || row.getRefundCount() != 0.0) {
+                dateRangeRows.add(row);
+            }
+
+            tbc += row.getBillCount();
+            tcc += row.getCanceledCount();
+            trc += row.getRefundCount();
+            tht += row.getTotalHosFee();
+            tst += row.getTotalDocFee();
+
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(nowDate);
+            cal.add(Calendar.DATE, 1);
+            nowDate = cal.getTime();
+        }
+        ChannelSummeryDateRangeRow row = new ChannelSummeryDateRangeRow();
+        row.setBillCount(tbc);
+        row.setCanceledCount(tcc);
+        row.setRefundCount(trc);
+        row.setTotalHosFee(tht);
+        row.setTotalDocFee(tst);
+        row.setBold(true);
+        dateRangeRows.add(row);
+
+        channelTotal.setTotalBillCount(channelTotal.getTotalBillCount() + tbc);
+        channelTotal.setTotalCanceledCount(channelTotal.getTotalCanceledCount() + tcc);
+        channelTotal.setTotalRefundCount(channelTotal.getTotalRefundCount() + trc);
+        channelTotal.setTotalDocFee(channelTotal.getTotalDocFee() + tst);
+        channelTotal.setTotalHosFee(channelTotal.getTotalHosFee() + tht);
+
+        return dateRangeRows;
+    }
+
+    public List<ChannelSummeryDateRangeRow> fetchDateRangeRowsSession(Date fDate, Date tDate, WebUser webUser, BillType[] bts) {
+        List<ChannelSummeryDateRangeRow> dateRangeRows = new ArrayList<>();
+        Date nowDate = fDate;
+        double tbc = 0.0;
+        double tcc = 0.0;
+        double trc = 0.0;
+        double tht = 0.0;
+        double tst = 0.0;
+        while (nowDate.before(tDate)) {
+            ChannelSummeryDateRangeRow row = new ChannelSummeryDateRangeRow();
+            String formatedDate;
+            Date fd;
+            Date td;
+            fd = CommonFunctions.getStartOfDay(nowDate);
+            td = CommonFunctions.getEndOfDay(nowDate);
+
+            DateFormat df = new SimpleDateFormat("yyyy MMMM dd");
+            formatedDate = df.format(fd);
+            row.setDate(formatedDate);
+            row.setBillCount(fetchBillsTotalSessoin(bts, null, null, null, new BilledBill(), fd, td, null, null, false, true, null, null, webUser));
+            row.setCanceledCount(fetchBillsTotalSessoin(bts, null, null, null, new CancelledBill(), fd, td, null, null, false, true, null, null, webUser));
+            row.setRefundCount(fetchBillsTotalSessoin(bts, null, null, null, new RefundBill(), fd, td, null, null, false, true, null, null, webUser));
+            double netTotal = fetchBillsTotalSessoin(bts, null, null, null, null, fd, td, null, null, false, false, null, null, webUser);
+            double hosTotal = fetchBillsTotalSessoin(bts, null, null, null, null, fd, td, null, null, true, false, null, null, webUser);
+            row.setTotalHosFee(hosTotal);
+            row.setTotalDocFee(netTotal - hosTotal);
+            row.setBold(false);
+
+            if (row.getBillCount() != 0.0 || row.getCanceledCount() != 0.0 || row.getRefundCount() != 0.0) {
+                dateRangeRows.add(row);
+            }
+
+            tbc += row.getBillCount();
+            tcc += row.getCanceledCount();
+            trc += row.getRefundCount();
+            tht += row.getTotalHosFee();
+            tst += row.getTotalDocFee();
+
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(nowDate);
+            cal.add(Calendar.DATE, 1);
+            nowDate = cal.getTime();
+        }
+        ChannelSummeryDateRangeRow row = new ChannelSummeryDateRangeRow();
+        row.setBillCount(tbc);
+        row.setCanceledCount(tcc);
+        row.setRefundCount(trc);
+        row.setTotalHosFee(tht);
+        row.setTotalDocFee(tst);
+        row.setBold(true);
+        dateRangeRows.add(row);
+
+        channelTotal.setTotalBillCount(channelTotal.getTotalBillCount() + tbc);
+        channelTotal.setTotalCanceledCount(channelTotal.getTotalCanceledCount() + tcc);
+        channelTotal.setTotalRefundCount(channelTotal.getTotalRefundCount() + trc);
+        channelTotal.setTotalDocFee(channelTotal.getTotalDocFee() + tst);
+        channelTotal.setTotalHosFee(channelTotal.getTotalHosFee() + tht);
+
+        return dateRangeRows;
+    }
+
+    public void createChannelCountByUserOrDate() {
+        channelSummeryDateRangeOrUserRows = new ArrayList<>();
+        channelTotal = new ChannelTotal();
+        BillType[] bts;
+        if (agency) {
+            bts = new BillType[]{BillType.ChannelCash, BillType.ChannelPaid, BillType.ChannelAgent,};
+        } else {
+            bts = new BillType[]{BillType.ChannelCash, BillType.ChannelPaid,};
+        }
+
+        if (byDate) {
+            Date nowDate = getFromDate();
+            while (nowDate.before(getToDate())) {
+                ChannelSummeryDateRangeOrUserRow row = new ChannelSummeryDateRangeOrUserRow();
+                String formatedDate;
+                Date fd;
+                Date td;
+                fd = CommonFunctions.getStartOfDay(nowDate);
+                td = CommonFunctions.getEndOfDay(nowDate);
+
+                DateFormat df = new SimpleDateFormat("yyyy MMMM dd");
+                formatedDate = df.format(fd);
+                row.setDate(formatedDate);
+                row.setUserRows(fetchUserRows(fd, td, bts));
+                if (row.getUserRows().size() > 1) {
+                    channelSummeryDateRangeOrUserRows.add(row);
+                }
+
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(nowDate);
+                cal.add(Calendar.DATE, 1);
+                nowDate = cal.getTime();
+            }
+
+        } else {
+            for (WebUser webUser : fetchCashiers(bts)) {
+                ChannelSummeryDateRangeOrUserRow row = new ChannelSummeryDateRangeOrUserRow();
+                row.setUser(webUser);
+                row.setDateRangeRows(fetchDateRangeRows(getFromDate(), getToDate(), webUser, bts));
+                if (row.getDateRangeRows().size() > 1) {
+                    channelSummeryDateRangeOrUserRows.add(row);
+                }
+            }
+        }
+
+    }
+
+    public void createChannelCountByUserOrDate2() {
+        long lng = CommonFunctions.getDayCount(getFromDate(), getToDate());
+
+        if (Math.abs(lng) > 2) {
+            JsfUtil.addErrorMessage("Date Range is too Long");
+            return;
+        }
+        channelSummeryDateRangeOrUserRows = new ArrayList<>();
+        channelTotal = new ChannelTotal();
+        BillType[] bts;
+        bts = new BillType[]{BillType.ChannelCash, BillType.ChannelPaid,};
+
+        for (WebUser webUser : fetchCashiersSession(bts)) {
+            ChannelSummeryDateRangeOrUserRow row = new ChannelSummeryDateRangeOrUserRow();
+            row.setUser(webUser);
+            String sql;
+            Map m = new HashMap();
+
+            sql = "select b from Bill b "
+                    + " where b.retired=false "
+                    + " and b.singleBillSession.sessionDate between :fromDate and :toDate"
+                    + " and b.billType in :bt "
+                    + " and b.creater=:wu";
+
+            m.put("bt", Arrays.asList(bts));
+            m.put("wu", webUser);
+
+            m.put("fromDate", getFromDate());
+            m.put("toDate", getToDate());
+            List<Bill> bills = getBillFacade().findByJpql(sql, m, TemporalType.TIMESTAMP);
+            Date fd = getFromDate();
+            for (Bill b : bills) {
+                if (b.getCreatedAt().getTime() < fd.getTime()) {
+                    fd = b.getCreatedAt();
+                }
+            }
+
+            row.setDateRangeRows(fetchDateRangeRowsSession(fd, CommonFunctions.getEndOfDay(new Date()), webUser, bts));
+            if (row.getDateRangeRows().size() > 1) {
+                channelSummeryDateRangeOrUserRows.add(row);
+            }
         }
 
     }
@@ -1164,6 +1652,265 @@ public class ChannelReportTempController implements Serializable {
 
     public void setAgencies(List<Institution> agencies) {
         this.agencies = agencies;
+    }
+
+    public boolean isAgency() {
+        return agency;
+    }
+
+    public void setAgency(boolean agency) {
+        this.agency = agency;
+    }
+
+    public ChannelTotal getChannelTotal() {
+        return channelTotal;
+    }
+
+    public void setChannelTotal(ChannelTotal channelTotal) {
+        this.channelTotal = channelTotal;
+    }
+
+    public List<ChannelSummeryDateRangeOrUserRow> getChannelSummeryDateRangeOrUserRows() {
+        return channelSummeryDateRangeOrUserRows;
+    }
+
+    public void setChannelSummeryDateRangeOrUserRows(List<ChannelSummeryDateRangeOrUserRow> channelSummeryDateRangeOrUserRows) {
+        this.channelSummeryDateRangeOrUserRows = channelSummeryDateRangeOrUserRows;
+    }
+
+    public WebUserFacade getWebUserFacade() {
+        return webUserFacade;
+    }
+
+    public void setWebUserFacade(WebUserFacade webUserFacade) {
+        this.webUserFacade = webUserFacade;
+    }
+
+    public class ChannelTotal {
+
+        double totalBillCount;
+        double totalCanceledCount;
+        double totalRefundCount;
+        double totalHosFee;
+        double totalDocFee;
+
+        public double getTotalBillCount() {
+            return totalBillCount;
+        }
+
+        public void setTotalBillCount(double totalBillCount) {
+            this.totalBillCount = totalBillCount;
+        }
+
+        public double getTotalCanceledCount() {
+            return totalCanceledCount;
+        }
+
+        public void setTotalCanceledCount(double totalCanceledCount) {
+            this.totalCanceledCount = totalCanceledCount;
+        }
+
+        public double getTotalRefundCount() {
+            return totalRefundCount;
+        }
+
+        public void setTotalRefundCount(double totalRefundCount) {
+            this.totalRefundCount = totalRefundCount;
+        }
+
+        public double getTotalHosFee() {
+            return totalHosFee;
+        }
+
+        public void setTotalHosFee(double totalHosFee) {
+            this.totalHosFee = totalHosFee;
+        }
+
+        public double getTotalDocFee() {
+            return totalDocFee;
+        }
+
+        public void setTotalDocFee(double totalDocFee) {
+            this.totalDocFee = totalDocFee;
+        }
+
+    }
+
+    public class ChannelSummeryDateRangeOrUserRow {
+
+        String date;
+        WebUser user;
+        List<ChannelSummeryUserRow> userRows;
+        List<ChannelSummeryDateRangeRow> dateRangeRows;
+
+        public String getDate() {
+            return date;
+        }
+
+        public void setDate(String date) {
+            this.date = date;
+        }
+
+        public WebUser getUser() {
+            return user;
+        }
+
+        public void setUser(WebUser user) {
+            this.user = user;
+        }
+
+        public List<ChannelSummeryUserRow> getUserRows() {
+            return userRows;
+        }
+
+        public void setUserRows(List<ChannelSummeryUserRow> userRows) {
+            this.userRows = userRows;
+        }
+
+        public List<ChannelSummeryDateRangeRow> getDateRangeRows() {
+            return dateRangeRows;
+        }
+
+        public void setDateRangeRows(List<ChannelSummeryDateRangeRow> dateRangeRows) {
+            this.dateRangeRows = dateRangeRows;
+        }
+
+    }
+
+    public class ChannelSummeryUserRow {
+
+        WebUser user;
+        double billCount;
+        double canceledCount;
+        double refundCount;
+        boolean bold;
+        double totalHosFee;
+        double totalDocFee;
+
+        public double getBillCount() {
+            return billCount;
+        }
+
+        public void setBillCount(double billCount) {
+            this.billCount = billCount;
+        }
+
+        public double getCanceledCount() {
+            return canceledCount;
+        }
+
+        public void setCanceledCount(double canceledCount) {
+            this.canceledCount = canceledCount;
+        }
+
+        public double getRefundCount() {
+            return refundCount;
+        }
+
+        public void setRefundCount(double refundCount) {
+            this.refundCount = refundCount;
+        }
+
+        public boolean isBold() {
+            return bold;
+        }
+
+        public void setBold(boolean bold) {
+            this.bold = bold;
+        }
+
+        public double getTotalHosFee() {
+            return totalHosFee;
+        }
+
+        public void setTotalHosFee(double totalHosFee) {
+            this.totalHosFee = totalHosFee;
+        }
+
+        public double getTotalDocFee() {
+            return totalDocFee;
+        }
+
+        public void setTotalDocFee(double totalDocFee) {
+            this.totalDocFee = totalDocFee;
+        }
+
+        public WebUser getUser() {
+            return user;
+        }
+
+        public void setUser(WebUser user) {
+            this.user = user;
+        }
+
+    }
+
+    public class ChannelSummeryDateRangeRow {
+
+        String date;
+        double billCount;
+        double canceledCount;
+        double refundCount;
+        boolean bold;
+        double totalHosFee;
+        double totalDocFee;
+
+        public double getBillCount() {
+            return billCount;
+        }
+
+        public void setBillCount(double billCount) {
+            this.billCount = billCount;
+        }
+
+        public double getCanceledCount() {
+            return canceledCount;
+        }
+
+        public void setCanceledCount(double canceledCount) {
+            this.canceledCount = canceledCount;
+        }
+
+        public double getRefundCount() {
+            return refundCount;
+        }
+
+        public void setRefundCount(double refundCount) {
+            this.refundCount = refundCount;
+        }
+
+        public boolean isBold() {
+            return bold;
+        }
+
+        public void setBold(boolean bold) {
+            this.bold = bold;
+        }
+
+        public double getTotalHosFee() {
+            return totalHosFee;
+        }
+
+        public void setTotalHosFee(double totalHosFee) {
+            this.totalHosFee = totalHosFee;
+        }
+
+        public double getTotalDocFee() {
+            return totalDocFee;
+        }
+
+        public void setTotalDocFee(double totalDocFee) {
+            this.totalDocFee = totalDocFee;
+        }
+
+        public String getDate() {
+            return date;
+        }
+
+        public void setDate(String date) {
+            this.date = date;
+        }
+
     }
 
 }

--- a/src/main/java/com/divudi/bean/channel/ChannelReportTempController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportTempController.java
@@ -248,14 +248,16 @@ public class ChannelReportTempController implements Serializable {
         sql += " from Bill b "
                 + " where b.retired=false ";
 
-        if (b.getClass().equals(BilledBill.class)) {
-            sql += " and b.singleBillSession.sessionDate between :fromDate and :toDate ";
-        }
-        if (b.getClass().equals(CancelledBill.class)) {
-            sql += " and b.createdAt between :fromDate and :toDate ";
-        }
-        if (b.getClass().equals(RefundBill.class)) {
-            sql += " and b.createdAt between :fromDate and :toDate ";
+        if (b != null) {
+            if (b.getClass().equals(BilledBill.class)) {
+                sql += " and b.singleBillSession.sessionDate between :fromDate and :toDate ";
+            }
+            if (b.getClass().equals(CancelledBill.class)) {
+                sql += " and b.createdAt between :fromDate and :toDate ";
+            }
+            if (b.getClass().equals(RefundBill.class)) {
+                sql += " and b.createdAt between :fromDate and :toDate ";
+            }
         }
 
         if (billTypes != null) {

--- a/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PastPatientEncounterController.java
@@ -16,6 +16,7 @@ import com.divudi.bean.pharmacy.PharmacySaleController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.SymanticType;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
+import com.divudi.core.data.clinical.DocumentTemplateType;
 import com.divudi.core.data.clinical.PrescriptionTemplateType;
 import com.divudi.core.data.inward.PatientEncounterType;
 import com.divudi.core.data.lab.InvestigationResultForGraph;
@@ -1401,6 +1402,7 @@ public class PastPatientEncounterController implements Serializable {
         for (DocumentTemplate t : dts) {
             if (t.isDefaultTemplate()) {
                 ClinicalFindingValue cfv = new ClinicalFindingValue();
+                cfv.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
                 cfv.setEncounter(encounter);
                 cfv.setDocumentTemplate(t);
                 cfv.setStringValue(t.getName());
@@ -1518,6 +1520,9 @@ public class PastPatientEncounterController implements Serializable {
         }
         if (encounterPrescreption != null) {
             encounterPrescreption.setLobValue(generateDocumentFromTemplate(encounterPrescreption.getDocumentTemplate(), current));
+            if (encounterPrescreption.getClinicalFindingValueType() == null) {
+                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
+            }
             if (encounterPrescreption.getId() == null) {
                 clinicalFindingValueFacade.create(encounterPrescreption);
             } else {
@@ -1533,7 +1538,7 @@ public class PastPatientEncounterController implements Serializable {
             }
             if (prescTemplate != null) {
                 encounterPrescreption = new ClinicalFindingValue();
-                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitDocument);
+                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
                 encounterPrescreption.setDocumentTemplate(prescTemplate);
                 encounterPrescreption.setEncounter(current);
                 encounterPrescreption.setLobValue(generateDocumentFromTemplate(prescTemplate, current));
@@ -2699,9 +2704,31 @@ public class PastPatientEncounterController implements Serializable {
     }
 
     private List<ClinicalFindingValue> fillEncounterPrescreptions(PatientEncounter encounter) {
-        List<ClinicalFindingValueType> clinicalFindingValueTypes = new ArrayList<>();
-        clinicalFindingValueTypes.add(ClinicalFindingValueType.VisitPrescription);
-        return loadCurrentEncounterFindingValues(encounter, clinicalFindingValueTypes);
+        List<ClinicalFindingValue> vs = new ArrayList<>();
+        if (encounterFindingValues == null) {
+            encounterFindingValues = fillEncounterFindingValues(encounter);
+        }
+        if (encounterFindingValues == null) {
+            encounterFindingValues = new ArrayList<>();
+        }
+        for (ClinicalFindingValue v : encounterFindingValues) {
+            if (v == null) {
+                continue;
+            }
+            if (v.getClinicalFindingValueType() == ClinicalFindingValueType.VisitPrescription) {
+                vs.add(v);
+                continue;
+            }
+            // Legacy prescriptions were persisted with a null or VisitDocument type;
+            // recognise them through their document template type instead.
+            boolean legacyType = v.getClinicalFindingValueType() == null
+                    || v.getClinicalFindingValueType() == ClinicalFindingValueType.VisitDocument;
+            if (legacyType && v.getDocumentTemplate() != null
+                    && v.getDocumentTemplate().getType() == DocumentTemplateType.Prescription) {
+                vs.add(v);
+            }
+        }
+        return vs;
     }
 
     private List<ClinicalFindingValue> fillPlanOfAction(PatientEncounter encounter) {

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -1344,6 +1344,16 @@ public class PatientEncounterController implements Serializable {
             encounterMedicines = new ArrayList<>();
         }
 
+        // The medicine selected via the "Medicine" autocomplete (acMedicine). Favourite
+        // lookups are scoped to this item so "Add Favourite" applies to the selected medicine.
+        Item selectedMedicine = getEncounterMedicine().getPrescription() != null
+                ? getEncounterMedicine().getPrescription().getItem() : null;
+
+        if (selectedMedicine == null) {
+            JsfUtil.addErrorMessage("Please select a medicine first");
+            return;
+        }
+
         List<PrescriptionTemplate> favouriteMedicines = new ArrayList<>();
         String lookupMethod = "";
 
@@ -1359,7 +1369,7 @@ public class PatientEncounterController implements Serializable {
         // Method 2: By Patient Weight Group (if weight is available)
         if (patientWeight != null && patientWeight > 0) {
             favouriteMedicines = favouriteController.listFavouriteItems(
-                    null,
+                    selectedMedicine,
                     PrescriptionTemplateType.FavouriteMedicine,
                     patientWeight,
                     null
@@ -1372,7 +1382,7 @@ public class PatientEncounterController implements Serializable {
         // Method 3: By Patient Age Group (fallback when weight is not available or no weight-based favourites found)
         if (favouriteMedicines.isEmpty() && patientAgeInDays != null && patientAgeInDays > 0) {
             favouriteMedicines = favouriteController.listFavouriteItems(
-                    null,
+                    selectedMedicine,
                     PrescriptionTemplateType.FavouriteMedicine,
                     null,
                     patientAgeInDays
@@ -1382,13 +1392,27 @@ public class PatientEncounterController implements Serializable {
             }
         }
 
+        // Method 4: No age/weight restriction — fallback when patient DOB and weight are not
+        // recorded so the doctor still gets the favourite configuration.
+        if (favouriteMedicines.isEmpty()) {
+            favouriteMedicines = favouriteController.listFavouriteItems(
+                    selectedMedicine,
+                    PrescriptionTemplateType.FavouriteMedicine,
+                    null,
+                    null
+            );
+            if (!favouriteMedicines.isEmpty()) {
+                lookupMethod = "medicine templates (no age/weight filter)";
+            }
+        }
+
         // Check if any favourites were found
         if (favouriteMedicines == null || favouriteMedicines.isEmpty()) {
-            String message = "No favourite medicines found";
+            String message = "No favourite configuration found for " + selectedMedicine.getName();
             if (patientWeight != null && patientWeight > 0) {
-                message += " for weight " + patientWeight + " kg";
+                message += " at weight " + patientWeight + " kg";
             } else if (patientAgeInDays != null && patientAgeInDays > 0) {
-                message += " for age " + (patientAgeInDays / 365) + " years";
+                message += " at age " + (patientAgeInDays / 365) + " years";
             }
             JsfUtil.addWarningMessage(message);
             return;
@@ -1527,7 +1551,7 @@ public class PatientEncounterController implements Serializable {
         }
 
         // Method 2: By Patient Age Group (fallback when weight is not available or no weight-based favourites found)
-        if (diagnosisMedicineList == null || diagnosisMedicineList.isEmpty() && patientAgeInDays != null && patientAgeInDays > 0) {
+        if ((diagnosisMedicineList == null || diagnosisMedicineList.isEmpty()) && patientAgeInDays != null && patientAgeInDays > 0) {
             System.out.println("DEBUG: Step 1 - Finding medicine list by age group: " + patientAgeInDays + " days");
             diagnosisMedicineList = favouriteController.listFavouriteItems(
                     selectedDiagnosis,
@@ -1536,8 +1560,25 @@ public class PatientEncounterController implements Serializable {
                     patientAgeInDays
             );
             System.out.println("DEBUG: Age-based lookup found " + (diagnosisMedicineList != null ? diagnosisMedicineList.size() : "null") + " medicine recommendations");
-            if (diagnosisMedicineList!=null && !diagnosisMedicineList.isEmpty()) {
+            if (diagnosisMedicineList != null && !diagnosisMedicineList.isEmpty()) {
                 lookupMethod = "age group (" + (patientAgeInDays / 365) + " years)";
+            }
+        }
+
+        // Method 3: No age/weight restriction — used when patient weight and DOB are not
+        // recorded (ageInDays == null or 0).  Returns all FavouriteDiagnosis templates for
+        // this diagnosis regardless of age range so the doctor still gets suggestions.
+        if (diagnosisMedicineList == null || diagnosisMedicineList.isEmpty()) {
+            System.out.println("DEBUG: Step 1 - No age/weight data available; fetching all templates for diagnosis");
+            diagnosisMedicineList = favouriteController.listFavouriteItems(
+                    selectedDiagnosis,
+                    PrescriptionTemplateType.FavouriteDiagnosis,
+                    null,
+                    null
+            );
+            System.out.println("DEBUG: Unrestricted lookup found " + (diagnosisMedicineList != null ? diagnosisMedicineList.size() : "null") + " medicine recommendations");
+            if (diagnosisMedicineList != null && !diagnosisMedicineList.isEmpty()) {
+                lookupMethod = "diagnosis templates (no age/weight filter)";
             }
         }
 
@@ -1578,6 +1619,17 @@ public class PatientEncounterController implements Serializable {
                     System.out.println("DEBUG: Age-based medicine config found " + (medicineConfigs != null ? medicineConfigs.size() : "null") + " results");
                 }
 
+                // Try no-filter if weight and age are both unavailable/zero
+                if (medicineConfigs == null || medicineConfigs.isEmpty()) {
+                    medicineConfigs = favouriteController.listFavouriteItems(
+                            diagnosisTemplate.getItem(),
+                            PrescriptionTemplateType.FavouriteMedicine,
+                            null,
+                            null
+                    );
+                    System.out.println("DEBUG: No-filter medicine config found " + (medicineConfigs != null ? medicineConfigs.size() : "null") + " results");
+                }
+
                 // Use the first valid configuration found
                 if (medicineConfigs != null && !medicineConfigs.isEmpty()) {
                     PrescriptionTemplate medicineTemplate = medicineConfigs.get(0);
@@ -1586,7 +1638,11 @@ public class PatientEncounterController implements Serializable {
                                      " with dose=" + medicineTemplate.getDose() +
                                      ", frequency=" + (medicineTemplate.getFrequencyUnit() != null ? medicineTemplate.getFrequencyUnit().getName() : "null"));
                 } else {
-                    System.out.println("DEBUG: No detailed configuration found for " + diagnosisTemplate.getItem().getName() + " - skipping");
+                    // No separate FavouriteMedicine configuration exists for this medicine -
+                    // fall back to the dose/frequency/duration already stored on the
+                    // FavouriteDiagnosis template itself.
+                    System.out.println("DEBUG: No separate FavouriteMedicine configuration found for " + diagnosisTemplate.getItem().getName() + " - using FavouriteDiagnosis template directly");
+                    favouriteMedicines.add(diagnosisTemplate);
                 }
             }
         }
@@ -2165,6 +2221,7 @@ public class PatientEncounterController implements Serializable {
         for (DocumentTemplate t : dts) {
             if (t.isDefaultTemplate()) {
                 ClinicalFindingValue cfv = new ClinicalFindingValue();
+                cfv.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
                 cfv.setEncounter(encounter);
                 cfv.setDocumentTemplate(t);
                 cfv.setStringValue(t.getName());
@@ -2323,6 +2380,9 @@ public class PatientEncounterController implements Serializable {
         }
         if (encounterPrescreption != null) {
             encounterPrescreption.setLobValue(generateDocumentFromTemplate(encounterPrescreption.getDocumentTemplate(), current));
+            if (encounterPrescreption.getClinicalFindingValueType() == null) {
+                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
+            }
             if (encounterPrescreption.getId() == null) {
                 clinicalFindingValueFacade.create(encounterPrescreption);
             } else {
@@ -2339,7 +2399,7 @@ public class PatientEncounterController implements Serializable {
             }
             if (prescTemplate != null) {
                 encounterPrescreption = new ClinicalFindingValue();
-                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitDocument);
+                encounterPrescreption.setClinicalFindingValueType(ClinicalFindingValueType.VisitPrescription);
                 encounterPrescreption.setDocumentTemplate(prescTemplate);
                 encounterPrescreption.setEncounter(current);
                 encounterPrescreption.setLobValue(generateDocumentFromTemplate(prescTemplate, current));
@@ -3842,9 +3902,31 @@ public class PatientEncounterController implements Serializable {
     }
 
     private List<ClinicalFindingValue> fillEncounterPrescreptions(PatientEncounter encounter) {
-        List<ClinicalFindingValueType> clinicalFindingValueTypes = new ArrayList<>();
-        clinicalFindingValueTypes.add(ClinicalFindingValueType.VisitPrescription);
-        return loadCurrentEncounterFindingValues(encounter, clinicalFindingValueTypes);
+        List<ClinicalFindingValue> vs = new ArrayList<>();
+        if (encounterFindingValues == null) {
+            encounterFindingValues = fillEncounterFindingValues(encounter);
+        }
+        if (encounterFindingValues == null) {
+            encounterFindingValues = new ArrayList<>();
+        }
+        for (ClinicalFindingValue v : encounterFindingValues) {
+            if (v == null) {
+                continue;
+            }
+            if (v.getClinicalFindingValueType() == ClinicalFindingValueType.VisitPrescription) {
+                vs.add(v);
+                continue;
+            }
+            // Legacy prescriptions were persisted with a null or VisitDocument type;
+            // recognise them through their document template type instead.
+            boolean legacyType = v.getClinicalFindingValueType() == null
+                    || v.getClinicalFindingValueType() == ClinicalFindingValueType.VisitDocument;
+            if (legacyType && v.getDocumentTemplate() != null
+                    && v.getDocumentTemplate().getType() == DocumentTemplateType.Prescription) {
+                vs.add(v);
+            }
+        }
+        return vs;
     }
 
     private List<ClinicalFindingValue> fillPlanOfAction(PatientEncounter encounter) {

--- a/src/main/java/com/divudi/bean/clinical/PracticeBookingController.java
+++ b/src/main/java/com/divudi/bean/clinical/PracticeBookingController.java
@@ -380,9 +380,11 @@ public class PracticeBookingController implements Serializable {
             logger.log(Level.FINE, "No prescription text to set");
         }
 
-        getPatientEncounterController().fillEncounterMedicines(opdVisit);
-        for(ClinicalFindingValue cli :patientEncounterController.getEncounterMedicines()){
-        }
+        // Auto-load the prescribed medicines onto the retail sale bill, mirroring
+        // the inward prescription-to-dispensing conversion on the admission profile.
+        List<ClinicalFindingValue> encounterMedicines
+                = getPatientEncounterController().fillEncounterMedicines(opdVisit);
+        getPharmacySaleController().addBillItemsFromEncounterMedicines(encounterMedicines);
         return "/pharmacy/pharmacy_bill_retail_sale?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/clinical/PracticeBookingController.java
+++ b/src/main/java/com/divudi/bean/clinical/PracticeBookingController.java
@@ -366,6 +366,8 @@ public class PracticeBookingController implements Serializable {
             getPatientEncounterController().setEncounterPrescreption(firstPrescription);
             logger.log(Level.FINE, "Set encounterPrescreption from list. Prescription ID: {0}", firstPrescription.getId());
         } else {
+            // Clear any prescription left over from a previously processed encounter
+            getPatientEncounterController().setEncounterPrescreption(null);
             logger.log(Level.FINE, "No prescriptions found in list");
         }
 
@@ -374,9 +376,11 @@ public class PracticeBookingController implements Serializable {
         logger.log(Level.FINE, "Prescription text status: {0}", hasPrescriptionText ? "found" : "not found");
 
         if (hasPrescriptionText) {
-            getPharmacySaleController().setComment(prescriptionText);
+            getPharmacySaleController().setPrescriptionHtml(prescriptionText);
+            getPharmacySaleController().setComment(htmlToPlainText(prescriptionText));
             logger.log(Level.FINE, "Set prescription text as comment (length: {0} characters)", prescriptionText.length());
         } else {
+            getPharmacySaleController().setPrescriptionHtml(null);
             logger.log(Level.FINE, "No prescription text to set");
         }
 
@@ -415,6 +419,26 @@ public class PracticeBookingController implements Serializable {
             logger.log(Level.SEVERE, "Error extracting prescription text: {0}", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Converts prescription HTML (Quill rich text) to readable plain text for
+     * the bill comment field, keeping line breaks for paragraphs and headings.
+     */
+    private String htmlToPlainText(String html) {
+        if (html == null) {
+            return null;
+        }
+        return html
+                .replaceAll("(?i)<br\\s*/?>", "\n")
+                .replaceAll("(?i)</(p|h[1-6]|li|div|tr)>", "\n")
+                .replaceAll("<[^>]+>", "")
+                .replace("&nbsp;", " ")
+                .replace("&amp;", "&")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replaceAll("\n{3,}", "\n\n")
+                .trim();
     }
 
     public void opdVisitFromServiceSession() {

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -362,6 +362,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), allNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.Pharmacy, "Pharmacy Menu"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdministration, "Pharmacy Administration"), pharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyItemNameEdit, "Pharmacy Item Name Edit"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDonation, "Pharmacy Donation"), pharmacyNode);
 
         // Channelling Privileges

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -230,6 +230,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     boolean billPreview = false;
     boolean fromOpdEncounter = false;
     String opdEncounterComments = "";
+    String prescriptionHtml;
     int patientSearchTab = 0;
 
     Staff toStaff;
@@ -4467,6 +4468,7 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         userStockContainer = null;
         fromOpdEncounter = false;
         opdEncounterComments = null;
+        prescriptionHtml = null;
         patientSearchTab = 0;
         errorMessage = "";
         comment = null;
@@ -4781,6 +4783,14 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     public void setOpdEncounterComments(String opdEncounterComments) {
         this.opdEncounterComments = opdEncounterComments;
+    }
+
+    public String getPrescriptionHtml() {
+        return prescriptionHtml;
+    }
+
+    public void setPrescriptionHtml(String prescriptionHtml) {
+        this.prescriptionHtml = prescriptionHtml;
     }
 
     public int getPatientSearchTab() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -43,6 +43,7 @@ import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.CashTransactionBean;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.ejb.PharmacyService;
+import com.divudi.ejb.PrescriptionToItemService;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.StaffService;
 import com.divudi.core.entity.Bill;
@@ -195,6 +196,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     private TokenFacade tokenFacade;
     @EJB
     private PharmacyService pharmacyService;
+    @EJB
+    private PrescriptionToItemService prescriptionToItemService;
     @EJB
     private BillService billService;
     @EJB
@@ -1832,6 +1835,134 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         clearBillItem();
         getBillItem();
         return addedQty;
+    }
+
+    /**
+     * Pre-loads the retail sale bill with the medicines prescribed in an OPD
+     * encounter (Pharmacy Bill button on the clinical queue). Each visit
+     * medicine's prescription is resolved to a dispensable item and quantity via
+     * {@link PrescriptionToItemService}, and the earliest-expiry (FEFO) in-date
+     * stock batch in the logged-in department is auto-picked. Items are added
+     * through {@link #addBillItemSingleItem()} so the usual checks (expiry,
+     * available quantity, duplicate batch, user stock locking, allergies) all
+     * apply, and the user can still edit or remove lines before settling.
+     *
+     * <p>Mirrors {@link PharmacySaleBhtController#prepareDischargeIssueFromPrescriptions}.
+     * Medicines with no stock (or whose conversion fails) are skipped with a
+     * visible warning, never silently dropped.</p>
+     *
+     * @param encounterMedicines visit medicines of the OPD encounter
+     */
+    public void addBillItemsFromEncounterMedicines(List<ClinicalFindingValue> encounterMedicines) {
+        if (encounterMedicines == null || encounterMedicines.isEmpty()) {
+            return;
+        }
+        Department dispensingDepartment = getSessionController().getLoggedUser() != null
+                ? getSessionController().getLoggedUser().getDepartment() : null;
+        if (dispensingDepartment == null) {
+            JsfUtil.addErrorMessage("No logged-in department to dispense the prescribed medicines from. Please add them manually.");
+            return;
+        }
+        List<String> skipped = new ArrayList<>();
+        for (ClinicalFindingValue encounterMedicine : encounterMedicines) {
+            if (encounterMedicine == null
+                    || encounterMedicine.getPrescription() == null
+                    || encounterMedicine.getPrescription().getItem() == null) {
+                continue;
+            }
+            Prescription sourcePrescription = encounterMedicine.getPrescription();
+            Item dispensableItem = sourcePrescription.getItem();
+            Double calculatedQty = null;
+            try {
+                PrescriptionToItemService.PrescriptionToItemResult result
+                        = prescriptionToItemService.calculateItemAndQuantity(sourcePrescription);
+                if (result != null && result.isSuccess()) {
+                    if (result.getItem() != null) {
+                        dispensableItem = result.getItem();
+                    }
+                    if (result.getQuantity() != null) {
+                        calculatedQty = result.getQuantity();
+                    }
+                }
+            } catch (Exception e) {
+                // Incomplete or unconvertible prescription: fall through to the
+                // qty=1 default so the pharmacist sets the real quantity on the page.
+            }
+            double requiredQty = (calculatedQty != null && calculatedQty > 0) ? Math.ceil(calculatedQty) : 1.0;
+
+            Stock fefoStock = findFefoStockForPrescribedItem(dispensableItem, dispensingDepartment, requiredQty);
+            if (fefoStock == null || fefoStock.getStock() <= 0) {
+                skipped.add(dispensableItem.getName() + " - no stock");
+                continue;
+            }
+
+            BillItem newBillItem = new BillItem();
+            newBillItem.setItem(fefoStock.getItemBatch().getItem());
+            // Carry the prescription details onto the bill item so dose/frequency/
+            // duration show on the bill and drug labels print correctly.
+            Prescription billItemPrescription = new Prescription();
+            billItemPrescription.setItem(fefoStock.getItemBatch().getItem());
+            billItemPrescription.setDose(sourcePrescription.getDose());
+            billItemPrescription.setDoseUnit(sourcePrescription.getDoseUnit());
+            billItemPrescription.setFrequencyUnit(sourcePrescription.getFrequencyUnit());
+            billItemPrescription.setDuration(sourcePrescription.getDuration());
+            billItemPrescription.setDurationUnit(sourcePrescription.getDurationUnit());
+            billItemPrescription.setComment(sourcePrescription.getComment());
+            billItemPrescription.setPatient(getPatient());
+            newBillItem.setPrescription(billItemPrescription);
+
+            setBillItem(newBillItem);
+            setStock(fefoStock);
+            setQty(Math.min(requiredQty, fefoStock.getStock()));
+
+            double addedQty = addBillItemSingleItem();
+            if (addedQty <= 0) {
+                String reason = (errorMessage != null && !errorMessage.trim().isEmpty())
+                        ? errorMessage : "could not be added";
+                skipped.add(dispensableItem.getName() + " - " + reason);
+                clearBillItem();
+            }
+        }
+        calculateBillItemsAndBillTotalsOfPreBill();
+        if (!skipped.isEmpty()) {
+            JsfUtil.addErrorMessage("Not auto-added from the prescription: " + String.join("; ", skipped)
+                    + ". Please add manually if needed.");
+        }
+    }
+
+    /**
+     * FEFO stock lookup for a prescribed item: in-date, positive-stock batches in
+     * the dispensing department, earliest expiry first. Prefers the first batch
+     * that covers the required quantity; otherwise returns the earliest-expiry
+     * batch (the caller caps the quantity to its stock). For VMP/VTM prescriptions
+     * the candidate AMPs are resolved first, as in the BHT discharge issue flow.
+     */
+    private Stock findFefoStockForPrescribedItem(Item dispensableItem, Department dispensingDepartment, double requiredQty) {
+        List<Amp> amps = pharmacyBean.resolveAmps(dispensableItem);
+        if (amps == null || amps.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> m = new HashMap<>();
+        m.put("amps", amps);
+        m.put("d", dispensingDepartment);
+        m.put("z", 0.0);
+        m.put("doe", new Date());
+        String jpql = "select s from Stock s "
+                + " where s.itemBatch.item in :amps "
+                + " and s.department=:d "
+                + " and s.stock > :z "
+                + " and s.itemBatch.dateOfExpire > :doe "
+                + " order by s.itemBatch.dateOfExpire";
+        List<Stock> availableStocks = getStockFacade().findByJpql(jpql, m, TemporalType.TIMESTAMP);
+        if (availableStocks == null || availableStocks.isEmpty()) {
+            return null;
+        }
+        for (Stock s : availableStocks) {
+            if (s.getStock() >= requiredQty) {
+                return s;
+            }
+        }
+        return availableStocks.get(0);
     }
 
     public void addBillItemMultipleBatches() {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -331,6 +331,7 @@ public enum Privileges {
     StoreReports("Store Reports"),
     StoreSummery("Store Summary"),
     StoreAdministration("Store Administration"),
+    PharmacyItemNameEdit("Pharmacy Item Name Edit"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Channel">
@@ -1018,7 +1019,8 @@ public enum Privileges {
             case PharmacyGrnFinalize:
             case PharmacyGrnApprove:
             case PrintOriginalPoBillFromReprint:
-            case PrintOriginalGrnBillFromReprint:    
+            case PrintOriginalGrnBillFromReprint:
+            case PharmacyItemNameEdit:
 
                 return "Pharmacy";
 

--- a/src/main/java/com/divudi/core/data/dto/clinical/FavouriteMedicineCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/clinical/FavouriteMedicineCreateRequestDTO.java
@@ -23,6 +23,9 @@ public class FavouriteMedicineCreateRequestDTO implements Serializable {
     private Double fromYears;           // Minimum age in years
     private Double toYears;             // Maximum age in years
 
+    // "FavouriteMedicine" (default) or "FavouriteDiagnosis"
+    private String type;
+
     // Medicine details
     private String categoryName;        // Medicine category (e.g., "suspension", "tablet")
 
@@ -41,7 +44,10 @@ public class FavouriteMedicineCreateRequestDTO implements Serializable {
     private boolean indoor = false;     // For indoor patients only
     private String sex;                 // "Male", "Female", or null for both
     private Double orderNo;             // Display order (auto-generated if not provided)
-    private String forItemName;         // The item this is a favourite for (optional)
+    // The item this is a favourite for. Optional for type=FavouriteMedicine (defaults to itemName itself).
+    // Required for type=FavouriteDiagnosis: the diagnosis name (resolved via
+    // GET /entities/diagnoses) that itemName is being suggested for.
+    private String forItemName;
 
     // Control flags
     private boolean createMissingEntities = false; // Auto-create missing entities
@@ -83,6 +89,14 @@ public class FavouriteMedicineCreateRequestDTO implements Serializable {
 
     public void setToYears(Double toYears) {
         this.toYears = toYears;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public String getCategoryName() {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1342,9 +1342,11 @@ public class PharmacyBean {
         Map<String, Object> m = new HashMap<>();
         m.put("vtm", vtm);
         m.put("ret", false);
-        String jpql = "select vpi from VirtualProductIngredient vpi "
+
+        // Primary path: VirtualProductIngredient join table
+        String vpiJpql = "select vpi from VirtualProductIngredient vpi "
                 + " where vpi.retired=:ret and vpi.vtm=:vtm";
-        List<VirtualProductIngredient> vpis = virtualProductIngredientFacade.findByJpql(jpql, m);
+        List<VirtualProductIngredient> vpis = virtualProductIngredientFacade.findByJpql(vpiJpql, m);
         List<Amp> allAmps = new ArrayList<>();
         if (vpis != null) {
             for (VirtualProductIngredient vpi : vpis) {
@@ -1353,6 +1355,22 @@ public class PharmacyBean {
                     if (amps != null) {
                         allAmps.addAll(amps);
                     }
+                }
+            }
+        }
+        if (!allAmps.isEmpty()) {
+            return allAmps;
+        }
+
+        // Fallback: VirtualProductIngredient table is unpopulated on many deployments.
+        // VMPs carry a direct vtm reference (VMP.VTM_ID) — use that instead.
+        String vmpJpql = "select vmp from Vmp vmp where vmp.retired=:ret and vmp.vtm=:vtm";
+        List<Vmp> vmps = vmpFacade.findByJpql(vmpJpql, m);
+        if (vmps != null) {
+            for (Vmp vmp : vmps) {
+                List<Amp> amps = findAmpsForVmp(vmp);
+                if (amps != null) {
+                    allAmps.addAll(amps);
                 }
             }
         }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3246,13 +3246,17 @@ public class AnthropicApiService implements Serializable {
                 });
 
         appendModule(sb, "Clinical - Favourite Medicines", "/clinical/favourite_medicines",
-                "Manage clinician favourite medicine templates. "
+                "Manage clinician favourite medicine templates and favourite-diagnosis "
+                + "medicine suggestions (PrescriptionTemplate types FavouriteMedicine / FavouriteDiagnosis). "
+                + "POST/GET accept type=FavouriteMedicine (default) or type=FavouriteDiagnosis. "
+                + "For FavouriteDiagnosis, forItemName (resolved via /entities/diagnoses) is required "
+                + "and is set as the diagnosis (forItem); itemName/itemType is the suggested medicine. "
                 + "/validate (bulk entity validation) is live. "
                 + "/parse and /suggest are not yet implemented (return 501).",
                 githubUrl(branch, "developer_docs/API_CLINICAL_FAVOURITE_MEDICINES.md"),
                 new String[][]{
-                    {"GET",    "/clinical/favourite_medicines",              "List favourite medicine templates"},
-                    {"POST",   "/clinical/favourite_medicines",              "Create a new template"},
+                    {"GET",    "/clinical/favourite_medicines",              "List favourite medicine/diagnosis templates. Use type=FavouriteDiagnosis for diagnosis suggestions"},
+                    {"POST",   "/clinical/favourite_medicines",              "Create a new template. Set type=FavouriteDiagnosis + forItemName=<diagnosis name> for diagnosis suggestions"},
                     {"GET",    "/clinical/favourite_medicines/{id}",         "Get template by ID"},
                     {"PUT",    "/clinical/favourite_medicines/{id}",         "Update a template"},
                     {"DELETE", "/clinical/favourite_medicines/{id}",         "Retire a template"},
@@ -3260,7 +3264,8 @@ public class AnthropicApiService implements Serializable {
                     {"POST",   "/clinical/favourite_medicines/suggest",      "Not implemented (501) — reserved for future auto-suggest"},
                     {"POST",   "/clinical/favourite_medicines/validate",     "Bulk-validate a set of medicine entities"},
                     {"GET",    "/clinical/favourite_medicines/entities/vtms","List/search Virtual Therapeutic Moieties"},
-                    {"GET",    "/clinical/favourite_medicines/entities/amps", "List/search Actual Medicinal Products"}
+                    {"GET",    "/clinical/favourite_medicines/entities/amps", "List/search Actual Medicinal Products"},
+                    {"GET",    "/clinical/favourite_medicines/entities/diagnoses", "List/search diagnoses (ClinicalEntity, Disease_or_Syndrome) for use as forItemName"}
                 });
 
         // ── FHIR ──────────────────────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/clinical/FavouriteMedicineApiService.java
+++ b/src/main/java/com/divudi/service/clinical/FavouriteMedicineApiService.java
@@ -10,10 +10,12 @@ import com.divudi.bean.common.ItemController;
 import com.divudi.bean.pharmacy.MeasurementUnitController;
 import com.divudi.bean.pharmacy.VmpController;
 import com.divudi.core.data.ItemType;
+import com.divudi.core.data.SymanticType;
 import com.divudi.core.data.clinical.PrescriptionTemplateType;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.clinical.ClinicalEntity;
 import com.divudi.core.entity.clinical.PrescriptionTemplate;
 import com.divudi.core.entity.lab.Antibiotic;
 import com.divudi.core.entity.pharmacy.MeasurementUnit;
@@ -24,6 +26,7 @@ import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Vtm;
 import com.divudi.core.facade.CategoryFacade;
+import com.divudi.core.facade.ClinicalEntityFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.MeasurementUnitFacade;
 import com.divudi.core.facade.PrescriptionTemplateFacade;
@@ -63,6 +66,9 @@ public class FavouriteMedicineApiService implements Serializable {
     @EJB
     private MeasurementUnitFacade measurementUnitFacade;
 
+    @EJB
+    private ClinicalEntityFacade clinicalEntityFacade;
+
     // =================== CONTROLLER INJECTIONS ===================
 
     @Inject
@@ -84,6 +90,9 @@ public class FavouriteMedicineApiService implements Serializable {
      */
     public PrescriptionTemplate createFavouriteMedicine(WebUser user, Map<String, Object> requestData) {
         try {
+            // Determine whether this is a FavouriteMedicine or a FavouriteDiagnosis entry
+            PrescriptionTemplateType templateType = parseTemplateType((String) requestData.get("type"));
+
             // Extract required fields
             String itemName = (String) requestData.get("itemName");
             String itemType = (String) requestData.get("itemType");
@@ -136,10 +145,41 @@ public class FavouriteMedicineApiService implements Serializable {
 
             // Create the prescription template
             PrescriptionTemplate template = new PrescriptionTemplate();
-            template.setType(PrescriptionTemplateType.FavouriteMedicine);
+            template.setType(templateType);
             template.setForWebUser(user);
             template.setItem(item);
-            template.setForItem(item); // Default to same item
+
+            if (templateType == PrescriptionTemplateType.FavouriteDiagnosis) {
+                // forItem = the diagnosis this medicine is being suggested for
+                String forItemName = (String) requestData.get("forItemName");
+                if (forItemName == null || forItemName.trim().isEmpty()) {
+                    throw new IllegalArgumentException("forItemName (the diagnosis name) is required for type=FavouriteDiagnosis");
+                }
+
+                ClinicalEntity diagnosis = findClinicalEntityByName(forItemName.trim());
+                if (diagnosis == null) {
+                    StringBuilder errorMessage = new StringBuilder();
+                    errorMessage.append("Diagnosis not found: ").append(forItemName);
+
+                    List<ClinicalEntity> similarDiagnoses = searchDiagnoses(forItemName.trim(), 5);
+                    if (!similarDiagnoses.isEmpty()) {
+                        errorMessage.append(". Did you mean: ");
+                        for (int i = 0; i < similarDiagnoses.size(); i++) {
+                            if (i > 0) {
+                                errorMessage.append(", ");
+                            }
+                            errorMessage.append(similarDiagnoses.get(i).getName());
+                        }
+                        errorMessage.append("?");
+                    }
+
+                    throw new IllegalArgumentException(errorMessage.toString());
+                }
+
+                template.setForItem(diagnosis);
+            } else {
+                template.setForItem(item); // Default to same item
+            }
 
             // Set age range (convert years to days)
             template.setFromDays(convertYearsToDays(fromYears));
@@ -152,7 +192,7 @@ public class FavouriteMedicineApiService implements Serializable {
             Double orderNo = getDoubleValue(requestData.get("orderNo"));
             if (orderNo == null) {
                 // Auto-generate order number
-                orderNo = getNextOrderNumber(user);
+                orderNo = getNextOrderNumber(user, templateType);
             }
             template.setOrderNo(orderNo);
 
@@ -181,7 +221,9 @@ public class FavouriteMedicineApiService implements Serializable {
 
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("user", user);
-            parameters.put("type", PrescriptionTemplateType.FavouriteMedicine);
+            // Defaults to FavouriteMedicine for backward compatibility; pass type=FavouriteDiagnosis
+            // to search favourite-diagnosis entries instead
+            parameters.put("type", parseTemplateType((String) searchCriteria.get("type")));
 
             // Add filters based on search criteria
             String query = (String) searchCriteria.get("query");
@@ -302,12 +344,14 @@ public class FavouriteMedicineApiService implements Serializable {
 
         String jpql = "SELECT p FROM PrescriptionTemplate p " +
                      "WHERE p.id = :id AND p.retired = false " +
-                     "AND p.forWebUser = :user AND p.type = :type";
+                     "AND p.forWebUser = :user " +
+                     "AND p.type IN (:favouriteMedicine, :favouriteDiagnosis)";
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("id", id);
         parameters.put("user", user);
-        parameters.put("type", PrescriptionTemplateType.FavouriteMedicine);
+        parameters.put("favouriteMedicine", PrescriptionTemplateType.FavouriteMedicine);
+        parameters.put("favouriteDiagnosis", PrescriptionTemplateType.FavouriteDiagnosis);
 
         PrescriptionTemplate template = prescriptionTemplateFacade.findFirstByJpql(jpql, parameters);
 
@@ -1050,26 +1094,87 @@ public class FavouriteMedicineApiService implements Serializable {
         if (sex != null && !sex.trim().isEmpty()) {
             // TODO: Set sex enum if needed
         }
-
-        String forItemName = (String) requestData.get("forItemName");
-        if (forItemName != null && !forItemName.trim().isEmpty()) {
-            // TODO: Find and set forItem if different from main item
-        }
     }
 
     /**
-     * Get next order number for user's favourite medicines
+     * Get next order number for user's favourite medicines (or favourite diagnoses)
      */
-    private Double getNextOrderNumber(WebUser user) {
+    private Double getNextOrderNumber(WebUser user, PrescriptionTemplateType type) {
         String jpql = "SELECT MAX(p.orderNo) FROM PrescriptionTemplate p " +
                      "WHERE p.retired = false AND p.forWebUser = :user " +
                      "AND p.type = :type";
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("user", user);
-        parameters.put("type", PrescriptionTemplateType.FavouriteMedicine);
+        parameters.put("type", type);
 
         Double maxOrder = prescriptionTemplateFacade.findDoubleByJpql(jpql, parameters);
         return (maxOrder != null ? maxOrder + 1.0 : 1.0);
+    }
+
+    /**
+     * Parse the "type" request field to a PrescriptionTemplateType.
+     * Defaults to FavouriteMedicine when not provided, for backward compatibility.
+     * Only FavouriteMedicine and FavouriteDiagnosis are accepted via the API.
+     */
+    private PrescriptionTemplateType parseTemplateType(String type) {
+        if (type == null || type.trim().isEmpty()) {
+            return PrescriptionTemplateType.FavouriteMedicine;
+        }
+
+        switch (type.trim().toLowerCase()) {
+            case "favouritemedicine":
+                return PrescriptionTemplateType.FavouriteMedicine;
+            case "favouritediagnosis":
+                return PrescriptionTemplateType.FavouriteDiagnosis;
+            default:
+                throw new IllegalArgumentException("Invalid type: " + type + ". Must be one of: FavouriteMedicine, FavouriteDiagnosis");
+        }
+    }
+
+    // =================== DIAGNOSIS (CLINICAL ENTITY) OPERATIONS ===================
+
+    /**
+     * Search diagnoses (ClinicalEntity with SymanticType.Disease_or_Syndrome) by name
+     * Used to resolve forItemName when creating FavouriteDiagnosis entries
+     */
+    public List<ClinicalEntity> searchDiagnoses(String query, Integer limit) {
+        if (query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String jpql = "SELECT c FROM ClinicalEntity c WHERE c.retired = false " +
+                     "AND c.symanticType = :symanticType " +
+                     "AND UPPER(c.name) LIKE :query " +
+                     "ORDER BY c.name";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("symanticType", SymanticType.Disease_or_Syndrome);
+        parameters.put("query", "%" + query.trim().toUpperCase() + "%");
+
+        if (limit != null && limit > 0) {
+            return clinicalEntityFacade.findByJpql(jpql, parameters, limit);
+        } else {
+            return clinicalEntityFacade.findByJpql(jpql, parameters);
+        }
+    }
+
+    /**
+     * Find a diagnosis (ClinicalEntity with SymanticType.Disease_or_Syndrome) by exact name
+     */
+    public ClinicalEntity findClinicalEntityByName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return null;
+        }
+
+        String jpql = "SELECT c FROM ClinicalEntity c WHERE c.retired = false " +
+                     "AND c.symanticType = :symanticType " +
+                     "AND UPPER(c.name) = :name";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("symanticType", SymanticType.Disease_or_Syndrome);
+        parameters.put("name", name.trim().toUpperCase());
+
+        return clinicalEntityFacade.findFirstByJpql(jpql, parameters);
     }
 }

--- a/src/main/java/com/divudi/service/clinical/FavouriteMedicineApiService.java
+++ b/src/main/java/com/divudi/service/clinical/FavouriteMedicineApiService.java
@@ -98,13 +98,30 @@ public class FavouriteMedicineApiService implements Serializable {
             String itemType = (String) requestData.get("itemType");
             Double fromYears = getDoubleValue(requestData.get("fromYears"));
             Double toYears = getDoubleValue(requestData.get("toYears"));
+            Double fromKg = getDoubleValue(requestData.get("fromKg"));
+            Double toKg = getDoubleValue(requestData.get("toKg"));
 
-            if (itemName == null || itemType == null || fromYears == null || toYears == null) {
-                throw new IllegalArgumentException("Required fields missing: itemName, itemType, fromYears, toYears");
+            if (itemName == null || itemType == null) {
+                throw new IllegalArgumentException("Required fields missing: itemName, itemType");
             }
 
-            if (fromYears < 0 || toYears < 0 || fromYears >= toYears) {
-                throw new IllegalArgumentException("Invalid age range: fromYears must be less than toYears and both must be >= 0");
+            boolean hasAgeRange = fromYears != null && toYears != null;
+            boolean hasWeightRange = fromKg != null && toKg != null;
+
+            if (!hasAgeRange && !hasWeightRange) {
+                throw new IllegalArgumentException("Required fields missing: provide either fromYears+toYears (age range) or fromKg+toKg (weight range)");
+            }
+
+            if (hasAgeRange) {
+                if (fromYears < 0 || toYears < 0 || fromYears >= toYears) {
+                    throw new IllegalArgumentException("Invalid age range: fromYears must be less than toYears and both must be >= 0");
+                }
+            }
+
+            if (hasWeightRange) {
+                if (fromKg < 0 || toKg < 0 || fromKg >= toKg) {
+                    throw new IllegalArgumentException("Invalid weight range: fromKg must be less than toKg and both must be >= 0");
+                }
             }
 
             // Find or create the item based on type
@@ -181,9 +198,17 @@ public class FavouriteMedicineApiService implements Serializable {
                 template.setForItem(item); // Default to same item
             }
 
-            // Set age range (convert years to days)
-            template.setFromDays(convertYearsToDays(fromYears));
-            template.setToDays(convertYearsToDays(toYears));
+            // Set age range (convert years to days); default to 0-120 yr when only weight range given
+            template.setFromDays(convertYearsToDays(fromYears != null ? fromYears : 0.0));
+            template.setToDays(convertYearsToDays(toYears != null ? toYears : 120.0));
+
+            // Set weight range when provided
+            if (fromKg != null) {
+                template.setFromKg(fromKg);
+            }
+            if (toKg != null) {
+                template.setToKg(toKg);
+            }
 
             // Set optional fields
             setOptionalFields(template, requestData);
@@ -392,6 +417,26 @@ public class FavouriteMedicineApiService implements Serializable {
                 if (template.getFromDays() >= template.getToDays()) {
                     throw new IllegalArgumentException("fromYears must be less than toYears");
                 }
+            }
+
+            // Update weight range if provided
+            Double fromKg = getDoubleValue(updateData.get("fromKg"));
+            Double toKg = getDoubleValue(updateData.get("toKg"));
+            if (fromKg != null) {
+                if (fromKg < 0) {
+                    throw new IllegalArgumentException("fromKg must be >= 0");
+                }
+                template.setFromKg(fromKg);
+            }
+            if (toKg != null) {
+                if (toKg < 0) {
+                    throw new IllegalArgumentException("toKg must be >= 0");
+                }
+                template.setToKg(toKg);
+            }
+            if (template.getFromKg() != null && template.getToKg() != null
+                    && template.getFromKg() >= template.getToKg()) {
+                throw new IllegalArgumentException("fromKg must be less than toKg");
             }
 
             // Update other optional fields

--- a/src/main/java/com/divudi/ws/clinical/FavouriteMedicineApi.java
+++ b/src/main/java/com/divudi/ws/clinical/FavouriteMedicineApi.java
@@ -877,6 +877,10 @@ public class FavouriteMedicineApi {
         map.put("fromYears", favouriteMedicineService.convertDaysToYears(template.getFromDays()));
         map.put("toYears", favouriteMedicineService.convertDaysToYears(template.getToDays()));
 
+        // Weight range
+        map.put("fromKg", template.getFromKg());
+        map.put("toKg", template.getToKg());
+
         // Category
         if (template.getCategory() != null) {
             map.put("categoryName", template.getCategory().getName());

--- a/src/main/java/com/divudi/ws/clinical/FavouriteMedicineApi.java
+++ b/src/main/java/com/divudi/ws/clinical/FavouriteMedicineApi.java
@@ -10,6 +10,7 @@ import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.clinical.ClinicalEntity;
 import com.divudi.core.entity.clinical.PrescriptionTemplate;
 import com.divudi.core.entity.pharmacy.MeasurementUnit;
 import com.divudi.service.clinical.FavouriteMedicineApiService;
@@ -504,6 +505,56 @@ public class FavouriteMedicineApi {
     }
 
     /**
+     * Search diagnoses (ClinicalEntity with SymanticType.Disease_or_Syndrome)
+     * GET /api/clinical/favourite_medicines/entities/diagnoses?query=respiratory&limit=20
+     *
+     * Use this to resolve the "forItemName" value when creating a
+     * FavouriteDiagnosis entry (POST /api/clinical/favourite_medicines with type=FavouriteDiagnosis)
+     */
+    @GET
+    @Path("/entities/diagnoses")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response searchDiagnoses() {
+        try {
+            WebUser user = validateApiKey();
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            // Get query parameters
+            String query = uriInfo.getQueryParameters().getFirst("query");
+            String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+
+            if (query == null || query.trim().isEmpty()) {
+                return errorResponse("Query parameter is required", 400);
+            }
+
+            Integer limit = null;
+            if (limitStr != null && !limitStr.trim().isEmpty()) {
+                try {
+                    limit = Integer.parseInt(limitStr.trim());
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid limit format", 400);
+                }
+            }
+
+            // Search diagnoses
+            List<ClinicalEntity> diagnoses = favouriteMedicineService.searchDiagnoses(query.trim(), limit);
+
+            // Convert to DTOs
+            List<Map<String, Object>> responseData = new ArrayList<>();
+            for (ClinicalEntity diagnosis : diagnoses) {
+                responseData.add(convertItemToMap(diagnosis));
+            }
+
+            return successResponse(responseData);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
      * Search measurement units
      * GET /api/clinical/favourite_medicines/entities/units?query=ml&unitType=DoseUnit&limit=20
      */
@@ -812,6 +863,7 @@ public class FavouriteMedicineApi {
         }
 
         map.put("id", template.getId());
+        map.put("type", template.getType() != null ? template.getType().toString() : null);
 
         // Item information
         if (template.getItem() != null) {
@@ -863,9 +915,10 @@ public class FavouriteMedicineApi {
         map.put("indoor", template.isIndoor());
         map.put("sex", template.getSex() != null ? template.getSex().toString() : null);
 
-        // For item
+        // For item (the medicine itself for FavouriteMedicine; the diagnosis for FavouriteDiagnosis)
         if (template.getForItem() != null) {
             map.put("forItem", template.getForItem().getName());
+            map.put("forItemId", template.getForItem().getId());
         }
 
         // Audit information
@@ -946,6 +999,12 @@ public class FavouriteMedicineApi {
         String forItemName = uriInfo.getQueryParameters().getFirst("forItemName");
         if (forItemName != null && !forItemName.trim().isEmpty()) {
             searchCriteria.put("forItemName", forItemName.trim());
+        }
+
+        // Template type: FavouriteMedicine (default) or FavouriteDiagnosis
+        String type = uriInfo.getQueryParameters().getFirst("type");
+        if (type != null && !type.trim().isEmpty()) {
+            searchCriteria.put("type", type.trim());
         }
 
         // Pagination and ordering

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -80,7 +80,9 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Clinical Favourite Medicines", "/api/clinical/favourite_medicines",
-                        "Clinical favourite medicine management",
+                        "Clinical favourite medicine templates and favourite-diagnosis medicine suggestions "
+                        + "(type=FavouriteMedicine default, or type=FavouriteDiagnosis). "
+                        + "Includes /entities/diagnoses for searching diagnoses to use as forItemName.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Membership", "/api/apiMembership",

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/clinical/clinical_queue.xhtml
+++ b/src/main/webapp/clinical/clinical_queue.xhtml
@@ -215,6 +215,7 @@
                                                          styleClass="ui-button-info me-1"
                                                          ajax="false"
                                                          title="Create OPD bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         onclick="this.disabled=true;"
                                                          action="#{practiceBookingController.issueServices()}">
                                             <f:setPropertyActionListener value="#{bsc}"
                                                                          target="#{practiceBookingController.billSession}"/>
@@ -226,11 +227,12 @@
                                                          styleClass="ui-button-info"
                                                          ajax="false"
                                                          title="Create pharmacy bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         onclick="this.disabled=true;"
                                                          action="#{practiceBookingController.issuePharmacyBill()}"
                                                          actionListener="#{pharmacySaleController.resetAll()}">
                                             <f:setPropertyActionListener value="#{bsc}"
                                                                          target="#{practiceBookingController.billSession}"/>
-                                            <f:setPropertyActionListener value="#{practiceBookingController.opdVisit.patient}"
+                                            <f:setPropertyActionListener value="#{bsc.bill.patient}"
                                                                          target="#{pharmacySaleController.patient}"/>
                                         </p:commandButton>
                                     </p:column>

--- a/src/main/webapp/clinical/clinical_queue.xhtml
+++ b/src/main/webapp/clinical/clinical_queue.xhtml
@@ -12,134 +12,240 @@
 
             <ui:define name="content">
 
-                <p:panel >
+                <p:panel id="panelQueue">
 
+                    <f:facet name="header">
+                        <h:outputText value="Clinical Queue" styleClass="fw-bold"/>
+                    </f:facet>
 
-                    <p:panel  id="panelQueue" header="Queue" >
+                    <h:form id="filterForm">
+                        <p:growl id="msg" showDetail="true"/>
 
-                        <h:form>
-                            <p:growl id="msg"/>
-                            <h:panelGrid columns="3" >
-                                <h:outputLabel value="Date" id="calSessionDate" ></h:outputLabel>
-                                <p:calendar value="#{practiceBookingController.sessionDate}" pattern="#{sessionController.applicationPreference.longDateFormat}" >
+                        <div class="row g-3 align-items-end">
+                            <div class="col-12 col-md-3">
+                                <p:outputLabel for="calSessionDate" value="Date" styleClass="form-label fw-bold"/>
+                                <p:calendar id="calSessionDate"
+                                            value="#{practiceBookingController.sessionDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                            navigator="true"
+                                            styleClass="w-100">
                                     <f:ajax event="dateSelect"
+                                            execute="@this"
                                             listener="#{practiceBookingController.listCompleteAndToCompleteBillSessions}"
-                                            execute="calSessionDate" render=":#{p:resolveFirstComponentWithId('bSession',view).clientId}" ></f:ajax>
+                                            render=":queueForm"/>
                                 </p:calendar>
-                                <h:outputLabel value="" ></h:outputLabel>
-                                <h:outputLabel value="Speciality" ></h:outputLabel>
-                                <p:autoComplete value="#{practiceBookingController.speciality}"
-                                                id="acSpeciality" 
+                            </div>
+
+                            <div class="col-12 col-md-3">
+                                <p:outputLabel for="acSpeciality" value="Speciality" styleClass="form-label fw-bold"/>
+                                <p:autoComplete id="acSpeciality"
+                                                value="#{practiceBookingController.speciality}"
                                                 completeMethod="#{specialityController.completeSpeciality}"
                                                 var="dsp" itemLabel="#{dsp.name}" itemValue="#{dsp}"
-                                                >
-                                    <f:ajax event="itemSelect" execute="acSpeciality" render="acStaff" ></f:ajax>
+                                                maxResults="20"
+                                                placeholder="Search speciality"
+                                                styleClass="w-100" inputStyleClass="w-100">
+                                    <f:ajax event="itemSelect" execute="acSpeciality" render="acStaff"/>
                                 </p:autoComplete>
-                                <h:outputLabel value="" ></h:outputLabel>
+                            </div>
 
-                                <h:outputLabel value="Doctor" ></h:outputLabel>
-                                <p:autoComplete value="#{practiceBookingController.doctor}"
-                                                id="acStaff" 
+                            <div class="col-12 col-md-3">
+                                <p:outputLabel for="acStaff" value="Doctor" styleClass="form-label fw-bold"/>
+                                <p:autoComplete id="acStaff"
+                                                value="#{practiceBookingController.doctor}"
                                                 completeMethod="#{practiceBookingController.completeDoctorsOfSelectedSpeciality}"
                                                 var="doc"
                                                 itemLabel="#{doc.person.nameWithTitle}" itemValue="#{doc}"
-                                                >
-                                    <f:ajax  event="itemSelect" execute="@this" render=":#{p:resolveFirstComponentWithId('bSession',view).clientId}"  
-                                             listener="#{practiceBookingController.listCompleteAndToCompleteBillSessions}" />                                                
+                                                maxResults="20"
+                                                placeholder="Search doctor"
+                                                styleClass="w-100" inputStyleClass="w-100">
+                                    <f:ajax event="itemSelect" execute="@this"
+                                            listener="#{practiceBookingController.listCompleteAndToCompleteBillSessions}"
+                                            render=":queueForm"/>
                                 </p:autoComplete>
-                                <h:outputLabel value="" ></h:outputLabel>
+                            </div>
 
-                                <p:commandButton   value="Process" ajax="false" style="float: right;"
-                                                   class="ui-button-warning"
-                                                   icon="fas fa-arrows-rotate"
-                                                   action="#{practiceBookingController.listCompleteAndToCompleteBillSessions}"  >                        
-                                </p:commandButton>
+                            <div class="col-12 col-md-3">
+                                <p:commandButton id="btnProcess"
+                                                 value="Process"
+                                                 ajax="false"
+                                                 styleClass="ui-button-warning w-100"
+                                                 icon="fas fa-arrows-rotate"
+                                                 title="Load the queue for the selected date, speciality and doctor"
+                                                 action="#{practiceBookingController.listCompleteAndToCompleteBillSessions}"/>
+                            </div>
+                        </div>
+                    </h:form>
 
-                            </h:panelGrid>
-                        </h:form>
+                    <h:form id="queueForm">
 
-                        <h:form>
+                        <p:tabView id="queueTabs" styleClass="mt-3">
 
-                            <p:tabView >
-                                <p:tab id="bSession" title="To Complete" >
+                            <p:tab id="bSession"
+                                   title="To Complete (#{empty practiceBookingController.toCompleteSessions ? 0 : practiceBookingController.toCompleteSessions.size()})">
 
-                                    <p:dataTable id="bSessionToComplete" 
-                                                 value="#{practiceBookingController.toCompleteSessions}" 
-                                                 var='bs'
-                                                 selectionMode="single" rowKey="#{bs.id}"
-                                                 selection="#{practiceBookingController.selectedBillSession}">
-                                        <p:column headerText="No">#{bs.serialNo}</p:column>
-                                        <p:column headerText="Patient Name">#{bs.bill.patient.person.nameWithTitle}</p:column>
-                                        <p:column headerText="Visit">
-                                            <p:commandButton disabled="#{bs.absent}" value="Visit" 
-                                                             action="#{practiceBookingController.opdVisitFromQueue()}" ajax="false"  >
-                                                <f:setPropertyActionListener value="#{bs}" 
-                                                                             target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
-                                        </p:column>
+                                <p:dataTable id="bSessionToComplete"
+                                             widgetVar="tblToComplete"
+                                             value="#{practiceBookingController.toCompleteSessions}"
+                                             var="bs"
+                                             selectionMode="single" rowKey="#{bs.id}"
+                                             selection="#{practiceBookingController.selectedBillSession}"
+                                             paginator="true" rows="25"
+                                             paginatorPosition="bottom"
+                                             paginatorAlwaysVisible="false"
+                                             rowStyleClass="#{bs.absent ? 'table-warning' : ''}"
+                                             emptyMessage="No patients waiting for the selected date, speciality and doctor.">
 
+                                    <p:column headerText="No" style="width: 4rem; text-align: center;">
+                                        <h:outputText value="#{bs.serialNo}"/>
+                                    </p:column>
 
-                                        <p:column headerText="Absent">
-                                            <p:outputLabel value="Patient is Absent."  rendered="#{bs.absent}" ></p:outputLabel>
-                                            <p:commandButton rendered="#{bs.absent}" value="Mark As Present" action="#{practiceBookingController.markAsPresent()}" ajax="false"  >
-                                                <f:setPropertyActionListener value="#{bs}" target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
-                                            <p:commandButton rendered="#{!bs.absent}" value="Mark As Absent" action="#{practiceBookingController.markAsAbent()}" ajax="false"  >
-                                                <f:setPropertyActionListener value="#{bs}" target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
-                                        </p:column>
-                                    </p:dataTable>  
+                                    <p:column headerText="Patient Name">
+                                        <h:outputText value="#{bs.bill.patient.person.nameWithTitle}" styleClass="fw-bold"/>
+                                    </p:column>
 
-                                </p:tab>
-                                <p:tab title="Completed" >
+                                    <p:column headerText="Age" style="width: 7rem;">
+                                        <h:outputText value="#{bs.bill.patient.person.ageAsString}"/>
+                                    </p:column>
 
-                                    <p:dataTable id="bSessionCompleted" 
-                                                 value="#{practiceBookingController.completedSessions}" var='bsc'
-                                                 selectionMode="single" rowKey="#{bsc.id}"
-                                                 selection="#{practiceBookingController.selectedBillSession}">
-                                        <p:column headerText="No" style="width: 6%">#{bsc.serialNo}</p:column>
-                                        <p:column headerText="Patient Name">#{bsc.bill.patient.person.nameWithTitle}</p:column>
-                                        <p:column headerText="View/Edit">
-                                            <p:commandButton disabled="#{bsc.absent}" value="Visit" action="#{practiceBookingController.opdVisitFromQueue()}" ajax="false"  >
-                                                <f:setPropertyActionListener value="#{bsc}" target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
-                                        </p:column>
-                                        <p:column headerText="Details">
-                                            <h:outputText value="#{bsc.patientEncounter.comments}" ></h:outputText>
-                                        </p:column>
-                                        <p:column headerText="Billing" >
-                                            <p:commandButton disabled="#{bsc.absent}" value="View Visit" action="#{pastPatientEncounterController.navigateToViewPastEncounter()}" ajax="false"  >
-                                                <f:setPropertyActionListener value="#{bsc.patientEncounter}" target="#{pastPatientEncounterController.current}" />
-                                            </p:commandButton>
-                                            
-                                            <p:commandButton ajax="false" value="OPD Bill" class="m-1" action="#{practiceBookingController.issueServices()}"  >
-                                                <f:setPropertyActionListener value="#{bsc}" target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
-                                            <p:commandButton ajax="false" value="Pharmacy Bill" action="#{practiceBookingController.issuePharmacyBill()}" 
-                                                             actionListener="#{pharmacySaleController.resetAll()}">
-                                                <f:setPropertyActionListener value="#{bsc}" target="#{practiceBookingController.billSession}" ></f:setPropertyActionListener>
-                                                <f:setPropertyActionListener value="#{practiceBookingController.opdVisit.patient}" target="#{pharmacySaleController.patient}" ></f:setPropertyActionListener>
-                                            </p:commandButton>
+                                    <p:column headerText="Phone" style="width: 9rem;">
+                                        <h:outputText value="#{bs.bill.patient.person.phone}"/>
+                                    </p:column>
 
-                                        </p:column>
+                                    <p:column headerText="Status" style="width: 7rem; text-align: center;">
+                                        <h:panelGroup rendered="#{bs.absent}">
+                                            <span class="badge bg-danger">Absent</span>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{!bs.absent}">
+                                            <span class="badge bg-info">Waiting</span>
+                                        </h:panelGroup>
+                                    </p:column>
 
-                                    </p:dataTable>  
+                                    <p:column headerText="Actions" style="width: 22rem;">
+                                        <p:commandButton id="btnVisit"
+                                                         value="Visit"
+                                                         icon="fas fa-stethoscope"
+                                                         styleClass="ui-button-success me-1"
+                                                         disabled="#{bs.absent}"
+                                                         title="Start visit for #{bs.bill.patient.person.nameWithTitle} - No #{bs.serialNo}"
+                                                         action="#{practiceBookingController.opdVisitFromQueue()}" ajax="false">
+                                            <f:setPropertyActionListener value="#{bs}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                        </p:commandButton>
 
-                                </p:tab>
+                                        <p:commandButton id="btnMarkPresent"
+                                                         rendered="#{bs.absent}"
+                                                         value="Mark As Present"
+                                                         icon="fas fa-user-check"
+                                                         styleClass="ui-button-warning"
+                                                         title="Mark #{bs.bill.patient.person.nameWithTitle} as present - No #{bs.serialNo}"
+                                                         action="#{practiceBookingController.markAsPresent()}" ajax="false">
+                                            <f:setPropertyActionListener value="#{bs}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                        </p:commandButton>
 
-                            </p:tabView>
+                                        <p:commandButton id="btnMarkAbsent"
+                                                         rendered="#{!bs.absent}"
+                                                         value="Mark As Absent"
+                                                         icon="fas fa-user-slash"
+                                                         styleClass="ui-button-danger ui-button-outlined"
+                                                         title="Mark #{bs.bill.patient.person.nameWithTitle} as absent - No #{bs.serialNo}"
+                                                         action="#{practiceBookingController.markAsAbent()}" ajax="false">
+                                            <f:setPropertyActionListener value="#{bs}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                        </p:commandButton>
+                                    </p:column>
 
-                        </h:form>
-                    </p:panel>
+                                </p:dataTable>
 
+                            </p:tab>
 
+                            <p:tab id="bSessionCompletedTab"
+                                   title="Completed (#{empty practiceBookingController.completedSessions ? 0 : practiceBookingController.completedSessions.size()})">
 
+                                <p:dataTable id="bSessionCompleted"
+                                             widgetVar="tblCompleted"
+                                             value="#{practiceBookingController.completedSessions}"
+                                             var="bsc"
+                                             selectionMode="single" rowKey="#{bsc.id}"
+                                             selection="#{practiceBookingController.selectedBillSession}"
+                                             paginator="true" rows="25"
+                                             paginatorPosition="bottom"
+                                             paginatorAlwaysVisible="false"
+                                             emptyMessage="No completed visits for the selected date, speciality and doctor.">
+
+                                    <p:column headerText="No" style="width: 4rem; text-align: center;">
+                                        <h:outputText value="#{bsc.serialNo}"/>
+                                    </p:column>
+
+                                    <p:column headerText="Patient Name">
+                                        <h:outputText value="#{bsc.bill.patient.person.nameWithTitle}" styleClass="fw-bold"/>
+                                    </p:column>
+
+                                    <p:column headerText="Details">
+                                        <h:outputText value="#{bsc.patientEncounter.comments}"/>
+                                    </p:column>
+
+                                    <p:column headerText="Actions" style="width: 32rem;">
+                                        <p:commandButton id="btnEditVisit"
+                                                         value="Visit"
+                                                         icon="fas fa-user-pen"
+                                                         styleClass="ui-button-success me-1"
+                                                         disabled="#{bsc.absent}"
+                                                         title="Open visit of #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         action="#{practiceBookingController.opdVisitFromQueue()}" ajax="false">
+                                            <f:setPropertyActionListener value="#{bsc}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                        </p:commandButton>
+
+                                        <p:commandButton id="btnViewVisit"
+                                                         value="View Visit"
+                                                         icon="fas fa-eye"
+                                                         styleClass="ui-button-info ui-button-outlined me-1"
+                                                         disabled="#{bsc.absent}"
+                                                         title="View past visit of #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         action="#{pastPatientEncounterController.navigateToViewPastEncounter()}" ajax="false">
+                                            <f:setPropertyActionListener value="#{bsc.patientEncounter}"
+                                                                         target="#{pastPatientEncounterController.current}"/>
+                                        </p:commandButton>
+
+                                        <p:commandButton id="btnOpdBill"
+                                                         value="OPD Bill"
+                                                         icon="fas fa-file-invoice-dollar"
+                                                         styleClass="ui-button-info me-1"
+                                                         ajax="false"
+                                                         title="Create OPD bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         action="#{practiceBookingController.issueServices()}">
+                                            <f:setPropertyActionListener value="#{bsc}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                        </p:commandButton>
+
+                                        <p:commandButton id="btnPharmacyBill"
+                                                         value="Pharmacy Bill"
+                                                         icon="fas fa-pills"
+                                                         styleClass="ui-button-info"
+                                                         ajax="false"
+                                                         title="Create pharmacy bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
+                                                         action="#{practiceBookingController.issuePharmacyBill()}"
+                                                         actionListener="#{pharmacySaleController.resetAll()}">
+                                            <f:setPropertyActionListener value="#{bsc}"
+                                                                         target="#{practiceBookingController.billSession}"/>
+                                            <f:setPropertyActionListener value="#{practiceBookingController.opdVisit.patient}"
+                                                                         target="#{pharmacySaleController.patient}"/>
+                                        </p:commandButton>
+                                    </p:column>
+
+                                </p:dataTable>
+
+                            </p:tab>
+
+                        </p:tabView>
+
+                    </h:form>
 
                 </p:panel>
 
             </ui:define>
-
-
 
         </ui:composition>
 

--- a/src/main/webapp/clinical/clinical_queue.xhtml
+++ b/src/main/webapp/clinical/clinical_queue.xhtml
@@ -215,7 +215,7 @@
                                                          styleClass="ui-button-info me-1"
                                                          ajax="false"
                                                          title="Create OPD bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
-                                                         onclick="this.disabled=true;"
+                                                         onclick="if (!confirm('Create OPD bill for this patient?')) return false;"
                                                          action="#{practiceBookingController.issueServices()}">
                                             <f:setPropertyActionListener value="#{bsc}"
                                                                          target="#{practiceBookingController.billSession}"/>
@@ -227,7 +227,7 @@
                                                          styleClass="ui-button-info"
                                                          ajax="false"
                                                          title="Create pharmacy bill for #{bsc.bill.patient.person.nameWithTitle} - No #{bsc.serialNo}"
-                                                         onclick="this.disabled=true;"
+                                                         onclick="if (!confirm('Create pharmacy bill for this patient?')) return false;"
                                                          action="#{practiceBookingController.issuePharmacyBill()}"
                                                          actionListener="#{pharmacySaleController.resetAll()}">
                                             <f:setPropertyActionListener value="#{bsc}"

--- a/src/main/webapp/emr/opd_visit.xhtml
+++ b/src/main/webapp/emr/opd_visit.xhtml
@@ -546,7 +546,7 @@
                                                             <p:commandButton
                                                                 id="btnAddRxFav"
                                                                 value="Add Favourite"
-                                                                process="@this"
+                                                                process="@this acMedicine txtDose cmbDose cmbFrequency txtDuration cmbDuration chkIndoor"
                                                                 class='ui-button-success'
                                                                 icon='fas fa-star'
                                                                 style="float: right; margin-right: 5px;"

--- a/src/main/webapp/pharmacy/admin/lab_vmp.xhtml
+++ b/src/main/webapp/pharmacy/admin/lab_vmp.xhtml
@@ -102,7 +102,7 @@
                                     update="acVmp detailPanel btnAdd btnEdit btnDelete btnSave btnCancel"
                                     icon="fas fa-plus"
                                     process="@this"
-                                    disabled="#{labVmpController.editable}"
+                                    disabled="#{labVmpController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                     title="Add a new Lab VMP record">
                                 </p:commandButton>
 
@@ -114,7 +114,7 @@
                                     update="detailPanel btnAdd btnEdit btnDelete btnSave btnCancel acVmp"
                                     process="@this"
                                     styleClass="ui-button-warning m-1"
-                                    disabled="#{labVmpController.editable or labVmpController.current.id eq null}"
+                                    disabled="#{labVmpController.editable or labVmpController.current.id eq null or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                     title="Edit selected Lab VMP record">
                                 </p:commandButton>
 
@@ -332,7 +332,7 @@
                                     process="@form"
                                     styleClass="ui-button-success"
                                     icon="fas fa-save"
-                                    disabled="#{!labVmpController.editable}"
+                                    disabled="#{!labVmpController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                     title="Save Lab VMP record"/>
 
                                 <p:commandButton

--- a/src/main/webapp/pharmacy/admin/lab_vtm.xhtml
+++ b/src/main/webapp/pharmacy/admin/lab_vtm.xhtml
@@ -72,7 +72,7 @@
                                                 class="m-1 ui-button-success"
                                                 update="acVtm gpDetail actionButtons statusFilterPanel vtmDetails"
                                                 process="@this"
-                                                disabled="#{labVtmController.editable}">
+                                                disabled="#{labVtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                                 <f:setPropertyActionListener target="#{labVtmController.selectedVtmDto}" value="#{null}" />
                                             </p:commandButton>
 
@@ -84,7 +84,7 @@
                                                 class="m-1 ui-button-info"
                                                 update="vtmDetails acVtm actionButtons statusFilterPanel"
                                                 process="@this"
-                                                disabled="#{labVtmController.editable or labVtmController.selectedVtmDto eq null}">
+                                                disabled="#{labVtmController.editable or labVtmController.selectedVtmDto eq null or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                             </p:commandButton>
 
                                             <p:commandButton
@@ -256,7 +256,7 @@
                                                 class="m-1 ui-button-warning w-25"
                                                 process="btnSave gpDetail"
                                                 update="acVtm gpDetail form:msg actionButtons vtmDetails statusFilterPanel"
-                                                disabled="#{!labVtmController.editable}"
+                                                disabled="#{!labVtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                                 oncomplete="try { if (PF('acVtm')) { PF('acVtm').cache = {}; } } catch(e) {}">
                                             </p:commandButton>
                                             <p:commandButton

--- a/src/main/webapp/pharmacy/admin/store_atm.xhtml
+++ b/src/main/webapp/pharmacy/admin/store_atm.xhtml
@@ -72,7 +72,7 @@
                                                 class="m-1 ui-button-success"
                                                 update="acAtm gpDetail actionButtons statusFilterPanel atmDetails"
                                                 process="@this"
-                                                disabled="#{storeAtmController.editable}">
+                                                disabled="#{storeAtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                                 <f:setPropertyActionListener target="#{storeAtmController.selectedAtmDto}" value="#{null}" />
                                             </p:commandButton>
 
@@ -84,7 +84,7 @@
                                                 class="m-1 ui-button-info"
                                                 update="atmDetails acAtm actionButtons statusFilterPanel"
                                                 process="@this"
-                                                disabled="#{storeAtmController.editable or storeAtmController.selectedAtmDto eq null}">
+                                                disabled="#{storeAtmController.editable or storeAtmController.selectedAtmDto eq null or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                             </p:commandButton>
 
                                             <p:commandButton
@@ -247,7 +247,7 @@
                                                 class="m-1 ui-button-warning w-25"
                                                 process="btnSave gpDetail"
                                                 update="acAtm gpDetail form:msg actionButtons atmDetails statusFilterPanel"
-                                                disabled="#{!storeAtmController.editable}"
+                                                disabled="#{!storeAtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                                 oncomplete="try { if (PF('acAtm')) { PF('acAtm').cache = {}; } } catch(e) {}">
                                             </p:commandButton>
                                             <p:commandButton

--- a/src/main/webapp/pharmacy/admin/store_vtm.xhtml
+++ b/src/main/webapp/pharmacy/admin/store_vtm.xhtml
@@ -72,7 +72,7 @@
                                                 class="m-1 ui-button-success"
                                                 update="acVtm gpDetail actionButtons statusFilterPanel vtmDetails"
                                                 process="@this"
-                                                disabled="#{storeVtmController.editable}">
+                                                disabled="#{storeVtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                                 <f:setPropertyActionListener target="#{storeVtmController.selectedVtmDto}" value="#{null}" />
                                             </p:commandButton>
 
@@ -84,7 +84,7 @@
                                                 class="m-1 ui-button-info"
                                                 update="vtmDetails acVtm actionButtons statusFilterPanel"
                                                 process="@this"
-                                                disabled="#{storeVtmController.editable or storeVtmController.selectedVtmDto eq null}">
+                                                disabled="#{storeVtmController.editable or storeVtmController.selectedVtmDto eq null or !webUserController.hasPrivilege('PharmacyItemNameEdit')}">
                                             </p:commandButton>
 
                                             <p:commandButton
@@ -255,7 +255,7 @@
                                                 class="m-1 ui-button-warning w-25"
                                                 process="btnSave gpDetail"
                                                 update="acVtm gpDetail form:msg actionButtons vtmDetails statusFilterPanel"
-                                                disabled="#{!storeVtmController.editable}"
+                                                disabled="#{!storeVtmController.editable or !webUserController.hasPrivilege('PharmacyItemNameEdit')}"
                                                 oncomplete="try { if (PF('acVtm')) { PF('acVtm').cache = {}; } } catch(e) {}">
                                             </p:commandButton>
                                             <p:commandButton

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -937,6 +937,27 @@
                                                 </h:panelGroup>
                                             </h:panelGroup>
                                         </p:panel>
+                                        <p:panel id="panelPrescription"
+                                                 class="my-1 w-100"
+                                                 toggleable="true"
+                                                 rendered="#{not empty pharmacySaleController.prescriptionHtml}">
+                                            <f:facet name="header">
+                                                <h:outputText styleClass="fas fa-prescription" />
+                                                <h:outputLabel value="Prescription" class="mx-4"/>
+                                            </f:facet>
+                                            <style>
+                                                .rx-preview { line-height: 1.5; overflow-x: hidden; }
+                                                .rx-preview p { margin: 0; }
+                                                .rx-preview h1 { font-size: 1.4rem; margin: 0.2rem 0; }
+                                                .rx-preview h2 { font-size: 1.1rem; margin: 0.4rem 0 0.2rem 0; }
+                                                .rx-preview .ql-align-center { text-align: center; }
+                                                .rx-preview .ql-align-right { text-align: right; }
+                                                .rx-preview .ql-align-justify { text-align: justify; }
+                                            </style>
+                                            <h:panelGroup id="prescriptionView" layout="block" styleClass="rx-preview p-2">
+                                                <h:outputText value="#{pharmacySaleController.prescriptionHtml}" escape="false"/>
+                                            </h:panelGroup>
+                                        </p:panel>
                                         <div class="row">
                                             <div class="col">
                                                 <p:panel id="panelPayment"  class="w-100">


### PR DESCRIPTION
## Summary

Completes the favourite diagnosis/medicine API work described in #21452, adding weight range support to the API, no-filter fallbacks for clinical workflows when patient age/weight aren't recorded, channel report cashier summaries, a new pharmacy privilege, and several clinical workflow fixes.

## Changes

### Favourite Medicine/Diagnosis API
- **Weight range support**: `FavouriteMedicineApiService` now accepts `fromKg`/`toKg` fields; age range is made optional when weight range is provided
- **API response**: `FavouriteMedicineApi` serializes `fromKg`/`toKg` in JSON responses

### Clinical Workflow (OPD Visit)
- **No-filter fallbacks**: `PatientEncounterController` adds a method 4 fallback that loads favourite configurations even when patient DOB/weight aren't recorded, so doctors still get suggestions
- **FavouriteDiagnosis direct fallback**: when no separate `FavouriteMedicine` config exists for a diagnosis-recommended medicine, the `FavouriteDiagnosis` template's own dose/frequency/duration is used directly
- **Add Favourite validation**: a medicine must be selected before clicking 'Add Favourite'
- **Legacy prescription type detection**: both `PatientEncounterController` and `PastPatientEncounterController` now detect prescriptions saved with legacy `null` or `VisitDocument` type by checking `DocumentTemplateType.Prescription`; new prescriptions default to `VisitPrescription`

### Prescription → Pharmacy
- **Rich text separation**: `PracticeBookingController` now sets `prescriptionHtml` (rich Quill HTML) and converts it to plain text for the bill comment via `htmlToPlainText()`
- **Prescription preview panel**: `pharmacy_bill_retail_sale.xhtml` shows a toggleable panel rendering the prescription HTML
- **Stale data cleanup**: prescription data is cleared when switching to an encounter with no prescriptions

### Channel Reports
- **Cashier-based summaries**: `ChannelReportTempController` adds `fetchBillsTotal`, `fetchBillsTotalSessoin`, `fetchCashiers`, `fetchUserRows`, `fetchDateRangeRows` with WebUser/agency support

### Pharmacy Administration
- **New privilege**: `PharmacyItemNameEdit` — registered in `Privileges` enum, `getCategory()`, and `UserPrivilageController` tree; gates Add/Edit/Save on VMP/VTM/ATM admin pages
- **VMP fallback lookup**: `PharmacyBean` falls back to direct `VMP.VTM_ID` when `VirtualProductIngredient` join table is unpopulated

Closes #21452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel reporting can group appointment/count summaries by cashier or by date.
  * Retail pharmacy can auto-populate bills from OPD prescriptions with FEFO stock selection.
  * Prescription preview added to pharmacy billing UI.
  * API support for searching clinical diagnoses and distinguishing favourite-diagnosis templates.

* **Improvements**
  * Clinical queue UI reorganized with improved filtering and tabbed layout.
  * Medicine suggestion/prescription logic gains robust fallback resolution and legacy-prescription handling.
  * Pharmacy bill text now converts rich prescription HTML to readable plain text.

* **Security**
  * New privilege to control pharmacy item name editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->