### PR TITLE
fix: re-fetch PatientRoom from DB to fix stale session cache blocking admin discharge

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1731,7 +1731,11 @@ public class BhtSummeryController implements Serializable {
 
         if (getPatientEncounter().getAdmissionType() != null
                 && getPatientEncounter().getAdmissionType().isRoomChargesAllowed()) {
-            if (getPatientEncounter().getCurrentPatientRoom() != null && getPatientEncounter().getCurrentPatientRoom().getDischargedAt() == null) {
+            PatientRoom currentRoom = getPatientEncounter().getCurrentPatientRoom();
+            if (currentRoom != null) {
+                currentRoom = patientRoomFacade.find(currentRoom.getId());
+            }
+            if (currentRoom != null && currentRoom.getDischargedAt() == null) {
                 JsfUtil.addErrorMessage("Cannot discharge patient: the current room has not been discharged. " + "Please discharge the room first to record an accurate billing end time.");
                 return;
             }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1731,10 +1731,13 @@ public class BhtSummeryController implements Serializable {
 
         if (getPatientEncounter().getAdmissionType() != null
                 && getPatientEncounter().getAdmissionType().isRoomChargesAllowed()) {
-            PatientRoom currentRoom = getPatientEncounter().getCurrentPatientRoom();
-            if (currentRoom != null) {
-                currentRoom = patientRoomFacade.find(currentRoom.getId());
-            }
+            // Re-fetch the encounter from the DB/L2 cache to get the authoritative currentPatientRoom FK.
+            // The session-scoped patientEncounter may be stale: a room change via RoomChangeController
+            // updates PatientEncounter.currentPatientRoom in the DB but not in this session object,
+            // so reading currentPatientRoom directly from the session would check the OLD room (which
+            // is already discharged) and incorrectly let the guard pass while the new room is still active.
+            PatientEncounter freshEncounter = patientEncounterFacade.find(getPatientEncounter().getId());
+            PatientRoom currentRoom = freshEncounter != null ? freshEncounter.getCurrentPatientRoom() : null;
             if (currentRoom != null && currentRoom.getDischargedAt() == null) {
                 JsfUtil.addErrorMessage("Cannot discharge patient: the current room has not been discharged. " + "Please discharge the room first to record an accurate billing end time.");
                 return;


### PR DESCRIPTION
## Summary

- Fixes administrative discharge being incorrectly blocked with *"Cannot discharge patient: the current room has not been discharged"* even when the room is fully discharged in the database
- Root cause: `BhtSummeryController` is `@SessionScoped`, so `patientEncounter.currentPatientRoom` is a stale Java object loaded at page-open time — after room discharge updates the DB, the session-held reference still has `dischargedAt = null`
- Fix: call `patientRoomFacade.find(currentRoom.getId())` to re-fetch a fresh `PatientRoom` from the database before the discharge guard check

Closes #21480

## Test plan

- [ ] Admit a patient with a room type that has `roomChargesAllowed = true`
- [ ] Open the Interim Bill page (loads the session bean)
- [ ] Perform room discharge from the Room Discharge page
- [ ] Return to the Interim Bill page and click **Discharge** → should succeed without the stale-cache error
- [ ] Verify that clicking Discharge when the room is genuinely NOT yet discharged still shows the correct error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patient discharge validation by ensuring the system checks the most up-to-date room status before allowing discharge, reducing cases where outdated room information could block or incorrectly permit the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->