### PR TITLE
docs(skills): integrate screenshot/wiki evidence workflow into dev-issue and playwright-e2e

### DIFF
--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -88,7 +88,7 @@ Run the `playwright-e2e` skill workflow:
 - **Take screenshots** (`browser_take_screenshot`) into the project `tmp/`
   folder at each meaningful stage (before/after states, confirmation dialogs,
   final result) — per playwright-e2e §0. These double as evidence for the
-  issue/PR and wiki in step 9.
+  issue/PR and wiki in step 10.
 - Verify the result in the local DB (credentials: see the
   `local_mysql_credentials.md` memory)
 

--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "<issue-number>"
 # Full Issue Lifecycle (HMIS)
 
 Invoking this skill is the explicit authorization for every commit/push/PR
-step below — do not re-ask before each one. Discussion gates (steps 3, 4, 13)
+step below — do not re-ask before each one. Discussion gates (steps 3, 4, 14)
 are the points where you pause for the user.
 
 ## 1. Setup
@@ -85,6 +85,10 @@ errors before moving on.
 Run the `playwright-e2e` skill workflow:
 - Login, select the department from step 4
 - Exercise the feature using the records chosen in step 4
+- **Take screenshots** (`browser_take_screenshot`) into the project `tmp/`
+  folder at each meaningful stage (before/after states, confirmation dialogs,
+  final result) — per playwright-e2e §0. These double as evidence for the
+  issue/PR and wiki in step 9.
 - Verify the result in the local DB (credentials: see the
   `local_mysql_credentials.md` memory)
 
@@ -100,13 +104,29 @@ quirk, a new accessibility gap, a new verification pattern), append it to
 `developer_docs/testing/playwright-e2e-workflow.md` — same pattern as the
 §0a/§5a additions from issue #21499. Don't force this if nothing new came up.
 
