### PR TITLE
docs: capture PrimeFaces oncomplete timing, Staff.getName(), and Playwright vis-timeline learnings

### DIFF
--- a/developer_docs/dto/implementation-guidelines.md
+++ b/developer_docs/dto/implementation-guidelines.md
@@ -249,6 +249,43 @@ facade.findLightsByJpql(jpql, params)     // Missing TemporalType when using Dat
 6a. **`BigDecimal` constructor param for a `double`/`Double` column** → loud `IllegalArgumentException: argument type mismatch` at construction time (see § Numeric Type Mismatch)
 7. **Including cancellation details in list DTOs** → Unnecessary complexity and performance issues
 8. **Using derived/calculated properties in JPQL** → JPQL only supports persisted fields, not getter methods (see below)
+9. **Calling `Staff.getName()` to display a person's name** → returns the `Staff` entity's own (usually unset) `name` field, not the linked person's name — see below
+
+## 🚨 CRITICAL: `Staff.getName()` Does NOT Return the Person's Name
+
+`Staff` has its own `name` field (often `null`/unset) **separate** from the
+linked `Person` entity's `name`. Calling `staff.getName()` to display "who did
+this" silently renders blank or the literal string `"null"` — there is no
+exception, so this is easy to miss in code review.
+
+### ❌ WRONG
+
+```xhtml
+<h:outputText value="#{bean.selectedRecord.administeredBy.name}" />
+```
+```java
+sb.append(" by ").append(mar.getAdministeredBy().getName()); // "by null"
+```
+
+### ✅ CORRECT — go through `Person`
+
+```xhtml
+<h:outputText value="#{bean.selectedRecord.administeredBy.person.name}" />
+```
+```java
+if (mar.getAdministeredBy() != null && mar.getAdministeredBy().getPerson() != null
+        && mar.getAdministeredBy().getPerson().getName() != null) {
+    sb.append(" by ").append(mar.getAdministeredBy().getPerson().getName());
+}
+```
+
+Guard each hop (`administeredBy`, `.getPerson()`, `.getName()`) — all three can
+be `null` for incompletely-seeded `Staff` records.
+
+**Found during #21488**: the Ward Medicines Timeline's "Administered By" field
+showed "by null" until switched to `administeredBy.person.name`.
+
+---
 
 ## 🚨 CRITICAL: Type Handling in DTO Constructor Queries
 

--- a/developer_docs/jsf/ajax-update-guidelines.md
+++ b/developer_docs/jsf/ajax-update-guidelines.md
@@ -216,6 +216,78 @@ When a `p:commandButton` (or any submit button) has `ajax="false"`, the browser 
 
 ---
 
+## Critical Rule: Conditional `oncomplete` EL Expressions Are Frozen at Initial Render
+
+### The Problem
+
+`p:ajax oncomplete="..."` (and other client-behavior attributes like `onclick`,
+`onstart`) are plain HTML attributes. Any `#{bean.property}` EL inside them is
+evaluated **once, when the enclosing component is rendered** — not on every
+AJAX response. If the component that owns the `p:ajax` (e.g. `p:timeline`,
+`p:dataTable`) is **not** part of the AJAX `update=` target, it never
+re-renders, so the `oncomplete` string is permanently baked-in using whatever
+the bean properties were at **initial page load** (often `null`).
+
+### ❌ WRONG — conditional JS frozen with stale/initial values
+
+```xhtml
+<p:timeline value="#{bean.timelineModel}" ...>
+    <p:ajax event="select"
+            listener="#{bean.onTimelineSelect}"
+            update="panelA panelB"
+            oncomplete="if (#{bean.selectedA ne null}) { PF('dlgA').show(); }
+                        else if (#{bean.selectedB ne null}) { PF('dlgB').show(); }" />
+</p:timeline>
+```
+
+Symptom: the AJAX POST returns 200 OK, `panelA`/`panelB` are updated with the
+correct data server-side, but **no dialog ever opens** — because
+`#{bean.selectedA ne null}` was evaluated as `false` at page load and is now
+permanently part of the rendered `oncomplete` JS string.
+
+### ✅ CORRECT — dispatch from the listener with `PrimeFaces.current().executeScript(...)`
+
+```java
+import org.primefaces.PrimeFaces;
+
+public void onTimelineSelect(TimelineSelectEvent<MyEntry> e) {
+    MyEntry entry = e.getTimelineEvent().getData();
+    if (entry.isTypeA()) {
+        selectedA = entry.getA();
+        selectedB = null;
+        PrimeFaces.current().executeScript("PF('dlgA').show();");
+    } else {
+        selectedB = entry.getB();
+        selectedA = null;
+        PrimeFaces.current().executeScript("PF('dlgB').show();");
+    }
+}
+```
+
+```xhtml
+<p:ajax event="select"
+        listener="#{bean.onTimelineSelect}"
+        update="panelA panelB" />
+```
+
+`PrimeFaces.current().executeScript(...)` queues JavaScript to run as part of
+the **current** AJAX response — it always reflects this request's state, with
+no EL-in-attribute timing issue.
+
+**When this applies**: any client-behavior attribute (`oncomplete`, `onstart`,
+`onerror`) on a component whose own id is **not** in `update=`, where the
+attribute's EL references a bean property set by the same listener. Existing
+correct usages of this pattern: `AdmissionController.java` (~line 2226),
+`SurgeryBillController.java` (~line 948).
+
+**Root cause of a regression during #21488**: the Ward Medicines Timeline
+detail dialogs (Prescription / Medicine Administration) silently stopped
+opening after adding a conditional `oncomplete` to `p:timeline`'s `select`
+event — fixed by switching to `PrimeFaces.current().executeScript(...)` in
+`InpatientClinicalDataController.onTimelineSelect()`.
+
+---
+
 ## Related JSF Concepts
 
 - **Component Tree**: Only JSF components are part of the component tree

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -178,6 +178,63 @@ ones into the wiki so they are not accidentally committed with application code.
 
 ---
 
