### PR TITLE
feat(inward): group assistant doctor fees under lead doctor on final bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1935,37 +1935,19 @@ public class BhtSummeryController implements Serializable {
         createTables();
 
         if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
-            
-            System.out.println("DEBUG: Merging fees - ProfFee size = " + profesionallFee.size());
-            System.out.println("DEBUG: Merging fees - AssistFee size = " + doctorAndNurseFee.size());
-
-            // Assisting fees (non-Consultant staff) are never touched by setProfesionallFeeAdjusted,
-            // so their feeAdjusted stays 0. When merged into the Professional Fee list they would show
-            // a blank/zero Adjusted Value. Seed it from feeValue (mirrors the professional-fee behaviour)
-            // so the combined list shows a correct adjusted value for assistant doctors too.
-            for (BillFee assistFee : doctorAndNurseFee) {
-                if (assistFee.getFeeAdjusted() == 0.0) {
-                    assistFee.setFeeAdjusted(assistFee.getFeeValue());
-                    getBillFeeFacade().edit(assistFee);
-                }
-            }
-
+            // Both lists already have feeAdjusted = feeValue (set by setProfesionallFeeAdjusted /
+            // setAssistingFeeAdjusted in createTables), so the merged list shows matching adjusted values.
             allDoctorCharges = new ArrayList<>();
             allDoctorCharges.addAll(profesionallFee);
             allDoctorCharges.addAll(doctorAndNurseFee);
-            
-            System.out.println("DEBUG: Merged total size = " + allDoctorCharges.size());
-            
+
             profesionallFee.clear();
             doctorAndNurseFee.clear();
-            System.out.println("DEBUG: Clear --> Profesionall Fee and  Assist Fee");
-            
+
             profesionallFee.addAll(allDoctorCharges);
-            System.out.println("DEBUG: Back to Merged Profesionall Fee = " + profesionallFee.size());
-            
+
             allDoctorCharges.clear();
-            System.out.println("DEBUG: Clear --> All Doctor harges");
-            
+
             createChargeItemTotals();
         }
 
