### PR TITLE
feat(inward): show medication administrations on Ward Medicines Timeline

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -15,6 +15,7 @@ import com.divudi.bean.common.SessionController;
 
 import com.divudi.bean.pharmacy.PharmacySaleController;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.MedicationAdministrationStatus;
 import com.divudi.core.data.SymanticType;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
 import com.divudi.core.data.clinical.DocumentTemplateType;
@@ -34,6 +35,7 @@ import com.divudi.core.entity.clinical.ClinicalEntity;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.entity.clinical.DocumentTemplate;
 import com.divudi.core.entity.clinical.ItemUsage;
+import com.divudi.core.entity.clinical.MedicationAdministrationRecord;
 import com.divudi.core.entity.clinical.Prescription;
 import com.divudi.core.entity.clinical.PrescriptionTemplate;
 import com.divudi.core.entity.pharmacy.MeasurementUnit;
@@ -80,6 +82,7 @@ import com.divudi.core.util.CommonFunctions;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.entity.AiMessage;
 import com.divudi.service.AnthropicApiService;
+import org.primefaces.PrimeFaces;
 import org.primefaces.event.CaptureEvent;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.file.UploadedFile;
@@ -157,6 +160,8 @@ public class InpatientClinicalDataController implements Serializable {
     com.divudi.bean.pharmacy.PharmacySaleBhtController pharmacySaleBhtController;
     @Inject
     com.divudi.bean.common.NotificationController notificationController;
+    @Inject
+    private MedicationAdministrationController medicationAdministrationController;
 
     /**
      * Properties
@@ -237,9 +242,45 @@ public class InpatientClinicalDataController implements Serializable {
     private MeasurementUnit newDoseUnit;
     private MeasurementUnit newFrequencyUnit;
 
-    private TimelineModel<ClinicalFindingValue, String> wardMedicineTimelineModel;
+    private TimelineModel<WardMedicineTimelineEntry, String> wardMedicineTimelineModel;
     private ClinicalFindingValue selectedTimelineMedicine;
+    private MedicationAdministrationRecord selectedTimelineAdministration;
     private boolean hasWardMedicineTimelineEvents;
+
+    /**
+     * A single entry on the Ward Medicines Timeline (#21488): either a range
+     * bar for a prescription's active period, or a point marker for a single
+     * {@link MedicationAdministrationRecord} given/refused/held against it.
+     */
+    public static class WardMedicineTimelineEntry implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ClinicalFindingValue medicine;
+        private final MedicationAdministrationRecord administration;
+
+        public WardMedicineTimelineEntry(ClinicalFindingValue medicine) {
+            this.medicine = medicine;
+            this.administration = null;
+        }
+
+        public WardMedicineTimelineEntry(MedicationAdministrationRecord administration) {
+            this.medicine = null;
+            this.administration = administration;
+        }
+
+        public ClinicalFindingValue getMedicine() {
+            return medicine;
+        }
+
+        public MedicationAdministrationRecord getAdministration() {
+            return administration;
+        }
+
+        public boolean isAdministrationEvent() {
+            return administration != null;
+        }
+    }
 
     private List<ItemUsage> currentEncounterMedicines;
     private List<ItemUsage> currentEncounterDiagnosis;
