### PR TITLE
fix(pharmacy): comments and referring doctor in sale bill search hotfix v2

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacySaleSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacySaleSearchDTO.java
@@ -63,6 +63,7 @@ public class PharmacySaleSearchDTO implements Serializable {
     }
 
     // New 15-parameter constructor that includes comments
+    // delegates to the 14-parameter constructor via this(...)
     public PharmacySaleSearchDTO(
             Long id,
             String deptId,
@@ -79,20 +80,9 @@ public class PharmacySaleSearchDTO implements Serializable {
             Boolean refunded,
             Boolean cancelled,
             String comments) {
-        this.id = id;
-        this.deptId = deptId;
-        this.departmentName = departmentName;
-        this.createdAt = createdAt;
-        this.creatorName = creatorName;
-        this.patientName = patientName;
-        this.referredByName = referredByName;
-        this.paymentMethod = paymentMethod;
-        this.paymentSchemeName = paymentSchemeName;
-        this.total = total;
-        this.discount = discount;
-        this.netTotal = netTotal;
-        this.refunded = refunded;
-        this.cancelled = cancelled;
+        this(id, deptId, departmentName, createdAt, creatorName, patientName,
+                referredByName, paymentMethod, paymentSchemeName, total, discount,
+                netTotal, refunded, cancelled);
         this.comments = comments;
     }
 


### PR DESCRIPTION
Hotfix v2 for `horizon-prod` — replaces the earlier merged #21519 with a corrected version.

**v2 fix:** CodeRabbit review on #21518 identified that the 15-parameter constructor duplicated field assignments instead of delegating to the 14-parameter constructor via `this(...)`. This is now fixed — the 15-param constructor delegates and only assigns `comments` directly.

## Changes (same as #21518)
- Added `comments` field (String) to `PharmacySaleSearchDTO` with a new 15-parameter constructor that delegates to the 14-parameter constructor via `this(...)`
- Updated JPQL query in `PharmacyBillSearch.fetchSaleSearchDtosFromNativeBills()` to select `COALESCE(b.comments, '')`
- Updated XHTML Comments column to display actual comment text alongside Refunded/Cancelled badges, with filter and sort support

## Original development PR
https://github.com/hmislk/hmis/pull/21518

## Related Issue
Closes #21517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