@@ -2388,6 +2370,7 @@ public class BhtSummeryController implements Serializable {
         departmentBillItems = getInwardBean().createDepartmentBillItemsOptimized(patientEncounter, null, childPatientEncouters);
         additionalChargeBill = getInwardBean().fetchOutSideBill(getPatientEncounter(), childPatientEncouters);
         getInwardBean().setProfesionallFeeAdjusted(getPatientEncounter(), childPatientEncouters);
+        getInwardBean().setAssistingFeeAdjusted(getPatientEncounter(), childPatientEncouters);
         profesionallFee = getInwardBean().createProfesionallFee(getPatientEncounter(), childPatientEncouters);
         doctorAndNurseFee = getInwardBean().createDoctorAndNurseFee(getPatientEncounter(), childPatientEncouters);
         paymentBill = getInwardBean().fetchPaymentBill(getPatientEncounter(), childPatientEncouters);
@@ -2428,6 +2411,7 @@ public class BhtSummeryController implements Serializable {
         departmentBillItems = getInwardBean().createDepartmentBillItemsOptimized(patientEncounter, null, childPatientEncouters);
         additionalChargeBill = getInwardBean().fetchOutSideBill(getPatientEncounter(), childPatientEncouters);
         getInwardBean().setProfesionallFeeAdjusted(getPatientEncounter(), childPatientEncouters);
+        getInwardBean().setAssistingFeeAdjusted(getPatientEncounter(), childPatientEncouters);
         profesionallFee = getInwardBean().createProfesionallFeeEstimated(getPatientEncounter());
         doctorAndNurseFee = getInwardBean().createDoctorAndNurseFee(getPatientEncounter(), childPatientEncouters);
         paymentBill = getInwardBean().fetchPaymentBill(getPatientEncounter(), childPatientEncouters);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -535,28 +535,51 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Handles manual drag-and-drop reordering of the Professional Fee table on
-     * the final bill. PrimeFaces has already moved the whole row (the BillFee
-     * object, with its name, fee value and adjusted value) within the bound
-     * {@code profesionallFee} list by the time this fires. We persist the new
-     * position into each fee's orderNo so the order survives without waiting for
-     * settle and is reproduced on the printed bill via @OrderBy("orderNo, ...").
+     * Handles drag-and-drop reordering of the doctor rows in the grouped
+     * Professional Fee table. The grouped list is rebuilt fresh on each render
+     * (so PrimeFaces' in-place reorder would be lost); instead we take the
+     * displayed order, apply the move via the event's from/to indices, and write
+     * a sequential orderNo onto every underlying fee. The next render re-groups
+     * ordered by orderNo, and the printed bill reproduces it via
+     * &#64;OrderBy("orderNo, feeAdjusted").
      */
-    public void onProfessionalFeeRowReorder(ReorderEvent event) {
-        if (profesionallFee != null) {
-            int serial = 0;
-            for (BillFee bf : profesionallFee) {
+    public void onGroupedProfessionalFeeReorder(ReorderEvent event) {
+        List<DoctorFeeGroup> groups = getGroupedProfessionalFees();
+        int from = event.getFromIndex();
+        int to = event.getToIndex();
+        if (from < 0 || to < 0 || from >= groups.size() || to >= groups.size()) {
+            return;
+        }
+        DoctorFeeGroup moved = groups.remove(from);
+        groups.add(to, moved);
+
+        int serial = 0;
+        for (DoctorFeeGroup grp : groups) {
+            for (BillFee bf : grp.getFees()) {
                 bf.setOrderNo(serial++);
-                // Keep the Adjusted Fee equal to the (read-only) Fee Value, which always travels
-                // correctly with its doctor. This re-syncs the editable Adjusted Value input after
-                // a drag so it never ends up showing the previous row's value.
-                bf.setFeeAdjusted(bf.getFeeValue());
                 getBillFeeFacade().edit(bf);
             }
         }
-        JsfUtil.addSuccessMessage("Row order updated");
+        JsfUtil.addSuccessMessage("Doctor order updated");
     }
 
+    /**
+     * Captures the professional fee list in its current displayed (grouped,
+     * doctor-by-doctor) order into orderNo. Called when Save Provisional Bill or
+     * Settle is clicked so the saved bill keeps exactly the order shown on screen,
+     * which the combined-doctor print preview then reproduces via
+     * &#64;OrderBy("orderNo, feeAdjusted").
+     */
+    private void persistGroupedProfessionalFeeOrder() {
+        int serial = 0;
+        for (DoctorFeeGroup grp : getGroupedProfessionalFees()) {
+            for (BillFee bf : grp.getFees()) {
+                bf.setOrderNo(serial++);
+                getBillFeeFacade().edit(bf);
+            }
+        }
+    }
+    
     /**
      * Groups the professional fee list by doctor so the final bill shows a single
      * line per doctor with the combined total. Each group keeps its individual
@@ -588,7 +611,18 @@ public class BhtSummeryController implements Serializable {
                 group.setTotalAdjusted(group.getTotalAdjusted() + adjusted);
             }
         }
-        return new ArrayList<>(groups.values());
+        List<DoctorFeeGroup> result = new ArrayList<>(groups.values());
+        // Order doctors by the smallest orderNo among their fees so a manual
+        // drag-reorder (which writes orderNo) is reproduced. A stable sort keeps
+        // first-appearance order when nothing has been reordered (all orderNo 0).
+        result.sort(Comparator.comparingInt(grp -> {
+            int min = Integer.MAX_VALUE;
+            for (BillFee bf : grp.getFees()) {
+                min = Math.min(min, bf.getOrderNo());
+            }
+            return min;
+        }));
+        return result;
     }
 
     /**
@@ -1501,6 +1535,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     public void createTempBill() {
+        // Capture the current grouped (doctor-by-doctor) professional fee order so the
+        // Temporary Bill preview shows the combined doctor list with the latest adjusted
+        // values, in the same order shown on screen.
+        persistGroupedProfessionalFeeOrder();
         tempBill = null;
         updateTotal();
         saveTempBill();
@@ -1511,6 +1549,8 @@ public class BhtSummeryController implements Serializable {
         if (errorCheck()) {
             return;
         }
+
+        
 
         originalBill.setDiscount(discount);
         originalBill.setNetTotal(originalBill.getGrantTotal() - discount);
@@ -1532,6 +1572,8 @@ public class BhtSummeryController implements Serializable {
         if (errorCheck()) {
             return;
         }
+
+        persistGroupedProfessionalFeeOrder();
 
         originalBill.setDiscount(discount);
         originalBill.setNetTotal(originalBill.getGrantTotal() - discount);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -661,12 +661,29 @@ public class BhtSummeryController implements Serializable {
             getBillFeeFacade().edit(bf);
         }
 
+        refreshProfessionalChargeAdjustedTotal();
+        updateTotal();
+    }
+
+    /**
+     * Refreshes the ProfessionalCharge category adjusted total from the grouped
+     * doctor fees the user actually sees. When the config flag merges assisting
+     * fees into {@code profesionallFee}, those fees live on a different bill type,
+     * so summing only {@code getProfessionalCharge(...)} (InwardProfessional) would
+     * silently drop the assisting-fee adjustments from settlement. Summing the
+     * grouped totals keeps the category total consistent with the displayed table
+     * in both the merged and non-merged configurations.
+     */
+    private void refreshProfessionalChargeAdjustedTotal() {
+        double groupedAdjusted = 0;
+        for (DoctorFeeGroup g : getGroupedProfessionalFees()) {
+            groupedAdjusted += g.getTotalAdjusted();
+        }
         for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
             if (chargeItemTotal.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                chargeItemTotal.setAdjustedTotal(getInwardBean().getProfessionalCharge(getPatientEncounter(), childPatientEncouters));
+                chargeItemTotal.setAdjustedTotal(groupedAdjusted);
             }
         }
-        updateTotal();
     }
 
     /**
@@ -690,11 +707,7 @@ public class BhtSummeryController implements Serializable {
             }
             selectedDoctorFeeGroup.setTotalAdjusted(sum);
         }
-        for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
-            if (chargeItemTotal.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                chargeItemTotal.setAdjustedTotal(getInwardBean().getProfessionalCharge(getPatientEncounter(), childPatientEncouters));
-            }
-        }
+        refreshProfessionalChargeAdjustedTotal();
         updateTotal();
     }
 
@@ -710,7 +723,9 @@ public class BhtSummeryController implements Serializable {
      * View model for one doctor's combined professional fee row on the final bill,
      * carrying the summed total and the individual fees behind it.
      */
-    public static class DoctorFeeGroup {
+    public static class DoctorFeeGroup implements Serializable {
+
+        private static final long serialVersionUID = 1L;
 
         private Staff staff;
         private final List<BillFee> fees = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2475,56 +2475,71 @@ public class BhtSummeryController implements Serializable {
         getBillFacade().edit(getOriginalBill());
     }
 
-    private void updateProBillFee(BillItem bItem) {
-        // Persist the current list order (set by drag-and-drop on the final bill) into
-        // orderNo so @OrderBy("orderNo, feeAdjusted") reproduces it on the printout.
-        int serial = 0;
-        for (BillFee bf : getProfesionallFee()) {
-            bf.setReferenceBillItem(bItem);
-            bf.setOrderNo(serial++);
-            getBillFeeFacade().edit(bf);
+    private List<BillFee> feesOrderedByOrderNo(List<BillFee> fees) {
+        List<BillFee> ordered = new ArrayList<>(fees);
+        ordered.sort(Comparator.comparingInt(BillFee::getOrderNo));
+        return ordered;
+    }
 
-            bItem.getProFees().add(bf);
-
+    /**
+     * Stores ONE professional fee per doctor on the saved bill: a doctor's
+     * individual fees are merged into a single new BillFee (summed feeValue and
+     * feeAdjusted) attached to the final/temp bill item via referenceBillItem,
+     * preserving the manual doctor order via orderNo.
+     * <p>
+     * The original per-encounter fees are left untouched on their
+     * InwardProfessional bills, so doctor-payment/commission reports (which read
+     * those bills) stay correct. The merged fees belong to the final bill
+     * (InwardFinalBill), so they are distinguishable from the source fees by bill
+     * type. When {@code persist} is false (temp preview) the merged fees are kept
+     * in memory only.
+     */
+    private void addMergedDoctorFeesToProFees(List<BillFee> sourceFees, BillItem bItem, boolean persist) {
+        Map<Staff, BillFee> merged = new LinkedHashMap<>();
+        for (BillFee bf : feesOrderedByOrderNo(sourceFees)) {
+            Staff staff = bf.getStaff();
+            if (staff == null) {
+                continue;
+            }
+            double adjusted = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+            BillFee m = merged.get(staff);
+            if (m == null) {
+                m = new BillFee();
+                m.setStaff(staff);
+                m.setFee(bf.getFee());
+                m.setBill(bItem.getBill());
+                m.setBillItem(bItem);
+                m.setReferenceBillItem(bItem);
+                m.setOrderNo(bf.getOrderNo());
+                m.setCreatedAt(new Date());
+                m.setCreater(getSessionController().getLoggedUser());
+                merged.put(staff, m);
+            }
+            m.setFeeValue(m.getFeeValue() + bf.getFeeValue());
+            m.setFeeAdjusted(m.getFeeAdjusted() + adjusted);
         }
+        for (BillFee m : merged.values()) {
+            if (persist) {
+                getBillFeeFacade().create(m);
+            }
+            bItem.getProFees().add(m);
+        }
+    }
 
+    private void updateProBillFee(BillItem bItem) {
+        addMergedDoctorFeesToProFees(getProfesionallFee(), bItem, true);
     }
 
     private void updateProTempBillFee(BillItem bItem) {
-        int serial = 0;
-        for (BillFee bf : getProfesionallFee()) {
-            bf.setReferenceBillItem(bItem);
-            bf.setOrderNo(serial++);
-
-            bItem.getProFees().add(bf);
-
-        }
-
+        addMergedDoctorFeesToProFees(getProfesionallFee(), bItem, false);
     }
 
     private void updateProBillFeeForDocAndNeurses(BillItem bItem) {
-        int serial = 0;
-        for (BillFee bf : getDoctorAndNurseFee()) {
-            bf.setReferenceBillItem(bItem);
-            bf.setOrderNo(serial++);
-            getBillFeeFacade().edit(bf);
-
-            bItem.getProFees().add(bf);
-
-        }
-
+        addMergedDoctorFeesToProFees(getDoctorAndNurseFee(), bItem, true);
     }
 
     private void updateProTempBillFeeForDocAndNeurses(BillItem bItem) {
-        int serial = 0;
-        for (BillFee bf : getDoctorAndNurseFee()) {
-            bf.setReferenceBillItem(bItem);
-            bf.setOrderNo(serial++);
-
-            bItem.getProFees().add(bf);
-
-        }
-
+        addMergedDoctorFeesToProFees(getDoctorAndNurseFee(), bItem, false);
     }
 
     private void saveRefencePatientRoom(PatientRoom pr) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1938,7 +1938,18 @@ public class BhtSummeryController implements Serializable {
             
             System.out.println("DEBUG: Merging fees - ProfFee size = " + profesionallFee.size());
             System.out.println("DEBUG: Merging fees - AssistFee size = " + doctorAndNurseFee.size());
-            
+
+            // Assisting fees (non-Consultant staff) are never touched by setProfesionallFeeAdjusted,
+            // so their feeAdjusted stays 0. When merged into the Professional Fee list they would show
+            // a blank/zero Adjusted Value. Seed it from feeValue (mirrors the professional-fee behaviour)
+            // so the combined list shows a correct adjusted value for assistant doctors too.
+            for (BillFee assistFee : doctorAndNurseFee) {
+                if (assistFee.getFeeAdjusted() == 0.0) {
+                    assistFee.setFeeAdjusted(assistFee.getFeeValue());
+                    getBillFeeFacade().edit(assistFee);
+                }
+            }
+
             allDoctorCharges = new ArrayList<>();
             allDoctorCharges.addAll(profesionallFee);
             allDoctorCharges.addAll(doctorAndNurseFee);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -151,6 +151,8 @@ public class BhtSummeryController implements Serializable {
     private List<BillFee> profesionallFee;
     private List<BillFee> doctorAndNurseFee;
     private List<BillFee> allDoctorCharges;
+    // Holds the doctor whose fee breakdown is shown in the "how the total is calculated" popup.
+    private DoctorFeeGroup selectedDoctorFeeGroup;
     List<BillItem> pharmacyItems;
     private List<Bill> paymentBill;
     private List<Bill> pharmacyIssues;
@@ -530,6 +532,191 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateTotal();
+    }
+
+    /**
+     * Handles manual drag-and-drop reordering of the Professional Fee table on
+     * the final bill. PrimeFaces has already moved the whole row (the BillFee
+     * object, with its name, fee value and adjusted value) within the bound
+     * {@code profesionallFee} list by the time this fires. We persist the new
+     * position into each fee's orderNo so the order survives without waiting for
+     * settle and is reproduced on the printed bill via @OrderBy("orderNo, ...").
+     */
+    public void onProfessionalFeeRowReorder(ReorderEvent event) {
+        if (profesionallFee != null) {
+            int serial = 0;
+            for (BillFee bf : profesionallFee) {
+                bf.setOrderNo(serial++);
+                // Keep the Adjusted Fee equal to the (read-only) Fee Value, which always travels
+                // correctly with its doctor. This re-syncs the editable Adjusted Value input after
+                // a drag so it never ends up showing the previous row's value.
+                bf.setFeeAdjusted(bf.getFeeValue());
+                getBillFeeFacade().edit(bf);
+            }
+        }
+        JsfUtil.addSuccessMessage("Row order updated");
+    }
+
+    /**
+     * Groups the professional fee list by doctor so the final bill shows a single
+     * line per doctor with the combined total. Each group keeps its individual
+     * fees so the breakdown popup can show how the total was calculated.
+     * Only the fees that are actually billed (not cancelled, real billed bill,
+     * non-zero amount) are included, matching what the per-fee table displayed.
+     */
+    public List<DoctorFeeGroup> getGroupedProfessionalFees() {
+        Map<Staff, DoctorFeeGroup> groups = new LinkedHashMap<>();
+        if (profesionallFee != null) {
+            for (BillFee bf : profesionallFee) {
+                if (bf.getStaff() == null || bf.getBill() == null) {
+                    continue;
+                }
+                if (bf.getBill().isCancelled() || !(bf.getBill() instanceof BilledBill)) {
+                    continue;
+                }
+                if (bf.getFeeValue() == 0) {
+                    continue;
+                }
+                double adjusted = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+                DoctorFeeGroup group = groups.get(bf.getStaff());
+                if (group == null) {
+                    group = new DoctorFeeGroup(bf.getStaff());
+                    groups.put(bf.getStaff(), group);
+                }
+                group.getFees().add(bf);
+                group.setTotal(group.getTotal() + bf.getFeeValue());
+                group.setTotalAdjusted(group.getTotalAdjusted() + adjusted);
+            }
+        }
+        return new ArrayList<>(groups.values());
+    }
+
+    /**
+     * Applies an edited doctor-level Adjusted Value back onto that doctor's
+     * individual fees, split in proportion to their current adjusted amounts so
+     * the persisted bill and the printout stay consistent. The last fee absorbs
+     * any rounding remainder so the parts always sum to the entered total.
+     */
+    public void changeGroupedAdjustedValue(DoctorFeeGroup group) {
+        if (group == null || group.getFees().isEmpty()) {
+            return;
+        }
+        double newTotal = group.getTotalAdjusted();
+        List<BillFee> fees = group.getFees();
+
+        double oldSum = 0;
+        for (BillFee bf : fees) {
+            oldSum += bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+        }
+
+        double allocated = 0;
+        for (int k = 0; k < fees.size(); k++) {
+            BillFee bf = fees.get(k);
+            double share;
+            if (k == fees.size() - 1) {
+                share = newTotal - allocated;
+            } else if (oldSum != 0) {
+                double base = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+                share = Math.round((newTotal * base / oldSum) * 100.0) / 100.0;
+                allocated += share;
+            } else {
+                share = Math.round((newTotal / fees.size()) * 100.0) / 100.0;
+                allocated += share;
+            }
+            bf.setFeeAdjusted(share);
+            getBillFeeFacade().edit(bf);
+        }
+
+        for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
+            if (chargeItemTotal.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                chargeItemTotal.setAdjustedTotal(getInwardBean().getProfessionalCharge(getPatientEncounter(), childPatientEncouters));
+            }
+        }
+        updateTotal();
+    }
+
+    /**
+     * Selects the doctor whose fee breakdown should be shown in the popup.
+     */
+    public void viewDoctorFeeBreakdown(DoctorFeeGroup group) {
+        selectedDoctorFeeGroup = group;
+    }
+
+    /**
+     * Persists an Adjusted Value edited directly on a single fee inside the
+     * breakdown popup, then refreshes the doctor's adjusted total (popup footer
+     * and grouped row) and the professional charge totals.
+     */
+    public void changeFeeAdjustedInBreakdown(BillFee billFee) {
+        getBillFeeFacade().edit(billFee);
+        if (selectedDoctorFeeGroup != null) {
+            double sum = 0;
+            for (BillFee bf : selectedDoctorFeeGroup.getFees()) {
+                sum += bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+            }
+            selectedDoctorFeeGroup.setTotalAdjusted(sum);
+        }
+        for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
+            if (chargeItemTotal.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                chargeItemTotal.setAdjustedTotal(getInwardBean().getProfessionalCharge(getPatientEncounter(), childPatientEncouters));
+            }
+        }
+        updateTotal();
+    }
+
+    public DoctorFeeGroup getSelectedDoctorFeeGroup() {
+        return selectedDoctorFeeGroup;
+    }
+
+    public void setSelectedDoctorFeeGroup(DoctorFeeGroup selectedDoctorFeeGroup) {
+        this.selectedDoctorFeeGroup = selectedDoctorFeeGroup;
+    }
+
+    /**
+     * View model for one doctor's combined professional fee row on the final bill,
+     * carrying the summed total and the individual fees behind it.
+     */
+    public static class DoctorFeeGroup {
+
+        private Staff staff;
+        private final List<BillFee> fees = new ArrayList<>();
+        private double total;
+        private double totalAdjusted;
+
+        public DoctorFeeGroup() {
+        }
+
+        public DoctorFeeGroup(Staff staff) {
+            this.staff = staff;
+        }
+
+        public Staff getStaff() {
+            return staff;
+        }
+
+        public void setStaff(Staff staff) {
+            this.staff = staff;
+        }
+
+        public List<BillFee> getFees() {
+            return fees;
+        }
+
+        public double getTotal() {
+            return total;
+        }
+
+        public void setTotal(double total) {
+            this.total = total;
+        }
+
+        public double getTotalAdjusted() {
+            return totalAdjusted;
+        }
+
+        public void setTotalAdjusted(double totalAdjusted) {
+            this.totalAdjusted = totalAdjusted;
+        }
     }
 
     public void changeAdjustedValueRoomCharge(PatientRoom pR) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -148,6 +148,7 @@ public class BhtSummeryController implements Serializable {
     private List<DepartmentBillItems> departmentBillItems;
     private List<BillFee> profesionallFee;
     private List<BillFee> doctorAndNurseFee;
+    private List<BillFee> allDoctorCharges;
     List<BillItem> pharmacyItems;
     private List<Bill> paymentBill;
     private List<Bill> pharmacyIssues;
@@ -1904,9 +1905,6 @@ public class BhtSummeryController implements Serializable {
     }
 
     public String toSettle() {
-        Date startTime = new Date();
-        Date fromDate = null;
-        Date toDate = null;
 
         if (getPatientEncounter() == null) {
             return "";
@@ -1935,6 +1933,31 @@ public class BhtSummeryController implements Serializable {
 
         childPatientEncouters = getInwardBean().fetchChildPatientEncounter(patientEncounter);
         createTables();
+
+        if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
+            
+            System.out.println("DEBUG: Merging fees - ProfFee size = " + profesionallFee.size());
+            System.out.println("DEBUG: Merging fees - AssistFee size = " + doctorAndNurseFee.size());
+            
+            allDoctorCharges = new ArrayList<>();
+            allDoctorCharges.addAll(profesionallFee);
+            allDoctorCharges.addAll(doctorAndNurseFee);
+            
+            System.out.println("DEBUG: Merged total size = " + allDoctorCharges.size());
+            
+            profesionallFee.clear();
+            doctorAndNurseFee.clear();
+            System.out.println("DEBUG: Clear --> Profesionall Fee and  Assist Fee");
+            
+            profesionallFee.addAll(allDoctorCharges);
+            System.out.println("DEBUG: Back to Merged Profesionall Fee = " + profesionallFee.size());
+            
+            allDoctorCharges.clear();
+            System.out.println("DEBUG: Clear --> All Doctor harges");
+            
+            createChargeItemTotals();
+        }
+
         calculateDiscount();
         updateTotal();
         settleOriginalBill();
@@ -2129,7 +2152,7 @@ public class BhtSummeryController implements Serializable {
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
-                        updateProBillFeeForDocAndNeurses(temBi);;
+                        updateProBillFeeForDocAndNeurses(temBi);
                     }
                 }
                 temHosFee += cit.getTotal();
@@ -2170,7 +2193,7 @@ public class BhtSummeryController implements Serializable {
             } else {
                 if (configOptionApplicationController.getBooleanValueByKey("Create Professional Bill Fees For Assistant Chargers", false)) {
                     if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
-                        updateProTempBillFeeForDocAndNeurses(temBi);;
+                        updateProTempBillFeeForDocAndNeurses(temBi);
                     }
                 }
                 temHosFee += cit.getTotal();
@@ -2357,6 +2380,7 @@ public class BhtSummeryController implements Serializable {
         profesionallFee = getInwardBean().createProfesionallFee(getPatientEncounter(), childPatientEncouters);
         doctorAndNurseFee = getInwardBean().createDoctorAndNurseFee(getPatientEncounter(), childPatientEncouters);
         paymentBill = getInwardBean().fetchPaymentBill(getPatientEncounter(), childPatientEncouters);
+
         createChargeItemTotals();
         updateTotal();
 
@@ -2464,6 +2488,7 @@ public class BhtSummeryController implements Serializable {
         paid = 0.0;
         profesionallFee = null;
         doctorAndNurseFee = null;
+        allDoctorCharges = null;
         patientItems = null;
         paymentBill = null;
         departmentBillItems = null;
@@ -3185,10 +3210,20 @@ public class BhtSummeryController implements Serializable {
                     i.setTotal(getInwardBean().calNetCostOfIssue(getPatientEncounter(), BillType.StoreBhtPre, childPatientEncouters));
                     break;
                 case ProfessionalCharge:
-                    i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
+                    if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
+                        double professionalFee = getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView);
+                        double assistingFee = getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters);
+                        i.setTotal(professionalFee + assistingFee);
+                    }else{
+                        i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
+                    }
                     break;
                 case DoctorAndNurses:
-                    i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
+                    if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
+                        i.setTotal(0.0);
+                    }else{
+                        i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
+                    }
                     break;
             }
         }
@@ -3623,6 +3658,14 @@ public class BhtSummeryController implements Serializable {
 
         return new RoomDurationBreakdown(totalMinutes, slotMinutes, completeSlots,
                 remainderMinutes, overshootMinutes, extraSlotCharged, billedSlots);
+    }
+
+    public List<BillFee> getAllDoctorCharges() {
+        return allDoctorCharges;
+    }
+
+    public void setAllDoctorCharges(List<BillFee> allDoctorCharges) {
+        this.allDoctorCharges = allDoctorCharges;
     }
 
     public static class RoomDurationBreakdown {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -80,12 +80,14 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.primefaces.event.ReorderEvent;
 import org.primefaces.event.RowEditEvent;
 
 /**
@@ -2245,8 +2247,12 @@ public class BhtSummeryController implements Serializable {
     }
 
     private void updateProBillFee(BillItem bItem) {
+        // Persist the current list order (set by drag-and-drop on the final bill) into
+        // orderNo so @OrderBy("orderNo, feeAdjusted") reproduces it on the printout.
+        int serial = 0;
         for (BillFee bf : getProfesionallFee()) {
             bf.setReferenceBillItem(bItem);
+            bf.setOrderNo(serial++);
             getBillFeeFacade().edit(bf);
 
             bItem.getProFees().add(bf);
@@ -2256,8 +2262,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     private void updateProTempBillFee(BillItem bItem) {
+        int serial = 0;
         for (BillFee bf : getProfesionallFee()) {
             bf.setReferenceBillItem(bItem);
+            bf.setOrderNo(serial++);
 
             bItem.getProFees().add(bf);
 
@@ -2266,8 +2274,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     private void updateProBillFeeForDocAndNeurses(BillItem bItem) {
+        int serial = 0;
         for (BillFee bf : getDoctorAndNurseFee()) {
             bf.setReferenceBillItem(bItem);
+            bf.setOrderNo(serial++);
             getBillFeeFacade().edit(bf);
 
             bItem.getProFees().add(bf);
@@ -2277,8 +2287,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     private void updateProTempBillFeeForDocAndNeurses(BillItem bItem) {
+        int serial = 0;
         for (BillFee bf : getDoctorAndNurseFee()) {
             bf.setReferenceBillItem(bItem);
+            bf.setOrderNo(serial++);
 
             bItem.getProFees().add(bf);
 
@@ -2523,7 +2535,9 @@ public class BhtSummeryController implements Serializable {
 
     public List<BillItem> getSummaryOfDoctorChargers(List<BillItem> bi, PatientEncounter pe) {
         List<BillItem> newBillItems = new ArrayList<>();
-        Map<Staff, BillFee> staffFeeMap = new HashMap<>();
+        // LinkedHashMap preserves first-appearance order of each staff member, which follows
+        // the orderNo ordering of proFees, so the manual drag order survives in this layout too.
+        Map<Staff, BillFee> staffFeeMap = new LinkedHashMap<>();
         double totalFee = 0.0;
 
         for (BillItem i : bi) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -715,6 +715,32 @@ public class InwardBeanController implements Serializable {
         getBillFeeFacade().updateByJpql(sql, hm);
     }
 
+    /**
+     * Mirror of {@link #setProfesionallFeeAdjusted} for assisting fees
+     * (non-Consultant staff). Keeps the adjusted fee equal to the fee value for
+     * assistant doctors on every navigation, so the Professional Fee and
+     * Adjusted Fee columns always match - exactly as they do for consultants.
+     */
+    public void setAssistingFeeAdjusted(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
+        HashMap hm = new HashMap();
+        String sql = "UPDATE BillFee bt SET bt.feeAdjusted = bt.feeValue"
+                + " WHERE bt.retired=false"
+                + " AND type(bt.staff)!=:class"
+                + " AND bt.fee.feeType=:ftp"
+                + " AND bt.bill.billType=:btp"
+                + " AND bt.bill.patientEncounter IN :pe";
+        hm.put("class", Consultant.class);
+        hm.put("ftp", FeeType.Staff);
+        hm.put("btp", BillType.InwardProfessional);
+        hm.put("pe", pts);
+        getBillFeeFacade().updateByJpql(sql, hm);
+    }
+
     public void bulkClearServiceBillFeesWithOutMatrix(InwardChargeType inwardChargeType, PatientEncounter patientEncounter) {
         String sql = "UPDATE BillFee s SET s.feeDiscount = 0.0, s.feeValue = s.feeGrossValue + s.feeMargin"
                 + " WHERE s.retired = false"

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -202,7 +202,10 @@ public class BillItem implements Serializable, RetirableEntity {
     @OneToMany(mappedBy = "billItem", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<BillFee> billFees = new ArrayList<>();
     @OneToMany(mappedBy = "referenceBillItem", fetch = FetchType.LAZY)
-    @OrderBy("feeAdjusted")
+    // orderNo holds the manual (drag-and-drop) display order set at settle time;
+    // feeAdjusted is the secondary key so historical bills (orderNo all 0) keep
+    // their original adjusted-fee ordering.
+    @OrderBy("orderNo, feeAdjusted")
     private List<BillFee> proFees = new ArrayList<>();
     @OneToMany(mappedBy = "parentBillItem")
     private List<BillItem> chiledBillItems;

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -61,7 +61,7 @@
                                     class="ui-button-info"
                                     icon="fas fa-print"
                                     value="Check Final Bill"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false) and configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
                                     <p:printer target="printTempBill" />
                                 </p:commandButton>
 
@@ -229,8 +229,9 @@
                                         <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
                                     </p:column>
                                     <p:column headerText="Printing Room">
-                                        <p:autoComplete 
+                                        <p:autoComplete
                                             forceSelection="true"
+                                            maxResults="20"
                                             value="#{b.printRoomFacilityCharge}"
                                             completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
                                             var="rf" 
@@ -704,7 +705,7 @@
                             </p:column>
 
                             <p:column headerText="Adjusted Value" style="text-align: right; padding: 7px;">
-                                <h:outputLabel value="#{g.totalAdjusted}">
+                                <p:inputText autocomplete="off" value="#{g.totalAdjusted}" style="text-align: right;">
                                     <f:convertNumber pattern="#,##0.00"/>
                                     <p:ajax event="blur" process="@this"
                                             update=":#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
@@ -712,11 +713,12 @@
                                     <p:ajax process="@this" event="keyup"
                                             update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
                                             listener="#{bhtSummeryController.changeIsMade()}"/>
-                                </h:outputLabel>
+                                </p:inputText>
                             </p:column>
 
                             <p:column headerText="Breakdown" style="text-align: center; padding: 7px; width: 14em;">
                                 <p:commandButton value="View"
+                                                 id="viewDoctorFeeBreakdown"
                                                  icon="fa fa-list-ul"
                                                  class="ui-button-info ui-button-outlined"
                                                  process="@this"

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -219,7 +219,7 @@
                             </h:panelGroup>
                         </h:panelGrid>
                     </div>
-                    
+
                     <p:panel header="Mandatory Charge Types" class="mt-3">
                         <p:tabView id="tabView">
 
@@ -229,30 +229,41 @@
                                         <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
                                     </p:column>
                                     <p:column headerText="Printing Room">
-                                        <p:autoComplete forceSelection="true"
-                                                        value="#{b.printRoomFacilityCharge}"
-                                                        completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
-                                                        var="rf" itemLabel="#{rf.name}" itemValue="#{rf}">
-                                            <p:ajax event="itemSelect" process="@this"
-                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        <p:autoComplete 
+                                            forceSelection="true"
+                                            value="#{b.printRoomFacilityCharge}"
+                                            completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
+                                            var="rf" 
+                                            itemLabel="#{rf.name}" 
+                                            itemValue="#{rf}">
+                                            <p:ajax 
+                                                event="itemSelect" 
+                                                process="@this"
+                                                listener="#{patientRoomController.edit(b)}"/>
                                         </p:autoComplete>
                                     </p:column>
                                     <p:column headerText="AdmittedAt">
-                                        <p:calendar navigator="true"
-                                                    id="printingRoomAdmittedTimeStamp"
-                                                    value="#{b.printAdmittedAt}"
-                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                            <p:ajax event="change" process="@this"
-                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        <p:calendar 
+                                            navigator="true"
+                                            id="printingRoomAdmittedTimeStamp"
+                                            value="#{b.printAdmittedAt}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                            <p:ajax 
+                                                event="change" 
+                                                process="@this"
+                                                listener="#{patientRoomController.edit(b)}"/>
                                         </p:calendar>
                                     </p:column>
                                     <p:column headerText="DischargeAt">
-                                        <p:calendar navigator="true"
-                                                    id="printingRoomDischargeTimeStamp"
-                                                    value="#{b.printDischargeAt}"
-                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                            <p:ajax event="change" process="@this"
-                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        <p:calendar
+                                            navigator="true"
+                                            id="printingRoomDischargeTimeStamp"
+                                            value="#{b.printDischargeAt}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                            <p:ajax 
+                                                event="change" 
+                                                process="@this"
+                                                listener="#{patientRoomController.edit(b)}"/>
                                         </p:calendar>
 
                                     </p:column>
@@ -547,7 +558,7 @@
                         </p:tabView>
 
                     </p:panel>
-                    
+
                     <p:panel header="Charge Types" class="mt-3">
                         <p:dataTable 
                             id="dList" 
@@ -729,54 +740,54 @@
                               width="1200"
                               style="max-height:70vh; overflow:auto; padding:20px; font-size:1.05rem;">
                         <h:panelGroup id="docFeeBreakdownContent" layout="block">
-                        <h:panelGroup rendered="#{bhtSummeryController.selectedDoctorFeeGroup ne null}">
-                            <div class="mb-3 fw-bold" style="font-size:1.2rem;">
-                                <i class="fa fa-user-md me-2"/>
-                                <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.staff.person.nameWithTitle}"/>
-                            </div>
-                            <p:dataTable id="breakdownTable" value="#{bhtSummeryController.selectedDoctorFeeGroup.fees}" var="fb">
-                                <p:column headerText="Bill No" style="padding: 6px;">
-                                    <h:outputText value="#{fb.bill.deptId}"/>
-                                </p:column>
-                                <p:column headerText="Date" style="padding: 6px;">
-                                    <h:outputText value="#{fb.feeAt ne null ? fb.feeAt : fb.createdAt}">
-                                        <f:convertDateTime timeZone="Asia/Colombo"
-                                                           pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
-                                    </h:outputText>
-                                </p:column>
-                                <p:column headerText="Added User" style="padding: 6px;">
-                                    <h:outputText value="#{fb.bill.creater.webUserPerson.nameWithTitle}"/>
-                                </p:column>
-                                <p:column headerText="Fee Value" style="text-align: right; padding: 6px;">
-                                    <h:outputText value="#{fb.feeValue}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </h:outputText>
-                                </p:column>
-                                <p:column headerText="Adjusted Value" style="text-align: right; padding: 6px;">
-                                    <p:inputText autocomplete="off" value="#{fb.feeAdjusted}" style="text-align: right;">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this"
-                                                update=":#{p:resolveFirstComponentWithId('breakdownTable',view).clientId} :#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
-                                                listener="#{bhtSummeryController.changeFeeAdjustedInBreakdown(fb)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:columnGroup type="footer">
-                                    <p:row>
-                                        <p:column footerText="Total" colspan="4" style="text-align: right; padding: 6px; font-weight: bold;"/>
-                                        <p:column style="text-align: right; padding: 6px; font-weight: bold;">
-                                            <f:facet name="footer">
-                                                <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.totalAdjusted}">
-                                                    <f:convertNumber pattern="#,##0.00"/>
-                                                </h:outputText>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                </p:columnGroup>
-                            </p:dataTable>
-                        </h:panelGroup>
+                            <h:panelGroup rendered="#{bhtSummeryController.selectedDoctorFeeGroup ne null}">
+                                <div class="mb-3 fw-bold" style="font-size:1.2rem;">
+                                    <i class="fa fa-user-md me-2"/>
+                                    <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.staff.person.nameWithTitle}"/>
+                                </div>
+                                <p:dataTable id="breakdownTable" value="#{bhtSummeryController.selectedDoctorFeeGroup.fees}" var="fb">
+                                    <p:column headerText="Bill No" style="padding: 6px;">
+                                        <h:outputText value="#{fb.bill.deptId}"/>
+                                    </p:column>
+                                    <p:column headerText="Date" style="padding: 6px;">
+                                        <h:outputText value="#{fb.feeAt ne null ? fb.feeAt : fb.createdAt}">
+                                            <f:convertDateTime timeZone="Asia/Colombo"
+                                                               pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Added User" style="padding: 6px;">
+                                        <h:outputText value="#{fb.bill.creater.webUserPerson.nameWithTitle}"/>
+                                    </p:column>
+                                    <p:column headerText="Fee Value" style="text-align: right; padding: 6px;">
+                                        <h:outputText value="#{fb.feeValue}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Adjusted Value" style="text-align: right; padding: 6px;">
+                                        <p:inputText autocomplete="off" value="#{fb.feeAdjusted}" style="text-align: right;">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this"
+                                                    update=":#{p:resolveFirstComponentWithId('breakdownTable',view).clientId} :#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeFeeAdjustedInBreakdown(fb)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:columnGroup type="footer">
+                                        <p:row>
+                                            <p:column footerText="Total" colspan="4" style="text-align: right; padding: 6px; font-weight: bold;"/>
+                                            <p:column style="text-align: right; padding: 6px; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.totalAdjusted}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                </p:dataTable>
+                            </h:panelGroup>
                         </h:panelGroup>
                     </p:dialog>
 

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -666,19 +666,29 @@
                     </p:panel>
 
                     <p:panel header="Profesionall Fee" class="mt-3">  
-                        <p:dataTable value="#{bhtSummeryController.profesionallFee}" var="pf"
+                        <p:dataTable 
+                            value="#{bhtSummeryController.profesionallFee}" 
+                            rowIndexVar="i"
+                            var="pf"
                                      rowStyleClass="#{pf.feeValue ne 0 
                                                       and pf.bill.cancelled eq false
                                                       and pf.bill.billClass eq 'class com.divudi.entity.BilledBill' ? '':'noDisplayRow'}">
-                            <p:column headerText="Name">
-                                #{pf.staff.person.nameWithTitle}
+                            
+                            <p:column headerText="#" style="padding: 7px; width: 2em;">
+                                <h:outputLabel value="#{i+1}"/>
                             </p:column>
-                            <p:column headerText="Fee Value" style="text-align: right;">
+                            
+                            <p:column headerText="Name" style="padding: 7px;">
+                                <h:outputLabel value="#{pf.staff.person.nameWithTitle}"/>
+                            </p:column>
+                            
+                            <p:column headerText="Fee Value" style="text-align: right; padding: 7px;">
                                 <h:outputLabel value="#{pf.feeValue}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>
                             </p:column>
-                            <p:column headerText="Adjusted Value" style="text-align: right;">
+                            
+                            <p:column headerText="Adjusted Value" style="text-align: right; padding: 7px;">
                                 <p:inputText autocomplete="off" value="#{pf.feeAdjusted}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                     <p:ajax event="blur" process="@this"

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -665,45 +665,116 @@
                         </p:dataTable>
                     </p:panel>
 
-                    <p:panel header="Profesionall Fee" class="mt-3">  
-                        <p:dataTable 
-                            value="#{bhtSummeryController.profesionallFee}" 
+                    <p:panel header="Profesionall Fee" class="mt-3">
+                        <p:dataTable
+                            id="professionalFeeTable"
+                            value="#{bhtSummeryController.groupedProfessionalFees}"
                             rowIndexVar="i"
-                            var="pf"
-                                     rowStyleClass="#{pf.feeValue ne 0 
-                                                      and pf.bill.cancelled eq false
-                                                      and pf.bill.billClass eq 'class com.divudi.entity.BilledBill' ? '':'noDisplayRow'}">
-                            
+                            var="g">
+
                             <p:column headerText="#" style="padding: 7px; width: 2em;">
                                 <h:outputLabel value="#{i+1}"/>
                             </p:column>
-                            
+
                             <p:column headerText="Name" style="padding: 7px;">
-                                <h:outputLabel value="#{pf.staff.person.nameWithTitle}"/>
+                                <h:outputLabel value="#{g.staff.person.nameWithTitle}"/>
                             </p:column>
-                            
+
                             <p:column headerText="Fee Value" style="text-align: right; padding: 7px;">
-                                <h:outputLabel value="#{pf.feeValue}">
+                                <h:outputLabel value="#{g.total}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>
                             </p:column>
-                            
+
                             <p:column headerText="Adjusted Value" style="text-align: right; padding: 7px;">
-                                <p:inputText autocomplete="off" value="#{pf.feeAdjusted}">
+                                <h:outputLabel value="#{g.totalAdjusted}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                     <p:ajax event="blur" process="@this"
-                                            update=":#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
-                                            listener="#{bhtSummeryController.changeAdjustedProValue(pf)}"/>
+                                            update=":#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                            listener="#{bhtSummeryController.changeGroupedAdjustedValue(g)}"/>
                                     <p:ajax process="@this" event="keyup"
                                             update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
                                             listener="#{bhtSummeryController.changeIsMade()}"/>
-                                </p:inputText>
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Breakdown" style="text-align: center; padding: 7px; width: 14em;">
+                                <p:commandButton value="View"
+                                                 icon="fa fa-list-ul"
+                                                 class="ui-button-info ui-button-outlined"
+                                                 process="@this"
+                                                 actionListener="#{bhtSummeryController.viewDoctorFeeBreakdown(g)}"
+                                                 update=":#{p:resolveFirstComponentWithId('docFeeBreakdownContent',view).clientId}"
+                                                 oncomplete="PF('docFeeBreakdownDlgWv').show()"/>
                             </p:column>
 
                         </p:dataTable>
                     </p:panel>
 
-                    <p:panel id="printTempBill" header="Tempory Bill Priview" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}">
+                    <p:dialog header="Fee Breakdown"
+                              id="docFeeBreakdownDlg"
+                              widgetVar="docFeeBreakdownDlgWv"
+                              modal="true"
+                              showEffect="fade"
+                              hideEffect="fade"
+                              resizable="false"
+                              position="center"
+                              fitViewport="true"
+                              width="1200"
+                              style="max-height:70vh; overflow:auto; padding:20px; font-size:1.05rem;">
+                        <h:panelGroup id="docFeeBreakdownContent" layout="block">
+                        <h:panelGroup rendered="#{bhtSummeryController.selectedDoctorFeeGroup ne null}">
+                            <div class="mb-3 fw-bold" style="font-size:1.2rem;">
+                                <i class="fa fa-user-md me-2"/>
+                                <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.staff.person.nameWithTitle}"/>
+                            </div>
+                            <p:dataTable id="breakdownTable" value="#{bhtSummeryController.selectedDoctorFeeGroup.fees}" var="fb">
+                                <p:column headerText="Bill No" style="padding: 6px;">
+                                    <h:outputText value="#{fb.bill.deptId}"/>
+                                </p:column>
+                                <p:column headerText="Date" style="padding: 6px;">
+                                    <h:outputText value="#{fb.feeAt ne null ? fb.feeAt : fb.createdAt}">
+                                        <f:convertDateTime timeZone="Asia/Colombo"
+                                                           pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Added User" style="padding: 6px;">
+                                    <h:outputText value="#{fb.bill.creater.webUserPerson.nameWithTitle}"/>
+                                </p:column>
+                                <p:column headerText="Fee Value" style="text-align: right; padding: 6px;">
+                                    <h:outputText value="#{fb.feeValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Adjusted Value" style="text-align: right; padding: 6px;">
+                                    <p:inputText autocomplete="off" value="#{fb.feeAdjusted}" style="text-align: right;">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                        <p:ajax event="blur" process="@this"
+                                                update=":#{p:resolveFirstComponentWithId('breakdownTable',view).clientId} :#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                                listener="#{bhtSummeryController.changeFeeAdjustedInBreakdown(fb)}"/>
+                                        <p:ajax process="@this" event="keyup"
+                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                listener="#{bhtSummeryController.changeIsMade()}"/>
+                                    </p:inputText>
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column footerText="Total" colspan="4" style="text-align: right; padding: 6px; font-weight: bold;"/>
+                                        <p:column style="text-align: right; padding: 6px; font-weight: bold;">
+                                            <f:facet name="footer">
+                                                <h:outputText value="#{bhtSummeryController.selectedDoctorFeeGroup.totalAdjusted}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputText>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:dataTable>
+                        </h:panelGroup>
+                        </h:panelGroup>
+                    </p:dialog>
+
+                    <p:panel id="printTempBill" class="mt-3" header="Tempory Bill Priview" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}">
                         <bi:finalBill
                             bill="#{bhtSummeryController.tempBill}"
                             hosCopy="true">

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -46,7 +46,7 @@
                                     style="width: 150px; padding: 1px; margin: auto;"
                                     rendered="#{!configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
                                 </p:commandButton>
-                                
+
                                 <p:commandButton 
                                     class="ui-button-warning mx-2"
                                     icon="fas fa-cogs"
@@ -56,7 +56,7 @@
                                     action="#{bhtSummeryController.createTempBill()}" 
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
                                 </p:commandButton>
-                                
+
                                 <p:commandButton 
                                     class="ui-button-info"
                                     icon="fas fa-print"
@@ -64,7 +64,7 @@
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
                                     <p:printer target="printTempBill" />
                                 </p:commandButton>
-                                
+
                                 <p:commandButton 
                                     value="Save Provisional Bill" 
                                     action="#{bhtSummeryController.saveProvisionalBill()}"
@@ -76,7 +76,7 @@
                                     style="width: 200px; padding: 1px; margin: auto;"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false)}">
                                 </p:commandButton>