-## 10. Pre-push check
+## 10. Publish evidence (wiki, issue, PR)
+
+Follow playwright-e2e
+[§8 Publishing screenshot evidence](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence):
+
+1. Review the screenshots from step 7 and discard/crop any that expose
+   patient data, credentials, or other sensitive information.
+2. Copy the durable, non-sensitive screenshots into `../hmis.wiki/images/`,
+   then commit and push the wiki from `../hmis.wiki`.
+3. Add a comment (or update the description) on issue `$0` showing the
+   verified before/after flow, embedding the wiki images via their raw URLs
+   (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`).
+4. Remove the temporary screenshots from the project `tmp/` folder.
+
+These wiki image URLs are reused in the PR description in step 13.
+
+## 11. Pre-push check
 
 Run the `verify-persistence` skill's pre-push step: swap `persistence.xml`
 back to the `${JDBC_DATASOURCE}` / `${JDBC_AUDIT_DATASOURCE}` placeholders,
 remembering the local JNDI names for the post-push restore.
 
-## 11. Commit and push
+## 12. Commit and push
 
 Stage the intended source/doc files (`git add <files>`), including
 `persistence.xml` now that it has placeholders. Then run `commit-code` with
@@ -114,13 +134,15 @@ Stage the intended source/doc files (`git add <files>`), including
 `verify-persistence`'s post-push step to restore `persistence.xml` to the
 local JNDI names, leaving that change **unstaged**.
 
-## 12. Create the PR
+## 13. Create the PR
 
 Target `development`. The PR description should state what was implemented
 and summarize the Playwright + DB verification performed in steps 7-8
-(concrete enough that a reviewer trusts it was actually tested).
+(concrete enough that a reviewer trusts it was actually tested), and embed
+the same wiki-hosted screenshots from step 10 so reviewers can see the
+verified behavior without redeploying locally.
 
-## 13. Review loop (until mergeable)
+## 14. Review loop (until mergeable)
 
 Repeat, up to **3 cycles**:
 
@@ -140,7 +162,8 @@ If 3 cycles pass without convergence (flaky CI, unresolved disagreement with
 a reviewer, etc.), stop and ask the user how to proceed rather than looping
 indefinitely.
 
-## 14. Notify
+## 15. Notify
 
-Report the PR link, a short summary of what changed, and what was verified.
+Report the PR link, the issue comment from step 10, a short summary of what
+changed, and what was verified (including the published screenshots).
 **Never merge** — that's the user's call.

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -28,6 +28,11 @@ Full operational workflow lives in
 read it before driving the browser. This skill is the entry point and adds the
 rebuild/redeploy and permission context.
 
+For general MCP tool mechanics (tool reference, clicking/dropdown/file-upload
+patterns, common errors) see the companion
+[Playwright MCP Guide](../../../developer_docs/tools/playwright-mcp-guide.md) —
+the workflow doc above is HMIS-specific; the guide is generic Playwright MCP usage.
+
 ## Workflow
 
 1. **Confirm the target** with the user: which feature/page, which local
@@ -41,15 +46,24 @@ rebuild/redeploy and permission context.
 4. **Drive the feature** using accessibility snapshots (`browser_snapshot`)
    to locate elements, real key events for PrimeFaces inputs (§3), and
    `browser_handle_dialog` for `confirm()` guards (§4). Wait on the expected
-   result (`browser_wait_for`) rather than fixed sleeps (§5a).
-5. **Verify in the database** — read-only `mysql` queries against the local
+   result (`browser_wait_for`) rather than fixed sleeps (§5a). Watch for
+   [§12](../../../developer_docs/testing/playwright-e2e-workflow.md#12-jsf-form-validation-blocks-navigation-buttons)
+   (required-field validation blocking unrelated nav buttons),
+   [§13](../../../developer_docs/testing/playwright-e2e-workflow.md#13-primefaces-pselectonemenu-is-not-a-native-select)
+   (`p:selectOneMenu` click-option pattern), and
+   [§14](../../../developer_docs/testing/playwright-e2e-workflow.md#14-non-ajax-search-buttons-can-timeout-on-click)
+   (non-AJAX search clicks that time out but still succeed).
+5. **If the DB lacks suitable test data, generate it through the app** — see
+   [§15](../../../developer_docs/testing/playwright-e2e-workflow.md#15-always-generate-test-data--never-fall-back-to-code-only-verification).
+   Never fall back to "code looks correct" as evidence.
+6. **Verify in the database** — read-only `mysql` queries against the local
    DB per [§6](../../../developer_docs/testing/playwright-e2e-workflow.md#6-verify-against-the-database).
    Credentials come from `C:\Credentials\` (outside the repo).
-6. **Capture evidence** into the project `tmp/` folder, then follow
+7. **Capture evidence** into the project `tmp/` folder, then follow
    [§8](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence)
    for anything destined for the wiki/issue. Remove temp screenshots from the
    repo afterwards.
-7. If Playwright can't find a control, treat it as a product accessibility gap
+8. If Playwright can't find a control, treat it as a product accessibility gap
    (§7) — fix the page, not the test.
 
 ## Required permissions

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -62,7 +62,7 @@ the workflow doc above is HMIS-specific; the guide is generic Playwright MCP usa
 7. **Capture evidence** into the project `tmp/` folder, then follow
    [§8](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence)
    for anything destined for the wiki/issue. Remove temp screenshots from the
-   repo afterwards.
+   repo afterward.
 8. If Playwright can't find a control, treat it as a product accessibility gap
    (§7) — fix the page, not the test.
 


### PR DESCRIPTION
## Summary
- `playwright-e2e` skill now links the [Playwright MCP Guide](developer_docs/tools/playwright-mcp-guide.md) as a companion reference, and surfaces the newer workflow learnings (§12-15: JSF validation blocking nav buttons, `p:selectOneMenu` click pattern, non-AJAX search timeouts, always generate test data through the app).
- `dev-issue` skill now: captures screenshots during Playwright testing (step 7), publishes durable non-sensitive screenshots to the `hmis.wiki` and comments on the issue with embedded wiki images (new step 10), and embeds the same screenshots in the PR description (step 13).

## Why
The Playwright workflow doc already documented how to capture/publish screenshot evidence (§8), but it wasn't wired into the `dev-issue` lifecycle, so verification screenshots weren't consistently published to the wiki, issue, or PR.

## Test plan
- [x] Docs-only change — no application code touched, no build/deploy/Playwright verification required.
- [x] Verified step renumbering and cross-references in `dev-issue/SKILL.md` are internally consistent.

Closes #21524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing workflow documentation with enhanced screenshot evidence capture and management procedures.
  * Expanded Playwright testing guidance with improved strategies for waits, form validation handling, and UI control interactions.
  * Refined workflow step structure and cross-references for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->