### PR TITLE
feat(pharmacy): auto-convert BHT request items to AMPs on issue

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2673,9 +2673,11 @@ public class PharmacySaleBhtController implements Serializable {
 
             Amp sameStrengthAmp = null;
             List<StockQty> sameStrengthStockQtys = null;
+            Date sameStrengthEarliestExpiry = null;
 
             Amp fallbackAmp = null;
             List<StockQty> fallbackStockQtys = null;
+            Date fallbackEarliestExpiry = null;
 
             for (Amp candidate : candidateAmps) {
                 Double ampStrength = candidate.getStrengthOfAnIssueUnit();
@@ -2692,6 +2694,13 @@ public class PharmacySaleBhtController implements Serializable {
                     continue;
                 }
 
+                // getStockByQty returns batches ORDER BY dateOfExpire, so first entry is earliest
+                Date candidateEarliestExpiry = null;
+                StockQty first = stockQtys.get(0);
+                if (first.getStock() != null && first.getStock().getItemBatch() != null) {
+                    candidateEarliestExpiry = first.getStock().getItemBatch().getDateOfExpire();
+                }
+
                 boolean isExact = (requestedItem instanceof Amp)
                         && requestedItem.getId() != null
                         && requestedItem.getId().equals(candidate.getId());
@@ -2702,12 +2711,20 @@ public class PharmacySaleBhtController implements Serializable {
                     exactAmp = candidate;
                     exactStockQtys = stockQtys;
                     break; // exact match is optimal
-                } else if (isSameStrength && sameStrengthAmp == null) {
+                } else if (isSameStrength
+                        && (sameStrengthAmp == null
+                        || (candidateEarliestExpiry != null && (sameStrengthEarliestExpiry == null
+                        || candidateEarliestExpiry.before(sameStrengthEarliestExpiry))))) {
                     sameStrengthAmp = candidate;
                     sameStrengthStockQtys = stockQtys;
-                } else if (fallbackAmp == null) {
+                    sameStrengthEarliestExpiry = candidateEarliestExpiry;
+                } else if (!isSameStrength
+                        && (fallbackAmp == null
+                        || (candidateEarliestExpiry != null && (fallbackEarliestExpiry == null
+                        || candidateEarliestExpiry.before(fallbackEarliestExpiry))))) {
                     fallbackAmp = candidate;
                     fallbackStockQtys = stockQtys;
+                    fallbackEarliestExpiry = candidateEarliestExpiry;
                 }
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1768,21 +1768,20 @@ public class PharmacySaleBhtController implements Serializable {
         itemForSubstitution = bi;
         selectedSubstituteStock = null;
         substituteStocks = new ArrayList<>();
-        if (bi != null && bi.getItem() instanceof Amp) {
-            Amp amp = (Amp) bi.getItem();
-            if (amp.getVmp() != null) {
-                List<Amp> amps = vmpController.ampsOfVmp(amp.getVmp());
-                for (Amp substituteAmp : amps) {
-                    List<Stock> stocks = pharmacyBean.getStockByQty(substituteAmp, sessionController.getDepartment());
-                    if (stocks != null) {
-                        for (Stock stock : stocks) {
-                            if (stock.getStock() > 0 && stock.getItemBatch() != null && stock.getItemBatch().getDateOfExpire() != null) {
-                                Date currentDate = new Date();
-                                if (stock.getItemBatch().getDateOfExpire().after(currentDate)) {
-                                    substituteStocks.add(stock);
-                                }
-                            }
-                        }
+        if (bi == null || bi.getItem() == null) {
+            return;
+        }
+        List<Amp> amps = pharmacyBean.resolveAmps(bi.getItem());
+        Date currentDate = new Date();
+        for (Amp substituteAmp : amps) {
+            List<Stock> stocks = pharmacyBean.getStockByQty(substituteAmp, sessionController.getDepartment());
+            if (stocks != null) {
+                for (Stock stock : stocks) {
+                    if (stock.getStock() > 0
+                            && stock.getItemBatch() != null
+                            && stock.getItemBatch().getDateOfExpire() != null
+                            && stock.getItemBatch().getDateOfExpire().after(currentDate)) {
+                        substituteStocks.add(stock);
                     }
                 }
             }
@@ -2651,7 +2650,22 @@ public class PharmacySaleBhtController implements Serializable {
 
             // Resolve VTM/VMP/AMP/ATM to concrete AMP candidates with stock priority:
             // 1. Exact requested AMP  2. Same-strength sibling AMP  3. Any available AMP
-            List<Amp> candidateAmps = pharmacyBean.resolveAmps(requestedItem);
+            // For AMP requests also include VMP siblings so substitution can fire when
+            // the exact brand is out of stock.
+            List<Amp> candidateAmps = new ArrayList<>(pharmacyBean.resolveAmps(requestedItem));
+            if (requestedItem instanceof Amp) {
+                Vmp vmp = ((Amp) requestedItem).getVmp();
+                if (vmp != null) {
+                    List<Amp> siblings = pharmacyBean.findAmpsForVmp(vmp);
+                    if (siblings != null) {
+                        for (Amp sibling : siblings) {
+                            if (!sibling.getId().equals(requestedItem.getId())) {
+                                candidateAmps.add(sibling);
+                            }
+                        }
+                    }
+                }
+            }
             Double requestedStrength = requestedItem.getStrengthOfAnIssueUnit();
 
             Amp exactAmp = null;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2642,39 +2642,84 @@ public class PharmacySaleBhtController implements Serializable {
             if (i.getQty() == null) {
                 continue;
             }
-            Item item = i.getItem();
-            Double requestingQty = i.getQty();
-
-            List<Stock> usedStocks = new ArrayList<>();
-
-            if (item instanceof Amp) {
-
-            } else if (item instanceof Vmp) {
-
-            } else if (item instanceof Ampp) {
-                JsfUtil.addErrorMessage("No Supported Yet");
-                return;
-            } else if (item instanceof Vmpp) {
-                JsfUtil.addErrorMessage("No Supported Yet");
-                return;
-            }
+            Item requestedItem = i.getItem();
 
             double billedIssue = getPharmacyCalculation().getBilledInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
             double cancelledIssue = getPharmacyCalculation().getCancelledInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
             double refundedIssue = getPharmacyCalculation().getRefundedInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
-
             double issuableQty = Math.abs(i.getQty()) - (Math.abs(billedIssue) - (Math.abs(cancelledIssue) + Math.abs(refundedIssue)));
 
-            List<StockQty> stockQtys = pharmacyBean.getStockByQty(i.getItem(), issuableQty, getSessionController().getDepartment());
+            // Resolve VTM/VMP/AMP/ATM to concrete AMP candidates with stock priority:
+            // 1. Exact requested AMP  2. Same-strength sibling AMP  3. Any available AMP
+            List<Amp> candidateAmps = pharmacyBean.resolveAmps(requestedItem);
+            Double requestedStrength = requestedItem.getStrengthOfAnIssueUnit();
 
-            if (stockQtys != null && !stockQtys.isEmpty()) {
+            Amp exactAmp = null;
+            List<StockQty> exactStockQtys = null;
 
-                for (StockQty sq : stockQtys) {
+            Amp sameStrengthAmp = null;
+            List<StockQty> sameStrengthStockQtys = null;
+
+            Amp fallbackAmp = null;
+            List<StockQty> fallbackStockQtys = null;
+
+            for (Amp candidate : candidateAmps) {
+                Double ampStrength = candidate.getStrengthOfAnIssueUnit();
+                double candidateQty;
+                if (requestedStrength != null && requestedStrength > 0
+                        && ampStrength != null && ampStrength > 0) {
+                    candidateQty = Math.ceil(issuableQty * requestedStrength / ampStrength);
+                } else {
+                    candidateQty = issuableQty;
+                }
+
+                List<StockQty> stockQtys = pharmacyBean.getStockByQty((Item) candidate, candidateQty, getSessionController().getDepartment());
+                if (stockQtys == null || stockQtys.isEmpty()) {
+                    continue;
+                }
+
+                boolean isExact = (requestedItem instanceof Amp)
+                        && requestedItem.getId() != null
+                        && requestedItem.getId().equals(candidate.getId());
+                boolean isSameStrength = (requestedStrength == null || ampStrength == null)
+                        || (requestedStrength.doubleValue() == ampStrength.doubleValue());
+
+                if (isExact) {
+                    exactAmp = candidate;
+                    exactStockQtys = stockQtys;
+                    break; // exact match is optimal
+                } else if (isSameStrength && sameStrengthAmp == null) {
+                    sameStrengthAmp = candidate;
+                    sameStrengthStockQtys = stockQtys;
+                } else if (fallbackAmp == null) {
+                    fallbackAmp = candidate;
+                    fallbackStockQtys = stockQtys;
+                }
+            }
+
+            // Pick best available candidate
+            final List<StockQty> selectedStockQtys;
+            final boolean isSubstitute;
+
+            if (exactAmp != null) {
+                selectedStockQtys = exactStockQtys;
+                isSubstitute = false;
+            } else if (sameStrengthAmp != null) {
+                selectedStockQtys = sameStrengthStockQtys;
+                isSubstitute = true;
+            } else if (fallbackAmp != null) {
+                selectedStockQtys = fallbackStockQtys;
+                isSubstitute = true;
+            } else {
+                selectedStockQtys = null;
+                isSubstitute = false;
+            }
+
+            if (selectedStockQtys != null && !selectedStockQtys.isEmpty()) {
+                for (StockQty sq : selectedStockQtys) {
                     if (sq.getQty() == 0) {
                         continue;
                     }
-
-                    //Checking User Stock Entity
                     if (!userStockController.isStockAvailable(sq.getStock(), sq.getQty(), getSessionController().getLoggedUser())) {
                         JsfUtil.addErrorMessage("Sorry Already Other User Try to Billing This Stock You Cant Add");
                         continue;
@@ -2685,34 +2730,34 @@ public class PharmacySaleBhtController implements Serializable {
                     billItem.getPharmaceuticalBillItem().setQty(0 - sq.getQty());
                     billItem.getPharmaceuticalBillItem().setStock(sq.getStock());
                     billItem.getPharmaceuticalBillItem().setItemBatch(sq.getStock().getItemBatch());
-
                     billItem.setItem(sq.getStock().getItemBatch().getItem());
                     billItem.setQty(sq.getQty());
                     billItem.setDescreption(i.getDescreption());
-
                     billItem.getPharmaceuticalBillItem().setDoe(sq.getStock().getItemBatch().getDateOfExpire());
                     billItem.getPharmaceuticalBillItem().setFreeQty(0.0f);
                     billItem.getPharmaceuticalBillItem().setItemBatch(sq.getStock().getItemBatch());
                     billItem.setGrossValue(sq.getStock().getItemBatch().getRetailsaleRate() * sq.getQty());
                     billItem.setNetValue(sq.getQty() * sq.getStock().getItemBatch().getRetailsaleRate());
-
                     billItem.setInwardChargeType(InwardChargeType.Medicine);
                     billItem.getPharmaceuticalBillItem().setBillItem(billItem);
-                    billItem.setItem(sq.getStock().getItemBatch().getItem());
                     billItem.setReferanceBillItem(i);
                     billItem.setSearialNo(getBillItems().size() + 1);
+                    if (isSubstitute) {
+                        billItem.setAutoSubstituted(true);
+                        billItem.setRequestedItemName(requestedItem.getName());
+                    }
                     calculateRates(billItem);
                     billItems.add(billItem);
-
                 }
             } else {
+                // No stock found for any AMP — add placeholder for manual resolution
                 billItem = new BillItem();
                 billItem.setPharmaceuticalBillItem(new PharmaceuticalBillItem());
                 billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - issuableQty);
                 billItem.getPharmaceuticalBillItem().setQty(0 - issuableQty);
                 billItem.getPharmaceuticalBillItem().setStock(null);
                 billItem.getPharmaceuticalBillItem().setItemBatch(null);
-                billItem.setItem(i.getItem());
+                billItem.setItem(requestedItem);
                 billItem.setQty(issuableQty);
                 billItem.setDescreption(i.getDescreption());
                 billItem.setInwardChargeType(InwardChargeType.Medicine);
@@ -2722,7 +2767,6 @@ public class PharmacySaleBhtController implements Serializable {
                 calculateRates(billItem);
                 billItems.add(billItem);
             }
-
         }
 
         calCurrentBillItemTotal(billItems);

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -213,6 +213,10 @@ public class BillItem implements Serializable, RetirableEntity {
     double transWithOutCCFee;
     @Transient
     boolean transRefund;
+    @Transient
+    private boolean autoSubstituted = false;
+    @Transient
+    private String requestedItemName = null;
 
     public double getVat() {
         return vat;
@@ -996,6 +1000,22 @@ public class BillItem implements Serializable, RetirableEntity {
 
     public void setTransRefund(boolean transRefund) {
         this.transRefund = transRefund;
+    }
+
+    public boolean isAutoSubstituted() {
+        return autoSubstituted;
+    }
+
+    public void setAutoSubstituted(boolean autoSubstituted) {
+        this.autoSubstituted = autoSubstituted;
+    }
+
+    public String getRequestedItemName() {
+        return requestedItemName;
+    }
+
+    public void setRequestedItemName(String requestedItemName) {
+        this.requestedItemName = requestedItemName;
     }
 
     public double getVatPlusNetValue() {

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -204,6 +204,7 @@
                                 <h:outputText
                                     rendered="#{bItm.autoSubstituted}"
                                     value="&#xf0ec;"
+                                    escape="false"
                                     style="font-family:'Font Awesome 5 Free';font-weight:900;color:#e67e22;"
                                     title="Auto-substituted for: #{bItm.requestedItemName}" />
                                 <p:commandButton

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -184,18 +184,28 @@
                 </h:panelGroup>
 
                 <p:panel header="Available Items" class="mt-2">
-                    <p:dataTable 
+                    <style>
+                        .auto-substituted-row { background-color: #FFF3CD !important; }
+                        .auto-substituted-row td { background-color: #FFF3CD !important; }
+                    </style>
+                    <p:dataTable
                         var="bItm"
                         value="#{pharmacySaleBhtController.billItems}"
                         id="itemList"
-                        sortBy="#{bItm.searialNo}"  
+                        sortBy="#{bItm.searialNo}"
+                        rowStyleClass="#{bItm.autoSubstituted ? 'auto-substituted-row' : ''}"
                         editable="true">
                         <p:ajax event="rowEdit" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
                         <p:ajax event="rowEditCancel" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
 
                         <p:column headerText="Requested Item" style="width: 50px!important; padding: 6px;">
-                            <div style="display:flex;align-items:center;">
+                            <div style="display:flex;align-items:center;gap:4px;">
                                 <h:outputText id="item" value="#{bItm.referanceBillItem.item.name}" />
+                                <h:outputText
+                                    rendered="#{bItm.autoSubstituted}"
+                                    value="&#xf0ec;"
+                                    style="font-family:'Font Awesome 5 Free';font-weight:900;color:#e67e22;"
+                                    title="Auto-substituted for: #{bItm.requestedItemName}" />
                                 <p:commandButton
                                     icon="pi pi-refresh"
                                     id="btnSelectSubstitute"
@@ -214,9 +224,12 @@
                         </p:column>
 
 
-                        <p:column headerText="Description" style="width: 50px!important; padding: 6px;"  >
-                            <h:outputText id="dis" value="#{bItm.item.descreption}" >
-                            </h:outputText>
+                        <p:column headerText="Description" style="width: 50px!important; padding: 6px;">
+                            <h:outputText id="dis" value="#{bItm.item.descreption}" />
+                            <h:panelGroup rendered="#{bItm.autoSubstituted}" layout="block"
+                                          style="margin-top:2px;font-size:0.85em;color:#e67e22;font-style:italic;">
+                                <h:outputText value="Auto-sub: #{bItm.requestedItemName} → #{bItm.item.name}" />
+                            </h:panelGroup>
                         </p:column>
 
                         <p:column headerText="Batch No"  style="width:50px!important; text-align: right; padding: 6px;">


### PR DESCRIPTION
## Summary

- Replaces the stub (empty if-blocks + manual substitution only) in `generateIssueBillComponentsForBhtRequest` with full AMP resolution using `PharmacyBean.resolveAmps()` — handles VTM→VPI→VMP→AMP, VMP→AMP, AMP direct, and ATM→AMP hierarchies
- Tiered candidate selection: exact requested AMP → same-strength sibling AMP → any available sibling AMP (all expiry-filtered, FIFO by expiry date)
- Strength-adjusted quantity when a different-strength AMP is used: `ceil(issuableQty × requestedStrength / substituteStrength)`; null strength treated as equivalent (ratio = 1)
- Auto-substituted rows in the issue page are visually marked: yellow background, orange exchange icon with tooltip, italic "Auto-sub: X → Y" note in the Description column
- Null-stock placeholder rows are preserved for items with no stock anywhere, so pharmacists can still use the manual substitute dialog

## Supported prescription scenarios

| Prescribed item | Dispensed AMP | Qty adjustment |
|---|---|---|
| Amoxicillin 500mg tab (VMP) 1 tab TDS 5d | Decamox 500 | 15 tabs (1:1) |
| Amoxicillin 500mg tab (VMP) 1 tab TDS 5d | Decamox 250 | 30 tabs (×2) |
| Amoxicillin (VTM) → VMP → AMP | Any stocked AMP | Strength-adjusted |
| Amoxil 500 (AMP) — exact stock available | Amoxil 500 | No substitution |
| Amoxil 500 (AMP) — out of stock | Decamox 500 or 250 | Strength-adjusted |

**Prerequisite data:** `AMP.vmp` and `AMP.strengthOfAnIssueUnit` must be set. Existing UI (`pharmacy/admin/amp.xhtml`) and REST API (`PUT /api/pharmaceutical_items/amp/{id}` with `vmpId`) support this. REST API strength field support tracked in #21457.

## Test plan

- [ ] Request with AMP item that has stock → issues exact AMP, no yellow row
- [ ] Request with AMP item out of stock, sibling same-strength AMP in stock → yellow row, correct qty, icon + "Auto-sub" note
- [ ] Request with AMP item out of stock, only different-strength sibling in stock → yellow row, qty adjusted by strength ratio
- [ ] Request with VMP item → resolves to first in-stock AMP for that VMP
- [ ] Request with VTM item (VPI or direct Vmp.vtm link) → resolves through chain to stocked AMP
- [ ] Request item with no stock anywhere → null-stock placeholder row, substitute dialog still works
- [ ] Multiple batches needed to fill qty → split across batches as before

Closes #16132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic medication substitution when exact items are unavailable, preferring same-strength or closest alternatives and creating bill lines per available stock.
  * Placeholder bill line added when no alternative stock exists to preserve requested quantity and pricing.
* **UI**
  * Visual indicators (row highlighting and warning icon) for substituted items.
  * Tooltips and descriptive messaging showing requested versus substituted item names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->