### PR TITLE
feat(inward): add email capability for inpatient dashboard documents

### DIFF
--- a/developer_docs/navigation/inward_navigation.md
+++ b/developer_docs/navigation/inward_navigation.md
@@ -89,11 +89,26 @@ The top-level menu entry is **Inpatient** (privilege: `Inward`).
 | Direct Issue to Theatre Cases | `/theater/inward_bill_surgery_issue.xhtml` | For theatre/OT pharmacy issues |
 | BHT Issue Requests | `/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml` | Pharmacist view to action pending requests |
 | View Pharmacy Requests | `/ward/ward_pharmacy_bht_issue_request_bill_search.xhtml` | Search/view requests; Privilege: `InwardPharmacyIssueRequestSearch` |
+| Accept Returns from Ward | `/pharmacy/pharmacy_return_from_ward_receive_list.xhtml` | Pharmacy confirms receipt of returned medicines from ward via porter |
 | Search Inpatient Direct Issues by Bill | `/inward/pharmacy_search_sale_bill_bht.xhtml` | |
 | Search Inpatient Direct Issues by Item | `/inward/pharmacy_search_sale_bill_item_bht.xhtml` | |
 | Search Inpatient Direct Issue Returns by Bill/Item | `/inward/pharmacy_search_return_bill_bht.xhtml` | |
 | Investigation Trace | `/inward/investigation_search_for_reporting_bht.xhtml` | |
 | Inpatient Analytics | `/inward/inward_reports.xhtml` | |
+
+### Ward Pharmacy (accessible from admission profile)
+
+| Menu Item | Page | Controller | Notes |
+|---|---|---|---|
+| Receive Medicines from Pharmacy | `/ward/ward_pharmacy_bht_issue_receive_list.xhtml` → `/ward/ward_pharmacy_bht_issue_receive.xhtml` | `WardPharmacyBhtIssueReceiveController` | Ward confirms receipt of medicines issued via porter |
+| Return Medicines to Pharmacy | `/ward/ward_pharmacy_return_to_pharmacy.xhtml` | `WardPharmacyReturnToPharmacyController` | Ward returns unused stock to pharmacy via porter |
+| Deduct from Ward Stock | `/ward/ward_medication_administration_settle.xhtml` | `MedicationAdministrationStockSettlementController` | Bulk-deduct administered medicines from ward stock |
+
+### Clinical Data (privilege: varies)
+
+| Menu Item | Page | Controller | Notes |
+|---|---|---|---|
+| Letters | `/inward/inward_letters.xhtml` | `InpatientClinicalDataController` / `DocumentTemplateController` | Template-based covering letters with AI generation; Privilege: `InpatientLetter` |
 
 ---
 
