### PR TITLE
feat(ward-pharmacy): transfer issued stock to porter staff on BHT medicine request fulfillment

### DIFF
--- a/developer_docs/navigation/inward_navigation.md
+++ b/developer_docs/navigation/inward_navigation.md
@@ -294,6 +294,46 @@ Two parallel workflows exist:
 
 ---
 
+## Porter-Mediated Ward Pharmacy Workflow (Design — Issues #21466–#21472)
+
+Investigation for #21466/#21467 found that the **existing pharmacy disbursement "Direct Issue" mechanism already implements most of the low-level machinery** needed for porter-mediated ward issue. This section records the findings and the proposed design so each sub-issue can be implemented incrementally without re-investigating.
+
+### What already exists and works
+
+- `TransferIssueDirectController` (`pharmacy_transfer_issue_direct_department.xhtml` → `pharmacy_transfer_issue_direct.xhtml`) lets pharmacy staff issue items to any department — **including ward-type departments**. Confirmed live: searching "ward" in the destination-department picker returns `Inward`, `Temp-Inward`, `Ward Pharmacy`.
+- On settle, `updateStocks()` already does exactly what #21467 asks for:
+  - Deducts from the issuing department's `Stock` via `PharmacyBean.deductFromStock(...)`.
+  - Adds the same quantity to the **selected porter's staff stock** via `PharmacyBean.addToStock(PharmaceuticalBillItem, qty, Staff)` (`Stock.staff` + `StockHistory.staff`).
+  - Bill is created with `BillTypeAtomic.PHARMACY_DIRECT_ISSUE`, `fromDepartment` = issuing pharmacy, `toDepartment` = destination department, `toStaff` = porter.
+- `TransferReceiveController` already implements the receive-side mirror (#21468's "receive from porter" pattern): it queries `Stock` where `staff = <porter>`, deducts it, and credits the receiving department's `Stock` — this is the template for #21468 and #21471.
+
+### The gap: no link to a specific admission (BHT)
+
+The disbursement flow above is **department-to-department** and has no concept of *which patient* the medicines are for. Ward medicine issue (`ward_pharmacy_bht_issue.xhtml`, originating from a request created in `ward_pharmacy_bht_issue_request_bill.xhtml`) is always tied to one **BHT / `PatientEncounter`**.
+
+Two entity fields already exist and are unused by the disbursement controllers, but solve this:
+
+- `Bill.fromDepartment` and `Bill.patientEncounter` (`Bill.java`) — every bill can carry a `PatientEncounter` reference.
+- `PatientEncounter.department` (`PatientEncounter.java`) — every admission already records **its own ward** as a `Department`. This means we don't need new per-ward `Department` records or a new destination picker — `patientEncounter.getDepartment()` gives the ward directly.
+
+### Proposed design for #21467 onward
+
+When a ward medicine request (tied to a `PatientEncounter`) is settled via the porter-issue mechanism:
+
+1. **fromDepartment** = the issuing pharmacy (as today).
+2. **toDepartment** = `patientEncounter.getDepartment()` — the ward where the patient is admitted (not a manually-picked department).
+3. **patientEncounter** = the BHT's `PatientEncounter`, set on the issue bill so every downstream step (#21468 ward receive, #21469 administration, #21470/#21471 returns) can trace back to the same admission.
+4. **toStaff** = the porter, with stock moved via the existing `addToStock(pbi, qty, Staff)` + `StockHistory` mechanism — no new entity needed for #21467.
+
+This reuses the proven staff-stock + stock-history mechanics from `TransferIssueDirectController` while adding the one missing link (`patientEncounter`) that the rest of the porter workflow (#21468–#21472) depends on. #21468's ward-receive step would then look up porter `Stock` filtered by `patientEncounter` (in addition to `staff`), crediting ward-held `Stock` (`department` = `patientEncounter.getDepartment()`). #21469 (administration) and #21470/#21471 (returns) chain off the same `patientEncounter` reference. #21472 (reporting) needs to add `patientEncounter`-based grouping to stock-in-transit/ward-stock reports, alongside the existing department-based grouping.
+
+### Open questions for implementation
+
+- Whether the porter-issue bill should be created from `ward_pharmacy_bht_issue.xhtml` directly (extending `PharmacySaleBhtController`) or by adapting `TransferIssueDirectController` to accept an optional `PatientEncounter` — needs a decision when #21467 is implemented.
+- Porter role/identification: #21467 originally proposed a dedicated "Porter" staff role; the existing `toStaff` field on `TransferIssueDirectController` already accepts any staff member via `staffController.completeStaffWithoutDoctors` — a dedicated role may be a UI/filtering nicety rather than a new entity.
+
+---
+
 ## Reports
 
 | Page | Purpose |

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -42,6 +42,7 @@ import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PreBill;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.pharmacy.Amp;
 import com.divudi.core.entity.pharmacy.Ampp;
@@ -1329,6 +1330,24 @@ public class PharmacySaleBhtController implements Serializable {
         getBillFacade().edit(getPreBill());
     }
 
+    /**
+     * After stock is deducted from the issuing pharmacy, credit the same
+     * quantities to the porter's staff stock (with stock history), so the
+     * medicines are tracked as carried by the porter on the way to the ward.
+     */
+    private void transferIssuedStockToPorter(List<BillItem> list, Staff porter) {
+        if (porter == null) {
+            return;
+        }
+        for (BillItem tbi : list) {
+            PharmaceuticalBillItem pbi = tbi.getPharmaceuticalBillItem();
+            double qty = Math.abs(pbi.getQty());
+            Stock staffStock = pharmacyBean.addToStock(pbi, qty, porter);
+            pbi.setStaffStock(staffStock);
+            getPharmaceuticalBillItemFacade().edit(pbi);
+        }
+    }
+
     private void savePreBillItemsFinallyRequest(List<BillItem> list) {
         // Initialize bill items list if null
         if (getPreBill().getBillItems() == null) {
@@ -1543,15 +1562,21 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("No BHT request selected.");
             return;
         }
-        
+
         if( bhtRequestBill.isCompleted()){
             JsfUtil.addErrorMessage("This request has already been completed..");
             return;
         }
-        
+
         if (hasAllergyConflicts(getBillItems())) {
             return;
         }
+
+        if (getPreBill().getToStaff() == null) {
+            JsfUtil.addErrorMessage("Please select the staff member (porter) who will carry the medicines to the ward.");
+            return;
+        }
+
         BillTypeAtomic bta = BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD;
         BillType bt = BillType.PharmacyBhtPre;
 
@@ -1949,6 +1974,7 @@ public class PharmacySaleBhtController implements Serializable {
 
         savePreBillFinally(pt, matrixDepartment, btp, bta);
         savePreBillItemsFinally(tmpBillItems);
+        transferIssuedStockToPorter(tmpBillItems, getPreBill().getToStaff());
         billService.createBillFinancialDetailsForInpatientDirectIssueBill(getPreBill());
 
         // Calculation Margin

--- a/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
@@ -21,6 +21,8 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
     private Boolean allowFractions;
     private Boolean consumptionAllowed;
     private Boolean refundsAllowed;
+    private Double strengthOfAnIssueUnit;
+    private Long strengthUnitId;
 
     public AmpRequestDTO() {
     }
@@ -95,5 +97,21 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
 
     public void setRefundsAllowed(Boolean refundsAllowed) {
         this.refundsAllowed = refundsAllowed;
+    }
+
+    public Double getStrengthOfAnIssueUnit() {
+        return strengthOfAnIssueUnit;
+    }
+
+    public void setStrengthOfAnIssueUnit(Double strengthOfAnIssueUnit) {
+        this.strengthOfAnIssueUnit = strengthOfAnIssueUnit;
+    }
+
+    public Long getStrengthUnitId() {
+        return strengthUnitId;
+    }
+
+    public void setStrengthUnitId(Long strengthUnitId) {
+        this.strengthUnitId = strengthUnitId;
     }
 }

--- a/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
+++ b/src/main/java/com/divudi/ejb/PrescriptionToItemService.java
@@ -224,11 +224,22 @@ public class PrescriptionToItemService {
             return null;
         }
 
-        // For AMP with strength in issue unit case:
-        // Total quantity = dose × doses per day × number of days
-        Double totalQuantity = dose * dosesPerDay * durationInDays;
+        // Number of administrations over the course of treatment
+        Double administrations = dosesPerDay * durationInDays;
 
-        return totalQuantity;
+        // If the AMP's strength (e.g. 500 mg per capsule) is known and is in the
+        // same unit as the prescribed dose (e.g. 500 mg), convert the dose into
+        // a number of issue units (capsules) per administration: dose / strength.
+        // Otherwise assume the prescribed dose already refers to one issue unit
+        // (e.g. "1 tablet" tds) and just count administrations.
+        Double strength = amp.getStrengthOfAnIssueUnit();
+        MeasurementUnit strengthUnit = amp.getStrengthUnit();
+        if (strength != null && strength > 0 && doseUnit != null && strengthUnit != null
+                && doseUnit.getName() != null && doseUnit.getName().equalsIgnoreCase(strengthUnit.getName())) {
+            return (dose / strength) * administrations;
+        }
+
+        return administrations;
     }
 
     /**
@@ -300,10 +311,30 @@ public class PrescriptionToItemService {
         try {
             // This is a simplified implementation
             // In practice, this would involve complex matching based on:
-            // - Strength requirements
             // - Dosage form preferences
             // - Availability
-            String jpql = "SELECT i FROM Item i WHERE i.name LIKE :pattern AND i.retired = false";
+            String jpql = "SELECT i FROM Item i WHERE i.name LIKE :pattern AND i.retired = false AND TYPE(i) IN (Vmp, Amp)";
+
+            // VMP/AMP names embed the strength (e.g. "Amoxicillin 500.0 mg
+            // capsules"), but the VTM itself does not. When the prescription
+            // carries a dose, narrow the match to items whose name also
+            // mentions that strength so a "500mg" prescription of the VTM
+            // "Amoxicillin" resolves to the 500mg VMP/AMP rather than the
+            // first name match (which could be the 250mg item).
+            Double dose = prescription.getDose();
+            if (dose != null) {
+                String doseStr = (dose == Math.floor(dose) && !Double.isInfinite(dose))
+                        ? String.valueOf(dose.longValue())
+                        : String.valueOf(dose);
+                String strengthPattern = "%" + genericItem.getName() + "%" + doseStr + "%";
+                Map<String, Object> strengthParameters = new HashMap<>();
+                strengthParameters.put("pattern", strengthPattern);
+                List<Item> strengthMatches = itemFacade.findByJpql(jpql, strengthParameters);
+                if (!strengthMatches.isEmpty()) {
+                    return strengthMatches;
+                }
+            }
+
             String pattern = "%" + genericItem.getName() + "%";
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("pattern", pattern);

--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -951,6 +951,16 @@ public class PharmaceuticalItemApiService implements Serializable {
         if (request.getRefundsAllowed() != null) {
             item.setRefundsAllowed(request.getRefundsAllowed());
         }
+        if (request.getStrengthOfAnIssueUnit() != null) {
+            item.setStrengthOfAnIssueUnit(request.getStrengthOfAnIssueUnit());
+        }
+        if (request.getStrengthUnitId() != null) {
+            MeasurementUnit strengthUnit = measurementUnitFacade.find(request.getStrengthUnitId());
+            if (strengthUnit == null) {
+                throw new Exception("Measurement unit not found with ID: " + request.getStrengthUnitId());
+            }
+            item.setStrengthUnit(strengthUnit);
+        }
     }
 
     private void applyAmpSpecificFieldsIfProvided(Amp item, AmpRequestDTO request) throws Exception {

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -218,7 +218,9 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST", "PUT", "PATCH"))
                 .add(resource("Pharmaceutical Items", "/api/pharmaceutical_items",
-                        "Pharmaceutical item master data",
+                        "Pharmaceutical item master data. AMP create/update accepts "
+                        + "strengthOfAnIssueUnit (Double) and strengthUnitId (Long, MeasurementUnit) "
+                        + "for strength-ratio based dispensing substitution.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Pharmacy Adjustments", "/api/pharmacy_adjustments",

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/rhAuditDS</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/inward/inward_ward_medicines.xhtml
+++ b/src/main/webapp/inward/inward_ward_medicines.xhtml
@@ -9,7 +9,7 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form id="formWardMedicines">
-                    <p:growl id="growlWardMedicines" showDetail="true" life="4000" />
+                    <p:growl id="growlWardMedicines" life="4000" />
                     <div class="row">
                         <div class="col-12 px-4">
                             <p:commandButton

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -46,6 +46,7 @@
                                         forceSelection="true"
                                         var="w" itemLabel="#{w.person.name}" itemValue="#{w}"
                                         value="#{pharmacySaleBhtController.preBill.toStaff}"
+                                        maxResults="10"
                                         placeholder="Search staff by name">
 
                             <p:column headerText="Name">

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -38,6 +38,29 @@
 
                 </f:facet>
 
+                <div class="row">
+                    <div class="col-md-6">
+                        <h:outputLabel value="Porter / Staff Carrying Medicines to Ward:" for="acPorter" />
+                        <p:autoComplete id="acPorter"
+                                        completeMethod="#{staffController.completeStaffWithoutDoctors}"
+                                        forceSelection="true"
+                                        var="w" itemLabel="#{w.person.name}" itemValue="#{w}"
+                                        value="#{pharmacySaleBhtController.preBill.toStaff}"
+                                        placeholder="Search staff by name">
+
+                            <p:column headerText="Name">
+                                <h:outputText value="#{w.person.nameWithTitle}" />
+                            </p:column>
+                            <p:column headerText="Speciality">
+                                <h:outputText value="#{w.speciality.name}" />
+                            </p:column>
+                            <p:column headerText="Staff Code">
+                                <h:outputText value="#{w.code}" />
+                            </p:column>
+                        </p:autoComplete>
+                    </div>
+                </div>
+
                 <h:panelGroup class="row">
                     <h:panelGroup class="row" rendered="#{configOptionApplicationController.getBooleanValueByKey('Adding new items for inpatient requests are allowed.',true)}">
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -77,7 +77,7 @@
                                                              styleClass="#{pharmacyRequestForBhtController.isDefaultRequestedPharmacy(recentPh) ? 'ui-button-info ui-button-sm' : 'ui-button-info ui-button-outlined ui-button-sm'}"
                                                              disabled="#{pharmacyRequestForBhtController.department ne null}"
                                                              process="@this"
-                                                             update=":bill:departmentId :bill:acPt2 :bill:recentPharmacies"
+                                                             update="@form"
                                                              action="#{pharmacyRequestForBhtController.selectRequestedPharmacy(recentPh)}" />
                                         </ui:repeat>
                                     </h:panelGroup>
@@ -96,12 +96,12 @@
                                         <p:ajax
                                             event="itemSelect"
                                             process="@this"
-                                            update="@this acPt2" />
+                                            update="@form" />
                                     </p:autoComplete>
                                 </div>
 
                                 <div class="d-flex flex-column col-6">
-                                    
+
                                     <div class="d-flex align-items-center my-1">
                                         <i class="fa-solid fa-user me-2 text-primary"></i>
                                         <h:outputLabel for="acPt2_input" style="font-weight: bold" value="Patient Name or BHT or PHN No"/>
@@ -140,7 +140,7 @@
                                                 </span>
                                             </div>
                                         </p:column>
-                                        <p:ajax event="itemSelect" process="acPt2" />
+                                        <p:ajax event="itemSelect" process="acPt2" update="@form" />
                                     </p:autoComplete>
                                 </div>
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -77,7 +77,7 @@
                                                              styleClass="#{pharmacyRequestForBhtController.isDefaultRequestedPharmacy(recentPh) ? 'ui-button-info ui-button-sm' : 'ui-button-info ui-button-outlined ui-button-sm'}"
                                                              disabled="#{pharmacyRequestForBhtController.department ne null}"
                                                              process="@this"
-                                                             update="departmentId acPt2 recentPharmacies"
+                                                             update=":bill:departmentId :bill:acPt2 :bill:recentPharmacies"
                                                              action="#{pharmacyRequestForBhtController.selectRequestedPharmacy(recentPh)}" />
                                         </ui:repeat>
                                     </h:panelGroup>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
@@ -152,12 +152,13 @@
                                     <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
                                 </p:commandButton>
                                 
-                                <p:commandButton 
+                                <p:commandButton
                                     id="btnNavigtateToIssueMedicine"
                                     title="Issue Medicines"
-                                    class="ui-button-success m-1" 
-                                    ajax="false" 
+                                    class="ui-button-success m-1"
+                                    ajax="false"
                                     icon="fa fa-prescription-bottle-alt"
+                                    onclick="PF('issueMedicinesProcessingDialog').show();"
                                     action="#{pharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()}"
                                     disabled="#{p.cancelled eq true}">
                                     <f:setPropertyActionListener value="#{p}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
@@ -208,7 +209,20 @@
                 </div>
 
             </p:panel>
+
+            <p:dialog widgetVar="issueMedicinesProcessingDialog"
+                      modal="true"
+                      closable="false"
+                      resizable="false"
+                      draggable="false"
+                      header="Please Wait"
+                      width="320">
+                <div class="d-flex align-items-center gap-2 py-2">
+                    <i class="fa fa-spinner fa-spin fa-2x"/>
+                    <span>Loading medicines for this request, please wait...</span>
+                </div>
+            </p:dialog>
         </h:form>
-    </ui:define>  
+    </ui:define>
 
 </ui:composition>


### PR DESCRIPTION
## Summary
- When pharmacy fulfills a ward's medicine request for an inpatient (`ward_pharmacy_bht_issue.xhtml` / `PharmacySaleBhtController.settlePharmacyBhtIssueAccept`), staff now select a **porter/staff member** who carries the medicines to the ward.
- After stock is deducted from the issuing pharmacy as before, the same quantities are credited to that staff member's staff stock (`PharmacyBean.addToStock`), with stock history recorded — mirroring the existing disbursement "Issue for Requests" staff-stock pattern.
- Fixes a frozen "Recent"/Process button on `ward_pharmacy_bht_issue_request_bill.xhtml` when navigating there from `inward_ward_medicines.xhtml` (Request Selected from Pharmacy) for the first time — caused by a PrimeFaces AJAX `update` targeting components inside a panel whose `rendered` condition flips to `false` in the same request; widened `update` to `@form`.
- Adds a "Please Wait" modal dialog to the Issue Medicines button on `ward_pharmacy_bht_issue_request_list_for_issue.xhtml`, since navigating to the issue page can take a noticeable amount of time.
- Includes the AMP-strength-fields fix from `21457-amp-api-strength-fields` (merged into this branch): resolves VTM prescriptions to correct-strength AMP/VMP, fixes quantity calculation, and adds AMP strength fields to the pharmacy REST API.
- Adds design doc updates to `developer_docs/navigation/inward_navigation.md` for the porter-mediated ward pharmacy workflow (issues #21466-#21472).

Closes #21467

## Test plan
- [ ] On `ward_pharmacy_bht_issue.xhtml`, accept a ward medicine request, select a porter/staff member, and confirm the request cannot be accepted without selecting a porter
- [ ] After issuing, verify stock is deducted from the issuing pharmacy and credited to the porter's staff stock (with stock history) for each issued item
- [ ] Navigate from `inward_ward_medicines.xhtml` → "Request Selected from Pharmacy" → `ward_pharmacy_bht_issue_request_bill.xhtml`; confirm selecting a recent pharmacy and clicking Process works on the first try without needing a page reload
- [ ] On `ward_pharmacy_bht_issue_request_list_for_issue.xhtml`, click "Issue Medicines" and confirm the "Please Wait" dialog appears while the page navigates
- [ ] Verify VTM prescriptions resolve to correct-strength AMP/VMP with correct quantities (from #21457)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added porter/staff selection for medicine delivery to wards during BHT requests, including automatic porter stock transfer on acceptance.
  * Enhanced pharmaceutical item management for strength-aware issue-unit calculations and stronger matching for AMP items.
  * Added an issuance “Please Wait” loading dialog while processing issue actions.
* **Bug Fixes**
  * Improved form refresh behavior for department and patient selection in pharmacy workflows.
* **Documentation**
  * Added developer documentation describing the ward pharmacy porter-mediated workflow and remaining implementation questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->