### PR TITLE
AMP strength API fields + ward medicines VTM prescription fixes

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
@@ -21,6 +21,8 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
     private Boolean allowFractions;
     private Boolean consumptionAllowed;
     private Boolean refundsAllowed;
+    private Double strengthOfAnIssueUnit;
+    private Long strengthUnitId;
 
     public AmpRequestDTO() {
     }
@@ -95,5 +97,21 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
 
     public void setRefundsAllowed(Boolean refundsAllowed) {
         this.refundsAllowed = refundsAllowed;
+    }
+
+    public Double getStrengthOfAnIssueUnit() {
+        return strengthOfAnIssueUnit;
+    }
+
+    public void setStrengthOfAnIssueUnit(Double strengthOfAnIssueUnit) {
+        this.strengthOfAnIssueUnit = strengthOfAnIssueUnit;
+    }
+
+    public Long getStrengthUnitId() {
+        return strengthUnitId;
+    }
+
+    public void setStrengthUnitId(Long strengthUnitId) {
+        this.strengthUnitId = strengthUnitId;
     }
 }

--- a/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
+++ b/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
@@ -224,11 +224,22 @@ public class PrescriptionToItemService {
             return null;
         }
 
-        // For AMP with strength in issue unit case:
-        // Total quantity = dose × doses per day × number of days
-        Double totalQuantity = dose * dosesPerDay * durationInDays;
+        // Number of administrations over the course of treatment
+        Double administrations = dosesPerDay * durationInDays;
 