-                                
+
                                 <p:commandButton 
                                     value="Settle"
                                     action="#{bhtSummeryController.settle}"
@@ -87,7 +87,7 @@
                                     icon="fa fa-check"
                                     style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
                                 </p:commandButton>
-                                
+
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                     <p:commandButton
                                         ajax="false"
@@ -177,9 +177,6 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Charges Overview"/>
                                     </f:facet>
-<!--                                    <h:panelGroup id="crd" rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'}">
-                                        <credit:outputCredit patientEncounter="#{bhtSummeryController.patientEncounter}"/>
-                                    </h:panelGroup>-->
                                     <p:panelGrid columns="2" id="tot" style="min-width: 100%;">
                                         <h:outputLabel value="Total Charges" style="font-weight: bold"/>
                                         <h:outputLabel value="#{bhtSummeryController.grantTotal}">
@@ -222,84 +219,414 @@
                             </h:panelGroup>
                         </h:panelGrid>
                     </div>
+                    
+                    <p:panel header="Mandatory Charge Types" class="mt-3">
+                        <p:tabView id="tabView">
 
-                    <p:dataTable 
-                        id="dList" 
-                        value="#{bhtSummeryController.chargeItemTotals}" 
-                        var="c" 
-                        scrollHeight="300"
-                        scrollable="true">
+                            <p:tab title="Room Name">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Printing Room">
+                                        <p:autoComplete forceSelection="true"
+                                                        value="#{b.printRoomFacilityCharge}"
+                                                        completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
+                                                        var="rf" itemLabel="#{rf.name}" itemValue="#{rf}">
+                                            <p:ajax event="itemSelect" process="@this"
+                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        </p:autoComplete>
+                                    </p:column>
+                                    <p:column headerText="AdmittedAt">
+                                        <p:calendar navigator="true"
+                                                    id="printingRoomAdmittedTimeStamp"
+                                                    value="#{b.printAdmittedAt}"
+                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                            <p:ajax event="change" process="@this"
+                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        </p:calendar>
+                                    </p:column>
+                                    <p:column headerText="DischargeAt">
+                                        <p:calendar navigator="true"
+                                                    id="printingRoomDischargeTimeStamp"
+                                                    value="#{b.printDischargeAt}"
+                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
+                                            <p:ajax event="change" process="@this"
+                                                    listener="#{patientRoomController.edit(b)}"/>
+                                        </p:calendar>
 
