### PR TITLE
Template-based covering letters with multi-credit-company support

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
+++ b/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
@@ -176,8 +176,26 @@ public class DocumentTemplateController implements Serializable {
         current = new DocumentTemplate();
         current.setWebUser(sessionController.getLoggedUser());
         current.setType(DocumentTemplateType.InpatientLetter);
-        current.setContents(generateDefaultTemplateContents());
+        current.setContents(generateDefaultLetterTemplateContents());
         return "/emr/settings/document_template?faces-redirect=true";
+    }
+
+    public String generateDefaultLetterTemplateContents() {
+        return "Date: {letter_date}<br/>"
+                + "To: {credit_company}<br/>"
+                + "{credit_company_address}<br/><br/>"
+                + "Dear Sir/Madam,<br/><br/>"
+                + "Re: {patient_name} ({patient_age} / {patient_sex})<br/>"
+                + "BHT No: {bht}<br/>"
+                + "Policy No: {policy_no}<br/>"
+                + "Reference No: {reference_no}<br/><br/>"
+                + "Date of Admission: {doa}<br/>"
+                + "Admitting Doctor: {doctor}<br/>"
+                + "Final Bill Value: {final_bill}<br/><br/>"
+                + "Please find the covering letter for the above admission.<br/><br/>"
+                + "Yours faithfully,<br/>"
+                + "{institution}<br/>"
+                + "{department}<br/>";
     }
 
     public String navigateToListLetterTemplates() {

--- a/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
+++ b/src/main/java/com/divudi/bean/clinical/DocumentTemplateController.java
@@ -159,6 +159,32 @@ public class DocumentTemplateController implements Serializable {
         return "/emr/settings/document_templates?faces-redirect=true";
     }
 
+    public String navigateToAddDiagnosisCardTemplate() {
+        current = new DocumentTemplate();
+        current.setWebUser(sessionController.getLoggedUser());
+        current.setType(DocumentTemplateType.InpatientDiagnosisCard);
+        current.setContents(generateDefaultTemplateContents());
+        return "/emr/settings/document_template?faces-redirect=true";
+    }
+
+    public String navigateToListDiagnosisCardTemplates() {
+        items = fillByType(DocumentTemplateType.InpatientDiagnosisCard);
+        return "/emr/settings/document_templates?faces-redirect=true";
+    }
+
+    public String navigateToAddLetterTemplate() {
+        current = new DocumentTemplate();
+        current.setWebUser(sessionController.getLoggedUser());
+        current.setType(DocumentTemplateType.InpatientLetter);
+        current.setContents(generateDefaultTemplateContents());
+        return "/emr/settings/document_template?faces-redirect=true";
+    }
+
+    public String navigateToListLetterTemplates() {
+        items = fillByType(DocumentTemplateType.InpatientLetter);
+        return "/emr/settings/document_templates?faces-redirect=true";
+    }
+
     public void saveUserDocumentTemplate() {
         if (current == null) {
             JsfUtil.addErrorMessage("Nothing Selected");
@@ -181,6 +207,7 @@ public class DocumentTemplateController implements Serializable {
         saveSelected();
         fillAllItems(null);
         inpatientClinicalDataController.refreshDiagnosisCardTemplates();
+        inpatientClinicalDataController.refreshLetterTemplates();
 
     }
 
@@ -193,6 +220,7 @@ public class DocumentTemplateController implements Serializable {
         delete();
         fillAllItems(sessionController.getLoggedUser());
         inpatientClinicalDataController.refreshDiagnosisCardTemplates();
+        inpatientClinicalDataController.refreshLetterTemplates();
         JsfUtil.addSuccessMessage("Saved");
     }
 

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -220,6 +220,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalDischarge, "Clinical Discharge"), inwardClinicalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDocumentUpload, "Document Upload"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientLetter, "Generate Inpatient Letters"), inwardClinicalNode);
 
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -430,6 +430,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         return inpatientClinicalDataController.navigateToDiagnosisCards(current);
     }
 
