### PR TITLE
docs(testing): add playwright-e2e skill with rebuild and AJAX-wait guidance

### DIFF
--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: playwright-e2e
+description: >
+  Drive the running HMIS app with the Playwright MCP server for end-to-end
+  verification of a feature (login, department selection, PrimeFaces AJAX
+  forms, confirm dialogs, DB-backed verification). Use when asked to test,
+  verify, or screenshot a feature in the browser, or to confirm a fix works
+  end-to-end against a real deployment. Rebuilds/redeploys local changes via
+  Maven + asadmin first if needed.
+allowed-tools: Read, Glob, Grep, Bash, PowerShell, mcp__playwright__browser_navigate,
+  mcp__playwright__browser_navigate_back, mcp__playwright__browser_click,
+  mcp__playwright__browser_type, mcp__playwright__browser_fill_form,
+  mcp__playwright__browser_select_option, mcp__playwright__browser_hover,
+  mcp__playwright__browser_drag, mcp__playwright__browser_drop,
+  mcp__playwright__browser_press_key, mcp__playwright__browser_file_upload,
+  mcp__playwright__browser_handle_dialog, mcp__playwright__browser_wait_for,
+  mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot,
+  mcp__playwright__browser_console_messages, mcp__playwright__browser_network_request,
+  mcp__playwright__browser_network_requests, mcp__playwright__browser_evaluate,
+  mcp__playwright__browser_run_code_unsafe, mcp__playwright__browser_resize,
+  mcp__playwright__browser_tabs, mcp__playwright__browser_close
+---
+
+# Playwright E2E Testing (HMIS)
+
+Full operational workflow lives in
+[Playwright E2E Testing Workflow](../../../developer_docs/testing/playwright-e2e-workflow.md) —
+read it before driving the browser. This skill is the entry point and adds the
+rebuild/redeploy and permission context.
+
+## Workflow
+
+1. **Confirm the target** with the user: which feature/page, which local
+   deployment URL, and whether the code under test is already deployed.
+2. **If not yet deployed**, rebuild and redeploy — see
+   [§0a Rebuild and redeploy](../../../developer_docs/testing/playwright-e2e-workflow.md#0a-rebuild-and-redeploy-local-code-changes-before-testing).
+   A redeploy invalidates the session, so this must happen *before* login.
+3. **Login + department selection** — see
+   [§1](../../../developer_docs/testing/playwright-e2e-workflow.md#1-login-and-department-selection).
+   Never hit an inner page URL directly before department selection.
+4. **Drive the feature** using accessibility snapshots (`browser_snapshot`)
+   to locate elements, real key events for PrimeFaces inputs (§3), and
+   `browser_handle_dialog` for `confirm()` guards (§4). Wait on the expected
+   result (`browser_wait_for`) rather than fixed sleeps (§5a).
+5. **Verify in the database** — read-only `mysql` queries against the local
+   DB per [§6](../../../developer_docs/testing/playwright-e2e-workflow.md#6-verify-against-the-database).
+   Credentials come from `C:\Credentials\` (outside the repo).
+6. **Capture evidence** into the project `tmp/` folder, then follow
+   [§8](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence)
+   for anything destined for the wiki/issue. Remove temp screenshots from the
+   repo afterwards.
+7. If Playwright can't find a control, treat it as a product accessibility gap
+   (§7) — fix the page, not the test.
+
+## Required permissions
+
+This skill needs, beyond the defaults:
+
+- The full `mcp__playwright__*` tool set (browser automation).
+- Maven `clean package` and Payara `asadmin redeploy`/`deploy`/`undeploy` for
+  the local rebuild step (paths in `CLAUDE.md` § Local build tools).
+- `mysql` read access to the local database for verification queries.
+
+If any of these prompt for approval, the user's `settings.local.json` should
+already allow them for this project — flag it if a prompt appears repeatedly.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -27,6 +27,28 @@ waste a session.
 
 ---
 
+## 0a. Rebuild and redeploy local code changes before testing
+
+If the change under test isn't deployed yet, rebuild and redeploy to the local
+Payara instance first (see [Local build tools](../../CLAUDE.md) for tool
+locations):
+
+```powershell
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
+& "D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" clean package -DskipTests
+& "D:\Payara\bin\asadmin.bat" redeploy --name rh "D:\Development\2024\hmis\target\rh-3.0.0.war"
+```
+
+- `clean` is required when switching branches or after structural changes
+  (new/renamed/deleted classes, resources); a plain `compile`/`package` can
+  leave stale `.class` files in `target/`.
+- A redeploy invalidates the current session (see §1) — log in again
+  afterwards.
+- Watch `D:\Payara\glassfish\domains\*\logs\server.log` for deployment errors
+  before starting the browser flow.
+
+---
+
 ## 1. Login and department selection
 
 The HMIS login + landing flow has a fixed shape:
@@ -116,6 +138,22 @@ fires first. If a **required** field is empty (e.g. the transfer **Comment**
 field), the submit is rejected and the action — including an unrelated
 `remove(row)` button on the same form — silently does nothing. Fill required
 fields before exercising any non-AJAX button on the page.
+
+---
+
+## 5a. Waiting for AJAX without hard timeouts
+
+- Prefer `browser_snapshot` (accessibility tree) over screenshots for finding
+  and confirming elements — it's far cheaper in tokens and is what the agent
+  actually reasons over.
+- After an AJAX action (PrimeFaces `p:ajax`/`update`), use `browser_wait_for`
+  on the expected resulting text/element rather than a fixed `sleep`. Fall
+  back to the explicit waits in §3 (slow type + ~1–1.5 s) only for the known
+  PrimeFaces commit-timing gotchas, since those are races against a keyup
+  handler that no DOM state change reliably signals.
+- `browser_network_requests` is useful to confirm a `javax.faces.partial.ajax`
+  POST actually fired (and what it returned) when a UI update silently does
+  nothing — cheaper than guessing at another `wait_for`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `.claude/skills/playwright-e2e/SKILL.md` as a `/playwright-e2e` entry point for driving the running HMIS app via the Playwright MCP server (login/department selection, PrimeFaces AJAX gotchas, DB verification).
- Extend `developer_docs/testing/playwright-e2e-workflow.md`:
  - §0a: rebuild (`mvn clean package`) and redeploy (`asadmin redeploy`) local code changes before testing — a redeploy invalidates the session, so this must happen before login.
  - §5a: waiting for PrimeFaces AJAX without hard timeouts — prefer `browser_snapshot` over screenshots, `browser_wait_for` on expected results, `browser_network_requests` to confirm a `javax.faces.partial.ajax` POST fired.

Local permission allow-list for the `mcp__playwright__*` tool set was added to the untracked `.claude/settings.local.json` (not part of this PR).

Closes #21499

## Test plan
- [x] Doc/skill-only change (JSF/docs, no Java) — no compilation required
- [ ] Reviewer confirms the skill links resolve correctly within `.claude/skills/playwright-e2e/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced testing workflow documentation with improved guidance for local environment setup and asynchronous UI interaction validation.
  * Added best practices for verifying network activity during automated testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->