-                        <p:column headerText="Inward Charge Type" filterBy="#{c.inwardChargeType.name}" filterMatchMode="contains">
-                            <h:outputLabel value="#{c.inwardChargeType.name}"/>
-                        </p:column>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
 
-                        <p:column headerText="Total" sortBy="#{c.total}" class="text-end" width="14em;">
-                            <h:outputLabel value="#{c.total}" class="w-100 text-end">
-                                <f:convertNumber pattern="#,##0.00"/>
-                            </h:outputLabel>
-                        </p:column>
+                            <p:tab title="Room Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
 
-                        <p:column headerText="Discount" class="text-end" width="14em;">
-                            <p:inputText 
-                                autocomplete="off" 
-                                id="catDiscount" 
-                                class="w-100 text-end"
-                                value="#{c.discount}"
-                                disabled="#{c.inwardChargeType eq 'RoomCharges'
-                                            or c.inwardChargeType eq 'MOCharges'
-                                            or c.inwardChargeType eq 'MaintainCharges'
-                                            or c.inwardChargeType eq 'NursingCharges'
-                                            or c.inwardChargeType eq 'LinenCharges'
-                                            or c.inwardChargeType eq 'MedicalCareICU'
-                                            or c.inwardChargeType eq 'AdministrationCharge'
-                                            or c.inwardChargeType eq 'ProfessionalCharge'
-                                            or c.inwardChargeType eq 'MedicalCare' 
-                                            or c.total eq 0}">
-                                <f:convertNumber pattern="#,##0.00"/>
-                                <p:ajax process="@this"
-                                        update="@this catNetTotal :#{p:resolveFirstComponentWithId('tot',view).clientId}  "
-                                        event="blur"
-                                        listener="#{bhtSummeryController.changeDiscountListener(c)}"/>
-                                <p:ajax process="@this" event="keyup"
-                                        update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                        listener="#{bhtSummeryController.changeIsMade()}"/>
-                            </p:inputText>
-                        </p:column>
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedRoomCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountRoomCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this" update="chargeNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomRoomCharge(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="chargeNet"
+                                                       value="#{b.calculatedRoomCharge-b.discountRoomCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="chargeAdj" value="#{b.adjustedRoomCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueRoomCharge(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
 
-                        <p:column headerText="NetTotal" class="text-end" width="14em;">
-                            <h:outputLabel id="catNetTotal" value="#{c.netTotal}" class="w-100 text-end">
-                                <f:convertNumber pattern="#,##0.00"/>
-                            </h:outputLabel>
-                        </p:column>
+                            <p:tab title="Maintain Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedMaintainCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountMaintainCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this" update="mainNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMaintain(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="mainNet"
+                                                       value="#{b.calculatedMaintainCharge-b.discountMaintainCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="mainAdj" value="#{b.adjustedMaintainCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueMaintain(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
 
-                        <p:column class="text-end" width="14em;" headerText="Adjusted Total">
-                            <p:inputText 
-                                autocomplete="off" 
-                                id="catAdj" 
-                                class="w-100 text-end"
-                                value="#{c.adjustedTotal}"
-                                disabled="#{c.inwardChargeType eq 'RoomCharges' 
-                                            or c.inwardChargeType eq 'MOCharges'
-                                            or c.inwardChargeType eq 'MaintainCharges'
-                                            or c.inwardChargeType eq 'NursingCharges'
-                                            or c.inwardChargeType eq 'LinenCharges'
-                                            or c.inwardChargeType eq 'MedicalCareICU'
-                                            or c.inwardChargeType eq 'AdministrationCharge'
-                                            or c.inwardChargeType eq 'ProfessionalCharge'}">
-                                <f:convertNumber pattern="#,##0.00"/>
-                                <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('tot',view).clientId} "
-                                        event="blur"
-                                        listener="#{bhtSummeryController.updateTotal()}"/>
-                                <p:ajax process="@this" event="keyup"
-                                        update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                        listener="#{bhtSummeryController.changeIsMade()}"/>
-                            </p:inputText>
-                        </p:column>
+                                </p:dataTable>
+                            </p:tab>
 
