### PR TITLE
Add GOP upload type and Documents section to admission profile

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -240,6 +240,7 @@ public class InwardDocumentUploadController implements Serializable {
         types.add(UploadType.Inward_Consent_Form);
         types.add(UploadType.Inward_Insurance_Document);
         types.add(UploadType.Inward_Referral_Letter);
+        types.add(UploadType.Inward_GOP);
         types.add(UploadType.Inward_Other);
         return types;
     }

--- a/src/main/java/com/divudi/core/data/UploadType.java
+++ b/src/main/java/com/divudi/core/data/UploadType.java
@@ -38,6 +38,7 @@ public enum UploadType {
     Inward_Consent_Form("Consent Form"),
     Inward_Insurance_Document("Insurance Document"),
     Inward_Referral_Letter("Referral Letter"),
+    Inward_GOP("GOP"),
     Inward_Other("Other Document");
 
     private final String label;

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -775,30 +775,10 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
-                                        value="Forms"
-                                        ajax="false"
-                                        rendered="#{webUserController.hasPrivilege('InwardFormFill')}"
-                                        action="#{inwardFormController.navigateToInwardFormsFromAdmissionProfile(admissionController.current)}"
-                                        icon="fa fa-wpforms"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
                                         value="Diagnosis Card"
                                         ajax="false"
                                         action="#{admissionController.navigateToInpatientDiagnosisCard()}"
                                         icon="fa fa-diagnoses"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Documents"
-                                        ajax="false"
-                                        rendered="#{webUserController.hasPrivilege('InwardDocumentUpload')}"
-                                        action="#{admissionController.navigateToInpatientDocuments()}"
-                                        icon="fa fa-file-alt"
                                         class="w-100">
                                     </p:commandButton>
                                 </div>
@@ -957,6 +937,31 @@
                                         <f:setPropertyActionListener
                                             value="#{admissionController.current}"
                                             target="#{searchController.patientEncounter}" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <p:panel header="Documents" class="m-1">
+                            <div class="row g-2">
+                                <div class="col-6">
+                                    <p:commandButton
+                                        value="Fill Forms"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardFormFill')}"
+                                        action="#{inwardFormController.navigateToInwardFormsFromAdmissionProfile(admissionController.current)}"
+                                        icon="fa fa-wpforms"
+                                        class="w-100">
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        value="Documents"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardDocumentUpload')}"
+                                        action="#{admissionController.navigateToInpatientDocuments()}"
+                                        icon="fa fa-file-alt"
+                                        class="w-100">
                                     </p:commandButton>
                                 </div>
                             </div>


### PR DESCRIPTION
## Changes

### 1. New GOP upload type
- Added `Inward_GOP("GOP")` enum value to `UploadType`
- Included in the inward document upload type dropdown

### 2. Documents section on admission profile
- Created new **Documents** panel on the admission profile page (Column 4, between Pharmaceuticals and Reports)
- Moved **Fill Forms** and **Documents** buttons from Clinical Data panel into this new section
- Clinical Data panel now has cleaner layout with remaining buttons

### How to test
1. Open an admission profile
2. Click the **Documents** button in the new Documents section
3. Select **GOP** from the Document Type dropdown
4. Choose a file and click Upload

Closes #21170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading GOP documents alongside existing inward document types.
  * Updated the admission profile screen with new navigation options, including Diagnosis Card and Clinical Discharge.
  * Added quick access to Fill Forms and Documents from the Documents area.

* **UI Changes**
  * Reorganized action buttons on the admission profile page for easier access to clinical and document-related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->