+    public String navigateToInpatientLetters() {
+        return inpatientClinicalDataController.navigateToInpatientLetters(current);
+    }
+
     public void dateChangeListen() {
         getPatient().getPerson().setDob(CommonFunctions.guessDob(yearMonthDay));
 

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -24,6 +24,7 @@ import com.divudi.core.data.lab.InvestigationResultForGraph;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Doctor;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
@@ -48,7 +49,9 @@ import com.divudi.core.entity.inward.EncounterComponent;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.ClinicalEntityFacade;
 import com.divudi.core.facade.ClinicalFindingValueFacade;
+import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.facade.EncounterComponentFacade;
+import com.divudi.core.facade.EncounterCreditCompanyFacade;
 import com.divudi.core.facade.ItemUsageFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PatientFacade;
@@ -136,6 +139,8 @@ public class InpatientClinicalDataController implements Serializable {
     private AnthropicApiService anthropicApiService;
     @EJB
     private PrescriptionService prescriptionService;
+    @EJB
+    private EncounterCreditCompanyFacade encounterCreditCompanyFacade;
     /**
      * Controllers
      */
@@ -184,8 +189,12 @@ public class InpatientClinicalDataController implements Serializable {
 
     private List<DocumentTemplate> userDocumentTemplates;
     private List<DocumentTemplate> diagnosisCardTemplates;
+    private List<DocumentTemplate> letterTemplates;
     private DocumentTemplate selectedDocumentTemplate;
     private boolean editingDiagnosisCard;
+
+    private List<EncounterCreditCompany> encounterCreditCompanies;
+    private Long selectedEncounterCreditCompanyId;
 
     private ClinicalFindingValue patientAllergy;
     private ClinicalFindingValue patientMedicine;
@@ -721,6 +730,51 @@ public class InpatientClinicalDataController implements Serializable {
             }
         }
 
+        // Credit company placeholders — use the user-selected EncounterCreditCompany if set,
+        // otherwise fall back to the first one linked to this encounter.
+        String creditCompanyName = "";
+        String creditCompanyAddress = "";
+        String policyNo = "";
+        String referenceNo = "";
+        String creditLimit = "";
+        EncounterCreditCompany ecc = getSelectedEncounterCreditCompany();
+        if (ecc == null) {
+            String jpqlCC = "select ecc from EncounterCreditCompany ecc "
+                    + "where ecc.retired = false and ecc.patientEncounter = :pe "
+                    + "order by ecc.id asc";
+            Map<String, Object> ccParams = new HashMap<>();
+            ccParams.put("pe", e);
+            List<EncounterCreditCompany> creditCompanies = encounterCreditCompanyFacade.findByJpql(jpqlCC, ccParams, 1);
+            if (creditCompanies != null && !creditCompanies.isEmpty()) {
+                ecc = creditCompanies.get(0);
+            }
+        }
+        if (ecc != null) {
+            if (ecc.getInstitution() != null) {
+                creditCompanyName = ecc.getInstitution().getName() != null ? ecc.getInstitution().getName() : "";
+                creditCompanyAddress = ecc.getInstitution().getAddress() != null ? ecc.getInstitution().getAddress() : "";
+            }
+            policyNo = ecc.getPolicyNo() != null ? ecc.getPolicyNo() : "";
+            referenceNo = ecc.getReferanceNo() != null ? ecc.getReferanceNo() : "";
+            creditLimit = ecc.getCreditLimit() > 0 ? String.format("%.2f", ecc.getCreditLimit()) : "";
+        } else if (e.getCreditCompany() != null) {
+            creditCompanyName = e.getCreditCompany().getName() != null ? e.getCreditCompany().getName() : "";
+            creditCompanyAddress = e.getCreditCompany().getAddress() != null ? e.getCreditCompany().getAddress() : "";
+        }
+
+        String finalBill = String.format("%.2f", e.getNetTotal());
+
+        String institutionName = e.getInstitution() != null && e.getInstitution().getName() != null
+                ? e.getInstitution().getName() : "";
+        String departmentName = e.getDepartment() != null && e.getDepartment().getName() != null
+                ? e.getDepartment().getName() : "";
+        String doctorName = "";
+        Staff doctor = e.getOpdDoctor() != null ? e.getOpdDoctor() : e.getReferringDoctor();
+        if (doctor != null && doctor.getPerson() != null && doctor.getPerson().getNameWithTitle() != null) {
+            doctorName = doctor.getPerson().getNameWithTitle();
+        }
+        String letterDate = CommonFunctions.formatDate(new Date(), sessionController.getApplicationPreference().getLongDateFormat());
+
         output = input.replace("{name}", name)
                 .replace("{age}", age)
                 .replace("{comments}", comments)
@@ -752,7 +806,20 @@ public class InpatientClinicalDataController implements Serializable {
                 .replace("{bp-series}", bpSeries)
                 .replace("{pr-series}", prSeries)
                 .replace("{rr-series}", rrSeries)
-                .replace("{sat-series}", satSeries);
+                .replace("{sat-series}", satSeries)
+                .replace("{credit_company}", creditCompanyName)
+                .replace("{credit_company_address}", creditCompanyAddress)
+                .replace("{policy_no}", policyNo)
+                .replace("{reference_no}", referenceNo)
+                .replace("{credit_limit}", creditLimit)
+                .replace("{institution}", institutionName)
+                .replace("{department}", departmentName)
+                .replace("{doctor}", doctorName)
+                .replace("{letter_date}", letterDate)
+                .replace("{final_bill}", finalBill)
+                .replace("{patient_name}", name)
+                .replace("{patient_age}", age)
+                .replace("{patient_sex}", sex);
         return output;
 
     }
@@ -1108,6 +1175,125 @@ public class InpatientClinicalDataController implements Serializable {
             Logger.getLogger(InpatientClinicalDataController.class.getName()).log(Level.SEVERE, "AI diagnosis card generation failed", ex);
             JsfUtil.addErrorMessage("AI generation failed: " + ex.getMessage());
         }
+    }
+
+    public void generateLetterWithAi() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("No encounter selected");
+            return;
+        }
+
+        String apiKey = configOptionApplicationController.getShortTextValueByKey("AI Chat - Claude API Key", "");
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("AI API key is not configured. Please set 'AI Chat - Claude API Key' in application settings.");
+            return;
+        }
+
+        String model = configOptionApplicationController.getShortTextValueByKey("AI Chat - Claude Model", "claude-sonnet-4-20250514");
+        Integer maxTokensConfig = configOptionApplicationController.getIntegerValueByKey("AI Chat - Max Tokens", 4096);
+        int maxTokens = (maxTokensConfig != null && maxTokensConfig > 0) ? Math.max(maxTokensConfig, 4096) : 4096;
+
+        String clinicalSummary = buildLetterDataSummary(current);
+        String systemPrompt = buildLetterSystemPrompt();
+        String letterTitle = "AI Generated Letter";
+        if (selectedDocumentTemplate != null
+                && selectedDocumentTemplate.getContents() != null
+                && !selectedDocumentTemplate.getContents().trim().isEmpty()) {
+            systemPrompt += "\n\nTEMPLATE INSTRUCTIONS (follow these exactly while preserving the rules above):\n"
+                    + selectedDocumentTemplate.getContents().trim();
+            letterTitle = selectedDocumentTemplate.getName();
+        }
+
+        try {
+            AnthropicApiService.AnthropicResponse response = anthropicApiService.sendMessage(
+                    apiKey,
+                    model,
+                    maxTokens,
+                    systemPrompt,
+                    new ArrayList<>(),
+                    clinicalSummary,
+                    null,
+                    null
+            );
+
+            if (response == null || response.getContent() == null || response.getContent().trim().isEmpty()) {
+                JsfUtil.addErrorMessage("AI returned an empty response. Please try again.");
+                return;
+            }
+
+            String html = response.getContent().trim();
+            if (html.startsWith("```html")) html = html.substring(7);
+            else if (html.startsWith("```")) html = html.substring(3);
+            if (html.endsWith("```")) html = html.substring(0, html.length() - 3);
+            html = html.trim();
+
+            ClinicalFindingValue ref = new ClinicalFindingValue();
+            ref.setClinicalFindingValueType(ClinicalFindingValueType.VisitDocument);
+            ref.setLobValue(html);
+            ref.setStringValue(letterTitle);
+            ref.setEncounter(current);
+            ref.setOrderNo(getEncounterDocuments().size() + 1);
+            clinicalFindingValueFacade.create(ref);
+            encounterReferral = ref;
+            getEncounterDocuments().add(ref);
+            JsfUtil.addSuccessMessage("Letter generated with AI");
+        } catch (Exception ex) {
+            Logger.getLogger(InpatientClinicalDataController.class.getName()).log(Level.SEVERE, "AI letter generation failed", ex);
+            JsfUtil.addErrorMessage("AI generation failed: " + ex.getMessage());
+        }
+    }
+
+    private String buildLetterSystemPrompt() {
+        return "You are a medical correspondence formatter for a hospital information system. "
+                + "Your task is to generate a professional formal letter in HTML format based on the patient and admission data provided.\n\n"
+                + "RULES:\n"
+                + "1. Output ONLY the HTML markup. No markdown fencing, no explanations, no preamble.\n"
+                + "2. Use inline CSS styles on every element. The output must be self-contained and suitable for printing.\n"
+                + "3. Format as a formal letter: sender block (hospital/institution), date, recipient block (credit company or patient), salutation, body paragraphs, closing.\n"
+                + "4. OMIT any field that has no meaningful data.\n"
+                + "5. NEVER fabricate, infer, or add clinical or financial data that is not provided. Only use the data given.\n"
+                + "6. The letter should fit on an A4 page when printed.\n"
+                + "7. The INSTITUTION name must appear prominently in the header.\n"
+                + "8. If credit company information is provided, address the letter to the credit company.\n"
+                + "9. Include BHT number, admission date, patient name and diagnosis in the letter body.\n"
+                + "10. The letter date must be today's date as provided in the data.\n"
+                + "11. If a final bill value is provided, include it when referring to the outstanding/total amount.\n";
+    }
+
+    private String buildLetterDataSummary(PatientEncounter e) {
+        StringBuilder sb = new StringBuilder(buildClinicalDataSummary(e));
+
+        EncounterCreditCompany ecc = getSelectedEncounterCreditCompany();
+        if (ecc == null) {
+            String jpqlCC = "select ecc from EncounterCreditCompany ecc "
+                    + "where ecc.retired = false and ecc.patientEncounter = :pe order by ecc.id asc";
+            Map<String, Object> ccParams = new HashMap<>();
+            ccParams.put("pe", e);
+            List<EncounterCreditCompany> companies = encounterCreditCompanyFacade.findByJpql(jpqlCC, ccParams, 1);
+            if (companies != null && !companies.isEmpty()) {
+                ecc = companies.get(0);
+            }
+        }
+        if (ecc != null) {
+            sb.append("\nCREDIT COMPANY:\n");
+            if (ecc.getInstitution() != null) {
+                sb.append("  Name: ").append(ecc.getInstitution().getName() != null ? ecc.getInstitution().getName() : "").append("\n");
+                sb.append("  Address: ").append(ecc.getInstitution().getAddress() != null ? ecc.getInstitution().getAddress() : "").append("\n");
+            }
+            if (ecc.getPolicyNo() != null && !ecc.getPolicyNo().isEmpty())
+                sb.append("  Policy No: ").append(ecc.getPolicyNo()).append("\n");
+            if (ecc.getReferanceNo() != null && !ecc.getReferanceNo().isEmpty())
+                sb.append("  Reference No: ").append(ecc.getReferanceNo()).append("\n");
+            if (ecc.getCreditLimit() > 0)
+                sb.append("  Credit Limit: ").append(String.format("%.2f", ecc.getCreditLimit())).append("\n");
+        } else if (e.getCreditCompany() != null) {
+            sb.append("\nCREDIT COMPANY:\n");
+            sb.append("  Name: ").append(e.getCreditCompany().getName() != null ? e.getCreditCompany().getName() : "").append("\n");
+            sb.append("  Address: ").append(e.getCreditCompany().getAddress() != null ? e.getCreditCompany().getAddress() : "").append("\n");
+        }
+        sb.append("\nFINAL BILL VALUE: ").append(String.format("%.2f", e.getNetTotal())).append("\n");
+        sb.append("\nLETTER DATE: ").append(CommonFunctions.formatDate(new Date(), sessionController.getApplicationPreference().getLongDateFormat())).append("\n");
+        return sb.toString();
     }
 
     private String buildClinicalDataSummary(PatientEncounter e) {
@@ -4462,6 +4648,76 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void refreshDiagnosisCardTemplates() {
         diagnosisCardTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientDiagnosisCard);
+    }
+
+    public String navigateToInpatientLetters(PatientEncounter admission) {
+        if (admission == null) {
+            JsfUtil.addErrorMessage("Nothing Selected");
+            return "";
+        }
+        this.parentAdmission = admission;
+        this.current = admission;
+        fillClinicalAssessments();
+        fillCurrentPatientLists(admission.getPatient());
+        fillCurrentEncounterLists(admission);
+        letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
+        refreshEncounterCreditCompanies();
+        return "/inward/inward_letters?faces-redirect=true";
+    }
+
+    public List<EncounterCreditCompany> getEncounterCreditCompanies() {
+        if (encounterCreditCompanies == null) {
+            refreshEncounterCreditCompanies();
+        }
+        return encounterCreditCompanies;
+    }
+
+    public void refreshEncounterCreditCompanies() {
+        String jpql = "select ecc from EncounterCreditCompany ecc "
+                + "where ecc.retired = false and ecc.patientEncounter = :pe "
+                + "order by ecc.id asc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", current);
+        encounterCreditCompanies = encounterCreditCompanyFacade.findByJpql(jpql, params);
+        if (encounterCreditCompanies == null) {
+            encounterCreditCompanies = new ArrayList<>();
+        }
+        if (encounterCreditCompanies.size() == 1) {
+            selectedEncounterCreditCompanyId = encounterCreditCompanies.get(0).getId();
+        } else {
+            selectedEncounterCreditCompanyId = null;
+        }
+    }
+
+    public Long getSelectedEncounterCreditCompanyId() {
+        return selectedEncounterCreditCompanyId;
+    }
+
+    public void setSelectedEncounterCreditCompanyId(Long selectedEncounterCreditCompanyId) {
+        this.selectedEncounterCreditCompanyId = selectedEncounterCreditCompanyId;
+    }
+
+    private EncounterCreditCompany getSelectedEncounterCreditCompany() {
+        if (selectedEncounterCreditCompanyId == null || encounterCreditCompanies == null) {
+            return null;
+        }
+        for (EncounterCreditCompany ecc : encounterCreditCompanies) {
+            if (ecc.getId() != null && ecc.getId().equals(selectedEncounterCreditCompanyId)) {
+                return ecc;
+            }
+        }
+        return null;
+    }
+
+    public List<DocumentTemplate> getLetterTemplates() {
+        if (letterTemplates == null) {
+            letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
+        }
+        return letterTemplates;
+    }
+
+    public void refreshLetterTemplates() {
+        letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
     }
 
     public boolean isEditingDiagnosisCard() {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -4669,11 +4669,16 @@ public class InpatientClinicalDataController implements Serializable {
         fillCurrentPatientLists(admission.getPatient());
         fillCurrentEncounterLists(admission);
         letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
-        if (selectedDocumentTemplate != null && (letterTemplates == null || !letterTemplates.contains(selectedDocumentTemplate))) {
-            selectedDocumentTemplate = null;
-        }
+        clearInvalidSelectedLetterTemplate();
         refreshEncounterCreditCompanies();
         return "/inward/inward_letters?faces-redirect=true";
+    }
+
+    private void clearInvalidSelectedLetterTemplate() {
+        if (selectedDocumentTemplate != null
+                && (letterTemplates == null || !letterTemplates.contains(selectedDocumentTemplate))) {
+            selectedDocumentTemplate = null;
+        }
     }
 
     public List<EncounterCreditCompany> getEncounterCreditCompanies() {
@@ -4717,7 +4722,7 @@ public class InpatientClinicalDataController implements Serializable {
     private boolean requiresCreditCompanySelection() {
         return encounterCreditCompanies != null
                 && encounterCreditCompanies.size() > 1
-                && selectedEncounterCreditCompanyId == null;
+                && getSelectedEncounterCreditCompany() == null;
     }
 
     private EncounterCreditCompany getSelectedEncounterCreditCompany() {
@@ -4741,6 +4746,7 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void refreshLetterTemplates() {
         letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
+        clearInvalidSelectedLetterTemplate();
     }
 
     public boolean isEditingDiagnosisCard() {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -1091,6 +1091,10 @@ public class InpatientClinicalDataController implements Serializable {
             JsfUtil.addErrorMessage("Select a template");
             return;
         }
+        if (requiresCreditCompanySelection()) {
+            JsfUtil.addErrorMessage("This admission has multiple linked credit companies. Please select one before generating.");
+            return;
+        }
         String generatedDoc = generateDocumentFromTemplate(selectedDocumentTemplate, current);
         ClinicalFindingValue ref = new ClinicalFindingValue();
         ref.setClinicalFindingValueType(ClinicalFindingValueType.VisitDocument);
@@ -1180,6 +1184,10 @@ public class InpatientClinicalDataController implements Serializable {
     public void generateLetterWithAi() {
         if (current == null) {
             JsfUtil.addErrorMessage("No encounter selected");
+            return;
+        }
+        if (requiresCreditCompanySelection()) {
+            JsfUtil.addErrorMessage("This admission has multiple linked credit companies. Please select one before generating.");
             return;
         }
 
@@ -4661,6 +4669,9 @@ public class InpatientClinicalDataController implements Serializable {
         fillCurrentPatientLists(admission.getPatient());
         fillCurrentEncounterLists(admission);
         letterTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientLetter);
+        if (selectedDocumentTemplate != null && (letterTemplates == null || !letterTemplates.contains(selectedDocumentTemplate))) {
+            selectedDocumentTemplate = null;
+        }
         refreshEncounterCreditCompanies();
         return "/inward/inward_letters?faces-redirect=true";
     }
@@ -4695,6 +4706,18 @@ public class InpatientClinicalDataController implements Serializable {
 
     public void setSelectedEncounterCreditCompanyId(Long selectedEncounterCreditCompanyId) {
         this.selectedEncounterCreditCompanyId = selectedEncounterCreditCompanyId;
+    }
+
+    /**
+     * Returns true when the admission has more than one linked, non-retired
+     * credit company and the user has not yet picked which one to use.
+     * Letter generation must be blocked in this case to avoid silently
+     * addressing the letter to the wrong insurer/guarantor.
+     */
+    private boolean requiresCreditCompanySelection() {
+        return encounterCreditCompanies != null
+                && encounterCreditCompanies.size() > 1
+                && selectedEncounterCreditCompanyId == null;
     }
 
     private EncounterCreditCompany getSelectedEncounterCreditCompany() {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -123,6 +123,7 @@ public enum Privileges {
     InpatientClinicalAssessment("Inpatient Clinical Assessment"),
     InpatientClinicalDischarge("Inpatient Clinical Discharge"),
     InwardDocumentUpload("Inward Document Upload"),
+    InpatientLetter("Inpatient Letter"),
     //</editor-fold>
     
     //<editor-fold defaultstate="collapsed" desc="Nurse">
@@ -1086,6 +1087,7 @@ public enum Privileges {
             case InpatientClinicalAssessment:
             case InpatientClinicalDischarge:
             case InwardDocumentUpload:
+            case InpatientLetter:
             case InwardFormTemplateAdmin:
             case InwardFormFill:
                 return "Inward";

--- a/src/main/java/com/divudi/core/data/clinical/DocumentTemplateType.java
+++ b/src/main/java/com/divudi/core/data/clinical/DocumentTemplateType.java
@@ -15,4 +15,5 @@ public enum DocumentTemplateType {
     FitnessCertificate,
     Referral,
     InpatientDiagnosisCard,
+    InpatientLetter,
 }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -2909,6 +2909,7 @@ public class AnthropicApiService implements Serializable {
                     if (!templateType.isEmpty()) url.append("&type=").append(URLEncoder.encode(templateType, StandardCharsets.UTF_8));
                     if (!query.isEmpty()) url.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url.toString()))
+                            .timeout(Duration.ofSeconds(15))
                             .header("Finance", hmisApiKey).GET().build();
                     HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
                     return resp.body();
@@ -2916,6 +2917,7 @@ public class AnthropicApiService implements Serializable {
                 case "GET": {
                     if (id.isEmpty()) return "Error: id is required for GET.";
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .timeout(Duration.ofSeconds(15))
                             .header("Finance", hmisApiKey).GET().build();
                     HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
                     return resp.body();
@@ -2927,10 +2929,11 @@ public class AnthropicApiService implements Serializable {
                             .add("name", name)
                             .add("type", templateType);
                     if (!contents.isEmpty()) bodyBuilder.add("contents", contents);
-                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", defaultTemplate);
-                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", autoGenerate);
+                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", Boolean.parseBoolean(defaultTemplate));
+                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", Boolean.parseBoolean(autoGenerate));
                     String bodyStr = bodyBuilder.build().toString();
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl))
+                            .timeout(Duration.ofSeconds(15))
                             .header("Finance", hmisApiKey).header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString(bodyStr)).build();
                     HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
@@ -2942,10 +2945,11 @@ public class AnthropicApiService implements Serializable {
                     if (!name.isEmpty()) bodyBuilder.add("name", name);
                     if (!templateType.isEmpty()) bodyBuilder.add("type", templateType);
                     if (!contents.isEmpty()) bodyBuilder.add("contents", contents);
-                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", defaultTemplate);
-                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", autoGenerate);
+                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", Boolean.parseBoolean(defaultTemplate));
+                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", Boolean.parseBoolean(autoGenerate));
                     String bodyStr = bodyBuilder.build().toString();
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .timeout(Duration.ofSeconds(15))
                             .header("Finance", hmisApiKey).header("Content-Type", "application/json")
                             .PUT(HttpRequest.BodyPublishers.ofString(bodyStr)).build();
                     HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
@@ -2954,6 +2958,7 @@ public class AnthropicApiService implements Serializable {
                 case "DELETE": {
                     if (id.isEmpty()) return "Error: id is required for DELETE.";
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .timeout(Duration.ofSeconds(15))
                             .header("Finance", hmisApiKey).DELETE().build();
                     HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
                     return resp.body();

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -950,6 +950,64 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject manageInpatientTemplates = Json.createObjectBuilder()
+                .add("name", "manage_inpatient_templates")
+                .add("description",
+                        "Create, read, update, and retire inpatient document templates stored in the HMIS. "
+                        + "Templates are HTML-based with placeholder tokens that are substituted at generation time. "
+                        + "Two types are supported: InpatientDiagnosisCard and InpatientLetter.\n\n"
+                        + "method: LIST | GET | POST | PUT | DELETE\n\n"
+                        + "LIST: returns all non-retired templates; optional filters: type, query (name search), size.\n"
+                        + "GET: returns a single template including the full contents field; requires id.\n"
+                        + "POST: creates a new template; requires name, type, contents.\n"
+                        + "PUT: updates an existing template; requires id; optional fields: name, type, contents, defaultTemplate, autoGenerate.\n"
+                        + "DELETE: soft-retires the template; requires id.\n\n"
+                        + "InpatientLetter placeholder tokens available in contents:\n"
+                        + "  Patient: {name} {age} {sex} {address} {phone} {bht} {doa} {dod}\n"
+                        + "  Clinical: {dx} {past-dx} {allergies} {routine-medicines} {rx} {drx} {ix} {procedures}\n"
+                        + "  Vitals: {bp} {pr} {rr} {sat} {height} {weight} {bmi} {pfr}\n"
+                        + "  Vital series: {temp-series} {bp-series} {pr-series} {rr-series} {sat-series}\n"
+                        + "  Credit company: {credit_company} {credit_company_address} {policy_no} {reference_no} {credit_limit}\n"
+                        + "  Institution: {institution} {department} {doctor} {letter_date}\n"
+                        + "  Billing: {final_bill} (admission net total) {patient_name} {patient_age} {patient_sex} (aliases of name/age/sex)\n"
+                        + "If the admission has more than one credit company, the user selects which one to use on the "
+                        + "inward_letters page before generating; the credit company placeholders resolve to the selected company.\n"
+                        + "InpatientDiagnosisCard uses the same placeholders (credit company fields resolve to empty if not applicable).")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("GET").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "Operation to perform"))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Template ID — required for GET, PUT, DELETE"))
+                                .add("type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("InpatientDiagnosisCard").add("InpatientLetter"))
+                                        .add("description", "Template type — required for POST; optional filter for LIST"))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Template name — required for POST; optional for PUT"))
+                                .add("contents", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "HTML template body with placeholder tokens — required for POST; optional for PUT"))
+                                .add("defaultTemplate", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' or 'false' — marks this as the default template for its type"))
+                                .add("autoGenerate", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' or 'false' — auto-regenerate on encounter changes"))
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Name search string for LIST"))
+                                .add("size", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Max results for LIST (default 200)")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         return Json.createArrayBuilder()
                 .add(searchCodeTool)
                 .add(fetchFileTool)
@@ -963,6 +1021,7 @@ public class AnthropicApiService implements Serializable {
                 .add(manageInvestigationFormatTool)
                 .add(manageFormsTool)
                 .add(manageSubscriptionsTool)
+                .add(manageInpatientTemplates)
                 .build();
     }
 
@@ -1201,6 +1260,19 @@ public class AnthropicApiService implements Serializable {
                     String applicationWide = toolInput.containsKey("applicationWide") ? toolInput.getString("applicationWide", "") : "";
                     return callSubscriptionApi(method, id, triggerType, userId, departmentId, applicationWide,
                             hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_inpatient_templates": {
+                    String method        = toolInput.getString("method", "LIST");
+                    String id            = toolInput.containsKey("id")             ? toolInput.getString("id", "")            : "";
+                    String templateType  = toolInput.containsKey("type")           ? toolInput.getString("type", "")          : "";
+                    String name          = toolInput.containsKey("name")           ? toolInput.getString("name", "")          : "";
+                    String contents      = toolInput.containsKey("contents")       ? toolInput.getString("contents", "")      : "";
+                    String defTemplate   = toolInput.containsKey("defaultTemplate") ? toolInput.getString("defaultTemplate", "") : "";
+                    String autoGenerate  = toolInput.containsKey("autoGenerate")   ? toolInput.getString("autoGenerate", "")  : "";
+                    String query         = toolInput.containsKey("query")          ? toolInput.getString("query", "")         : "";
+                    String size          = toolInput.containsKey("size")           ? toolInput.getString("size", "")          : "";
+                    return callInpatientTemplateApi(method, id, templateType, name, contents, defTemplate, autoGenerate,
+                            query, size, hmisBaseUrl, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -2818,6 +2890,85 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    private String callInpatientTemplateApi(String method, String id, String templateType,
+            String name, String contents, String defaultTemplate, String autoGenerate,
+            String query, String size, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        try {
+            String baseUrl = hmisBaseUrl.replaceAll("/$", "") + "/api/inward/document-templates";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+            switch (method.toUpperCase()) {
+                case "LIST": {
+                    StringBuilder url = new StringBuilder(baseUrl).append("?size=").append(size.isEmpty() ? "200" : size);
+                    if (!templateType.isEmpty()) url.append("&type=").append(URLEncoder.encode(templateType, StandardCharsets.UTF_8));
+                    if (!query.isEmpty()) url.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url.toString()))
+                            .header("Finance", hmisApiKey).GET().build();
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    return resp.body();
+                }
+                case "GET": {
+                    if (id.isEmpty()) return "Error: id is required for GET.";
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .header("Finance", hmisApiKey).GET().build();
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    return resp.body();
+                }
+                case "POST": {
+                    if (name.isEmpty()) return "Error: name is required for POST.";
+                    if (templateType.isEmpty()) return "Error: type is required for POST.";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder()
+                            .add("name", name)
+                            .add("type", templateType);
+                    if (!contents.isEmpty()) bodyBuilder.add("contents", contents);
+                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", defaultTemplate);
+                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", autoGenerate);
+                    String bodyStr = bodyBuilder.build().toString();
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl))
+                            .header("Finance", hmisApiKey).header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(bodyStr)).build();
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    return resp.body();
+                }
+                case "PUT": {
+                    if (id.isEmpty()) return "Error: id is required for PUT.";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    if (!name.isEmpty()) bodyBuilder.add("name", name);
+                    if (!templateType.isEmpty()) bodyBuilder.add("type", templateType);
+                    if (!contents.isEmpty()) bodyBuilder.add("contents", contents);
+                    if (!defaultTemplate.isEmpty()) bodyBuilder.add("defaultTemplate", defaultTemplate);
+                    if (!autoGenerate.isEmpty()) bodyBuilder.add("autoGenerate", autoGenerate);
+                    String bodyStr = bodyBuilder.build().toString();
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .header("Finance", hmisApiKey).header("Content-Type", "application/json")
+                            .PUT(HttpRequest.BodyPublishers.ofString(bodyStr)).build();
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    return resp.body();
+                }
+                case "DELETE": {
+                    if (id.isEmpty()) return "Error: id is required for DELETE.";
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                            .header("Finance", hmisApiKey).DELETE().build();
+                    HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                    return resp.body();
+                }
+                default:
+                    return "Unknown method: " + method + ". Valid: LIST, GET, POST, PUT, DELETE";
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Inpatient template API call interrupted.";
+        } catch (Exception e) {
+            return "Inpatient template API error: " + e.getMessage();
+        }
+    }
+
     public String buildSystemPrompt(String hmisApiBaseUrl, String userHmisApiKey, String githubBranch) {
         String branch = (githubBranch != null && !githubBranch.trim().isEmpty())
                 ? githubBranch.trim() : "development";
@@ -2846,7 +2997,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have twelve tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, and notification subscriptions:\n\n");
+        sb.append("You have thirteen tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, notification subscriptions, and inpatient document templates:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");
@@ -2945,6 +3096,17 @@ public class AnthropicApiService implements Serializable {
           .append("POST returns 'already_exists' with the existing id when an identical non-retired subscription exists. ")
           .append("Use DELETE to soft-retire a subscription by id. ")
           .append("Always confirm with the user before POST or DELETE — these changes affect who receives live notifications.\n\n");
+        sb.append("### manage_inpatient_templates\n");
+        sb.append("Create, read, update, and retire inpatient document templates (HTML with placeholder tokens). ")
+          .append("Types: InpatientDiagnosisCard (diagnosis & treatment cards) and InpatientLetter (covering letters, credit company letters, etc.). ")
+          .append("method: LIST | GET | POST | PUT | DELETE. ")
+          .append("LIST: browse templates by type and name. GET /{id}: retrieve a template including its full HTML contents. ")
+          .append("POST: create a new template (name, type, contents required). PUT: update name, type, contents, defaultTemplate, or autoGenerate flags. DELETE: soft-retire. ")
+          .append("InpatientLetter placeholders available in contents: {credit_company} {credit_company_address} {policy_no} {reference_no} {credit_limit} ")
+          .append("{institution} {department} {doctor} {letter_date} {final_bill} {patient_name} {patient_age} {patient_sex} — plus all Inpatient Diagnosis Card placeholders ")
+          .append("({name} {age} {sex} {bht} {doa} {dod} {dx} {past-dx} {allergies} {rx} {drx} {ix} {procedures} {routine-medicines} vitals). ")
+          .append("If an admission has multiple credit companies, the user picks one on the inward_letters page before generating. ")
+          .append("Always confirm with the user before POST, PUT, or DELETE — these templates appear on the inpatient dashboard Documents page.\n\n");
 
         sb.append("## How to Use the Tools\n");
         sb.append("- When a user describes a problem or asks why something behaves a certain way, search the source code first.\n");

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -63,6 +63,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
+        resources.add(com.divudi.ws.inward.InwardDocumentTemplateApi.class);
         resources.add(com.divudi.ws.inward.InwardPriceAdjustmentApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomCategoryApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -164,6 +164,14 @@ public class CapabilityStatementResource {
                         + "POST returns HTTP 409 with existing id when a duplicate name already exists.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Inward Document Templates", "/api/inward/document-templates",
+                        "Manage inpatient document templates (HTML templates with placeholders). "
+                        + "Supports types: InpatientDiagnosisCard, InpatientLetter. "
+                        + "Optional query params: type (filter by type), query (name search), size. "
+                        + "GET /{id} includes full contents field. "
+                        + "POST/PUT fields: name, type, contents (HTML with placeholders), defaultTemplate, autoGenerate.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Inward Room Facility Charges", "/api/inward/room-facility-charges",
                         "Manage inward room facility charges / room fees (backs /inward/inward_room_facility.xhtml). "
                         + "Supports optional filters roomId and roomCategoryId. "

--- a/src/main/java/com/divudi/ws/inward/InwardDocumentTemplateApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardDocumentTemplateApi.java
@@ -244,6 +244,9 @@ public class InwardDocumentTemplateApi {
             }
             if (body.containsKey("type")) {
                 String typeStr = asString(body.get("type"));
+                if (typeStr == null || typeStr.trim().isEmpty()) {
+                    return errorResponse("type cannot be empty", 400);
+                }
                 try {
                     DocumentTemplateType newType = DocumentTemplateType.valueOf(typeStr.trim());
                     if (!INPATIENT_TYPES.contains(newType)) return errorResponse("type must be InpatientDiagnosisCard or InpatientLetter", 400);

--- a/src/main/java/com/divudi/ws/inward/InwardDocumentTemplateApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardDocumentTemplateApi.java
@@ -1,0 +1,381 @@
+package com.divudi.ws.inward;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.clinical.DocumentTemplateType;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.clinical.DocumentTemplate;
+import com.divudi.core.facade.DocumentTemplateFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API for inpatient document template management (InpatientDiagnosisCard,
+ * InpatientLetter, and any future inpatient DocumentTemplateType values).
+ *
+ * All endpoints require the Finance API key header.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Path("inward/document-templates")
+@RequestScoped
+public class InwardDocumentTemplateApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private DocumentTemplateFacade documentTemplateFacade;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    private static final List<DocumentTemplateType> INPATIENT_TYPES = Arrays.asList(
+            DocumentTemplateType.InpatientDiagnosisCard,
+            DocumentTemplateType.InpatientLetter
+    );
+
+    // =========================================================================
+    // GET /api/inward/document-templates
+    // =========================================================================
+
+    /**
+     * List inpatient document templates.
+     * Optional query params: type (InpatientDiagnosisCard | InpatientLetter),
+     * query (name search), size (max results, default 200).
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String typeParam = param("type");
+            String query = param("query");
+            int size = intParam("size", 200, 1, 1000);
+
+            DocumentTemplateType filterType = null;
+            if (typeParam != null && !typeParam.trim().isEmpty()) {
+                try {
+                    filterType = DocumentTemplateType.valueOf(typeParam.trim());
+                    if (!INPATIENT_TYPES.contains(filterType)) {
+                        return errorResponse("type must be one of: InpatientDiagnosisCard, InpatientLetter", 400);
+                    }
+                } catch (IllegalArgumentException e) {
+                    return errorResponse("Unknown type: " + typeParam + ". Valid values: InpatientDiagnosisCard, InpatientLetter", 400);
+                }
+            }
+
+            StringBuilder jpql = new StringBuilder(
+                    "select t from DocumentTemplate t where t.retired = false");
+            Map<String, Object> params = new HashMap<>();
+
+            if (filterType != null) {
+                jpql.append(" and t.type = :type");
+                params.put("type", filterType);
+            } else {
+                jpql.append(" and t.type in :types");
+                params.put("types", INPATIENT_TYPES);
+            }
+
+            if (query != null && !query.trim().isEmpty()) {
+                jpql.append(" and upper(t.name) like :q");
+                params.put("q", "%" + query.trim().toUpperCase() + "%");
+            }
+            jpql.append(" order by t.type, t.name");
+
+            List<DocumentTemplate> items = documentTemplateFacade.findByJpql(jpql.toString(), params, size);
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (items != null) {
+                for (DocumentTemplate t : items) {
+                    payload.add(toDto(t, false));
+                }
+            }
+            return successResponse(payload);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // GET /api/inward/document-templates/{id}
+    // =========================================================================
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            DocumentTemplate t = documentTemplateFacade.find(id);
+            if (t == null || t.isRetired()) {
+                return errorResponse("Document template not found: " + id, 404);
+            }
+            if (!INPATIENT_TYPES.contains(t.getType())) {
+                return errorResponse("Document template not found: " + id, 404);
+            }
+            return successResponse(toDto(t, true));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // POST /api/inward/document-templates
+    // =========================================================================
+
+    /**
+     * Create a new inpatient document template.
+     * Body: { "name": "...", "type": "InpatientLetter|InpatientDiagnosisCard",
+     * "contents": "...", "defaultTemplate": false, "autoGenerate": false }
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Map<?, ?> body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+
+            String name = asString(body.get("name"));
+            if (name == null || name.trim().isEmpty()) return errorResponse("name is required", 400);
+            name = name.trim();
+
+            String typeStr = asString(body.get("type"));
+            if (typeStr == null || typeStr.trim().isEmpty()) return errorResponse("type is required", 400);
+            DocumentTemplateType type;
+            try {
+                type = DocumentTemplateType.valueOf(typeStr.trim());
+                if (!INPATIENT_TYPES.contains(type)) {
+                    return errorResponse("type must be one of: InpatientDiagnosisCard, InpatientLetter", 400);
+                }
+            } catch (IllegalArgumentException e) {
+                return errorResponse("Unknown type: " + typeStr + ". Valid values: InpatientDiagnosisCard, InpatientLetter", 400);
+            }
+
+            DocumentTemplate t = new DocumentTemplate();
+            t.setName(name);
+            t.setType(type);
+            String contents = asString(body.get("contents"));
+            if (contents != null) t.setContents(contents);
+            if (body.containsKey("defaultTemplate")) t.setDefaultTemplate(Boolean.parseBoolean(asString(body.get("defaultTemplate"))));
+            if (body.containsKey("autoGenerate")) t.setAutoGenerate(Boolean.parseBoolean(asString(body.get("autoGenerate"))));
+            t.setCreater(user);
+            t.setCreatedAt(new Date());
+            documentTemplateFacade.create(t);
+
+            return Response.status(201).entity(gson.toJson(successData(toDto(t, true)))).build();
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // PUT /api/inward/document-templates/{id}
+    // =========================================================================
+
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            DocumentTemplate t = documentTemplateFacade.find(id);
+            if (t == null || t.isRetired()) return errorResponse("Document template not found: " + id, 404);
+            if (!INPATIENT_TYPES.contains(t.getType())) return errorResponse("Document template not found: " + id, 404);
+
+            Map<?, ?> body = parseBody(requestBody);
+            if (body == null) return errorResponse("Request body is required", 400);
+
+            if (body.containsKey("name")) {
+                String name = asString(body.get("name"));
+                if (name == null || name.trim().isEmpty()) return errorResponse("name cannot be empty", 400);
+                t.setName(name.trim());
+            }
+            if (body.containsKey("type")) {
+                String typeStr = asString(body.get("type"));
+                try {
+                    DocumentTemplateType newType = DocumentTemplateType.valueOf(typeStr.trim());
+                    if (!INPATIENT_TYPES.contains(newType)) return errorResponse("type must be InpatientDiagnosisCard or InpatientLetter", 400);
+                    t.setType(newType);
+                } catch (IllegalArgumentException e) {
+                    return errorResponse("Unknown type: " + typeStr, 400);
+                }
+            }
+            if (body.containsKey("contents")) {
+                t.setContents(asString(body.get("contents")));
+            }
+            if (body.containsKey("defaultTemplate")) {
+                t.setDefaultTemplate(Boolean.parseBoolean(asString(body.get("defaultTemplate"))));
+            }
+            if (body.containsKey("autoGenerate")) {
+                t.setAutoGenerate(Boolean.parseBoolean(asString(body.get("autoGenerate"))));
+            }
+
+            documentTemplateFacade.edit(t);
+            return successResponse(toDto(t, true));
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // DELETE /api/inward/document-templates/{id}
+    // =========================================================================
+
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retire(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            DocumentTemplate t = documentTemplateFacade.find(id);
+            if (t == null) return errorResponse("Document template not found: " + id, 404);
+            if (t.isRetired()) return errorResponse("Document template is already retired: " + id, 400);
+            if (!INPATIENT_TYPES.contains(t.getType())) return errorResponse("Document template not found: " + id, 404);
+
+            t.setRetired(true);
+            documentTemplateFacade.edit(t);
+
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("id", t.getId());
+            resp.put("retired", true);
+            return successResponse(resp);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Map<String, Object> toDto(DocumentTemplate t, boolean includeContents) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", t.getId());
+        row.put("name", t.getName());
+        row.put("type", t.getType() != null ? t.getType().name() : null);
+        row.put("defaultTemplate", t.isDefaultTemplate());
+        row.put("autoGenerate", t.isAutoGenerate());
+        row.put("createdAt", t.getCreatedAt());
+        if (includeContents) {
+            row.put("contents", t.getContents());
+        }
+        return row;
+    }
+
+    private Map<?, ?> parseBody(String body) {
+        if (body == null || body.trim().isEmpty()) return null;
+        try {
+            return gson.fromJson(body, Map.class);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
+    }
+
+    private String param(String name) {
+        return uriInfo.getQueryParameters().getFirst(name);
+    }
+
+    private int intParam(String name, int defaultValue, int min, int max) {
+        String v = param(name);
+        if (v == null || v.trim().isEmpty()) return defaultValue;
+        try {
+            int parsed = Integer.parseInt(v.trim());
+            return Math.min(Math.max(parsed, min), max);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private String asString(Object o) {
+        if (o == null) return null;
+        return o.toString();
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) return null;
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) return null;
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) return null;
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return Response.status(200).entity(gson.toJson(successData(data))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return response;
+    }
+}

--- a/src/main/webapp/emr/settings/document_template.xhtml
+++ b/src/main/webapp/emr/settings/document_template.xhtml
@@ -214,6 +214,40 @@
                                             </ul>
                                         </div>
                                     </div>
+                                    <div class="row mt-3">
+                                        <div class="col-12">
+                                            <h6 class="fw-bold text-success">Inpatient Letter Placeholders</h6>
+                                            <p class="small text-muted">All Inpatient Diagnosis Card placeholders also apply here, plus:</p>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <h6 class="fw-bold text-secondary">Credit Company</h6>
+                                            <ul class="list-unstyled small">
+                                                <li><code>{credit_company}</code> - Credit company name</li>
+                                                <li><code>{credit_company_address}</code> - Credit company address</li>
+                                                <li><code>{policy_no}</code> - Policy number</li>
+                                                <li><code>{reference_no}</code> - Reference number</li>
+                                                <li><code>{credit_limit}</code> - Credit limit</li>
+                                            </ul>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <h6 class="fw-bold text-secondary">Institution / Ward</h6>
+                                            <ul class="list-unstyled small">
+                                                <li><code>{institution}</code> - Hospital / institution name</li>
+                                                <li><code>{department}</code> - Ward / department name</li>
+                                                <li><code>{doctor}</code> - Admitting doctor name</li>
+                                                <li><code>{letter_date}</code> - Today's date (letter date)</li>
+                                            </ul>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <h6 class="fw-bold text-secondary">Billing</h6>
+                                            <ul class="list-unstyled small">
+                                                <li><code>{final_bill}</code> - Final bill / net total value for the admission</li>
+                                                <li><code>{patient_name}</code> - Patient name (alias of {name})</li>
+                                                <li><code>{patient_age}</code> - Patient age (alias of {age})</li>
+                                                <li><code>{patient_sex}</code> - Patient sex (alias of {sex})</li>
+                                            </ul>
+                                        </div>
+                                    </div>
                                 </p:panel>
                             </div>
                         </div>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -956,11 +956,21 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
-                                        value="Documents"
+                                        value="Uploads"
                                         ajax="false"
                                         rendered="#{webUserController.hasPrivilege('InwardDocumentUpload')}"
                                         action="#{admissionController.navigateToInpatientDocuments()}"
-                                        icon="fa fa-file-alt"
+                                        icon="fa fa-upload"
+                                        class="w-100">
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        value="Documents"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InpatientLetter')}"
+                                        action="#{admissionController.navigateToInpatientLetters()}"
+                                        icon="fa fa-file-text"
                                         class="w-100">
                                     </p:commandButton>
                                 </div>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -966,7 +966,7 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
-                                        value="Documents"
+                                        value="Letters"
                                         ajax="false"
                                         rendered="#{webUserController.hasPrivilege('InpatientLetter')}"
                                         action="#{admissionController.navigateToInpatientLetters()}"

--- a/src/main/webapp/inward/inward_administration.xhtml
+++ b/src/main/webapp/inward/inward_administration.xhtml
@@ -89,21 +89,47 @@
                                             <p:commandButton ajax="false" value="Inward Prices" class="w-100" action="/inward/?faces-redirect=true" ></p:commandButton>
                                         </div>
                                     </p:tab>
-                                    <p:tab title="Diagnosis Cards">
+                                    <p:tab title="Document Templates">
                                         <div class="d-grid gap-2">
-                                            <p:commandButton 
-                                                ajax="false" 
+                                            <h:outputText value="Diagnosis Cards" styleClass="fw-bold text-muted small mt-1"/>
+                                            <p:commandButton
+                                                ajax="false"
                                                 value="Add Diagnosis Card Template"
-                                                class="w-100" 
+                                                class="w-100"
+                                                action="#{documentTemplateController.navigateToAddDiagnosisCardTemplate()}" >
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="List Diagnosis Card Templates"
+                                                class="w-100"
+                                                action="#{documentTemplateController.navigateToListDiagnosisCardTemplates()}" >
+                                            </p:commandButton>
+                                            <h:outputText value="Letters" styleClass="fw-bold text-muted small mt-2"/>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Add Letter Template"
+                                                class="w-100"
+                                                action="#{documentTemplateController.navigateToAddLetterTemplate()}" >
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="List Letter Templates"
+                                                class="w-100"
+                                                action="#{documentTemplateController.navigateToListLetterTemplates()}" >
+                                            </p:commandButton>
+                                            <h:outputText value="Legacy Uploaded Templates" styleClass="fw-bold text-muted small mt-2"/>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Add Uploaded Diagnosis Card Template"
+                                                class="w-100 ui-button-secondary"
                                                 action="#{uploadController.toAddNewDiagnosisCardTemplateUpload()}" >
-                                            </p:commandButton> 
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                value="Uploaded Diagnosis Card Templates"
-                                                class="w-100" 
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="List Uploaded Diagnosis Card Templates"
+                                                class="w-100 ui-button-secondary"
                                                 action="#{uploadController.toListDiagnosisCardUploads()}" >
                                             </p:commandButton>
-
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/inward/inward_letters.xhtml
+++ b/src/main/webapp/inward/inward_letters.xhtml
@@ -1,0 +1,327 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formLetters">
+                    <p:growl id="msgLetter"/>
+
+                    <!-- Navigation bar -->
+                    <div class="row mb-2">
+                        <div class="col-12 px-4 d-flex gap-2">
+                            <p:commandButton
+                                value="Back to Inpatient Dashboard"
+                                ajax="false"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-warning">
+                                <f:setPropertyActionListener
+                                    value="#{inpatientClinicalDataController.parentAdmission}"
+                                    target="#{admissionController.current}" />
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Clinical Data"
+                                ajax="false"
+                                action="#{inpatientClinicalDataController.navigateToEncounterClinicalData()}"
+                                icon="fa fa-stethoscope"
+                                class="ui-button-secondary">
+                            </p:commandButton>
+                        </div>
+                    </div>
+
+                    <!-- Patient info strip -->
+                    <div class="row mx-2 mb-2">
+                        <div class="col-12">
+                            <p:panel>
+                                <div class="row">
+                                    <div class="col-md-3">
+                                        <p:outputLabel value="Patient: " styleClass="fw-bold"/>
+                                        <h:outputText value="#{inpatientClinicalDataController.parentAdmission.patient.person.nameWithTitle}"/>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel value="BHT: " styleClass="fw-bold"/>
+                                        <h:outputText value="#{inpatientClinicalDataController.parentAdmission.bhtNo}"/>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel value="Age/Sex: " styleClass="fw-bold"/>
+                                        <h:outputText value="#{inpatientClinicalDataController.parentAdmission.patient.person.ageAsString} / #{inpatientClinicalDataController.parentAdmission.patient.person.sex}"/>
+                                    </div>
+                                    <div class="col-md-2">
+                                        <p:outputLabel value="Admitted: " styleClass="fw-bold"/>
+                                        <h:outputText value="#{inpatientClinicalDataController.parentAdmission.dateOfAdmission}">
+                                            <f:convertDateTime pattern="dd/MM/yyyy"/>
+                                        </h:outputText>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <p:outputLabel value="Ward: " styleClass="fw-bold"/>
+                                        <h:outputText value="#{inpatientClinicalDataController.parentAdmission.department.name}"/>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </div>
+                    </div>
+
+                    <!-- Main two-panel layout -->
+                    <div class="row mx-2">
+
+                        <!-- Left panel: template selector + saved letters list -->
+                        <div class="col-md-4">
+
+                            <!-- Generate new letter -->
+                            <p:panel class="mb-2">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fa fa-envelope"/>
+                                    <h:outputText value=" Generate New Letter" class="mx-2"/>
+                                </f:facet>
+
+                                <h:panelGroup layout="block" styleClass="row mb-2"
+                                    rendered="#{not empty inpatientClinicalDataController.encounterCreditCompanies}">
+                                    <div class="col-12">
+                                        <p:outputLabel value="Credit Company" class="form-label fw-bold"/>
+                                        <p:selectOneMenu
+                                            id="somCreditCompany"
+                                            value="#{inpatientClinicalDataController.selectedEncounterCreditCompanyId}"
+                                            styleClass="w-100">
+                                            <f:selectItem itemLabel="-- Select Credit Company --" itemValue="#{null}"/>
+                                            <f:selectItems
+                                                value="#{inpatientClinicalDataController.encounterCreditCompanies}"
+                                                var="ecc"
+                                                itemLabel="#{ecc.institution.name} (#{ecc.policyNo})"
+                                                itemValue="#{ecc.id}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </h:panelGroup>
+
+                                <div class="row mb-2">
+                                    <div class="col-12">
+                                        <p:outputLabel value="Select Template" class="form-label fw-bold"/>
+                                    </div>
+                                </div>
+                                <div class="row mb-2">
+                                    <div class="col-10">
+                                        <p:selectOneMenu
+                                            id="somLetterTemplates"
+                                            value="#{inpatientClinicalDataController.selectedDocumentTemplate}"
+                                            styleClass="w-100">
+                                            <f:selectItem itemLabel="-- Select Template --" itemValue=""/>
+                                            <f:selectItems
+                                                value="#{inpatientClinicalDataController.letterTemplates}"
+                                                var="letterTpl"
+                                                itemLabel="#{letterTpl.name}"
+                                                itemValue="#{letterTpl}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                    <div class="col-2">
+                                        <p:commandButton
+                                            id="btnRefreshTemplates"
+                                            icon="fas fa-sync-alt"
+                                            title="Refresh templates"
+                                            class="ui-button-info"
+                                            process="btnRefreshTemplates"
+                                            update="somLetterTemplates"
+                                            action="#{inpatientClinicalDataController.refreshLetterTemplates}">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                                <div class="row mb-2">
+                                    <div class="col-12">
+                                        <p:commandButton
+                                            id="btnGenerateFromTemplate"
+                                            value="Generate from Template"
+                                            icon="fa fa-file-text"
+                                            title="Generate letter by substituting placeholders in the selected template"
+                                            class="ui-button-secondary w-100"
+                                            process="btnGenerateFromTemplate somLetterTemplates somCreditCompany"
+                                            update="lstSavedLetters gpLetterDoc msgLetter"
+                                            action="#{inpatientClinicalDataController.generateAndAddDocumentFromTemplate}">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-12">
+                                        <p:commandButton
+                                            id="btnGenerateAi"
+                                            value="Generate with AI"
+                                            icon="fa fa-magic"
+                                            title="Generate letter using AI (uses template as instructions if selected)"
+                                            class="ui-button-info w-100"
+                                            process="btnGenerateAi somLetterTemplates somCreditCompany"
+                                            update="lstSavedLetters gpLetterDoc msgLetter"
+                                            action="#{inpatientClinicalDataController.generateLetterWithAi}"
+                                            onstart="PF('aiLetterBlockUI').show();"
+                                            oncomplete="PF('aiLetterBlockUI').hide();">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </p:panel>
+
+                            <!-- Saved letters list -->
+                            <p:panel>
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fa fa-list"/>
+                                    <h:outputText value=" Saved Letters" class="mx-2"/>
+                                </f:facet>
+                                <p:selectOneListbox
+                                    id="lstSavedLetters"
+                                    value="#{inpatientClinicalDataController.encounterReferral}"
+                                    styleClass="w-100"
+                                    style="min-height: 200px;">
+                                    <f:selectItems
+                                        value="#{inpatientClinicalDataController.encounterDocuments}"
+                                        var="doc"
+                                        itemLabel="#{doc.stringValue}"
+                                        itemValue="#{doc}"/>
+                                    <p:ajax
+                                        process="lstSavedLetters"
+                                        update="gpLetterDoc"/>
+                                </p:selectOneListbox>
+                            </p:panel>
+
+                        </div>
+
+                        <!-- Right panel: viewer / editor + actions -->
+                        <div class="col-md-8">
+                            <p:panel id="gpLetterDoc">
+                                <f:facet name="header">
+                                    <div class="d-flex justify-content-between align-items-center w-100">
+                                        <h:outputText
+                                            id="txtLetterName"
+                                            rendered="#{inpatientClinicalDataController.encounterReferral.stringValue ne null}"
+                                            value="#{inpatientClinicalDataController.encounterReferral.stringValue}"
+                                            styleClass="fw-bold"/>
+                                        <h:outputText
+                                            rendered="#{inpatientClinicalDataController.encounterReferral.stringValue eq null}"
+                                            value="No letter selected"
+                                            styleClass="text-muted"/>
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                id="btnToggleEdit"
+                                                value="#{inpatientClinicalDataController.editingDiagnosisCard ? 'View' : 'Edit'}"
+                                                icon="#{inpatientClinicalDataController.editingDiagnosisCard ? 'pi pi-eye' : 'pi pi-pencil'}"
+                                                class="ui-button-secondary"
+                                                action="#{inpatientClinicalDataController.toggleEditingDiagnosisCard()}"
+                                                process="@this"
+                                                update="gpLetterDoc"
+                                                title="Toggle between view and edit mode">
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                id="btnSaveLetter"
+                                                value="Save"
+                                                icon="pi pi-save"
+                                                class="ui-button-warning"
+                                                action="#{inpatientClinicalDataController.saveEncounterReferral()}"
+                                                process="btnSaveLetter txeLetterEdit"
+                                                update="lstSavedLetters gpLetterDoc msgLetter"
+                                                title="Save changes to this letter">
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                id="btnDeleteLetter"
+                                                value="Delete"
+                                                icon="pi pi-trash"
+                                                class="ui-button-danger"
+                                                action="#{inpatientClinicalDataController.removeEncounterReferral()}"
+                                                process="btnDeleteLetter"
+                                                update="lstSavedLetters gpLetterDoc msgLetter"
+                                                onclick="if(!confirm('Are you sure you want to delete this letter?')) return false;"
+                                                title="Delete this letter">
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                id="btnPrintLetter"
+                                                ajax="false"
+                                                value="Print"
+                                                icon="pi pi-print"
+                                                class="ui-button-info"
+                                                title="Print this letter">
+                                                <p:printer target="pnlLetterView"/>
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                id="btnDownloadLetter"
+                                                ajax="false"
+                                                value="Download PDF"
+                                                icon="pi pi-file-pdf"
+                                                class="ui-button-success"
+                                                title="Download as PDF">
+                                                <p:fileDownload value="#{inpatientClinicalDataController.downloadAsPdf()}"/>
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+                                </f:facet>
+
+                                <!-- Rendered HTML view (default) -->
+                                <h:panelGroup id="pnlLetterView"
+                                    rendered="#{inpatientClinicalDataController.encounterReferral.lobValue ne null and not inpatientClinicalDataController.editingDiagnosisCard}"
+                                    layout="block"
+                                    style="width: 100%; min-height: 500px; border: 1px solid #dee2e6; padding: 15px; background: #fff; overflow: auto;">
+                                    <h:outputText id="txeLetterContent" value="#{inpatientClinicalDataController.encounterReferral.lobValue}" escape="false"/>
+                                </h:panelGroup>
+
+                                <!-- WYSIWYG editor using contenteditable -->
+                                <h:panelGroup
+                                    rendered="#{inpatientClinicalDataController.encounterReferral.lobValue ne null and inpatientClinicalDataController.editingDiagnosisCard}"
+                                    layout="block">
+                                    <div id="letterEditToolbar" class="mb-2 d-flex gap-1 flex-wrap p-2" style="background:#f0f0f0; border:1px solid #dee2e6; border-radius:4px;">
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('bold')" title="Bold"><b>B</b></button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('italic')" title="Italic"><i>I</i></button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('underline')" title="Underline"><u>U</u></button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('insertUnorderedList')" title="Bullet List">&#8226; List</button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('insertOrderedList')" title="Numbered List">1. List</button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('undo')" title="Undo">Undo</button>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="document.execCommand('redo')" title="Redo">Redo</button>
+                                    </div>
+                                    <div id="letterEditArea" contenteditable="true"
+                                         style="width:100%; min-height:500px; border:1px solid #dee2e6; padding:15px; background:#fff; overflow:auto; outline:none;">
+                                    </div>
+                                    <h:inputHidden id="txeLetterEdit" value="#{inpatientClinicalDataController.encounterReferral.lobValue}"/>
+                                    <script type="text/javascript">
+                                        //<![CDATA[
+                                        (function() {
+                                            var editArea = document.getElementById('letterEditArea');
+                                            var hiddenInput = document.querySelector("[id$='txeLetterEdit']");
+                                            if (editArea && hiddenInput) {
+                                                editArea.innerHTML = hiddenInput.value;
+                                                editArea.addEventListener('input', function() {
+                                                    hiddenInput.value = editArea.innerHTML;
+                                                });
+                                                editArea.addEventListener('blur', function() {
+                                                    hiddenInput.value = editArea.innerHTML;
+                                                });
+                                            }
+                                        })();
+                                        //]]>
+                                    </script>
+                                </h:panelGroup>
+
+                                <h:panelGroup
+                                    rendered="#{inpatientClinicalDataController.encounterReferral.lobValue eq null}"
+                                    layout="block"
+                                    styleClass="text-center py-5">
+                                    <h:outputText value="No letter selected" styleClass="text-muted fs-5"/>
+                                    <br/>
+                                    <h:outputText value="Select a saved letter from the list, or generate a new one using a template." styleClass="text-muted"/>
+                                </h:panelGroup>
+
+                            </p:panel>
+                        </div>
+
+                    </div>
+
+                    <p:blockUI block="formLetters" widgetVar="aiLetterBlockUI">
+                        <div style="text-align:center; padding:20px;">
+                            <i class="pi pi-spin pi-spinner" style="font-size:2rem;"></i>
+                            <div style="margin-top:10px; font-weight:bold;">Generating letter with AI...</div>
+                            <div style="margin-top:5px; color:#666;">This may take a few seconds</div>
+                        </div>
+                    </p:blockUI>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_letters.xhtml
+++ b/src/main/webapp/inward/inward_letters.xhtml
@@ -137,7 +137,7 @@
                                             icon="fa fa-file-text"
                                             title="Generate letter by substituting placeholders in the selected template"
                                             class="ui-button-secondary w-100"
-                                            process="btnGenerateFromTemplate somLetterTemplates somCreditCompany"
+                                            process="btnGenerateFromTemplate somLetterTemplates #{not empty inpatientClinicalDataController.encounterCreditCompanies ? 'somCreditCompany' : ''}"
                                             update="lstSavedLetters gpLetterDoc msgLetter"
                                             action="#{inpatientClinicalDataController.generateAndAddDocumentFromTemplate}">
                                         </p:commandButton>
@@ -151,7 +151,7 @@
                                             icon="fa fa-magic"
                                             title="Generate letter using AI (uses template as instructions if selected)"
                                             class="ui-button-info w-100"
-                                            process="btnGenerateAi somLetterTemplates somCreditCompany"
+                                            process="btnGenerateAi somLetterTemplates #{not empty inpatientClinicalDataController.encounterCreditCompanies ? 'somCreditCompany' : ''}"
                                             update="lstSavedLetters gpLetterDoc msgLetter"
                                             action="#{inpatientClinicalDataController.generateLetterWithAi}"
                                             onstart="PF('aiLetterBlockUI').show();"


### PR DESCRIPTION
## Summary
- Adds a new `InpatientLetter` document template type with admin UI for managing templates (`document_template.xhtml`), including a documented placeholder reference for inpatient letters.
- Adds `inward_letters.xhtml`, a page to generate, view/edit, save, print, and download covering letters for an admission, from either a plain template substitution or AI-assisted generation.
- Adds `InwardDocumentTemplateApi`, a REST endpoint for managing inpatient letter templates externally.
- Integrates inpatient letter template management into the AI chat tools (`AnthropicApiService`), including module registration in `ApplicationConfig` / `CapabilityStatementResource`.
- Adds a credit-company selector dropdown on the letters page for admissions linked to more than one credit company (`EncounterCreditCompany`), so the correct company's placeholders are substituted.
- Adds new placeholders: `{final_bill}` (admission net total), and `{patient_name}` / `{patient_age}` / `{patient_sex}` (aliases of name/age/sex).

Closes #21168

## Test plan
- [x] Created sample "normal" and "AI-assisted" credit letter templates via the new REST API and confirmed via GET that they were stored correctly.
- [x] Verified end-to-end on the `inward_letters.xhtml` page: template selection, credit-company dropdown (for an admission with multiple linked credit companies), generation from template, AI-assisted generation, edit/save, print, and PDF download.
- [x] Verified `{final_bill}`, `{patient_name}`, `{patient_age}`, `{patient_sex}` placeholders substitute correctly.
- [x] `mvn -o compile` succeeds with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Inward Letters** screen with credit-company–aware template selection, generate-from-template, and **AI-generated** letters, including save, print, and download.
  * Extended template administration to support **Inpatient Letters** (new template type), including inpatient letter placeholder tokens.
  * Added a secured REST API for inpatient document template **CRUD/retirement** and updated the published capability statement.
  * Introduced the **Generate Inpatient Letters** privilege and navigation wiring.

* **UI Updates**
  * Renamed the Documents button to **Uploads** in the admission profile page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->