-                    </p:dataTable>
+                            <p:tab title="MO Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedMoCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountMoCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this" update="moNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMo(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="moNet" value="#{b.calculatedMoCharge-b.discountMoCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="moAdj" value="#{b.adjustedMoCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
 
-                    <p:panel id="creditAllocationPanel" styleClass="mx-1 my-3" rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit' and not empty bhtSummeryController.creditCompanyAllocations}">
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueMo(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+
+                            </p:tab>
+
+                            <p:tab title="Nursing Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedNursingCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountNursingCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this" update="nurNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomNursing(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="nurNet"
+                                                       value="#{b.calculatedNursingCharge-b.discountNursingCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="nurAdj" value="#{b.ajdustedNursingCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueNursing(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
+
+                            <p:tab title="Administration Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedAdministrationCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountAdministrationCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this" update="admNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomAdministration(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="admNet"
+                                                       value="#{b.calculatedAdministrationCharge-b.discountAdministrationCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="admAdj"
+                                                     value="#{b.ajdustedAdministrationCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueAdministration(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
+
+                            <p:tab title="Madicare Care Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedMedicalCareCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountMedicalCareCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this" update="medNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMedicalCare(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="medNet"
+                                                       value="#{b.calculatedMedicalCareCharge-b.discountMedicalCareCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="medAdj" value="#{b.ajdustedMedicalCareCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueMedicalCare(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
+
+                            <p:tab title="Linen Charge">
+                                <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
+
+                                    <p:column headerText="Actual Room">
+                                        <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
+                                    </p:column>
+                                    <p:column headerText="Calculated">
+                                        <p:outputLabel value="#{b.calculatedLinenCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Discount">
+                                        <p:inputText autocomplete="off" value="#{b.discountLinenCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+
+                                            <p:ajax event="blur" process="@this" update="linNet"
+                                                    listener="#{bhtSummeryController.changeDiscountListenerPatientRoomLinen(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                    <p:column headerText="Net">
+                                        <p:outputLabel id="linNet" value="#{b.calculatedLinenCharge-b.discountLinenCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Adjusted">
+                                        <p:inputText autocomplete="off" id="linAdj" value="#{b.ajdustedLinenCharge}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                            <p:ajax event="blur" process="@this"
+                                                    listener="#{bhtSummeryController.changeAdjustedValueLinen(b)}"/>
+                                            <p:ajax process="@this" event="keyup"
+                                                    update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                                    listener="#{bhtSummeryController.changeIsMade()}"/>
+                                        </p:inputText>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:tab>
+                        </p:tabView>
+
+                    </p:panel>
+                    
+                    <p:panel header="Charge Types" class="mt-3">
+                        <p:dataTable 
+                            id="dList" 
+                            value="#{bhtSummeryController.chargeItemTotals}" 
+                            var="c" 
+                            scrollHeight="300"
+                            scrollable="true">
+
+                            <p:column headerText="Inward Charge Type" filterBy="#{c.inwardChargeType.name}" filterMatchMode="contains">
+                                <h:outputLabel value="#{c.inwardChargeType.name}"/>
+                            </p:column>
+
+                            <p:column headerText="Total" sortBy="#{c.total}" class="text-end" width="14em;">
+                                <h:outputLabel value="#{c.total}" class="w-100 text-end">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Discount" class="text-end" width="14em;">
+                                <p:inputText 
+                                    autocomplete="off" 
+                                    id="catDiscount" 
+                                    class="w-100 text-end"
+                                    value="#{c.discount}"
+                                    disabled="#{c.inwardChargeType eq 'RoomCharges'
+                                                or c.inwardChargeType eq 'MOCharges'
+                                                or c.inwardChargeType eq 'MaintainCharges'
+                                                or c.inwardChargeType eq 'NursingCharges'
+                                                or c.inwardChargeType eq 'LinenCharges'
+                                                or c.inwardChargeType eq 'MedicalCareICU'
+                                                or c.inwardChargeType eq 'AdministrationCharge'
+                                                or c.inwardChargeType eq 'ProfessionalCharge'
+                                                or c.inwardChargeType eq 'MedicalCare' 
+                                                or c.total eq 0}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                    <p:ajax process="@this"
+                                            update="@this catNetTotal :#{p:resolveFirstComponentWithId('tot',view).clientId}  "
+                                            event="blur"
+                                            listener="#{bhtSummeryController.changeDiscountListener(c)}"/>
+                                    <p:ajax process="@this" event="keyup"
+                                            update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                            listener="#{bhtSummeryController.changeIsMade()}"/>
+                                </p:inputText>
+                            </p:column>
+
+                            <p:column headerText="NetTotal" class="text-end" width="14em;">
+                                <h:outputLabel id="catNetTotal" value="#{c.netTotal}" class="w-100 text-end">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column class="text-end" width="14em;" headerText="Adjusted Total">
+                                <p:inputText 
+                                    autocomplete="off" 
+                                    id="catAdj" 
+                                    class="w-100 text-end"
+                                    value="#{c.adjustedTotal}"
+                                    disabled="#{c.inwardChargeType eq 'RoomCharges' 
+                                                or c.inwardChargeType eq 'MOCharges'
+                                                or c.inwardChargeType eq 'MaintainCharges'
+                                                or c.inwardChargeType eq 'NursingCharges'
+                                                or c.inwardChargeType eq 'LinenCharges'
+                                                or c.inwardChargeType eq 'MedicalCareICU'
+                                                or c.inwardChargeType eq 'AdministrationCharge'
+                                                or c.inwardChargeType eq 'ProfessionalCharge'}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                    <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('tot',view).clientId} "
+                                            event="blur"
+                                            listener="#{bhtSummeryController.updateTotal()}"/>
+                                    <p:ajax process="@this" event="keyup"
+                                            update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                            listener="#{bhtSummeryController.changeIsMade()}"/>
+                                </p:inputText>
+                            </p:column>
+
+                        </p:dataTable>
+                    </p:panel>
+
+                    <p:panel id="creditAllocationPanel" styleClass="mx-1 mt-3" rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit' and not empty bhtSummeryController.creditCompanyAllocations}">
                         <f:facet name="header">
                             <h:outputLabel value="Credit Company Allocation" />
                         </f:facet>