-        return totalQuantity;
+        // If the AMP's strength (e.g. 500 mg per capsule) is known and is in the
+        // same unit as the prescribed dose (e.g. 500 mg), convert the dose into
+        // a number of issue units (capsules) per administration: dose / strength.
+        // Otherwise assume the prescribed dose already refers to one issue unit
+        // (e.g. "1 tablet" tds) and just count administrations.
+        Double strength = amp.getStrengthOfAnIssueUnit();
+        MeasurementUnit strengthUnit = amp.getStrengthUnit();
+        if (strength != null && strength > 0 && doseUnit != null && strengthUnit != null
+                && doseUnit.getName() != null && doseUnit.getName().equalsIgnoreCase(strengthUnit.getName())) {
+            return (dose / strength) * administrations;
+        }
+
+        return administrations;
     }
 
     /**
@@ -300,10 +311,30 @@ public class PrescriptionToItemService {
         try {
             // This is a simplified implementation
             // In practice, this would involve complex matching based on:
-            // - Strength requirements
             // - Dosage form preferences
             // - Availability
-            String jpql = "SELECT i FROM Item i WHERE i.name LIKE :pattern AND i.retired = false";
+            String jpql = "SELECT i FROM Item i WHERE i.name LIKE :pattern AND i.retired = false AND TYPE(i) IN (Vmp, Amp)";
+
+            // VMP/AMP names embed the strength (e.g. "Amoxicillin 500.0 mg
+            // capsules"), but the VTM itself does not. When the prescription
+            // carries a dose, narrow the match to items whose name also
+            // mentions that strength so a "500mg" prescription of the VTM
+            // "Amoxicillin" resolves to the 500mg VMP/AMP rather than the
+            // first name match (which could be the 250mg item).
+            Double dose = prescription.getDose();
+            if (dose != null) {
+                String doseStr = (dose == Math.floor(dose) && !Double.isInfinite(dose))
+                        ? String.valueOf(dose.longValue())
+                        : String.valueOf(dose);
+                String strengthPattern = "%" + genericItem.getName() + "%" + doseStr + "%";
+                Map<String, Object> strengthParameters = new HashMap<>();
+                strengthParameters.put("pattern", strengthPattern);
+                List<Item> strengthMatches = itemFacade.findByJpql(jpql, strengthParameters);
+                if (!strengthMatches.isEmpty()) {
+                    return strengthMatches;
+                }
+            }
+
             String pattern = "%" + genericItem.getName() + "%";
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("pattern", pattern);

--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -951,6 +951,16 @@ public class PharmaceuticalItemApiService implements Serializable {
         if (request.getRefundsAllowed() != null) {
             item.setRefundsAllowed(request.getRefundsAllowed());
         }
+        if (request.getStrengthOfAnIssueUnit() != null) {
+            item.setStrengthOfAnIssueUnit(request.getStrengthOfAnIssueUnit());
+        }
+        if (request.getStrengthUnitId() != null) {
+            MeasurementUnit strengthUnit = measurementUnitFacade.find(request.getStrengthUnitId());
+            if (strengthUnit == null) {
+                throw new Exception("Measurement unit not found with ID: " + request.getStrengthUnitId());
+            }
+            item.setStrengthUnit(strengthUnit);
+        }
     }
 
     private void applyAmpSpecificFieldsIfProvided(Amp item, AmpRequestDTO request) throws Exception {

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -218,7 +218,9 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST", "PUT", "PATCH"))
                 .add(resource("Pharmaceutical Items", "/api/pharmaceutical_items",
-                        "Pharmaceutical item master data",
+                        "Pharmaceutical item master data. AMP create/update accepts "
+                        + "strengthOfAnIssueUnit (Double) and strengthUnitId (Long, MeasurementUnit) "
+                        + "for strength-ratio based dispensing substitution.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Pharmacy Adjustments", "/api/pharmacy_adjustments",

--- a/src/main/webapp/inward/inward_ward_medicines.xhtml
+++ b/src/main/webapp/inward/inward_ward_medicines.xhtml
@@ -9,7 +9,7 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form id="formWardMedicines">
-                    <p:growl id="growlWardMedicines" showDetail="true" life="4000" />
+                    <p:growl id="growlWardMedicines" life="4000" />
                     <div class="row">
                         <div class="col-12 px-4">
                             <p:commandButton

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -77,7 +77,7 @@
                                                              styleClass="#{pharmacyRequestForBhtController.isDefaultRequestedPharmacy(recentPh) ? 'ui-button-info ui-button-sm' : 'ui-button-info ui-button-outlined ui-button-sm'}"
                                                              disabled="#{pharmacyRequestForBhtController.department ne null}"
                                                              process="@this"
-                                                             update="departmentId acPt2 recentPharmacies"
+                                                             update=":bill:departmentId :bill:acPt2 :bill:recentPharmacies"
                                                              action="#{pharmacyRequestForBhtController.selectRequestedPharmacy(recentPh)}" />
                                         </ui:repeat>
                                     </h:panelGroup>


### PR DESCRIPTION
## Summary
- Add `strengthOfAnIssueUnit` and `strengthUnitId` to `AmpRequestDTO` so the Pharmaceutical Items REST API can set an AMP's strength-per-issue-unit ratio (used for dispensing/substitution calculations). Documented in the capability statement.
- Fix `findItemsForGeneric()` in `PrescriptionToItemService` so VTM-based ward medicine requests (e.g. "Amoxicillin 500mg tds for 5 days") resolve to the correct-strength AMP/VMP instead of failing with "Selected item is not AMP or VMP".
- Fix `calculateTotalQuantity()` so the dispensed quantity is correctly converted via the AMP's strength (e.g. 500mg dose / 500mg per capsule × 15 administrations = 15 capsules, instead of 7500).
- Fix the "Recent pharmacy" quick-select button on `ward_pharmacy_bht_issue_request_bill.xhtml` which failed with `ComponentNotFoundException` due to unresolved relative update targets inside a `ui:repeat`.

Closes #21457
Closes #16132

## Test plan
- [x] Verified via Playwright on live dev environment: "Request Selected from Pharmacy" for a VTM-based prescription ("Amoxicillin 500 mg Every 8 Hours for 5 Days") now resolves to the 500mg AMP and calculates 15 capsules.
- [x] Verified "Recent pharmacy" quick-select button updates correctly without errors.
- [ ] Compile/build verification pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for pharmaceutical strength unit and strength issue unit configurations for advanced dispensing substitution.

* **Bug Fixes**
  * Fixed message notification display behavior in ward medicines form.
  * Corrected component ID scoping in pharmacy request form to ensure proper state updates.

* **Documentation**
  * Updated capability documentation for pharmaceutical item creation and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->