+## 9. Interacting with non-accessible canvas widgets (e.g. `p:timeline` / vis-timeline)
+
+`p:timeline` renders into an HTML canvas-like DOM (vis-timeline `div`s with no
+useful accessibility tree), so `browser_click`/`browser_snapshot` `ref=`
+targeting won't find individual events. Use `browser_run_code_unsafe` instead:
+
+```js
+async (page) => {
+  const el = await page.$('.vis-item.mar-given'); // or .vis-item.timeline-active
+  const box = await el.boundingBox();
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(1500);
+  const dlg = await page.$('#formTimeline\\:panelAdministrationDetail');
+  return { style: await dlg.getAttribute('style'), text: await dlg.innerText() };
+}
+```
+
+To enumerate all items first (positions shift after dialogs open/close and
+change page layout):
+
+```js
+await page.$$eval('.vis-item', els =>
+  els.map(e => ({ cls: e.className, text: e.innerText, box: e.getBoundingClientRect() })));
+```
+
+**Closing a `p:dialog` after inspection**: pressing `Escape` does **not**
+reliably close a PrimeFaces modal `p:dialog` in a scripted session. Click the
+titlebar close button explicitly:
+
+```js
+await page.click('#formTimeline\\:panelAdministrationDetail .ui-dialog-titlebar-close');
+```
+
+If you click a timeline item while a previous dialog's overlay is still up, the
+click lands on the dialog/overlay (not the timeline) and silently produces no
+AJAX request — always close the prior dialog first and re-query item positions.
+
+## 10. `browser_click` / `browser_type` parameter name
+
+These tools take `target` (an element reference like `e123` from the latest
+`browser_snapshot`, or a selector) plus a human-readable `element` description —
+**not** `ref`. If a call fails with "expected string, received undefined at
+target", the tool schema may not be loaded yet; reload it via
+`ToolSearch` (`query: "browser_type playwright"`) and retry with `target`.
+
+## 11. Session is lost on redeploy and on stale snapshots
+
+- **A redeploy invalidates the session** (already noted in §1) — re-login and
+  re-select department before continuing.
+- If a click navigates somewhere unexpected (e.g. `about:blank` or a
+  `TypeError: Cannot read properties of undefined (reading 'url')`), the page
+  state and your last `browser_snapshot` have diverged. Re-navigate to the app
+  root (`/rh`), log in again, and re-take a snapshot before continuing — don't
+  keep issuing actions against stale `ref=` values.
+
+---
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -189,3 +246,6 @@ ones into the wiki so they are not accidentally committed with application code.
 - [ ] Verified stock + bill-item integrity in the DB; cleaned up temp files.
 - [ ] Filed/fixed any accessibility gap that blocked the test.
 - [ ] Published only non-sensitive screenshot evidence and removed temporary files.
+- [ ] For canvas-based widgets (vis-timeline etc.), used `page.$`/bounding-box
+      clicks and closed dialogs via `.ui-dialog-titlebar-close`, not `Escape`.
+- [ ] Re-logged in and re-selected department after any redeploy before continuing.


### PR DESCRIPTION
## Summary
- Documents the PrimeFaces `p:ajax oncomplete` EL-evaluation-timing pitfall and the `PrimeFaces.current().executeScript(...)` fix (`developer_docs/jsf/ajax-update-guidelines.md`)
- Documents `Staff.getName()` vs `Staff.getPerson().getName()` ("by null" gotcha) (`developer_docs/dto/implementation-guidelines.md`)
- Documents driving non-accessible vis-timeline widgets and PrimeFaces dialogs with Playwright (`developer_docs/testing/playwright-e2e-workflow.md`)

These are reusable lessons learned while developing #21488 (already merged via #21492). This is docs-only, no code changes.

Closes #21493

## Test plan
- [x] Docs-only change, no build/deploy needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced developer guidelines with three new documentation sections covering data object traversal patterns, JSF AJAX rendering behavior, and end-to-end testing workflows for non-standard UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->