@@ -338,365 +665,40 @@
                         </p:dataTable>
                     </p:panel>
 
-                    <p:spacer height="100"/>
+                    <p:panel header="Profesionall Fee" class="mt-3">  
+                        <p:dataTable value="#{bhtSummeryController.profesionallFee}" var="pf"
+                                     rowStyleClass="#{pf.feeValue ne 0 
+                                                      and pf.bill.cancelled eq false
+                                                      and pf.bill.billClass eq 'class com.divudi.entity.BilledBill' ? '':'noDisplayRow'}">
+                            <p:column headerText="Name">
+                                #{pf.staff.person.nameWithTitle}
+                            </p:column>
+                            <p:column headerText="Fee Value" style="text-align: right;">
+                                <h:outputLabel value="#{pf.feeValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Adjusted Value" style="text-align: right;">
+                                <p:inputText autocomplete="off" value="#{pf.feeAdjusted}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                    <p:ajax event="blur" process="@this"
+                                            update=":#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                            listener="#{bhtSummeryController.changeAdjustedProValue(pf)}"/>
+                                    <p:ajax process="@this" event="keyup"
+                                            update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                            listener="#{bhtSummeryController.changeIsMade()}"/>
+                                </p:inputText>
+                            </p:column>
 
+                        </p:dataTable>
+                    </p:panel>
 
