### PR TITLE
fix(pharmacy): add comments to pharmacy sale bill search hotfix

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacySaleSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacySaleSearchDTO.java
@@ -63,6 +63,7 @@ public class PharmacySaleSearchDTO implements Serializable {
     }
 
     // New 15-parameter constructor that includes comments
+    // delegates to the 14-parameter constructor via this(...)
     public PharmacySaleSearchDTO(
             Long id,
             String deptId,
@@ -79,20 +80,9 @@ public class PharmacySaleSearchDTO implements Serializable {
             Boolean refunded,
             Boolean cancelled,
             String comments) {
-        this.id = id;
-        this.deptId = deptId;
-        this.departmentName = departmentName;
-        this.createdAt = createdAt;
-        this.creatorName = creatorName;
-        this.patientName = patientName;
-        this.referredByName = referredByName;
-        this.paymentMethod = paymentMethod;
-        this.paymentSchemeName = paymentSchemeName;
-        this.total = total;
-        this.discount = discount;
-        this.netTotal = netTotal;
-        this.refunded = refunded;
-        this.cancelled = cancelled;
+        this(id, deptId, departmentName, createdAt, creatorName, patientName,
+                referredByName, paymentMethod, paymentSchemeName, total, discount,
+                netTotal, refunded, cancelled);
         this.comments = comments;
     }
 


### PR DESCRIPTION
Hotfix for `horizon-prod` — replaces earlier merged #21519 with corrected version including the constructor delegation fix from CodeRabbit review on #21518.

**Fix**: 15-parameter constructor now delegates to the 14-parameter constructor via `this(...)` instead of duplicating field assignments.

## Changes
- Added `comments` field (String) to `PharmacySaleSearchDTO` with a new 15-param constructor that delegates via `this(...)`
- Updated JPQL query in `PharmacyBillSearch.fetchSaleSearchDtosFromNativeBills()` to select `COALESCE(b.comments, '')`
- Updated XHTML Comments column to display actual comment text alongside Refunded/Cancelled badges, with filter and sort support

## Original PR
https://github.com/hmislk/hmis/pull/21518

## Related Issue
Closes #21517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