@@ -270,6 +285,11 @@ Accessed via **Admin → Manage Inpatient Services** → `/inward/inward_adminis
 | `InwardReportControllerBht` | `com.divudi.bean.inward` | BHT-level reports |
 | `AdmissionTypeController` | `com.divudi.bean.inward` | Admission type master data |
 | `InwardPriceAdjustmntController` | `com.divudi.bean.inward` | Price adjustments (note: typo in class name is intentional — DB compatibility) |
+| `WardPharmacyBhtIssueReceiveController` | `com.divudi.bean.pharmacy` | Ward-side confirmation of medicines received from porter (#21468) |
+| `WardPharmacyReturnToPharmacyController` | `com.divudi.bean.pharmacy` | Ward-side return of unused stock to pharmacy via porter (#21470) |
+| `PharmacyReturnFromWardReceiveController` | `com.divudi.bean.pharmacy` | Pharmacy-side confirmation of returned medicines from ward (#21471) |
+| `MedicationAdministrationController` | `com.divudi.bean.inward` | Record medicine administration events — Stage 1 (#21469) |
+| `MedicationAdministrationStockSettlementController` | `com.divudi.bean.inward` | Bulk-deduct administered medicines from ward stock — Stage 2 (#21469) |
 | `PatientSampleController` | `com.divudi.bean.lab` | Lab sample collection |
 | `SampleController` | `com.divudi.bean.lab` | Lab sample management, receive/reject |
 
@@ -292,45 +312,30 @@ Two parallel workflows exist:
 - Nurse-initiated return request → pharmacist accepts (partially implemented — Issue #19312 related)
 - Direct return by pharmacist: `/inward/pharmacy_bill_return_bht_issue.xhtml`
 
----
+### Porter-Mediated Ward Pharmacy Workflow (Implemented — #21467–#21471)
 
-## Porter-Mediated Ward Pharmacy Workflow (Design — Issues #21466–#21472)
+The porter-mediated ward pharmacy workflow is now fully implemented. The design documented below informed the implementation; the key difference is that the porter-issue step (#21467) was integrated into the existing `ward_pharmacy_bht_issue.xhtml` page (extending `PharmacySaleBhtController`) rather than adapting `TransferIssueDirectController`.
 
-Investigation for #21466/#21467 found that the **existing pharmacy disbursement "Direct Issue" mechanism already implements most of the low-level machinery** needed for porter-mediated ward issue. This section records the findings and the proposed design so each sub-issue can be implemented incrementally without re-investigating.
+#### Implemented Pages
 
-### What already exists and works
+| Step | Page | Controller | Purpose |
+|---|---|---|---|
+| Ward Receive | `/ward/ward_pharmacy_bht_issue_receive_list.xhtml` → `/ward/ward_pharmacy_bht_issue_receive.xhtml` | `WardPharmacyBhtIssueReceiveController` | Ward confirms receipt of medicines from porter |
+| Ward Administer | Clinical Assessment → dialog | `MedicationAdministrationController` | Record administration events (Stage 1) |
+| Ward Stock Deduction | `/ward/ward_medication_administration_settle.xhtml` | `MedicationAdministrationStockSettlementController` | Bulk-deduct administered medicines (Stage 2) |
+| Ward Return | `/ward/ward_pharmacy_return_to_pharmacy.xhtml` | `WardPharmacyReturnToPharmacyController` | Ward returns unused stock to pharmacy via porter |
+| Pharmacy Accept Return | `/pharmacy/pharmacy_return_from_ward_receive_list.xhtml` → `/pharmacy/pharmacy_return_from_ward_receive.xhtml` | `PharmacyReturnFromWardReceiveController` | Pharmacy confirms receipt of returned medicines |
 
-- `TransferIssueDirectController` (`pharmacy_transfer_issue_direct_department.xhtml` → `pharmacy_transfer_issue_direct.xhtml`) lets pharmacy staff issue items to any department — **including ward-type departments**. Confirmed live: searching "ward" in the destination-department picker returns `Inward`, `Temp-Inward`, `Ward Pharmacy`.
-- On settle, `updateStocks()` already does exactly what #21467 asks for:
-  - Deducts from the issuing department's `Stock` via `PharmacyBean.deductFromStock(...)`.
-  - Adds the same quantity to the **selected porter's staff stock** via `PharmacyBean.addToStock(PharmaceuticalBillItem, qty, Staff)` (`Stock.staff` + `StockHistory.staff`).
-  - Bill is created with `BillTypeAtomic.PHARMACY_DIRECT_ISSUE`, `fromDepartment` = issuing pharmacy, `toDepartment` = destination department, `toStaff` = porter.
-- `TransferReceiveController` already implements the receive-side mirror (#21468's "receive from porter" pattern): it queries `Stock` where `staff = <porter>`, deducts it, and credits the receiving department's `Stock` — this is the template for #21468 and #21471.
+#### BillTypeAtomic Values Used
 
-### The gap: no link to a specific admission (BHT)
+| Value | Direction | Description |
+|---|---|---|
+| `ISSUE_MEDICINE_ON_REQUEST_INWARD` | Pharmacy → Ward | Pharmacy issues medicines against a ward request |
+| `ACCEPT_ISSUED_MEDICINE_INWARD` | Ward confirms | Ward confirms receipt of issued medicines |
+| `RETURN_MEDICINE_INWARD` | Ward → Pharmacy | Ward returns unused medicines to pharmacy |
+| `ACCEPT_RETURN_MEDICINE_INWARD` | Pharmacy confirms | Pharmacy confirms receipt of returned medicines |
 
-The disbursement flow above is **department-to-department** and has no concept of *which patient* the medicines are for. Ward medicine issue (`ward_pharmacy_bht_issue.xhtml`, originating from a request created in `ward_pharmacy_bht_issue_request_bill.xhtml`) is always tied to one **BHT / `PatientEncounter`**.
-
-Two entity fields already exist and are unused by the disbursement controllers, but solve this:
-
-- `Bill.fromDepartment` and `Bill.patientEncounter` (`Bill.java`) — every bill can carry a `PatientEncounter` reference.
-- `PatientEncounter.department` (`PatientEncounter.java`) — every admission already records **its own ward** as a `Department`. This means we don't need new per-ward `Department` records or a new destination picker — `patientEncounter.getDepartment()` gives the ward directly.
-
-### Proposed design for #21467 onward
-
-When a ward medicine request (tied to a `PatientEncounter`) is settled via the porter-issue mechanism:
-
-1. **fromDepartment** = the issuing pharmacy (as today).
-2. **toDepartment** = `patientEncounter.getDepartment()` — the ward where the patient is admitted (not a manually-picked department).
-3. **patientEncounter** = the BHT's `PatientEncounter`, set on the issue bill so every downstream step (#21468 ward receive, #21469 administration, #21470/#21471 returns) can trace back to the same admission.
-4. **toStaff** = the porter, with stock moved via the existing `addToStock(pbi, qty, Staff)` + `StockHistory` mechanism — no new entity needed for #21467.
-
-This reuses the proven staff-stock + stock-history mechanics from `TransferIssueDirectController` while adding the one missing link (`patientEncounter`) that the rest of the porter workflow (#21468–#21472) depends on. #21468's ward-receive step would then look up porter `Stock` filtered by `patientEncounter` (in addition to `staff`), crediting ward-held `Stock` (`department` = `patientEncounter.getDepartment()`). #21469 (administration) and #21470/#21471 (returns) chain off the same `patientEncounter` reference. #21472 (reporting) needs to add `patientEncounter`-based grouping to stock-in-transit/ward-stock reports, alongside the existing department-based grouping.
-
-### Open questions for implementation
-
-- Whether the porter-issue bill should be created from `ward_pharmacy_bht_issue.xhtml` directly (extending `PharmacySaleBhtController`) or by adapting `TransferIssueDirectController` to accept an optional `PatientEncounter` — needs a decision when #21467 is implemented.
-- Porter role/identification: #21467 originally proposed a dedicated "Porter" staff role; the existing `toStaff` field on `TransferIssueDirectController` already accepts any staff member via `staffController.completeStaffWithoutDoctors` — a dedicated role may be a UI/filtering nicety rather than a new entity.
+All steps carry `patientEncounter` on the bill for traceability. Porter in-transit stock is tracked via `Stock.staff` and `StockHistory.staff`.
 
 ---
 

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -4649,6 +4649,7 @@ public class InpatientClinicalDataController implements Serializable {
         fillCurrentPatientLists(admission.getPatient());
         fillCurrentEncounterLists(admission);
         diagnosisCardTemplates = documentTemplateController.fillByType(DocumentTemplateType.InpatientDiagnosisCard);
+        refreshEncounterCreditCompanies();
         return "/inward/inward_diagnosis_cards?faces-redirect=true";
     }
 
@@ -4817,6 +4818,12 @@ public class InpatientClinicalDataController implements Serializable {
     }
 
     private String resolveDefaultEmailRecipient() {
+        EncounterCreditCompany selected = getSelectedEncounterCreditCompany();
+        if (selected != null && selected.getInstitution() != null
+                && selected.getInstitution().getEmail() != null
+                && !selected.getInstitution().getEmail().trim().isEmpty()) {
+            return selected.getInstitution().getEmail().trim();
+        }
         if (encounterCreditCompanies != null) {
             for (EncounterCreditCompany ecc : encounterCreditCompanies) {
                 if (ecc.getInstitution() != null

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -141,6 +141,10 @@ public class InpatientClinicalDataController implements Serializable {
     private PrescriptionService prescriptionService;
     @EJB
     private EncounterCreditCompanyFacade encounterCreditCompanyFacade;
+    @EJB
+    private com.divudi.core.facade.EmailFacade emailFacade;
+    @EJB
+    private com.divudi.ejb.EmailManagerEjb emailManagerEjb;
     /**
      * Controllers
      */
@@ -192,6 +196,7 @@ public class InpatientClinicalDataController implements Serializable {
     private List<DocumentTemplate> letterTemplates;
     private DocumentTemplate selectedDocumentTemplate;
     private boolean editingDiagnosisCard;
+    private String emailRecipient;
 
     private List<EncounterCreditCompany> encounterCreditCompanies;
     private Long selectedEncounterCreditCompanyId;
@@ -4793,6 +4798,99 @@ public class InpatientClinicalDataController implements Serializable {
             }
         }
         return sb.toString();
+    }
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
+    }
+
+    public void prepareDocumentEmailDialog() {
+        if (encounterReferral == null || encounterReferral.getLobValue() == null) {
+            JsfUtil.addErrorMessage("No document selected or document content is empty");
+            return;
+        }
+        emailRecipient = resolveDefaultEmailRecipient();
+    }
+
+    private String resolveDefaultEmailRecipient() {
+        if (encounterCreditCompanies != null) {
+            for (EncounterCreditCompany ecc : encounterCreditCompanies) {
+                if (ecc.getInstitution() != null
+                        && ecc.getInstitution().getEmail() != null
+                        && !ecc.getInstitution().getEmail().trim().isEmpty()) {
+                    return ecc.getInstitution().getEmail().trim();
+                }
+            }
+        }
+        if (current != null && current.getPatient() != null && current.getPatient().getPerson() != null
+                && current.getPatient().getPerson().getEmail() != null
+                && !current.getPatient().getPerson().getEmail().trim().isEmpty()) {
+            return current.getPatient().getPerson().getEmail().trim();
+        }
+        if (current != null && current.getGuardian() != null
+                && current.getGuardian().getEmail() != null
+                && !current.getGuardian().getEmail().trim().isEmpty()) {
+            return current.getGuardian().getEmail().trim();
+        }
+        return "";
+    }
+
+    public void sendDocumentEmail() {
+        if (encounterReferral == null || encounterReferral.getLobValue() == null) {
+            JsfUtil.addErrorMessage("No document selected or document content is empty");
+            return;
+        }
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter recipient email");
+            return;
+        }
+        String recipient = emailRecipient.trim();
+        if (!CommonFunctions.isValidEmail(recipient)) {
+            JsfUtil.addErrorMessage("Please enter a valid email address");
+            return;
+        }
+
+        String subject = encounterReferral.getStringValue() != null
+                ? encounterReferral.getStringValue() : "Inpatient Document";
+        String body = encounterReferral.getLobValue();
+
+        com.divudi.core.entity.AppEmail email = new com.divudi.core.entity.AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipient);
+        email.setMessageSubject(subject);
+        email.setMessageBody(body);
+        email.setDepartment(sessionController.getLoggedUser().getDepartment());
+        email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        email.setPatientEncounter(current);
+        email.setMessageType(com.divudi.core.data.MessageType.InpatientClinicalDocument);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            boolean success = emailManagerEjb.sendEmail(
+                    Collections.singletonList(recipient),
+                    body,
+                    subject,
+                    true
+            );
+            email.setSentSuccessfully(success);
+            email.setPending(!success);
+            if (success) {
+                email.setSentAt(new Date());
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+            emailFacade.edit(email);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
     }
 
     public StreamedContent downloadAsPdf() {

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -32,6 +32,10 @@ public class InwardDocumentUploadController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
     private UploadFacade uploadFacade;
+    @EJB
+    private com.divudi.core.facade.EmailFacade emailFacade;
+    @EJB
+    private com.divudi.ejb.EmailManagerEjb emailManagerEjb;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Controllers">
@@ -46,6 +50,7 @@ public class InwardDocumentUploadController implements Serializable {
     private String comments;
     private UploadedFile file;
     private Upload selectedDocument;
+    private String emailRecipient;
 
     private static final long SIZE_LIMIT = 10240000;
     private static final String ALLOWED_FILE_TYPES_REGEX = "(?i)\\.(pdf|jpeg|jpg|png)$";
@@ -216,6 +221,107 @@ public class InwardDocumentUploadController implements Serializable {
                 .build();
     }
 
+    public void prepareEmailDialog(Upload doc) {
+        if (doc == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        selectedDocument = doc;
+        emailRecipient = resolveDefaultEmailRecipient();
+    }
+
+    private String resolveDefaultEmailRecipient() {
+        if (currentEncounter != null && currentEncounter.getPatient() != null
+                && currentEncounter.getPatient().getPerson() != null
+                && currentEncounter.getPatient().getPerson().getEmail() != null
+                && !currentEncounter.getPatient().getPerson().getEmail().trim().isEmpty()) {
+            return currentEncounter.getPatient().getPerson().getEmail().trim();
+        }
+        if (currentEncounter != null && currentEncounter.getGuardian() != null
+                && currentEncounter.getGuardian().getEmail() != null
+                && !currentEncounter.getGuardian().getEmail().trim().isEmpty()) {
+            return currentEncounter.getGuardian().getEmail().trim();
+        }
+        return "";
+    }
+
+    public void sendDocumentEmail() {
+        if (selectedDocument == null) {
+            JsfUtil.addErrorMessage("No document selected");
+            return;
+        }
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter recipient email");
+            return;
+        }
+        String recipient = emailRecipient.trim();
+        if (!com.divudi.core.util.CommonFunctions.isValidEmail(recipient)) {
+            JsfUtil.addErrorMessage("Please enter a valid email address");
+            return;
+        }
+
+        String subject = "Document: " + (selectedDocument.getFileName() != null ? selectedDocument.getFileName() : "Attachment");
+        String body = buildDocumentEmailHtml();
+
+        com.divudi.core.entity.AppEmail email = new com.divudi.core.entity.AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipient);
+        email.setMessageSubject(subject);
+        email.setMessageBody(body);
+        email.setDepartment(sessionController.getLoggedUser().getDepartment());
+        email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        email.setPatientEncounter(currentEncounter);
+        email.setMessageType(com.divudi.core.data.MessageType.InpatientDocumentUpload);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            boolean success = emailManagerEjb.sendEmail(
+                    java.util.Collections.singletonList(recipient),
+                    body,
+                    subject,
+                    true
+            );
+            email.setSentSuccessfully(success);
+            email.setPending(!success);
+            if (success) {
+                email.setSentAt(new Date());
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+            emailFacade.edit(email);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
+    }
+
+    private String buildDocumentEmailHtml() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<p>Please find the details of the document below.</p>");
+        sb.append("<table border=\"0\" cellpadding=\"4\">");
+        sb.append("<tr><td><b>Document Type</b></td><td>").append(escapeHtml(selectedDocument.getUploadType() != null ? selectedDocument.getUploadType().getLabel() : "")).append("</td></tr>");
+        sb.append("<tr><td><b>File Name</b></td><td>").append(escapeHtml(selectedDocument.getFileName())).append("</td></tr>");
+        if (selectedDocument.getComments() != null && !selectedDocument.getComments().trim().isEmpty()) {
+            sb.append("<tr><td><b>Comments</b></td><td>").append(escapeHtml(selectedDocument.getComments())).append("</td></tr>");
+        }
+        sb.append("</table>");
+        sb.append("<p><i>Note: The file itself is not attached to this email. Please contact the hospital to obtain a copy of the document.</i></p>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    private static String escapeHtml(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("\"", "&quot;").replace("'", "&#39;");
+    }
+
     private String detectContentType(byte[] bytes, String fileName) {
         if (bytes == null || bytes.length < 4) {
             return null;
@@ -293,6 +399,14 @@ public class InwardDocumentUploadController implements Serializable {
 
     public void setFile(UploadedFile file) {
         this.file = file;
+    }
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
     }
 
     // </editor-fold>

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -50,6 +50,10 @@ public class InwardFormController implements Serializable {
     private DesignComponentFacade designComponentFacade;
     @EJB
     private DesignComponentChoiceFacade designComponentChoiceFacade;
+    @EJB
+    private com.divudi.core.facade.EmailFacade emailFacade;
+    @EJB
+    private com.divudi.ejb.EmailManagerEjb emailManagerEjb;
 
     @Inject
     private SessionController sessionController;
@@ -61,6 +65,7 @@ public class InwardFormController implements Serializable {
     private List<DesignComponent> availableTemplates;
     private DesignComponent selectedTemplate;
     private boolean viewMode = false;
+    private String emailRecipient;
 
     public String navigateToInwardFormsFromAdmissionProfile(PatientEncounter pe) {
         if (pe == null) {
@@ -241,6 +246,104 @@ public class InwardFormController implements Serializable {
         }
         JsfUtil.addSuccessMessage("Form Deleted");
         loadFormEntries();
+    }
+
+    public void prepareFormEmailDialog(PatientFormEntry entry) {
+        if (entry == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        editForm(entry);
+        emailRecipient = resolveDefaultEmailRecipient();
+    }
+
+    private String resolveDefaultEmailRecipient() {
+        if (patientEncounter != null && patientEncounter.getPatient() != null
+                && patientEncounter.getPatient().getPerson() != null
+                && patientEncounter.getPatient().getPerson().getEmail() != null
+                && !patientEncounter.getPatient().getPerson().getEmail().trim().isEmpty()) {
+            return patientEncounter.getPatient().getPerson().getEmail().trim();
+        }
+        if (patientEncounter != null && patientEncounter.getGuardian() != null
+                && patientEncounter.getGuardian().getEmail() != null
+                && !patientEncounter.getGuardian().getEmail().trim().isEmpty()) {
+            return patientEncounter.getGuardian().getEmail().trim();
+        }
+        return "";
+    }
+
+    public void sendFormEmail() {
+        if (currentEntry == null || currentCaptureComponents == null) {
+            JsfUtil.addErrorMessage("No form selected");
+            return;
+        }
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter recipient email");
+            return;
+        }
+        String recipient = emailRecipient.trim();
+        if (!com.divudi.core.util.CommonFunctions.isValidEmail(recipient)) {
+            JsfUtil.addErrorMessage("Please enter a valid email address");
+            return;
+        }
+
+        String formName = currentEntry.getDesignComponent() != null
+                ? currentEntry.getDesignComponent().getName() : "Inpatient Form";
+        String body = buildFormEmailHtml(formName);
+
+        com.divudi.core.entity.AppEmail email = new com.divudi.core.entity.AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipient);
+        email.setMessageSubject(formName);
+        email.setMessageBody(body);
+        email.setDepartment(sessionController.getLoggedUser().getDepartment());
+        email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        email.setPatientEncounter(patientEncounter);
+        email.setMessageType(com.divudi.core.data.MessageType.InpatientFilledForm);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            boolean success = emailManagerEjb.sendEmail(
+                    java.util.Collections.singletonList(recipient),
+                    body,
+                    formName,
+                    true
+            );
+            email.setSentSuccessfully(success);
+            email.setPending(!success);
+            if (success) {
+                email.setSentAt(new Date());
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+            emailFacade.edit(email);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
+    }
+
+    private String buildFormEmailHtml(String formName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<h3>").append(escapeHtml(formName)).append("</h3>");
+        sb.append("<div class=\"row\">");
+        for (CaptureComponent cc : currentCaptureComponents) {
+            sb.append(resolveViewWrapper(cc));
+        }
+        sb.append("</div></body></html>");
+        return sb.toString();
+    }
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
     }
 
     public void cancelForm() {

--- a/src/main/java/com/divudi/core/data/MessageType.java
+++ b/src/main/java/com/divudi/core/data/MessageType.java
@@ -37,5 +37,8 @@ public enum MessageType {
     @Deprecated
     OTP,
     PatientPortalOTP,
-    PatientPortal_Link
+    PatientPortal_Link,
+    InpatientDocumentUpload,
+    InpatientFilledForm,
+    InpatientClinicalDocument
 }

--- a/src/main/java/com/divudi/core/entity/AppEmail.java
+++ b/src/main/java/com/divudi/core/entity/AppEmail.java
@@ -40,6 +40,8 @@ public class AppEmail implements Serializable {
     private Bill bill;
     @ManyToOne
     private EncounterCreditCompany encounterCreditCompany;
+    @ManyToOne
+    private PatientEncounter patientEncounter;
     
     @Enumerated(EnumType.STRING)
     private MessageType messageType;
@@ -341,6 +343,14 @@ public class AppEmail implements Serializable {
 
     public void setEncounterCreditCompany(EncounterCreditCompany encounterCreditCompany) {
         this.encounterCreditCompany = encounterCreditCompany;
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
     }
     
     

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -119,6 +119,7 @@
                                     <p:fileDownload value="#{inwardDocumentUploadController.getDownloadStream(doc)}" />
                                 </p:commandButton>
                                 <p:commandButton
+                                    id="btnSendEmail"
                                     icon="fas fa-envelope"
                                     title="Send by Email"
                                     class="ui-button-secondary me-1"
@@ -182,7 +183,8 @@
                 <p:dialog widgetVar="emailDocDialog" modal="true"
                           header="Send Document by Email"
                           width="400px" height="auto" resizable="false">
-                    <h:form id="emailDocDialogForm">
+                    <h:form id="emailDocDialogForm"
+                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                         <div class="p-3">
                             <div class="mb-3">
                                 <p:outputLabel value="Document: " style="font-weight: bold;"/>
@@ -199,9 +201,9 @@
                                 <small class="text-muted">Note: The file is not attached. The recipient will be sent a cover note with the document details.</small>
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <p:commandButton value="Cancel" onclick="PF('emailDocDialog').hide();"
+                                <p:commandButton id="btnCancelDocEmail" value="Cancel" onclick="PF('emailDocDialog').hide();"
                                                  class="ui-button-secondary" type="button"/>
-                                <p:commandButton value="Send Email"
+                                <p:commandButton id="btnConfirmSendDocEmail" value="Send Email"
                                                  action="#{inwardDocumentUploadController.sendDocumentEmail}"
                                                  class="ui-button-success" icon="fas fa-envelope"
                                                  ajax="false" oncomplete="PF('emailDocDialog').hide();"/>

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -102,7 +102,7 @@
                             <p:column headerText="Uploaded By" width="160">
                                 <h:outputText value="#{doc.creater.name}" />
                             </p:column>
-                            <p:column headerText="Actions" width="145">
+                            <p:column headerText="Actions" width="180">
                                 <p:commandButton
                                     icon="fa fa-eye"
                                     title="View"
@@ -118,6 +118,14 @@
                                     class="ui-button-info me-1">
                                     <p:fileDownload value="#{inwardDocumentUploadController.getDownloadStream(doc)}" />
                                 </p:commandButton>
+                                <p:commandButton
+                                    icon="fas fa-envelope"
+                                    title="Send by Email"
+                                    class="ui-button-secondary me-1"
+                                    process="@this"
+                                    update=":emailDocDialogForm"
+                                    action="#{inwardDocumentUploadController.prepareEmailDialog(doc)}"
+                                    oncomplete="PF('emailDocDialog').show();" />
                                 <p:commandButton
                                     icon="fa fa-trash"
                                     title="Remove"
@@ -169,6 +177,38 @@
                     </p:confirmDialog>
 
                 </h:form>
+
+                <!-- Send Email dialog -->
+                <p:dialog widgetVar="emailDocDialog" modal="true"
+                          header="Send Document by Email"
+                          width="400px" height="auto" resizable="false">
+                    <h:form id="emailDocDialogForm">
+                        <div class="p-3">
+                            <div class="mb-3">
+                                <p:outputLabel value="Document: " style="font-weight: bold;"/>
+                                <p:outputLabel value="#{inwardDocumentUploadController.selectedDocument.fileName}"/>
+                            </div>
+                            <div class="mb-3">
+                                <p:outputLabel for="emailDocRecipient" value="Email Address:" class="form-label"/>
+                                <p:inputText id="emailDocRecipient"
+                                             value="#{inwardDocumentUploadController.emailRecipient}"
+                                             class="w-100" placeholder="Enter email address"
+                                             required="true" requiredMessage="Email address is required"/>
+                            </div>
+                            <div class="mb-3">
+                                <small class="text-muted">Note: The file is not attached. The recipient will be sent a cover note with the document details.</small>
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <p:commandButton value="Cancel" onclick="PF('emailDocDialog').hide();"
+                                                 class="ui-button-secondary" type="button"/>
+                                <p:commandButton value="Send Email"
+                                                 action="#{inwardDocumentUploadController.sendDocumentEmail}"
+                                                 class="ui-button-success" icon="fas fa-envelope"
+                                                 ajax="false" oncomplete="PF('emailDocDialog').hide();"/>
+                            </div>
+                        </div>
+                    </h:form>
+                </p:dialog>
 
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -42,7 +42,7 @@
                         <p:commandButton value="Edit" icon="fa fa-pen" class="me-1"
                                          process="@this" update="@form"
                                          action="#{inwardFormController.editForm(entry)}" />
-                        <p:commandButton icon="fas fa-envelope" title="Send by Email" class="me-1"
+                        <p:commandButton id="btnSendFormEmail" icon="fas fa-envelope" title="Send by Email" class="me-1"
                                          styleClass="ui-button-secondary"
                                          process="@this"
                                          update=":emailFormDialogForm"
@@ -242,7 +242,8 @@
         <p:dialog widgetVar="emailFormDialog" modal="true"
                   header="Send Form by Email"
                   width="400px" height="auto" resizable="false">
-            <h:form id="emailFormDialogForm">
+            <h:form id="emailFormDialogForm"
+                    onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                 <div class="p-3">
                     <div class="mb-3">
                         <p:outputLabel value="Form: " style="font-weight: bold;"/>
@@ -256,9 +257,9 @@
                                      required="true" requiredMessage="Email address is required"/>
                     </div>
                     <div class="d-flex justify-content-end gap-2">
-                        <p:commandButton value="Cancel" onclick="PF('emailFormDialog').hide();"
+                        <p:commandButton id="btnCancelFormEmail" value="Cancel" onclick="PF('emailFormDialog').hide();"
                                          class="ui-button-secondary" type="button"/>
-                        <p:commandButton value="Send Email"
+                        <p:commandButton id="btnConfirmSendFormEmail" value="Send Email"
                                          action="#{inwardFormController.sendFormEmail}"
                                          class="ui-button-success" icon="fas fa-envelope"
                                          ajax="false" oncomplete="PF('emailFormDialog').hide();"/>

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -38,10 +38,16 @@
                     <p:column headerText="Comments">
                         <h:outputText value="#{entry.comments}" />
                     </p:column>
-                    <p:column headerText="Actions" style="width:12rem;text-align:center">
+                    <p:column headerText="Actions" style="width:15rem;text-align:center">
                         <p:commandButton value="Edit" icon="fa fa-pen" class="me-1"
                                          process="@this" update="@form"
                                          action="#{inwardFormController.editForm(entry)}" />
+                        <p:commandButton icon="fas fa-envelope" title="Send by Email" class="me-1"
+                                         styleClass="ui-button-secondary"
+                                         process="@this"
+                                         update=":emailFormDialogForm"
+                                         action="#{inwardFormController.prepareFormEmailDialog(entry)}"
+                                         oncomplete="PF('emailFormDialog').show();" />
                         <p:commandButton value="Delete" icon="fa fa-trash"
                                          styleClass="ui-button-danger"
                                          process="@this" update="@form"
@@ -231,5 +237,34 @@
                                  styleClass="ui-confirmdialog-no ui-button-flat" icon="pi pi-times" />
             </p:confirmDialog>
         </h:form>
+
+        <!-- Send Email dialog -->
+        <p:dialog widgetVar="emailFormDialog" modal="true"
+                  header="Send Form by Email"
+                  width="400px" height="auto" resizable="false">
+            <h:form id="emailFormDialogForm">
+                <div class="p-3">
+                    <div class="mb-3">
+                        <p:outputLabel value="Form: " style="font-weight: bold;"/>
+                        <p:outputLabel value="#{inwardFormController.currentEntry.designComponent.name}"/>
+                    </div>
+                    <div class="mb-3">
+                        <p:outputLabel for="emailFormRecipient" value="Email Address:" class="form-label"/>
+                        <p:inputText id="emailFormRecipient"
+                                     value="#{inwardFormController.emailRecipient}"
+                                     class="w-100" placeholder="Enter email address"
+                                     required="true" requiredMessage="Email address is required"/>
+                    </div>
+                    <div class="d-flex justify-content-end gap-2">
+                        <p:commandButton value="Cancel" onclick="PF('emailFormDialog').hide();"
+                                         class="ui-button-secondary" type="button"/>
+                        <p:commandButton value="Send Email"
+                                         action="#{inwardFormController.sendFormEmail}"
+                                         class="ui-button-success" icon="fas fa-envelope"
+                                         ajax="false" oncomplete="PF('emailFormDialog').hide();"/>
+                    </div>
+                </div>
+            </h:form>
+        </p:dialog>
     </ui:define>
 </ui:composition>

--- a/src/main/webapp/inward/inward_diagnosis_cards.xhtml
+++ b/src/main/webapp/inward/inward_diagnosis_cards.xhtml
@@ -216,6 +216,16 @@
                                                 title="Download as PDF">
                                                 <p:fileDownload value="#{inpatientClinicalDataController.downloadAsPdf()}"/>
                                             </p:commandButton>
+                                            <p:commandButton
+                                                id="btnEmailCard"
+                                                icon="fas fa-envelope"
+                                                title="Send by Email"
+                                                class="ui-button-secondary"
+                                                action="#{inpatientClinicalDataController.prepareDocumentEmailDialog}"
+                                                process="@this"
+                                                update="emailCardDialogForm"
+                                                oncomplete="PF('emailCardDialog').show();">
+                                            </p:commandButton>
                                         </div>
                                     </div>
                                 </f:facet>
@@ -287,6 +297,35 @@
                     </p:blockUI>
 
                 </h:form>
+
+                <!-- Send Email dialog -->
+                <p:dialog widgetVar="emailCardDialog" modal="true"
+                          header="Send Diagnosis Card by Email"
+                          width="400px" height="auto" resizable="false">
+                    <h:form id="emailCardDialogForm">
+                        <div class="p-3">
+                            <div class="mb-3">
+                                <p:outputLabel value="Document: " style="font-weight: bold;"/>
+                                <p:outputLabel value="#{inpatientClinicalDataController.encounterReferral.stringValue}"/>
+                            </div>
+                            <div class="mb-3">
+                                <p:outputLabel for="emailCardRecipient" value="Email Address:" class="form-label"/>
+                                <p:inputText id="emailCardRecipient"
+                                             value="#{inpatientClinicalDataController.emailRecipient}"
+                                             class="w-100" placeholder="Enter email address"
+                                             required="true" requiredMessage="Email address is required"/>
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <p:commandButton value="Cancel" onclick="PF('emailCardDialog').hide();"
+                                                 class="ui-button-secondary" type="button"/>
+                                <p:commandButton value="Send Email"
+                                                 action="#{inpatientClinicalDataController.sendDocumentEmail}"
+                                                 class="ui-button-success" icon="fas fa-envelope"
+                                                 ajax="false" oncomplete="PF('emailCardDialog').hide();"/>
+                            </div>
+                        </div>
+                    </h:form>
+                </p:dialog>
 
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/inward/inward_diagnosis_cards.xhtml
+++ b/src/main/webapp/inward/inward_diagnosis_cards.xhtml
@@ -223,7 +223,7 @@
                                                 class="ui-button-secondary"
                                                 action="#{inpatientClinicalDataController.prepareDocumentEmailDialog}"
                                                 process="@this"
-                                                update="emailCardDialogForm"
+                                                update=":emailCardDialogForm"
                                                 oncomplete="PF('emailCardDialog').show();">
                                             </p:commandButton>
                                         </div>
@@ -302,7 +302,8 @@
                 <p:dialog widgetVar="emailCardDialog" modal="true"
                           header="Send Diagnosis Card by Email"
                           width="400px" height="auto" resizable="false">
-                    <h:form id="emailCardDialogForm">
+                    <h:form id="emailCardDialogForm"
+                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                         <div class="p-3">
                             <div class="mb-3">
                                 <p:outputLabel value="Document: " style="font-weight: bold;"/>
@@ -316,9 +317,9 @@
                                              required="true" requiredMessage="Email address is required"/>
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <p:commandButton value="Cancel" onclick="PF('emailCardDialog').hide();"
+                                <p:commandButton id="btnCancelCardEmail" value="Cancel" onclick="PF('emailCardDialog').hide();"
                                                  class="ui-button-secondary" type="button"/>
-                                <p:commandButton value="Send Email"
+                                <p:commandButton id="btnConfirmSendCardEmail" value="Send Email"
                                                  action="#{inpatientClinicalDataController.sendDocumentEmail}"
                                                  class="ui-button-success" icon="fas fa-envelope"
                                                  ajax="false" oncomplete="PF('emailCardDialog').hide();"/>

--- a/src/main/webapp/inward/inward_letters.xhtml
+++ b/src/main/webapp/inward/inward_letters.xhtml
@@ -249,6 +249,16 @@
                                                 title="Download as PDF">
                                                 <p:fileDownload value="#{inpatientClinicalDataController.downloadAsPdf()}"/>
                                             </p:commandButton>
+                                            <p:commandButton
+                                                id="btnEmailLetter"
+                                                icon="fas fa-envelope"
+                                                title="Send by Email"
+                                                class="ui-button-secondary"
+                                                action="#{inpatientClinicalDataController.prepareDocumentEmailDialog}"
+                                                process="@this"
+                                                update="emailLetterDialogForm"
+                                                oncomplete="PF('emailLetterDialog').show();">
+                                            </p:commandButton>
                                         </div>
                                     </div>
                                 </f:facet>
@@ -320,6 +330,35 @@
                     </p:blockUI>
 
                 </h:form>
+
+                <!-- Send Email dialog -->
+                <p:dialog widgetVar="emailLetterDialog" modal="true"
+                          header="Send Letter by Email"
+                          width="400px" height="auto" resizable="false">
+                    <h:form id="emailLetterDialogForm">
+                        <div class="p-3">
+                            <div class="mb-3">
+                                <p:outputLabel value="Document: " style="font-weight: bold;"/>
+                                <p:outputLabel value="#{inpatientClinicalDataController.encounterReferral.stringValue}"/>
+                            </div>
+                            <div class="mb-3">
+                                <p:outputLabel for="emailLetterRecipient" value="Email Address:" class="form-label"/>
+                                <p:inputText id="emailLetterRecipient"
+                                             value="#{inpatientClinicalDataController.emailRecipient}"
+                                             class="w-100" placeholder="Enter email address"
+                                             required="true" requiredMessage="Email address is required"/>
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <p:commandButton value="Cancel" onclick="PF('emailLetterDialog').hide();"
+                                                 class="ui-button-secondary" type="button"/>
+                                <p:commandButton value="Send Email"
+                                                 action="#{inpatientClinicalDataController.sendDocumentEmail}"
+                                                 class="ui-button-success" icon="fas fa-envelope"
+                                                 ajax="false" oncomplete="PF('emailLetterDialog').hide();"/>
+                            </div>
+                        </div>
+                    </h:form>
+                </p:dialog>
 
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/inward/inward_letters.xhtml
+++ b/src/main/webapp/inward/inward_letters.xhtml
@@ -256,7 +256,7 @@
                                                 class="ui-button-secondary"
                                                 action="#{inpatientClinicalDataController.prepareDocumentEmailDialog}"
                                                 process="@this"
-                                                update="emailLetterDialogForm"
+                                                update=":emailLetterDialogForm"
                                                 oncomplete="PF('emailLetterDialog').show();">
                                             </p:commandButton>
                                         </div>
@@ -335,7 +335,8 @@
                 <p:dialog widgetVar="emailLetterDialog" modal="true"
                           header="Send Letter by Email"
                           width="400px" height="auto" resizable="false">
-                    <h:form id="emailLetterDialogForm">
+                    <h:form id="emailLetterDialogForm"
+                            onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
                         <div class="p-3">
                             <div class="mb-3">
                                 <p:outputLabel value="Document: " style="font-weight: bold;"/>
@@ -349,9 +350,9 @@
                                              required="true" requiredMessage="Email address is required"/>
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <p:commandButton value="Cancel" onclick="PF('emailLetterDialog').hide();"
+                                <p:commandButton id="btnCancelLetterEmail" value="Cancel" onclick="PF('emailLetterDialog').hide();"
                                                  class="ui-button-secondary" type="button"/>
-                                <p:commandButton value="Send Email"
+                                <p:commandButton id="btnConfirmSendLetterEmail" value="Send Email"
                                                  action="#{inpatientClinicalDataController.sendDocumentEmail}"
                                                  class="ui-button-success" icon="fas fa-envelope"
                                                  ajax="false" oncomplete="PF('emailLetterDialog').hide();"/>


### PR DESCRIPTION
## Summary
- Adds a "Send by Email" action to uploaded documents, filled forms, diagnosis cards, and inpatient letters on the inpatient dashboard, following the existing Purchase Order email pattern.
- `AppEmail` gains a `patientEncounter` relation so sent emails can be traced back to the admission.
- New `MessageType` values (`InpatientDocumentUpload`, `InpatientFilledForm`, `InpatientClinicalDocument`) categorize these emails.
- Diagnosis cards and inpatient letters share one controller method set (`prepareDocumentEmailDialog`/`sendDocumentEmail`) since both operate on the same `ClinicalFindingValue`/`VisitDocument` data.
- Uploaded-file emails send a cover note only (the file itself is not attached); attachments are deferred to a follow-up.

Closes #21490

## Test plan
- [ ] Build the project and deploy locally
- [ ] From the inpatient dashboard, upload a document and use "Send by Email" — verify a cover-note email is logged in AppEmail and sent
- [ ] Fill a dynamic form and use "Send by Email" — verify the rendered form values are emailed as HTML
- [ ] Send a diagnosis card by email
- [ ] Send an inpatient letter by email
- [ ] Confirm default recipient resolves from patient email, falling back to guardian email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Send by Email” actions for inpatient admission documents, filled forms, diagnosis cards, and letters.
  * Recipient email is auto-filled from the patient or guardian and can be edited; emails are sent with cover details and sent status is tracked.

* **Documentation**
  * Updated the developer inward navigation reference to reflect updated ward pharmacy capabilities and porter-mediated ward pharmacy workflow documentation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->