-                    <p:tabView id="tabView">
-
-                        <p:tab title="Room Name">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Printing Room">
-                                    <p:autoComplete forceSelection="true"
-                                                    value="#{b.printRoomFacilityCharge}"
-                                                    completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
-                                                    var="rf" itemLabel="#{rf.name}" itemValue="#{rf}">
-                                        <p:ajax event="itemSelect" process="@this"
-                                                listener="#{patientRoomController.edit(b)}"/>
-                                    </p:autoComplete>
-                                </p:column>
-                                <p:column headerText="AdmittedAt">
-                                    <p:calendar navigator="true"
-                                                id="printingRoomAdmittedTimeStamp"
-                                                value="#{b.printAdmittedAt}"
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                        <p:ajax event="change" process="@this"
-                                                listener="#{patientRoomController.edit(b)}"/>
-                                    </p:calendar>
-                                </p:column>
-                                <p:column headerText="DischargeAt">
-                                    <p:calendar navigator="true"
-                                                id="printingRoomDischargeTimeStamp"
-                                                value="#{b.printDischargeAt}"
-                                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}">
-                                        <p:ajax event="change" process="@this"
-                                                listener="#{patientRoomController.edit(b)}"/>
-                                    </p:calendar>
-
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="Room Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedRoomCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountRoomCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this" update="chargeNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomRoomCharge(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="chargeNet"
-                                                   value="#{b.calculatedRoomCharge-b.discountRoomCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="chargeAdj" value="#{b.adjustedRoomCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueRoomCharge(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="Maintain Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedMaintainCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountMaintainCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this" update="mainNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMaintain(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="mainNet"
-                                                   value="#{b.calculatedMaintainCharge-b.discountMaintainCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="mainAdj" value="#{b.adjustedMaintainCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueMaintain(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="MO Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedMoCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountMoCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this" update="moNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMo(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="moNet" value="#{b.calculatedMoCharge-b.discountMoCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="moAdj" value="#{b.adjustedMoCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueMo(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-
-                        </p:tab>
-
-                        <p:tab title="Nursing Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedNursingCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountNursingCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this" update="nurNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomNursing(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="nurNet"
-                                                   value="#{b.calculatedNursingCharge-b.discountNursingCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="nurAdj" value="#{b.ajdustedNursingCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueNursing(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="Administration Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedAdministrationCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountAdministrationCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this" update="admNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomAdministration(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="admNet"
-                                                   value="#{b.calculatedAdministrationCharge-b.discountAdministrationCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="admAdj"
-                                                 value="#{b.ajdustedAdministrationCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueAdministration(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="Madicare Care Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedMedicalCareCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountMedicalCareCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this" update="medNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomMedicalCare(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="medNet"
-                                                   value="#{b.calculatedMedicalCareCharge-b.discountMedicalCareCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="medAdj" value="#{b.ajdustedMedicalCareCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueMedicalCare(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-
-                        <p:tab title="Linen Charge">
-                            <p:dataTable var="b" value="#{bhtSummeryController.patientRooms}">
-
-                                <p:column headerText="Actual Room">
-                                    <h:outputLabel value="#{b.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Calculated">
-                                    <p:outputLabel value="#{b.calculatedLinenCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Discount">
-                                    <p:inputText autocomplete="off" value="#{b.discountLinenCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-
-                                        <p:ajax event="blur" process="@this" update="linNet"
-                                                listener="#{bhtSummeryController.changeDiscountListenerPatientRoomLinen(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                                <p:column headerText="Net">
-                                    <p:outputLabel id="linNet" value="#{b.calculatedLinenCharge-b.discountLinenCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                    </p:outputLabel>
-                                </p:column>
-                                <p:column headerText="Adjusted">
-                                    <p:inputText autocomplete="off" id="linAdj" value="#{b.ajdustedLinenCharge}">
-                                        <f:convertNumber pattern="#,##0.00"/>
-                                        <p:ajax event="blur" process="@this"
-                                                listener="#{bhtSummeryController.changeAdjustedValueLinen(b)}"/>
-                                        <p:ajax process="@this" event="keyup"
-                                                update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                                listener="#{bhtSummeryController.changeIsMade()}"/>
-                                    </p:inputText>
-                                </p:column>
-                            </p:dataTable>
-                        </p:tab>
-                    </p:tabView>
-
-                    <p:dataTable value="#{bhtSummeryController.profesionallFee}" var="pf"
-                                 rowStyleClass="#{pf.feeValue ne 0 
-                                                  and pf.bill.cancelled eq false
-                                                  and pf.bill.billClass eq 'class com.divudi.entity.BilledBill' ? '':'noDisplayRow'}">
-                        <p:column headerText="Name">
-                            #{pf.staff.person.nameWithTitle}
-                        </p:column>
-                        <p:column headerText="Fee Value" style="text-align: right;">
-                            <h:outputLabel value="#{pf.feeValue}">
-                                <f:convertNumber pattern="#,##0.00"/>
-                            </h:outputLabel>
-                        </p:column>
-                        <p:column headerText="Adjusted Value" style="text-align: right;">
-                            <p:inputText autocomplete="off" value="#{pf.feeAdjusted}">
-                                <f:convertNumber pattern="#,##0.00"/>
-                                <p:ajax event="blur" process="@this"
-                                        update=":#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
-                                        listener="#{bhtSummeryController.changeAdjustedProValue(pf)}"/>
-                                <p:ajax process="@this" event="keyup"
-                                        update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
-                                        listener="#{bhtSummeryController.changeIsMade()}"/>
-                            </p:inputText>
-                        </p:column>
-
-                    </p:dataTable>
-
-                    <h:panelGroup id="printTempBill" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}">
+                    <p:panel id="printTempBill" header="Tempory Bill Priview" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}">
                         <bi:finalBill
                             bill="#{bhtSummeryController.tempBill}"
