### PR TITLE
fix: restore dedicated Add New Room and Add Guardian Room pages

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -750,6 +750,24 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         return "/inward/inward_room_change?faces-redirect=true";
     }
 
+    public String navigateToAddRoom() {
+        roomChangeController.createPatientRoom();
+        roomChangeController.setInstitution(sessionController.getInstitution());
+        roomChangeController.setNewRoomFacilityCharge(null);
+        roomChangeController.setChangeAt(null);
+        roomChangeController.setNewConsultant(null);
+        roomChangeController.setNewPrimeConsultant(null);
+        return "/inward/inward_add_room?faces-redirect=true";
+    }
+
+    public String navigateToAddGuardianRoom() {
+        roomChangeController.createGuardianRoom();
+        roomChangeController.setInstitution(sessionController.getInstitution());
+        roomChangeController.setNewRoomFacilityCharge(null);
+        roomChangeController.setChangeAt(null);
+        return "/inward/inward_add_guardian_room?faces-redirect=true";
+    }
+
     public String navigateToGuardianRoomChange() {
 //         roomChangeController.recreate();
         roomChangeController.createGuardianRoom();

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -639,6 +639,31 @@ public class RoomChangeController implements Serializable {
         createGuardianRoom();
     }
 
+    public void addNewGuardianRoom() {
+        if (getNewRoomFacilityCharge() == null) {
+            JsfUtil.addErrorMessage("Please select a room facility");
+            return;
+        }
+
+        GuardianRoom newGuardianRoom = new GuardianRoom();
+        newGuardianRoom = (GuardianRoom) getInwardBean().savePatientRoom(
+                newGuardianRoom, getNewRoomFacilityCharge(), current, changeAt,
+                getSessionController().getLoggedUser());
+
+        if (newGuardianRoom == null) {
+            JsfUtil.addErrorMessage("Failed to add guardian room");
+            return;
+        }
+
+        recordRoomAuditEvent(newGuardianRoom, "Guardian Room Added", null);
+        notificationController.createNotification(newGuardianRoom, "Admit");
+
+        JsfUtil.addSuccessMessage("Successfully Added Guardian Room");
+        newRoomFacilityCharge = null;
+        changeAt = null;
+        createGuardianRoom();
+    }
+
     public List<Admission> getSelectedItems() {
         selectedItems = getFacade().findByJpql("select c from Admission c where c.retired=false and c.discharged!=true and (c.bhtNo) like '%" + getSelectText().toUpperCase() + "%' or (c.patient.person.name) like '%" + getSelectText().toUpperCase() + "%' order by c.bhtNo");
         return selectedItems;

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -557,7 +557,7 @@
                                         disabled="#{admissionController.current.discharged eq true}"
                                         value="Add New Room"
                                         ajax="false"
-                                        action="#{admissionController.navigateToRoomChange}"
+                                        action="#{admissionController.navigateToAddRoom}"
                                         icon="fa fa-plus-circle"
                                         class="w-100 ui-button-success">
                                         <f:setPropertyActionListener
@@ -572,7 +572,7 @@
                                         value="Add Guardian Room"
                                         ajax="false"
                                         disabled="#{admissionController.current.discharged eq true}"
-                                        action="#{admissionController.navigateToGuardianRoomChange}"
+                                        action="#{admissionController.navigateToAddGuardianRoom}"
                                         icon="fa fa-user-plus"
                                         class="w-100 ui-button-success">
                                         <f:setPropertyActionListener

--- a/src/main/webapp/inward/inward_add_guardian_room.xhtml
+++ b/src/main/webapp/inward/inward_add_guardian_room.xhtml
@@ -10,7 +10,7 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form id="addGuardianRoomForm">
+                <h:form id="addGuardianRoomForm" onkeypress="if (event.keyCode === 13) { event.preventDefault(); return false; }">
                     <p:messages id="pageMessages"/>
 
                     <p:panel>
@@ -96,6 +96,7 @@
                                                         var="rf" itemLabel="#{rf.name}" itemValue="#{rf}"
                                                         style="width:100%;"
                                                         minQueryLength="1"
+                                                        maxResults="15"
                                                         placeholder="Type room number or facility name">
                                                     </p:autoComplete>
                                                 </div>
@@ -125,6 +126,7 @@
                                                     value="Add Guardian Room"
                                                     icon="fa fa-user-plus"
                                                     class="ui-button-success"
+                                                    onclick="return confirm('Assign this guardian room to the patient?');"
                                                     action="#{roomChangeController.addNewGuardianRoom()}"
                                                     ajax="false">
                                                 </p:commandButton>

--- a/src/main/webapp/inward/inward_add_guardian_room.xhtml
+++ b/src/main/webapp/inward/inward_add_guardian_room.xhtml
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="addGuardianRoomForm">
+                    <p:messages id="pageMessages"/>
+
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center">
+                                    <i class="fa-solid fa-user-plus fa-lg text-success me-3"></i>
+                                    <div>
+                                        <h:outputText value="Add Guardian Room" styleClass="text-success fw-bold"/>
+                                        <h:panelGroup rendered="#{roomChangeController.current ne null}" layout="block">
+                                            <small class="text-muted">
+                                                <h:outputText value="#{roomChangeController.current.patient.person.nameWithTitle}"/>
+                                                &nbsp;|&nbsp;BHT:&nbsp;
+                                                <h:outputText value="#{roomChangeController.current.bhtNo}"/>
+                                            </small>
+                                        </h:panelGroup>
+                                    </div>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Inpatient Dashboard"
+                                        ajax="false"
+                                        action="#{admissionController.navigateToAdmissionProfilePage()}"
+                                        icon="fa fa-id-card"
+                                        class="ui-button-secondary">
+                                        <f:setPropertyActionListener
+                                            value="#{roomChangeController.current}"
+                                            target="#{admissionController.current}"/>
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <h:panelGroup rendered="#{roomChangeController.current eq null}" layout="block">
+                            <div class="text-center py-5">
+                                <i class="fa-solid fa-exclamation-circle fa-3x text-warning mb-3"></i>
+                                <p class="text-muted">No patient selected. Please navigate from the Inpatient Dashboard.</p>
+                            </div>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{roomChangeController.current ne null}" layout="block">
+                            <div class="row">
+                                <!-- Left: Patient Details -->
+                                <div class="col-4">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <i class="fa-solid fa-id-card-alt me-2"/>
+                                            <h:outputText value="Patient Details"/>
+                                        </f:facet>
+                                        <in:bhtDetail admission="#{roomChangeController.current}"/>
+
+                                        <h:panelGroup rendered="#{roomChangeController.current.guardian ne null}">
+                                            <div class="mt-3 p-2 border rounded" style="background:#f8f9fa;">
+                                                <strong>Guardian:</strong>
+                                                <h:outputText value="#{roomChangeController.current.guardian.name}"/>
+                                                <br/>
+                                                <small class="text-muted">
+                                                    <h:outputText value="#{roomChangeController.current.guardian.mobile}"/>
+                                                </small>
+                                            </div>
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </div>
+
+                                <!-- Right: Room Selection -->
+                                <div class="col-8">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <i class="fa-solid fa-door-open me-2"/>
+                                            <h:outputText value="New Guardian Room Assignment"/>
+                                        </f:facet>
+                                        <div class="p-3">
+                                            <div class="row mb-3">
+                                                <div class="col-md-4">
+                                                    <p:outputLabel value="Room Facility"/>
+                                                </div>
+                                                <div class="col-md-8">
+                                                    <p:autoComplete
+                                                        forceSelection="true"
+                                                        id="roomFacility"
+                                                        value="#{roomChangeController.newRoomFacilityCharge}"
+                                                        completeMethod="#{roomFacilityChargeController.completeRoom}"
+                                                        var="rf" itemLabel="#{rf.name}" itemValue="#{rf}"
+                                                        style="width:100%;"
+                                                        minQueryLength="1"
+                                                        placeholder="Type room number or facility name">
+                                                    </p:autoComplete>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mb-3">
+                                                <div class="col-md-4">
+                                                    <p:outputLabel value="Date/Time"/>
+                                                </div>
+                                                <div class="col-md-8">
+                                                    <p:datePicker
+                                                        id="admissionTimestamp"
+                                                        value="#{roomChangeController.changeAt}"
+                                                        showTime="true"
+                                                        showButtonBar="true"
+                                                        timeInput="true"
+                                                        style="width:100%;"
+                                                        pattern="dd MMM yyyy HH:mm"
+                                                        timeZone="Asia/Colombo">
+                                                    </p:datePicker>
+                                                </div>
+                                            </div>
+
+                                            <div class="d-flex gap-2 mt-4">
+                                                <p:commandButton
+                                                    id="btnAddGuardianRoom"
+                                                    value="Add Guardian Room"
+                                                    icon="fa fa-user-plus"
+                                                    class="ui-button-success"
+                                                    action="#{roomChangeController.addNewGuardianRoom()}"
+                                                    ajax="false">
+                                                </p:commandButton>
+                                                <p:commandButton
+                                                    id="btnBackToDashboard"
+                                                    value="Back to Dashboard"
+                                                    icon="fa fa-arrow-left"
+                                                    class="ui-button-secondary"
+                                                    ajax="false"
+                                                    action="#{admissionController.navigateToAdmissionProfilePage()}">
+                                                    <f:setPropertyActionListener
+                                                        value="#{roomChangeController.current}"
+                                                        target="#{admissionController.current}"/>
+                                                </p:commandButton>
+                                            </div>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_add_room.xhtml
+++ b/src/main/webapp/inward/inward_add_room.xhtml
@@ -10,7 +10,7 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form id="addRoomForm">
+                <h:form id="addRoomForm" onkeypress="if (event.keyCode === 13) { event.preventDefault(); return false; }">
                     <p:messages id="pageMessages"/>
 
                     <p:panel>
@@ -87,6 +87,7 @@
                                                                 var="rf" itemLabel="#{rf.name}" itemValue="#{rf}"
                                                                 style="width:100%;"
                                                                 minQueryLength="1"
+                                                                maxResults="15"
                                                                 placeholder="Type room number or facility name">
                                                             </p:autoComplete>
                                                         </div>
@@ -116,6 +117,7 @@
                                                             value="Add Room"
                                                             icon="fa fa-plus-circle"
                                                             class="ui-button-success"
+                                                            onclick="return confirm('Assign this room to the patient?');"
                                                             action="#{roomChangeController.addNewRoom()}"
                                                             ajax="false">
                                                         </p:commandButton>

--- a/src/main/webapp/inward/inward_add_room.xhtml
+++ b/src/main/webapp/inward/inward_add_room.xhtml
@@ -1,0 +1,206 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="addRoomForm">
+                    <p:messages id="pageMessages"/>
+
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div class="d-flex align-items-center">
+                                    <i class="fa-solid fa-plus-circle fa-lg text-success me-3"></i>
+                                    <div>
+                                        <h:outputText value="Add New Room" styleClass="text-success fw-bold"/>
+                                        <h:panelGroup rendered="#{roomChangeController.current ne null}" layout="block">
+                                            <small class="text-muted">
+                                                <h:outputText value="#{roomChangeController.current.patient.person.nameWithTitle}"/>
+                                                &nbsp;|&nbsp;BHT:&nbsp;
+                                                <h:outputText value="#{roomChangeController.current.bhtNo}"/>
+                                            </small>
+                                        </h:panelGroup>
+                                    </div>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Inpatient Dashboard"
+                                        ajax="false"
+                                        action="#{admissionController.navigateToAdmissionProfilePage()}"
+                                        icon="fa fa-id-card"
+                                        class="ui-button-secondary">
+                                        <f:setPropertyActionListener
+                                            value="#{roomChangeController.current}"
+                                            target="#{admissionController.current}"/>
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <h:panelGroup rendered="#{roomChangeController.current eq null}" layout="block">
+                            <div class="text-center py-5">
+                                <i class="fa-solid fa-exclamation-circle fa-3x text-warning mb-3"></i>
+                                <p class="text-muted">No patient selected. Please navigate from the Inpatient Dashboard.</p>
+                            </div>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{roomChangeController.current ne null}" layout="block">
+                            <div class="row">
+                                <!-- Left: Patient Details -->
+                                <div class="col-4">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <i class="fa-solid fa-id-card-alt me-2"/>
+                                            <h:outputText value="Patient Details"/>
+                                        </f:facet>
+                                        <in:bhtDetail admission="#{roomChangeController.current}"/>
+                                    </p:panel>
+                                </div>
+
+                                <!-- Right: Room Selection -->
+                                <div class="col-8">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <i class="fa-solid fa-door-open me-2"/>
+                                            <h:outputText value="New Room Assignment"/>
+                                        </f:facet>
+                                        <p:tabView class="mt-2">
+                                            <p:tab title="Room Details">
+                                                <div class="p-3">
+                                                    <div class="row mb-3">
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="Room Facility"/>
+                                                        </div>
+                                                        <div class="col-md-8">
+                                                            <p:autoComplete
+                                                                forceSelection="true"
+                                                                id="roomFacility"
+                                                                value="#{roomChangeController.newRoomFacilityCharge}"
+                                                                completeMethod="#{roomFacilityChargeController.completeRoom}"
+                                                                var="rf" itemLabel="#{rf.name}" itemValue="#{rf}"
+                                                                style="width:100%;"
+                                                                minQueryLength="1"
+                                                                placeholder="Type room number or facility name">
+                                                            </p:autoComplete>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="row mb-3">
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="Admission Date/Time"/>
+                                                        </div>
+                                                        <div class="col-md-8">
+                                                            <p:datePicker
+                                                                id="admissionTimestamp"
+                                                                value="#{roomChangeController.changeAt}"
+                                                                showTime="true"
+                                                                showButtonBar="true"
+                                                                timeInput="true"
+                                                                style="width:100%;"
+                                                                pattern="dd MMM yyyy HH:mm"
+                                                                timeZone="Asia/Colombo">
+                                                            </p:datePicker>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="d-flex gap-2 mt-4">
+                                                        <p:commandButton
+                                                            id="btnAddRoom"
+                                                            value="Add Room"
+                                                            icon="fa fa-plus-circle"
+                                                            class="ui-button-success"
+                                                            action="#{roomChangeController.addNewRoom()}"
+                                                            ajax="false">
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            id="btnBackToDashboard"
+                                                            value="Back to Dashboard"
+                                                            icon="fa fa-arrow-left"
+                                                            class="ui-button-secondary"
+                                                            ajax="false"
+                                                            action="#{admissionController.navigateToAdmissionProfilePage()}">
+                                                            <f:setPropertyActionListener
+                                                                value="#{roomChangeController.current}"
+                                                                target="#{admissionController.current}"/>
+                                                        </p:commandButton>
+                                                    </div>
+                                                </div>
+                                            </p:tab>
+
+                                            <p:tab title="Consultant Details">
+                                                <div class="p-3">
+                                                    <div class="row mb-3">
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="Current Consultant"/>
+                                                        </div>
+                                                        <div class="col-md-8">
+                                                            <h:outputText
+                                                                value="#{roomChangeController.current.referringConsultant != null ? roomChangeController.current.referringConsultant.person.nameWithTitle : 'Not Set'}"
+                                                                styleClass="form-control-static"/>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="row mb-3">
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="New Consultant"/>
+                                                        </div>
+                                                        <div class="col-md-8">
+                                                            <p:autoComplete
+                                                                forceSelection="true"
+                                                                value="#{roomChangeController.newConsultant}"
+                                                                id="newConsultant"
+                                                                completeMethod="#{consultantController.completeConsultant}"
+                                                                var="mysp"
+                                                                itemLabel="#{mysp.person.nameWithTitle}"
+                                                                itemValue="#{mysp}"
+                                                                style="width:100%;"
+                                                                placeholder="Select New Consultant (optional)"
+                                                                maxResults="15">
+                                                            </p:autoComplete>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="row mb-3">
+                                                        <div class="col-md-4">
+                                                            <p:outputLabel value="Prime Consultant"/>
+                                                        </div>
+                                                        <div class="col-md-8">
+                                                            <p:autoComplete
+                                                                forceSelection="true"
+                                                                value="#{roomChangeController.newPrimeConsultant}"
+                                                                id="newPrimeConsultant"
+                                                                completeMethod="#{consultantController.completeConsultant}"
+                                                                var="mysp"
+                                                                itemLabel="#{mysp.person.nameWithTitle}"
+                                                                itemValue="#{mysp}"
+                                                                style="width:100%;"
+                                                                placeholder="Select Prime Consultant (optional)"
+                                                                maxResults="15">
+                                                            </p:autoComplete>
+                                                        </div>
+                                                    </div>
+
+                                                    <p:message for="newConsultant"/>
+                                                    <p:message for="newPrimeConsultant"/>
+                                                    <p:outputLabel value="Note: Consultant selections are optional and will be recorded with the room assignment."
+                                                                   style="font-style: italic; color: #666; font-size: 0.9em;"/>
+                                                </div>
+                                            </p:tab>
+                                        </p:tabView>
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Cherry-picks `798e1e77a2` which was pushed to the `restore-discharge-notification-fixes-21389-21390-21391` branch **after** PR #21456 was already merged. The dedicated Add Room pages and their navigation methods were never integrated into `development`.

## Root Cause

Commit `798e1e77a2` (`feat(inward): add dedicated Add New Room and Add Guardian Room pages`) was pushed to the remote branch after the PR merge completed, so it never made it into `development`. This caused a regression where the "Add New Room" and "Add Guardian Room" buttons in the Patient Dashboard navigate back to the old multi-function room change pages instead of the new dedicated pages.

## Changes

- **`AdmissionController.java`**: Add `navigateToAddRoom()` and `navigateToAddGuardianRoom()` methods pointing to new dedicated pages
- **`RoomChangeController.java`**: Add `addNewGuardianRoom()` method with audit and notification support
- **`admission_profile.xhtml`**: Update dashboard buttons to use new navigation methods
- **`inward_add_room.xhtml`** (new): Dedicated page for adding a new room
- **`inward_add_guardian_room.xhtml`** (new): Dedicated page for adding a guardian room

## Verification

- No other recent PRs had similar post-merge push regressions
- All other recently merged feature branches are fully merged into HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated workflows to assign new patient rooms with facility selection, date/time scheduling, and optional consultant assignment
  * Added workflow to assign new guardian rooms with facility and scheduling options
  * Updated Room Management interface navigation to direct to streamlined assignment workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->