### PR TITLE
feat(inward): ward staff return remaining stock to pharmacy via porter

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
@@ -1,0 +1,311 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.DepartmentController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.PharmacyBean;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Ward-side return of unused ward-held pharmacy stock back to the originating
+ * pharmacy via a porter (#21470, part of #21466).
+ *
+ * <p>Mirrors {@code PharmacySaleBhtController#transferIssuedStockToPorter}
+ * (#21467) but in reverse: ward staff free-select ward-held stock
+ * items/batches/quantities, pick a destination pharmacy department and a
+ * porter, and on confirm the quantities are deducted from ward department
+ * stock and credited to the porter's staff stock (with stock history). The
+ * resulting bill is {@link BillTypeAtomic#RETURN_MEDICINE_INWARD}. Pharmacy
+ * staff later receive the goods from the porter (#21471,
+ * {@link BillTypeAtomic#ACCEPT_RETURN_MEDICINE_INWARD}).</p>
+ */
+@Named
+@SessionScoped
+public class WardPharmacyReturnToPharmacyController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private StockFacade stockFacade;
+    @EJB
+    private PharmacyBean pharmacyBean;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private DepartmentController departmentController;
+
+    private Bill returnBill;
+    private List<BillItem> returnItems;
+    private Stock tmpStock;
+    private Double qty;
+    private Staff porter;
+    private Department toDepartment;
+    private boolean printPreview;
+    private boolean settling;
+
+    public String navigateToReturn() {
+        printPreview = false;
+        returnItems = new ArrayList<>();
+        tmpStock = null;
+        qty = null;
+        porter = null;
+        toDepartment = null;
+        returnBill = new BilledBill();
+        return "/ward/ward_pharmacy_return_to_pharmacy?faces-redirect=true";
+    }
+
+    public void addItem() {
+        if (tmpStock == null || tmpStock.getId() == null) {
+            JsfUtil.addErrorMessage("Select an item.");
+            return;
+        }
+        if (qty == null || qty <= 0) {
+            JsfUtil.addErrorMessage("Enter a quantity greater than zero.");
+            return;
+        }
+        if (qty > tmpStock.getStock()) {
+            JsfUtil.addErrorMessage("Quantity exceeds available ward stock (" + tmpStock.getStock() + ").");
+            return;
+        }
+
+        BillItem bi = new BillItem();
+        bi.setItem(tmpStock.getItemBatch().getItem());
+        bi.setQty(qty);
+
+        PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+        pbi.setBillItem(bi);
+        pbi.setItemBatch(tmpStock.getItemBatch());
+        pbi.setStock(tmpStock);
+        pbi.setQty(qty);
+        bi.setPharmaceuticalBillItem(pbi);
+
+        getReturnItems().add(bi);
+
+        tmpStock = null;
+        qty = null;
+    }
+
+    public void removeItem(BillItem item) {
+        getReturnItems().remove(item);
+    }
+
+    public void settle() {
+        if (settling) {
+            return;
+        }
+        settling = true;
+        try {
+            doSettle();
+        } finally {
+            settling = false;
+        }
+    }
+
+    private void doSettle() {
+        printPreview = false;
+        if (getReturnItems().isEmpty()) {
+            JsfUtil.addErrorMessage("Add at least one item to return.");
+            return;
+        }
+        if (porter == null) {
+            JsfUtil.addErrorMessage("Select the porter who will carry the medicines to the pharmacy.");
+            return;
+        }
+        if (toDepartment == null) {
+            JsfUtil.addErrorMessage("Select the destination pharmacy department.");
+            return;
+        }
+        if (!wardStockCoversAllLines()) {
+            return;
+        }
+
+        Department wardDept = sessionController.getDepartment();
+
+        BilledBill bill = new BilledBill();
+        bill.setBillType(BillType.PharmacyIssue);
+        bill.setBillTypeAtomic(BillTypeAtomic.RETURN_MEDICINE_INWARD);
+        bill.setInstitution(sessionController.getInstitution());
+        bill.setDepartment(wardDept);
+        bill.setFromDepartment(wardDept);
+        bill.setToDepartment(toDepartment);
+        bill.setToStaff(porter);
+        bill.setCreatedAt(new Date());
+        bill.setCreater(sessionController.getLoggedUser());
+
+        String deptId = billNumberBean.departmentBillNumberGeneratorYearly(wardDept, BillTypeAtomic.RETURN_MEDICINE_INWARD);
+        bill.setDeptId(deptId);
+        bill.setInsId(deptId);
+
+        billFacade.create(bill);
+
+        int serial = 1;
+        for (BillItem bi : getReturnItems()) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            double lineQty = bi.getQty();
+
+            bi.setBill(bill);
+            bi.setSearialNo(serial++);
+            bi.setCreatedAt(new Date());
+            bi.setCreater(sessionController.getLoggedUser());
+            billItemFacade.create(bi);
+
+            Stock wardStock = findWardStock(pbi.getItemBatch());
+            if (wardStock != null && pharmacyBean.deductFromStock(wardStock, lineQty, pbi, wardDept)) {
+                Stock porterStock = pharmacyBean.addToStock(pbi, lineQty, porter);
+                pbi.setStaffStock(porterStock);
+                pbi.setStock(wardStock);
+                billItemFacade.edit(bi);
+            } else {
+                JsfUtil.addErrorMessage("Insufficient ward stock for " + bi.getItem().getName()
+                        + " batch " + pbi.getItemBatch().getBatchNo() + " - this line was skipped.");
+                bi.setQty(0.0);
+                pbi.setQty(0.0);
+                billItemFacade.edit(bi);
+            }
+        }
+
+        bill.setBillItems(getReturnItems());
+        returnBill = bill;
+        printPreview = true;
+        JsfUtil.addSuccessMessage("Stock returned to pharmacy via porter.");
+    }
+
+    private Stock findWardStock(com.divudi.core.entity.pharmacy.ItemBatch itemBatch) {
+        String jpql = "SELECT s FROM Stock s WHERE s.itemBatch = :batch AND s.department = :dept";
+        Map<String, Object> params = new HashMap<>();
+        params.put("batch", itemBatch);
+        params.put("dept", sessionController.getDepartment());
+        return stockFacade.findFirstByJpql(jpql, params, true);
+    }
+
+    /**
+     * Validates that ward stock covers EVERY return line before any data is
+     * written, mirroring
+     * {@code MedicationAdministrationStockSettlementController#wardStockCoversAllLines}.
+     */
+    private boolean wardStockCoversAllLines() {
+        Map<Long, Double> requiredByBatch = new HashMap<>();
+        Map<Long, BillItem> sampleByBatch = new HashMap<>();
+        for (BillItem bi : getReturnItems()) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            if (pbi.getItemBatch() == null || pbi.getItemBatch().getId() == null) {
+                JsfUtil.addErrorMessage("Item " + (bi.getItem() != null ? bi.getItem().getName() : "?") + " has no batch - cannot return.");
+                return false;
+            }
+            Long batchId = pbi.getItemBatch().getId();
+            requiredByBatch.merge(batchId, bi.getQty(), Double::sum);
+            sampleByBatch.put(batchId, bi);
+        }
+
+        boolean allCovered = true;
+        for (Map.Entry<Long, Double> e : requiredByBatch.entrySet()) {
+            BillItem bi = sampleByBatch.get(e.getKey());
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            Stock wardStock = findWardStock(pbi.getItemBatch());
+            double available = wardStock == null ? 0.0 : wardStock.getStock();
+            if (available + 0.0001 < e.getValue()) {
+                JsfUtil.addErrorMessage("Insufficient ward stock for " + bi.getItem().getName()
+                        + " batch " + pbi.getItemBatch().getBatchNo()
+                        + ": need " + e.getValue() + " but only " + available + " available. Nothing was returned.");
+                allCovered = false;
+            }
+        }
+        return allCovered;
+    }
+
+    public List<Department> getPharmacies() {
+        return departmentController.getPharmacies();
+    }
+
+    public Bill getReturnBill() {
+        if (returnBill == null) {
+            returnBill = new BilledBill();
+        }
+        return returnBill;
+    }
+
+    public void setReturnBill(Bill returnBill) {
+        this.returnBill = returnBill;
+    }
+
+    public List<BillItem> getReturnItems() {
+        if (returnItems == null) {
+            returnItems = new ArrayList<>();
+        }
+        return returnItems;
+    }
+
+    public void setReturnItems(List<BillItem> returnItems) {
+        this.returnItems = returnItems;
+    }
+
+    public Stock getTmpStock() {
+        return tmpStock;
+    }
+
+    public void setTmpStock(Stock tmpStock) {
+        this.tmpStock = tmpStock;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Staff getPorter() {
+        return porter;
+    }
+
+    public void setPorter(Staff porter) {
+        this.porter = porter;
+    }
+
+    public Department getToDepartment() {
+        return toDepartment;
+    }
+
+    public void setToDepartment(Department toDepartment) {
+        this.toDepartment = toDepartment;
+    }
+
+    public boolean isPrintPreview() {
+        return printPreview;
+    }
+
+    public void setPrintPreview(boolean printPreview) {
+        this.printPreview = printPreview;
+    }
+
+}

--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
@@ -96,6 +96,18 @@ public class WardPharmacyReturnToPharmacyController implements Serializable {
             JsfUtil.addErrorMessage("Quantity exceeds available ward stock (" + tmpStock.getStock() + ").");
             return;
         }
+        double alreadyQueued = 0.0;
+        for (BillItem queuedItem : getReturnItems()) {
+            PharmaceuticalBillItem queuedPbi = queuedItem.getPharmaceuticalBillItem();
+            if (queuedPbi.getItemBatch() != null && queuedPbi.getItemBatch().getId() != null
+                    && queuedPbi.getItemBatch().getId().equals(tmpStock.getItemBatch().getId())) {
+                alreadyQueued += queuedItem.getQty();
+            }
+        }
+        if (qty + alreadyQueued > tmpStock.getStock()) {
+            JsfUtil.addErrorMessage("Total queued quantity (" + (qty + alreadyQueued) + ") exceeds available ward stock (" + tmpStock.getStock() + ").");
+            return;
+        }
 
         BillItem bi = new BillItem();
         bi.setItem(tmpStock.getItemBatch().getItem());

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -881,6 +881,15 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
+                                        id="btnReturnMedicinesToPharmacyInpatient"
+                                        value="Return Medicines to Pharmacy"
+                                        ajax="false"
+                                        action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"
+                                        icon="fa fa-truck-ramp-box"
+                                        class="w-100"/>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
                                         value="View Pharmacy Requests"
                                         action="#{admissionController.navigateToSearchInwardBills}"
                                         rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"

--- a/src/main/webapp/ward/ward_pharmacy_return_to_pharmacy.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_return_to_pharmacy.xhtml
@@ -1,0 +1,198 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <ui:define name="content">
+        <h:form id="formWardReturnToPharmacy" onkeypress="if(event.keyCode == 13 &amp;&amp; event.target.type != 'textarea') { return false; }">
+
+            <p:messages id="growlWardReturnToPharmacy" showDetail="true" autoUpdate="true"/>
+
+            <p:panel rendered="#{!wardPharmacyReturnToPharmacyController.printPreview}">
+                <f:facet name="header">
+                    <h:outputText styleClass="fa-solid fa-truck-ramp-box"/>
+                    <p:outputLabel value="Return Medicines to Pharmacy" class="mx-4"/>
+                </f:facet>
+
+                <div class="row">
+                    <div class="col-md-6">
+                        <p:outputLabel for="acReturnPorter" value="Porter / Staff Carrying Medicines to Pharmacy:"/>
+                        <p:autoComplete id="acReturnPorter"
+                                        completeMethod="#{staffController.completeStaffWithoutDoctors}"
+                                        forceSelection="true"
+                                        var="w" itemLabel="#{w.person.name}" itemValue="#{w}"
+                                        value="#{wardPharmacyReturnToPharmacyController.porter}"
+                                        maxResults="10"
+                                        styleClass="w-100"
+                                        placeholder="Search staff by name">
+                            <p:column headerText="Name">
+                                <h:outputText value="#{w.person.nameWithTitle}"/>
+                            </p:column>
+                            <p:column headerText="Speciality">
+                                <h:outputText value="#{w.speciality.name}"/>
+                            </p:column>
+                            <p:column headerText="Staff Code">
+                                <h:outputText value="#{w.code}"/>
+                            </p:column>
+                        </p:autoComplete>
+                    </div>
+                    <div class="col-md-6">
+                        <p:outputLabel for="selReturnToDepartment" value="Return to Pharmacy:"/>
+                        <p:selectOneMenu id="selReturnToDepartment"
+                                         value="#{wardPharmacyReturnToPharmacyController.toDepartment}"
+                                         styleClass="w-100">
+                            <f:selectItem itemLabel="Select a Pharmacy" itemValue="#{null}" noSelectionOption="true"/>
+                            <f:selectItems value="#{wardPharmacyReturnToPharmacyController.pharmacies}" var="ph"
+                                           itemLabel="#{ph.name}" itemValue="#{ph}"/>
+                        </p:selectOneMenu>
+                    </div>
+                </div>
+
+                <p:separator/>
+
+                <div class="row align-items-end">
+                    <div class="col-md-8">
+                        <p:outputLabel for="acReturnStock" value="Medicines/Devices (from ward stock)"/>
+                        <p:autoComplete id="acReturnStock"
+                                        value="#{wardPharmacyReturnToPharmacyController.tmpStock}"
+                                        minQueryLength="3" queryDelay="300"
+                                        completeMethod="#{stockController.completeAvailableStocks}"
+                                        var="i" itemLabel="#{i.itemBatch.item.name}" itemValue="#{i}"
+                                        maxResults="10" size="100"
+                                        styleClass="w-100"
+                                        inputStyleClass="w-100 form-control">
+                            <p:column headerText="Item">
+                                <h:outputText value="#{i.itemBatch.item.name}"/>
+                            </p:column>
+                            <p:column headerText="Batch No">
+                                <h:outputText value="#{i.itemBatch.batchNo}"/>
+                            </p:column>
+                            <p:column headerText="Expiry">
+                                <h:outputText value="#{i.itemBatch.dateOfExpire}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                </h:outputText>
+                            </p:column>
+                            <p:column headerText="Available">
+                                <h:outputText value="#{i.stock}">
+                                    <f:convertNumber pattern="#,###"/>
+                                </h:outputText>
+                            </p:column>
+                            <p:ajax event="itemSelect" process="@this" update="txtReturnQty btnAddReturnItem"/>
+                        </p:autoComplete>
+                    </div>
+                    <div class="col-md-2">
+                        <p:outputLabel for="txtReturnQty" value="Quantity"/>
+                        <p:inputNumber id="txtReturnQty"
+                                       value="#{wardPharmacyReturnToPharmacyController.qty}"
+                                       decimalPlaces="2"
+                                       styleClass="w-100"/>
+                    </div>
+                    <div class="col-md-2">
+                        <p:commandButton id="btnAddReturnItem"
+                                         value="Add"
+                                         icon="pi pi-plus"
+                                         class="w-100"
+                                         process="@this acReturnStock txtReturnQty"
+                                         update=":formWardReturnToPharmacy:panelReturnItems growlWardReturnToPharmacy"
+                                         actionListener="#{wardPharmacyReturnToPharmacyController.addItem}"/>
+                    </div>
+                </div>
+
+                <h:panelGroup id="panelReturnItems" layout="block" styleClass="mt-3">
+                    <p:dataTable
+                        id="tblReturnItems"
+                        widgetVar="tblReturnItems"
+                        rowKey="#{bi.hashCode()}"
+                        value="#{wardPharmacyReturnToPharmacyController.returnItems}"
+                        var="bi"
+                        class="w-100"
+                        emptyMessage="No items added yet.">
+
+                        <p:column headerText="Item">
+                            <h:outputText value="#{bi.item.name}"/>
+                        </p:column>
+
+                        <p:column headerText="Batch No">
+                            <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+                        </p:column>
+
+                        <p:column headerText="Expiry">
+                            <h:outputText value="#{bi.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Qty">
+                            <h:outputText value="#{bi.qty}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Action" style="width: 6rem; text-align: center;">
+                            <p:commandButton icon="pi pi-trash"
+                                             title="Remove #{bi.item.name}"
+                                             class="ui-button-danger"
+                                             process="@this"
+                                             update=":formWardReturnToPharmacy:panelReturnItems"
+                                             actionListener="#{wardPharmacyReturnToPharmacyController.removeItem(bi)}"/>
+                        </p:column>
+
+                    </p:dataTable>
+                </h:panelGroup>
+
+                <div class="d-flex justify-content-end mt-3">
+                    <p:commandButton
+                        id="btnConfirmReturn"
+                        value="Confirm Return to Pharmacy"
+                        icon="fas fa-check"
+                        class="ui-button-success"
+                        update=":formWardReturnToPharmacy"
+                        actionListener="#{wardPharmacyReturnToPharmacyController.settle}"
+                        onclick="if (!confirm('Return the selected items to the pharmacy via the selected porter? This cannot be undone.')) { return false; }"/>
+                </div>
+            </p:panel>
+
+            <p:panel rendered="#{wardPharmacyReturnToPharmacyController.printPreview}">
+                <f:facet name="header">
+                    <p:outputLabel value="Returned to Pharmacy - Bill #{wardPharmacyReturnToPharmacyController.returnBill.deptId}"/>
+                </f:facet>
+
+                <p:dataTable
+                    id="tblReturnedItems"
+                    rowKey="#{i.id}"
+                    value="#{wardPharmacyReturnToPharmacyController.returnBill.billItems}"
+                    var="i"
+                    class="w-100">
+
+                    <p:column headerText="Item">
+                        <h:outputText value="#{i.item.name}"/>
+                    </p:column>
+
+                    <p:column headerText="Batch No">
+                        <h:outputText value="#{i.pharmaceuticalBillItem.itemBatch.batchNo}"/>
+                    </p:column>
+
+                    <p:column headerText="Quantity Returned">
+                        <h:outputText value="#{i.qty}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputText>
+                    </p:column>
+
+                </p:dataTable>
+
+                <p:commandButton
+                    id="btnBackAfterReturn"
+                    value="New Return"
+                    icon="fas fa-arrow-left"
+                    ajax="false"
+                    class="ui-button-secondary mt-3"
+                    action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"/>
+
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
## Summary
- Adds a new ward-side workflow for returning unused ward-held pharmacy stock back to the originating pharmacy via a porter
- Ward staff free-select item/batch/quantity from ward stock, choose a destination pharmacy and porter
- On confirm, deducts ward department stock, credits the porter's staff stock, creates a `RETURN_MEDICINE_INWARD` bill
- New "Return Medicines to Pharmacy" button added to the admission profile page

Closes #21470 (part of epic #21466)

## Test plan
- [x] Built and deployed locally
- [x] E2E tested via Playwright: selected porter, destination pharmacy, item/batch/qty, added item, confirmed return
- [x] Verified DB: ward STOCK row deducted (11 → 9 → 8), porter staff stock created/incremented (0 → 2 → 3)
- [x] Verified BILL row created with BILLTYPEATOMIC=RETURN_MEDICINE_INWARD, correct fromDepartment/toDepartment/toStaff
- [x] Print preview shows returned item/batch/qty correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ward-to-pharmacy “Return Medicines to Pharmacy” workflow for returning unused ward-held stock to the originating pharmacy.
  * Introduced a new command button in the patient admission view to start the return process.
  * Delivered a dedicated return page with porter selection, destination pharmacy choice, ward-stock lookup, add/remove return items, quantity validation, and a settlement/print-preview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->