-                            hosCopy="true"/>
-                    </h:panelGroup>
+                            hosCopy="true">
+                        </bi:finalBill>
+                    </p:panel>
 
                 </p:panel>
 

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -669,8 +669,14 @@
                         <p:dataTable
                             id="professionalFeeTable"
                             value="#{bhtSummeryController.groupedProfessionalFees}"
+                            draggableRows="true"
                             rowIndexVar="i"
                             var="g">
+
+                            <p:ajax event="rowReorder"
+                                    listener="#{bhtSummeryController.onGroupedProfessionalFeeReorder}"
+                                    process="@this"
+                                    update="@this"/>
 
                             <p:column headerText="#" style="padding: 7px; width: 2em;">
                                 <h:outputLabel value="#{i+1}"/>

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -1096,8 +1096,12 @@
                                             </h:panelGroup>
                                         </p:column>
                                         
-                                        <p:column headerText="Value" >
-                                            <h:outputLabel  value="#{p.netTotal}">
+                                        <p:column headerText="Payment Method" >
+                                            <h:outputLabel value="#{p.paymentMethod}"/>
+                                        </p:column>
+                                        
+                                        <p:column headerText="Value" class="text-end" width="6em;">
+                                            <h:outputLabel  value="#{p.netTotal}" class="text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -312,9 +312,13 @@
                                                     placeholder="Search Doctor..."
                                                     completeMethod="#{inwardProfessionalBillController.completeStaff}"
                                                     var="mys" 
+                                                    maxResults="20"
                                                     itemLabel="#{mys.person.nameWithTitle}" 
                                                     itemValue="#{mys}">
                                                     <f:ajax event="itemSelect" execute="scStaff" render="pIxAdd pBillDetails" />
+                                                    <p:column headerText="Doctor Name" style="padding: 5px;">
+                                                        <h:outputLabel value="#{mys.person.nameWithTitle}" styleClass="fw-bold" />
+                                                    </p:column>
                                                 </p:autoComplete>
                                             </div>
                                         </div>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -435,6 +435,11 @@
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
+                                            <p:column headerText="Adjusted Fee" styleClass="text-end">
+                                                <h:outputLabel value="#{bif.feeAdjusted}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
                                         </p:dataTable>
                                     </p:panel>
                                 </h:panelGroup>

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -243,12 +243,12 @@
                                                                                       and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}" style="">
                                                                 <tr>
 
-                                                                    <td style="text-align: left;font-size: 10px!important;">
+                                                                    <td style="text-align: left;font-size: 10px!important;" width="90%">
                                                                         <h:panelGroup>
                                                                             #{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/>
                                                                         </h:panelGroup>
                                                                     </td>
-                                                                    <td  style="text-align: right;font-size: 10px!important; padding-left: 25px;">
+                                                                    <td  style="text-align: right;font-size: 10px!important; padding-left: 15px;" width="100%">
                                                                         <h:panelGroup>
                                                                             <h:outputLabel value="#{fe.feeAdjusted}">
                                                                                 <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
## Summary

Closes #21514.

On the inward final bill, professional and assisting doctor fees were previously listed as separate, ungrouped charge lines. This made it hard to see — and adjust — the total a single doctor earns when they act as both lead and assistant. This branch reworks the final-bill professional fee handling so that **all fees for a doctor are grouped under that doctor (the lead)**, with an editable total and a drill-down breakdown.

Key behaviour:

- **Fees grouped by doctor** — professional and assisting fees are merged into a single charge type per doctor on the final bill, instead of separate rows.
- **Editable group total + breakdown popup** — each doctor row shows one adjustable total; a breakdown dialog lists the individual contributing fees (bill no, date, added user, fee value, adjustable value) with a live running total.
- **Assisting-fee alignment** — assisting-fee adjusted values are seeded/kept equal to their fee value on navigation, so merged totals stay correct.
- **Drag-to-reorder doctor rows** — the lead-doctor ordering can be dragged and is persisted (via `orderNo`) on both save and settle, and honoured on print.
- **One merged fee per doctor persisted** on the saved bill.
- **Interim bill** now shows the payment method and right-aligns the value.

## Changes

| Area | File | Notes |
| --- | --- | --- |
| Controller | `BhtSummeryController.java` | Doctor fee grouping, breakdown editing, adjusted-value sync, order persistence |
| Controller | `InwardBeanController.java` | Supporting grouping/ordering logic |
| Entity | `BillItem.java` | Minor support for grouped fee / order |
| UI | `inward_bill_final.xhtml` | Grouped doctor fee table, breakdown dialog, drag-reorder, panel grouping |
| UI | `inward_bill_intrim.xhtml` | Payment method + right-aligned value |
| UI | `inward_bill_professional.xhtml` | Doctor name column, adjusted-fee column, capped staff search |
| Print | `resources/inward/bill/finalBill.xhtml` | Honour persisted doctor print order |

14 commits; 7 files; +912 / −474.

## Options / Notes for reviewers

- **No new config option / privilege** introduced — behaviour applies to the existing inward final-bill flow.
- **Branch is behind `development`** (merge-base is older). The GitHub diff is correct (7 files), but a rebase/merge from `development` may be advisable before merge to surface any conflicts. Happy to rebase on request.
- No schema/migration change. `orderNo` reuses the existing field on the fee row.
- `persistence.xml` intentionally **not** included (local JNDI dev config).

## Test Plan

1. **Group display** — Admit a patient, add professional + assisting fees for the same doctor, open the final bill. Verify the doctor appears once with a single merged total (not separate professional/assisting rows).
2. **Breakdown popup** — Open the breakdown dialog for a doctor. Verify each contributing fee shows bill no, date, added user, fee value, and an editable adjusted value, and that the dialog footer total updates live as you edit.
3. **Edit total** — Adjust a fee value in the breakdown; confirm the doctor's group total, the professional fee table, the charge list, and the bill grand total all update, and the Settle/Save buttons re-enable.
4. **Assisting-fee alignment** — Navigate away and back; confirm assisting-fee adjusted value stays equal to its fee value and the merged total is unchanged.
5. **Drag reorder** — Drag doctor rows into a new order. Save (provisional) and re-open; confirm the order persists. Settle the bill; confirm the order is honoured on the printed final bill.
6. **Persistence** — Settle the bill and re-open the saved bill; confirm one merged fee per doctor is stored and totals match what was settled.
7. **Interim bill** — Print/preview the interim bill; confirm payment method is shown and values are right-aligned.
8. **Regression** — Confirm a bill with a single doctor / professional-fee-only case still settles and prints correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering of doctor professional fees with persistent order in temp/final bills
  * Inline editing plus popup “Fee Breakdown” to adjust doctor fee values and refresh totals
  * When enabled, professional charges automatically include assisting fees
  * Added “Check Final Bill” print button
  * Payments table now shows a **Payment Method** column
* **UI Improvements**
  * Final bill charge screen reorganized into “Mandatory Charge Types” tabs (including **Room Name**)
  * Improved professional fees table: displays an **Adjusted Fee** column
  * Refined layout for the professional charge details table
<!-- end of auto-generated comment: release notes by coderabbit.ai -->