### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/.github/workflows/publish-wiki-docs.yml
+++ b/.github/workflows/publish-wiki-docs.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           python tools/convert-wiki-for-mkdocs.py wiki-source docs
 
+      - name: Copy extra site files
+        run: |
+          cp -r mkdocs-extra/. docs/
+
       - name: Build MkDocs site
         run: |
           mkdocs build --site-dir site

--- a/mkdocs-extra/google2e0fa0139b309484.html
+++ b/mkdocs-extra/google2e0fa0139b309484.html
@@ -1,0 +1,1 @@
+google-site-verification: google2e0fa0139b309484.html


### PR DESCRIPTION
Places `google2e0fa0139b309484.html` at the site root so Google can verify ownership of `https://hmislk.github.io/hmis/`.

Files in `mkdocs-extra/` are copied into `docs/` after wiki conversion and before the MkDocs build, so they land at the site root without being overwritten by wiki content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation build process to include additional static files in the generated site.

* **Chores**
  * Added Google Site verification configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->