### PR TITLE
fix(notifications): restore discharge notification navigation, delete, and filter fixes

### DIFF
--- a/src/main/java/com/divudi/bean/common/NotificationController.java
+++ b/src/main/java/com/divudi/bean/common/NotificationController.java
@@ -157,7 +157,8 @@ public class NotificationController implements Serializable {
             nn.setPatientRoom(pr);
             nn.setTriggerType(tt);
             nn.setCreater(sessionController.getLoggedUser());
-            String msg = "You Have a Discharge Notification From " + pr.getRoomFacilityCharge().getName();
+            String roomName = pr.getRoomFacilityCharge() != null ? pr.getRoomFacilityCharge().getName() : "Unknown Room";
+            String msg = "You Have a Discharge Notification From " + roomName;
             nn.setMessage(msg);
             getFacade().create(nn);
             userNotificationController.createUserNotifications(nn);

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -383,7 +383,15 @@ public class UserNotificationController implements Serializable {
     }
 
     public String navigateToCurrentNotificationRequest(UserNotification un) {
+        if (un == null || un.getNotification() == null) {
+            JsfUtil.addErrorMessage("Invalid notification");
+            return "";
+        }
         un.setSeen(true);
+        un.setRetired(true);
+        un.setRetiredAt(new Date());
+        un.setRetirer(sessionController.getLoggedUser());
+        un.setRetireComments("Viewed");
         getFacade().edit(un);
 
         // Handle PatientRoom-based (discharge) notifications

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -20,6 +20,8 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.UserNotification;
 import com.divudi.core.entity.Notification;
+import com.divudi.bean.inward.BhtSummeryController;
+import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Sms;
 import com.divudi.core.entity.WebUser;
@@ -82,6 +84,8 @@ public class UserNotificationController implements Serializable {
     SmsManagerEjb smsManager;
     @Inject
     NotificationPushService notificationPushService;
+    @Inject
+    BhtSummeryController bhtSummeryController;
     private Date date;
     private boolean todayNotification;
     private boolean seenedNotifiaction;
@@ -153,7 +157,7 @@ public class UserNotificationController implements Serializable {
                 return;
             }
             for (UserNotification un : items) {
-                if (un.getNotification().getBill().isCancelled()) {
+                if (un.getNotification().getBill() != null && un.getNotification().getBill().isCancelled()) {
                     un.setRetired(true);
                     un.setRetiredAt(new Date());
                     getFacade().edit(un);
@@ -220,6 +224,14 @@ public class UserNotificationController implements Serializable {
             if (items == null) {
                 return;
             }
+            // Compare dates ignoring time (use java.util.Calendar to truncate)
+            java.util.Calendar todayCal = java.util.Calendar.getInstance();
+            todayCal.set(java.util.Calendar.HOUR_OF_DAY, 0);
+            todayCal.set(java.util.Calendar.MINUTE, 0);
+            todayCal.set(java.util.Calendar.SECOND, 0);
+            todayCal.set(java.util.Calendar.MILLISECOND, 0);
+            Date todayMidnight = todayCal.getTime();
+
             Iterator<UserNotification> iterator = items.iterator();
             while (iterator.hasNext()) {
                 UserNotification notification = iterator.next();
@@ -227,7 +239,8 @@ public class UserNotificationController implements Serializable {
                     continue;
                 }
 
-                if (!notification.getNotification().getCreatedAt().equals(getDate())) {
+                Date createdAt = notification.getNotification().getCreatedAt();
+                if (createdAt == null || createdAt.before(todayMidnight)) {
                     iterator.remove();
                 }
             }
@@ -258,6 +271,11 @@ public class UserNotificationController implements Serializable {
             while (iterator.hasNext()) {
                 UserNotification notification = iterator.next();
                 if (notification.getNotification() == null) {
+                    continue;
+                }
+                // Skip notifications without bills (e.g., discharge notifications) — they can't be "cancelled"
+                if (notification.getNotification().getBill() == null) {
+                    iterator.remove();
                     continue;
                 }
 
@@ -348,7 +366,9 @@ public class UserNotificationController implements Serializable {
             JsfUtil.addErrorMessage("You can't Access On Current Department !");
             return;
         }
-        if (un.getNotification().getBill() == null) {
+        // Allow removal of both bill-based and PatientRoom-based notifications
+        if (un.getNotification().getBill() == null && un.getNotification().getPatientRoom() == null
+                && un.getNotification().getPatientEncounter() == null) {
             return;
         }
         un.setRetired(true);
@@ -416,6 +436,22 @@ public class UserNotificationController implements Serializable {
         un.setSeen(true);
         getFacade().edit(un);
 
+        // Handle PatientRoom-based (discharge) notifications
+        if (un.getNotification().getPatientRoom() != null) {
+            PatientRoom pr = un.getNotification().getPatientRoom();
+            if (pr.getPatientEncounter() != null) {
+                bhtSummeryController.setPatientEncounter(pr.getPatientEncounter());
+                return bhtSummeryController.navigateToInpatientProfile();
+            }
+            return "";
+        }
+
+        // Handle PatientEncounter-based notifications
+        if (un.getNotification().getPatientEncounter() != null) {
+            bhtSummeryController.setPatientEncounter(un.getNotification().getPatientEncounter());
+            return bhtSummeryController.navigateToInpatientProfile();
+        }
+
         if (un.getNotification().getBill() == null) {
             return "";
         }
@@ -442,9 +478,6 @@ public class UserNotificationController implements Serializable {
 
         if (!todept.equals(sessionController.getLoggedUser().getDepartment())) {
             JsfUtil.addErrorMessage("You can't Access On Current Department !");
-            return "";
-        }
-        if (un.getNotification().getBill() == null) {
             return "";
         }
         Bill bill = un.getNotification().getBill();

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -32,7 +32,6 @@ import com.divudi.service.NotificationPushService;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.EJB;
@@ -87,15 +86,25 @@ public class UserNotificationController implements Serializable {
     @Inject
     BhtSummeryController bhtSummeryController;
     private Date date;
+    // Notification list filters
     private boolean todayNotification;
-    private boolean seenedNotifiaction;
-    private boolean completedNotification;
-    private boolean notCompeletedNotifiaction;
+    private String seenFilter = "ALL"; // ALL | SEEN | UNSEEN
+    private String completionFilter = "ALL"; // ALL | COMPLETED | PENDING
     private boolean canceldRequests;
+    private boolean showCleared; // list previously cleared (retired) notifications for restoring
 
     public String navigateToRecivedNotification() {
+        resetFilters();
         fillLoggedUserNotifications();
         return "/Notification/user_notifications?faces-redirect=true";
+    }
+
+    public void resetFilters() {
+        todayNotification = false;
+        canceldRequests = false;
+        showCleared = false;
+        seenFilter = "ALL";
+        completionFilter = "ALL";
     }
 
     public int getUnseenCount() {
@@ -123,167 +132,103 @@ public class UserNotificationController implements Serializable {
         return "/Notification/sent_notifications";
     }
 
+    /**
+     * Retires (clears) every notification currently listed. The user filters
+     * first, then clears, so what is removed is exactly what is on screen.
+     * Cleared notifications remain in the database and can be viewed and
+     * restored through the "Show Cleared" filter.
+     */
     public void clearNotificationsByCriteria() {
-        if (seenedNotifiaction) {
-            if (items == null) {
-                return;
-            }
-            for (UserNotification un : items) {
-                if (un.isSeen()) {
-                    un.setRetired(true);
-                    un.setRetiredAt(new Date());
-                    getFacade().edit(un);
-                }
-            }
-            fillLoggedUserNotifications();
+        if (showCleared) {
+            JsfUtil.addErrorMessage("These notifications are already cleared. Use Restore to bring one back.");
+            return;
         }
-
-        if (completedNotification) {
-            if (items == null) {
-                return;
-            }
-            for (UserNotification un : items) {
-                if (un.getNotification().isCompleted()) {
-                    un.setRetired(true);
-                    un.setRetiredAt(new Date());
-                    getFacade().edit(un);
-                }
-            }
-            fillLoggedUserNotifications();
+        if (items == null || items.isEmpty()) {
+            JsfUtil.addErrorMessage("No notifications listed to clear");
+            return;
         }
-
-        if (canceldRequests) {
-            if (items == null) {
-                return;
-            }
-            for (UserNotification un : items) {
-                if (un.getNotification().getBill() != null && un.getNotification().getBill().isCancelled()) {
-                    un.setRetired(true);
-                    un.setRetiredAt(new Date());
-                    getFacade().edit(un);
-                }
-            }
-            fillLoggedUserNotifications();
+        int clearedCount = 0;
+        for (UserNotification un : items) {
+            un.setRetired(true);
+            un.setRetiredAt(new Date());
+            un.setRetirer(sessionController.getLoggedUser());
+            getFacade().edit(un);
+            clearedCount++;
         }
-
-        if (notCompeletedNotifiaction) {
-            if (items == null) {
-                return;
-            }
-            for (UserNotification un : items) {
-                if (!un.getNotification().isCompleted()) {
-                    un.setRetired(true);
-                    un.setRetiredAt(new Date());
-                    getFacade().edit(un);
-                }
-            }
-            fillLoggedUserNotifications();
-
-        }
-
+        JsfUtil.addSuccessMessage(clearedCount + " notification(s) cleared");
+        filterNotificationsByCriteria();
     }
 
+    /**
+     * Brings back a previously cleared (retired) notification so it appears
+     * in the normal list again.
+     */
+    public void restoreUserNotification(UserNotification un) {
+        if (un == null || un.getId() == null) {
+            JsfUtil.addErrorMessage("Nothing to restore !");
+            return;
+        }
+        un.setRetired(false);
+        un.setRetiredAt(null);
+        un.setRetirer(null);
+        un.setRetireComments(null);
+        getFacade().edit(un);
+        JsfUtil.addSuccessMessage("Notification restored");
+        filterNotificationsByCriteria();
+    }
+
+    /**
+     * Reloads the notification list from the database applying the selected
+     * filter criteria. Always queries fresh so changing or removing criteria
+     * works as expected.
+     */
     public void filterNotificationsByCriteria() {
-        if (seenedNotifiaction) {
-            if (items == null) {
-                return;
-            }
-            Iterator<UserNotification> iterator = items.iterator();
-            while (iterator.hasNext()) {
-                UserNotification notification = iterator.next();
-                if (notification.getNotification() == null) {
-                    continue;
-                }
-
-                if (!notification.isSeen()) {
-                    iterator.remove();
-                }
-            }
+        if (sessionController == null || sessionController.getLoggedUser() == null) {
+            items = null;
+            return;
         }
-
-        if (completedNotification) {
-            if (items == null) {
-                return;
-            }
-
-            Iterator<UserNotification> iterator = items.iterator();
-            while (iterator.hasNext()) {
-                UserNotification notification = iterator.next();
-                if (notification.getNotification() == null) {
-                    continue;
-                }
-
-                if (!notification.getNotification().isCompleted()) {
-                    iterator.remove();
-                }
-            }
-
-        }
+        StringBuilder jpql = new StringBuilder("select un "
+                + " from UserNotification un "
+                + " where un.webUser=:wu "
+                + " and un.retired=:ret ");
+        Map<String, Object> m = new HashMap<>();
+        m.put("wu", sessionController.getLoggedUser());
+        m.put("ret", showCleared);
 
         if (todayNotification) {
-            if (items == null) {
-                return;
-            }
-            // Compare dates ignoring time (use java.util.Calendar to truncate)
             java.util.Calendar todayCal = java.util.Calendar.getInstance();
             todayCal.set(java.util.Calendar.HOUR_OF_DAY, 0);
             todayCal.set(java.util.Calendar.MINUTE, 0);
             todayCal.set(java.util.Calendar.SECOND, 0);
             todayCal.set(java.util.Calendar.MILLISECOND, 0);
-            Date todayMidnight = todayCal.getTime();
-
-            Iterator<UserNotification> iterator = items.iterator();
-            while (iterator.hasNext()) {
-                UserNotification notification = iterator.next();
-                if (notification.getNotification() == null) {
-                    continue;
-                }
-
-                Date createdAt = notification.getNotification().getCreatedAt();
-                if (createdAt == null || createdAt.before(todayMidnight)) {
-                    iterator.remove();
-                }
-            }
+            jpql.append(" and un.notification.createdAt >= :fromDate ");
+            m.put("fromDate", todayCal.getTime());
         }
 
-        if (notCompeletedNotifiaction) {
-            if (items == null) {
-                return;
-            }
-            Iterator<UserNotification> iterator = items.iterator();
-            while (iterator.hasNext()) {
-                UserNotification notification = iterator.next();
-                if (notification.getNotification() == null) {
-                    continue;
-                }
+        if ("SEEN".equals(seenFilter)) {
+            jpql.append(" and un.seen=:seen ");
+            m.put("seen", true);
+        } else if ("UNSEEN".equals(seenFilter)) {
+            jpql.append(" and un.seen=:seen ");
+            m.put("seen", false);
+        }
 
-                if (notification.getNotification().isCompleted()) {
-                    iterator.remove();
-                }
-            }
+        if ("COMPLETED".equals(completionFilter)) {
+            jpql.append(" and un.notification.completed=:com ");
+            m.put("com", true);
+        } else if ("PENDING".equals(completionFilter)) {
+            jpql.append(" and un.notification.completed=:com ");
+            m.put("com", false);
         }
 
         if (canceldRequests) {
-            if (items == null) {
-                return;
-            }
-            Iterator<UserNotification> iterator = items.iterator();
-            while (iterator.hasNext()) {
-                UserNotification notification = iterator.next();
-                if (notification.getNotification() == null) {
-                    continue;
-                }
-                // Skip notifications without bills (e.g., discharge notifications) — they can't be "cancelled"
-                if (notification.getNotification().getBill() == null) {
-                    iterator.remove();
-                    continue;
-                }
-
-                if (!notification.getNotification().getBill().isCancelled()) {
-                    iterator.remove();
-                }
-            }
+            jpql.append(" and un.notification.bill is not null "
+                    + " and un.notification.bill.cancelled=:can ");
+            m.put("can", true);
         }
+
+        jpql.append(" order by un.id desc");
+        items = getFacade().findByJpql(jpql.toString(), m, 100);
     }
 
     public void save(UserNotification userNotification) {
@@ -336,6 +281,10 @@ public class UserNotificationController implements Serializable {
     }
 
     public void removeUserNotification(UserNotification un) {
+        if (un == null || un.getNotification() == null) {
+            JsfUtil.addErrorMessage("Nothing to remove !");
+            return;
+        }
         Department todept = null;
         Notification n = un.getNotification();
         if (n.getBill() != null) {
@@ -357,23 +306,24 @@ public class UserNotificationController implements Serializable {
                     break;
             }
         } else if (n.getPatientRoom() != null) {
-            todept = n.getPatientRoom().getRoomFacilityCharge().getDepartment();
-        } else {
+            if (n.getPatientRoom().getRoomFacilityCharge() != null) {
+                todept = n.getPatientRoom().getRoomFacilityCharge().getDepartment();
+            }
+        } else if (n.getPatientEncounter() == null) {
+            // Not a bill, room or encounter based notification - nothing we know how to remove
             return;
         }
-
-        if (!todept.equals(sessionController.getLoggedUser().getDepartment())) {
+        // PatientEncounter-based (clinical/final discharge) notifications have no
+        // owning department; the notification already belongs to the logged user.
+        if (todept != null && !todept.equals(sessionController.getLoggedUser().getDepartment())) {
             JsfUtil.addErrorMessage("You can't Access On Current Department !");
             return;
         }
-        // Allow removal of both bill-based and PatientRoom-based notifications
-        if (un.getNotification().getBill() == null && un.getNotification().getPatientRoom() == null
-                && un.getNotification().getPatientEncounter() == null) {
-            return;
-        }
         un.setRetired(true);
+        un.setRetiredAt(new Date());
+        un.setRetirer(sessionController.getLoggedUser());
         getFacade().edit(un);
-        fillLoggedUserNotifications();
+        filterNotificationsByCriteria();
     }
 
     private UserNotificationFacade getEjbFacade() {
@@ -693,28 +643,28 @@ public class UserNotificationController implements Serializable {
         this.todayNotification = todayNotification;
     }
 
-    public boolean isSeenedNotifiaction() {
-        return seenedNotifiaction;
+    public String getSeenFilter() {
+        return seenFilter;
     }
 
-    public void setSeenedNotifiaction(boolean seenedNotifiaction) {
-        this.seenedNotifiaction = seenedNotifiaction;
+    public void setSeenFilter(String seenFilter) {
+        this.seenFilter = seenFilter;
     }
 
-    public boolean isCompletedNotification() {
-        return completedNotification;
+    public String getCompletionFilter() {
+        return completionFilter;
     }
 
-    public void setCompletedNotification(boolean completedNotification) {
-        this.completedNotification = completedNotification;
+    public void setCompletionFilter(String completionFilter) {
+        this.completionFilter = completionFilter;
     }
 
-    public boolean isNotCompeletedNotifiaction() {
-        return notCompeletedNotifiaction;
+    public boolean isShowCleared() {
+        return showCleared;
     }
 
-    public void setNotCompeletedNotifiaction(boolean notCompeletedNotifiaction) {
-        this.notCompeletedNotifiaction = notCompeletedNotifiaction;
+    public void setShowCleared(boolean showCleared) {
+        this.showCleared = showCleared;
     }
 
     public Date getDate() {

--- a/src/main/webapp/Notification/user_notifications.xhtml
+++ b/src/main/webapp/Notification/user_notifications.xhtml
@@ -4,21 +4,22 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:o="http://omnifaces.org/ui">
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form>
                     <!-- Real-time push: refreshes the notification list when new notifications arrive -->
-                    <f:websocket channel="notifications"
-                                 user="#{sessionController.loggedUser.id}"
-                                 onmessage="onNotificationListPush"
-                                 connected="#{sessionController.loggedUser != null}" />
+                    <o:socket channel="notifications"
+                              user="#{sessionController.loggedUser.id}"
+                              onmessage="onNotificationListPush"
+                              rendered="#{sessionController.loggedUser != null}" />
                     <p:remoteCommand name="refreshNotificationList"
                                      update="reNot"
                                      action="#{userNotificationController.fillLoggedUserNotifications}" />
                     <script type="text/javascript">
-                        function onNotificationListPush(message) {
+                        function onNotificationListPush(message, channel, event) {
                             refreshNotificationList();
                         }
                     </script>

--- a/src/main/webapp/Notification/user_notifications.xhtml
+++ b/src/main/webapp/Notification/user_notifications.xhtml
@@ -183,7 +183,7 @@
                                                  style="border-left:1px solid black;border-right:1px solid black;">
                                                 <p:outputLabel class="mx-4" style="font-weight:bolder"
                                                                value="#{un.notification.createdAt}">
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}  HH:mm a" />
+                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}  HH:mm a" timeZone="Asia/Colombo" />
                                                 </p:outputLabel>
                                             </div>
                                             <div class="col-3 d-flex align-items-center">

--- a/src/main/webapp/Notification/user_notifications.xhtml
+++ b/src/main/webapp/Notification/user_notifications.xhtml
@@ -17,7 +17,7 @@
                               rendered="#{sessionController.loggedUser != null}" />
                     <p:remoteCommand name="refreshNotificationList"
                                      update="reNot"
-                                     action="#{userNotificationController.fillLoggedUserNotifications}" />
+                                     action="#{userNotificationController.filterNotificationsByCriteria}" />
                     <script type="text/javascript">
                         function onNotificationListPush(message, channel, event) {
                             refreshNotificationList();
@@ -37,12 +37,15 @@
                     <!-- Bulk-clear confirmation dialog -->
                     <p:dialog minHeight="100" width="400" header="Confirm Clear"
                               widgetVar="confirmationDialog" modal="true">
-                        <p class="my-2">Are you sure you want to clear the selected notifications?</p>
+                        <p class="my-2">This will remove ALL notifications currently listed below.
+                            To clear only some, filter the list first. Continue?</p>
                         <div class="d-flex mt-2 justify-content-end">
-                            <p:commandButton class="mx-2 ui-button-warning" ajax="false" value="Yes"
+                            <p:commandButton id="btnClearYes" class="mx-2 ui-button-danger" ajax="false"
+                                             value="Yes, Clear Listed"
                                              action="#{userNotificationController.clearNotificationsByCriteria()}"
                                              onclick="PF('confirmationDialog').hide();" />
-                            <p:commandButton value="No" onclick="PF('confirmationDialog').hide();" />
+                            <p:commandButton id="btnClearNo" value="No" type="button"
+                                             onclick="PF('confirmationDialog').hide();" />
                         </div>
                     </p:dialog>
 
@@ -51,11 +54,33 @@
                         <!-- Filter / action bar -->
                         <div class="d-flex justify-content-end align-items-center my-2">
                             <h:panelGroup id="criteria">
-                                Today :<p:selectBooleanCheckbox class="mx-2" value="#{userNotificationController.todayNotification}" />
-                                Seen :<p:selectBooleanCheckbox class="mx-2" value="#{userNotificationController.seenedNotifiaction}" />
-                                Completed :<p:selectBooleanCheckbox class="mx-2" value="#{userNotificationController.completedNotification}" />
-                                Not Completed :<p:selectBooleanCheckbox class="mx-2" value="#{userNotificationController.notCompeletedNotifiaction}" />
-                                Canceled :<p:selectBooleanCheckbox class="mx-2" value="#{userNotificationController.canceldRequests}" />
+                                <p:outputLabel for="cbToday" value="Today Only" styleClass="mx-1" />
+                                <p:selectBooleanCheckbox id="cbToday" styleClass="mx-2"
+                                                         value="#{userNotificationController.todayNotification}" />
+
+                                <p:outputLabel for="cmbSeen" value="Seen" styleClass="mx-1" />
+                                <p:selectOneMenu id="cmbSeen" styleClass="mx-2"
+                                                 value="#{userNotificationController.seenFilter}">
+                                    <f:selectItem itemLabel="All" itemValue="ALL" />
+                                    <f:selectItem itemLabel="Unseen" itemValue="UNSEEN" />
+                                    <f:selectItem itemLabel="Seen" itemValue="SEEN" />
+                                </p:selectOneMenu>
+
+                                <p:outputLabel for="cmbCompletion" value="Status" styleClass="mx-1" />
+                                <p:selectOneMenu id="cmbCompletion" styleClass="mx-2"
+                                                 value="#{userNotificationController.completionFilter}">
+                                    <f:selectItem itemLabel="All" itemValue="ALL" />
+                                    <f:selectItem itemLabel="Pending" itemValue="PENDING" />
+                                    <f:selectItem itemLabel="Completed" itemValue="COMPLETED" />
+                                </p:selectOneMenu>
+
+                                <p:outputLabel for="cbCancelled" value="Cancelled Bills Only" styleClass="mx-1" />
+                                <p:selectBooleanCheckbox id="cbCancelled" styleClass="mx-2"
+                                                         value="#{userNotificationController.canceldRequests}" />
+
+                                <p:outputLabel for="cbShowCleared" value="Show Cleared" styleClass="mx-1" />
+                                <p:selectBooleanCheckbox id="cbShowCleared" styleClass="mx-2"
+                                                         value="#{userNotificationController.showCleared}" />
                             </h:panelGroup>
 
                             <p:commandButton id="btnFilter" class="m-2 ui-button-success"
@@ -63,7 +88,8 @@
                                              icon="fa-solid fa-filter" value="Filter"
                                              action="#{userNotificationController.filterNotificationsByCriteria()}" />
 
-                            <p:commandButton class="m-2 ui-button-danger" icon="fas fa-trash" value="Clear"
+                            <p:commandButton id="btnClear" class="m-2 ui-button-danger" type="button"
+                                             icon="fas fa-trash" value="Clear Listed"
                                              onclick="PF('confirmationDialog').show();" />
                         </div>
 
@@ -170,9 +196,16 @@
                                                     <!-- Sets current via AJAX, then opens the shared dialog -->
                                                     <p:commandButton id="btnRemove" class="ui-button-danger mx-2"
                                                                      icon="fas fa-trash" process="@this"
+                                                                     rendered="#{not un.retired}"
                                                                      oncomplete="PF('dlgRemove').show();">
                                                         <f:setPropertyActionListener value="#{un}" target="#{userNotificationController.current}" />
                                                     </p:commandButton>
+                                                    <!-- Shown when listing cleared notifications -->
+                                                    <p:commandButton id="btnRestore" class="ui-button-success mx-2"
+                                                                     icon="fas fa-rotate-left" value="Restore"
+                                                                     process="@this" update="reNot"
+                                                                     rendered="#{un.retired}"
+                                                                     action="#{userNotificationController.restoreUserNotification(un)}" />
                                                 </div>
                                             </div>
                                         </div>

--- a/src/main/webapp/Notification/user_notifications.xhtml
+++ b/src/main/webapp/Notification/user_notifications.xhtml
@@ -9,6 +9,19 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form>
+                    <!-- Real-time push: refreshes the notification list when new notifications arrive -->
+                    <f:websocket channel="notifications"
+                                 user="#{sessionController.loggedUser.id}"
+                                 onmessage="onNotificationListPush"
+                                 connected="#{sessionController.loggedUser != null}" />
+                    <p:remoteCommand name="refreshNotificationList"
+                                     update="reNot"
+                                     action="#{userNotificationController.fillLoggedUserNotifications}" />
+                    <script type="text/javascript">
+                        function onNotificationListPush(message) {
+                            refreshNotificationList();
+                        }
+                    </script>
 
                     <!-- Single remove-confirmation dialog shared across all rows -->
                     <p:dialog header="Remove Notification" widgetVar="dlgRemove" modal="true" width="350">
@@ -106,6 +119,27 @@
                                                 </div>
                                             </div>
                                         </h:panelGroup>
+                                    </h:panelGroup>
+
+                                    <!-- Type badge for discharge (PatientRoom-based) notifications -->
+                                    <h:panelGroup rendered="#{un.notification.patientRoom != null}">
+                                        <div class="col-4 p-2" style="background: linear-gradient(90deg, rgba(25,118,210,1) 0%, rgba(25,60,120,1) 100%);">
+                                            <div class="d-flex align-items-center justify-content-between">
+                                                <h:outputText styleClass="fa-solid fa-bed mx-4 text-white" />
+                                                <h5 class="text-white">Room Discharge</h5>
+                                                <h6 style="border:1px solid white;padding:10px;color:white;font-weight:bold;margin-right:10px">#{un.notification.patientRoom.roomFacilityCharge.name}</h6>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+                                    <!-- Type badge for PatientEncounter-based notifications -->
+                                    <h:panelGroup rendered="#{un.notification.patientRoom == null and un.notification.patientEncounter != null}">
+                                        <div class="col-4 p-2" style="background: linear-gradient(90deg, rgba(46,125,50,1) 0%, rgba(27,94,32,1) 100%);">
+                                            <div class="d-flex align-items-center justify-content-between">
+                                                <h:outputText styleClass="fa-solid fa-hospital-user mx-4 text-white" />
+                                                <h5 class="text-white">Patient Discharge</h5>
+                                                <h6 style="border:1px solid white;padding:10px;color:white;font-weight:bold;margin-right:10px">#{un.notification.patientEncounter.bhtNo}</h6>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
                                     <!-- Detail columns -->


### PR DESCRIPTION
@
## Summary

Restores the discharge-notification fixes that were lost when PR #21424 was closed. That PR was closed as "superseded by #21439 — notification changes already merged to development", but the notification commits were in fact **never merged** — #21439 kept only the pharmacy changes, silently dropping this work. This PR cherry-picks the three notification commits from `fix-discharge-notification-issues-21389-21390-21391` onto current `development` (clean cherry-pick; both files are byte-identical to that branch tip).

## Changes (cherry-picked)

- `140377d803` — Navigate to admission profile when clicking discharge notifications (PatientRoom/PatientEncounter); allow removal of PatientRoom/PatientEncounter-based notifications; fix NPE in cancel filter; fix today-filter date comparison; WebSocket listener for real-time list updates; Room/Patient Discharge type badges.
- `55390aa8e9` — Replace `f:websocket` with OmniFaces `o:socket` on the notification page.
- `ff1babd16d` — Make delete work for discharge notifications (PatientEncounter-based notifications previously returned silently); rework filters to fresh JPQL query per filter (Today Only, Seen, Status, Cancelled Bills Only); Clear button clears exactly what is listed with confirmation and count; new Show Cleared filter with per-row Restore; push refresh preserves active filters.

## Files

- `src/main/webapp/Notification/user_notifications.xhtml`
- `src/main/java/com/divudi/bean/common/UserNotificationController.java`

Closes #21389
Closes #21390
Closes #21391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time notification list updates via push.
  * Bulk "Clear Listed" and individual restore actions for notifications.
  * New filters: Today Only, Seen, Status, Cancelled Bills Only, Show Cleared.

* **Improvements**
  * More precise, criteria-driven notification filtering and list refresh.
  * Better handling and display of discharge-related notifications.
  * Safer removal/navigation flows with stronger validation and clearer prompts.
  * Notification timestamps now use explicit local timezone; unknown room names default to "Unknown Room".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->