@@ -2366,6 +2407,8 @@ public class InpatientClinicalDataController implements Serializable {
         this.current = admission;
         this.patient = admission.getPatient();
         this.selectedTimelineMedicine = null;
+        this.selectedTimelineAdministration = null;
+        medicationAdministrationController.resetAdministrationHistoryCache();
         fillAdmissionWardMedicines(admission);
         buildWardMedicineTimeline();
         return "/inward/inward_ward_medicines_timeline?faces-redirect=true";
@@ -2408,8 +2451,8 @@ public class InpatientClinicalDataController implements Serializable {
             LocalDateTime end = endDate.toInstant()
                     .atZone(ZoneId.systemDefault()).toLocalDateTime();
 
-            TimelineEvent<ClinicalFindingValue> event = TimelineEvent.<ClinicalFindingValue>builder()
-                    .data(cfv)
+            TimelineEvent<WardMedicineTimelineEntry> event = TimelineEvent.<WardMedicineTimelineEntry>builder()
+                    .data(new WardMedicineTimelineEntry(cfv))
                     .startDate(start)
                     .endDate(end)
                     .group(groupId)
@@ -2417,17 +2460,82 @@ public class InpatientClinicalDataController implements Serializable {
                     .build();
             wardMedicineTimelineModel.add(event);
             hasWardMedicineTimelineEvents = true;
+
+            for (MedicationAdministrationRecord mar : medicationAdministrationController.getAdministrationHistory(rx)) {
+                if (mar.getAdministeredAt() == null) {
+                    continue;
+                }
+                LocalDateTime administeredAt = mar.getAdministeredAt().toInstant()
+                        .atZone(ZoneId.systemDefault()).toLocalDateTime();
+                TimelineEvent<WardMedicineTimelineEntry> marEvent = TimelineEvent.<WardMedicineTimelineEntry>builder()
+                        .data(new WardMedicineTimelineEntry(mar))
+                        .startDate(administeredAt)
+                        .type("point")
+                        .group(groupId)
+                        .styleClass(administrationStyleClass(mar.getStatus()))
+                        .title(administrationTitle(mar))
+                        .build();
+                wardMedicineTimelineModel.add(marEvent);
+            }
         }
     }
 
-    public void onTimelineSelect(TimelineSelectEvent<ClinicalFindingValue> e) {
-        if (e != null && e.getTimelineEvent() != null) {
-            selectedTimelineMedicine = e.getTimelineEvent().getData();
+    private String administrationStyleClass(MedicationAdministrationStatus status) {
+        if (status == null) {
+            return "mar-given";
+        }
+        switch (status) {
+            case REFUSED:
+                return "mar-refused";
+            case HELD:
+                return "mar-held";
+            default:
+                return "mar-given";
         }
     }
 
-    public TimelineModel<ClinicalFindingValue, String> getWardMedicineTimelineModel() {
+    private String administrationTitle(MedicationAdministrationRecord mar) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(mar.getStatus() != null ? mar.getStatus().getLabel() : "Administered");
+        if (mar.getQty() != null && mar.getItem() != null) {
+            sb.append(" - ").append(mar.getQty()).append(" ").append(mar.getItem().getName());
+        }
+        if (mar.getItemBatch() != null && mar.getItemBatch().getBatchNo() != null) {
+            sb.append(" (Batch ").append(mar.getItemBatch().getBatchNo()).append(")");
+        }
+        if (mar.getAdministeredBy() != null && mar.getAdministeredBy().getPerson() != null
+                && mar.getAdministeredBy().getPerson().getName() != null) {
+            sb.append(" by ").append(mar.getAdministeredBy().getPerson().getName());
+        }
+        return sb.toString();
+    }
+
+    public void onTimelineSelect(TimelineSelectEvent<WardMedicineTimelineEntry> e) {
+        if (e == null || e.getTimelineEvent() == null || e.getTimelineEvent().getData() == null) {
+            return;
+        }
+        WardMedicineTimelineEntry entry = e.getTimelineEvent().getData();
+        if (entry.isAdministrationEvent()) {
+            selectedTimelineAdministration = entry.getAdministration();
+            selectedTimelineMedicine = null;
+            PrimeFaces.current().executeScript("PF('dlgAdministrationDetail').show();");
+        } else {
+            selectedTimelineMedicine = entry.getMedicine();
+            selectedTimelineAdministration = null;
+            PrimeFaces.current().executeScript("PF('dlgMedicineDetail').show();");
+        }
+    }
+
+    public TimelineModel<WardMedicineTimelineEntry, String> getWardMedicineTimelineModel() {
         return wardMedicineTimelineModel;
+    }
+
+    public MedicationAdministrationRecord getSelectedTimelineAdministration() {
+        return selectedTimelineAdministration;
+    }
+
+    public void setSelectedTimelineAdministration(MedicationAdministrationRecord selectedTimelineAdministration) {
+        this.selectedTimelineAdministration = selectedTimelineAdministration;
     }
 
     public ClinicalFindingValue getSelectedTimelineMedicine() {

--- a/src/main/webapp/inward/inward_ward_medicines_timeline.xhtml
+++ b/src/main/webapp/inward/inward_ward_medicines_timeline.xhtml
@@ -24,6 +24,27 @@
                         border-color: #bd2130 !important;
                         color: #fff !important;
                     }
+                    .vis-item.mar-given,
+                    .vis-item.mar-refused,
+                    .vis-item.mar-held {
+                        border-radius: 50%;
+                        width: 12px !important;
+                        height: 12px !important;
+                        padding: 0;
+                        cursor: pointer;
+                    }
+                    .vis-item.mar-given {
+                        background-color: #007bff !important;
+                        border-color: #0056b3 !important;
+                    }
+                    .vis-item.mar-refused {
+                        background-color: #dc3545 !important;
+                        border-color: #bd2130 !important;
+                    }
+                    .vis-item.mar-held {
+                        background-color: #ffc107 !important;
+                        border-color: #d39e00 !important;
+                    }
                 </style>
                 <h:form id="formTimeline">
                     <div class="row">
@@ -53,12 +74,18 @@
                                         <span class="badge p-2 mr-2" style="background-color: #28a745; color: #fff;">Active</span>
                                         <span class="badge p-2 mr-2" style="background-color: #6c757d; color: #fff;">Expired (Duration)</span>
                                         <span class="badge p-2 mr-2" style="background-color: #dc3545; color: #fff;">Omitted</span>
+                                        <span class="badge p-2 mr-2" style="background-color: #007bff; color: #fff; border-radius: 50%;">&#160;</span>
+                                        <span class="mr-3">Given</span>
+                                        <span class="badge p-2 mr-2" style="background-color: #ffc107; color: #fff; border-radius: 50%;">&#160;</span>
+                                        <span class="mr-3">Held</span>
+                                        <span class="badge p-2 mr-2" style="background-color: #dc3545; color: #fff; border-radius: 50%;">&#160;</span>
+                                        <span class="mr-3">Refused</span>
                                     </div>
 
                                     <h:panelGroup layout="block" rendered="#{inpatientClinicalDataController.hasWardMedicineTimelineEvents}">
                                         <p:timeline id="wardTimeline"
                                                     value="#{inpatientClinicalDataController.wardMedicineTimelineModel}"
-                                                    var="cfv"
+                                                    var="entry"
                                                     zoomable="true"
                                                     moveable="true"
                                                     stackEvents="true"
@@ -66,9 +93,9 @@
                                                     style="width: 100%; min-height: 300px;">
                                             <p:ajax event="select"
                                                     listener="#{inpatientClinicalDataController.onTimelineSelect}"
-                                                    update="panelMedicineDetail"
-                                                    oncomplete="PF('dlgMedicineDetail').show()" />
-                                            <h:outputText value="#{cfv.prescription.formattedPrescriptionWithoutIndoorOutdoor}" />
+                                                    update="panelMedicineDetail panelAdministrationDetail" />
+                                            <h:outputText value="#{entry.medicine.prescription.formattedPrescriptionWithoutIndoorOutdoor}"
+                                                          rendered="#{not entry.administrationEvent}" />
                                         </p:timeline>
                                     </h:panelGroup>
 
@@ -169,6 +196,71 @@
                                             <td class="font-weight-bold">Omission Reason:</td>
                                             <td>
                                                 <h:outputText value="#{inpatientClinicalDataController.selectedTimelineMedicine.prescription.omissionReason}" />
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                </table>
+                            </h:panelGroup>
+                        </div>
+                    </p:dialog>
+
+                    <p:dialog id="panelAdministrationDetail"
+                             header="Medicine Administration"
+                             widgetVar="dlgAdministrationDetail"
+                             modal="true"
+                             resizable="false"
+                             closable="true"
+                             width="500">
+                        <div class="p-3">
+                            <h:panelGroup layout="block" rendered="#{inpatientClinicalDataController.selectedTimelineAdministration != null}">
+                                <table class="table table-borderless mb-0">
+                                    <tr>
+                                        <td class="font-weight-bold" style="width: 40%;">Medicine:</td>
+                                        <td>
+                                            <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.item.name}" />
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="font-weight-bold">Status:</td>
+                                        <td>
+                                            <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.status.label}" />
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="font-weight-bold">Administered At:</td>
+                                        <td>
+                                            <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.administeredAt}">
+                                                <f:convertDateTime pattern="yyyy-MM-dd HH:mm" />
+                                            </h:outputText>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="font-weight-bold">Administered By:</td>
+                                        <td>
+                                            <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.administeredBy.person.name}" />
+                                        </td>
+                                    </tr>
+                                    <h:panelGroup layout="block" rendered="#{inpatientClinicalDataController.selectedTimelineAdministration.qty != null}">
+                                        <tr>
+                                            <td class="font-weight-bold">Quantity:</td>
+                                            <td>
+                                                <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.qty}" />
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                    <h:panelGroup layout="block" rendered="#{inpatientClinicalDataController.selectedTimelineAdministration.itemBatch != null}">
+                                        <tr>
+                                            <td class="font-weight-bold">Batch:</td>
+                                            <td>
+                                                <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.itemBatch.batchNo}" />
+                                            </td>
+                                        </tr>
+                                    </h:panelGroup>
+                                    <h:panelGroup layout="block" rendered="#{not empty inpatientClinicalDataController.selectedTimelineAdministration.comments}">
+                                        <tr>
+                                            <td class="font-weight-bold">Comments:</td>
+                                            <td>
+                                                <h:outputText value="#{inpatientClinicalDataController.selectedTimelineAdministration.comments}" />
                                             </td>
                                         </tr>
                                     </h:panelGroup>


### PR DESCRIPTION
## Summary
- Adds point markers to the Ward Medicines Timeline for each `MedicationAdministrationRecord` (Given/Held/Refused), shown alongside existing prescription range bars
- Adds a "Medicine Administration" detail dialog (status, time, administered by, quantity, batch) opened by clicking a marker
- Fixes "Administered By" to read `Staff.person.name` instead of the unset `Staff.name`
- Replaces a stale EL-conditional `oncomplete` on the timeline `select` event with `PrimeFaces.executeScript`-based dialog dispatch so both the prescription and administration dialogs reliably open

Closes #21488

## Test plan
- [x] Compiled and packaged (`mvn -q -o compile` / `package -DskipTests`), deployed to local Payara
- [x] Verified in browser (BHT/55356, Mrs. Niluka): clicking the blue "Given" marker on the Amoxicillin row opens the Medicine Administration dialog with correct Medicine, Status, Administered At, Administered By (Buddhika), Quantity, and Batch
- [x] Verified clicking the green "Amoxicillin 500 mg Every 8 Hours for 5 Days" prescription bar still opens the Prescription Details dialog correctly
- [x] Legend updated with Given/Held/Refused badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)