### PR TITLE
feat(inward): add Occupation, Insurance Company, and Referring Doctor search filters

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -192,6 +192,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private String bhtNumberForSearch;
     private Doctor referringDoctorForSearch;
     private Institution institutionForSearch;
+    private String occupationForSearch;
+    private Institution creditCompanyForSearch;
     private AdmissionStatus admissionStatusForSearch;
     private AdmissionType admissionTypeForSearch;
     private Admission perantAddmission;
@@ -1030,6 +1032,22 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             m.put("nic", patientIdentityNumberFilter);
         }
 
+        if (referringDoctorForSearch != null) {
+            j += " and c.referringDoctor=:refDoc ";
+            m.put("refDoc", referringDoctorForSearch);
+        }
+
+        String occupationFilter = normalizeSearchFilter(occupationForSearch);
+        if (occupationFilter != null) {
+            j += " and c.patient.person.occupation.name like :occ ";
+            m.put("occ", "%" + occupationFilter + "%");
+        }
+
+        if (creditCompanyForSearch != null) {
+            j += " and c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc) ";
+            m.put("cc", creditCompanyForSearch);
+        }
+
         if (admissionStatusForSearch != null) {
             if (null != admissionStatusForSearch) {
                 switch (admissionStatusForSearch) {
@@ -1121,6 +1139,22 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (patientIdentityNumberFilter != null) {
             j += " and c.patient.person.nic =:nic";
             m.put("nic", patientIdentityNumberFilter);
+        }
+
+        if (referringDoctorForSearch != null) {
+            j += " and c.referringDoctor=:refDoc ";
+            m.put("refDoc", referringDoctorForSearch);
+        }
+
+        String occupationFilter = normalizeSearchFilter(occupationForSearch);
+        if (occupationFilter != null) {
+            j += " and c.patient.person.occupation.name like :occ ";
+            m.put("occ", "%" + occupationFilter + "%");
+        }
+
+        if (creditCompanyForSearch != null) {
+            j += " and c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc) ";
+            m.put("cc", creditCompanyForSearch);
         }
 
         if (admissionStatusForSearch != null) {
@@ -1371,6 +1405,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         patientNumberForSearch = null;
         bhtNumberForSearch = null;
         referringDoctorForSearch = null;
+        occupationForSearch = null;
+        creditCompanyForSearch = null;
         institutionForSearch = null;
         admissionStatusForSearch = null;
         admissionTypeForSearch = null;
@@ -2879,6 +2915,22 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     public void setReferringDoctorForSearch(Doctor referringDoctorForSearch) {
         this.referringDoctorForSearch = referringDoctorForSearch;
+    }
+
+    public String getOccupationForSearch() {
+        return occupationForSearch;
+    }
+
+    public void setOccupationForSearch(String occupationForSearch) {
+        this.occupationForSearch = occupationForSearch;
+    }
+
+    public Institution getCreditCompanyForSearch() {
+        return creditCompanyForSearch;
+    }
+
+    public void setCreditCompanyForSearch(Institution creditCompanyForSearch) {
+        this.creditCompanyForSearch = creditCompanyForSearch;
     }
 
     public InwardStaffPaymentBillController getInwardStaffPaymentBillController() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1044,7 +1044,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         if (creditCompanyForSearch != null) {
-            j += " and c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc) ";
+            j += " and (c.creditCompany=:cc or c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc)) ";
             m.put("cc", creditCompanyForSearch);
         }
 
@@ -1153,7 +1153,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         if (creditCompanyForSearch != null) {
-            j += " and c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc) ";
+            j += " and (c.creditCompany=:cc or c.id in (select ecc.patientEncounter.id from EncounterCreditCompany ecc where ecc.retired=false and ecc.institution=:cc)) ";
             m.put("cc", creditCompanyForSearch);
         }
 

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -112,6 +112,23 @@
                                     </p:column>
                                 </p:autoComplete>
 
+                                <p:outputLabel value="Occupation" ></p:outputLabel>
+                                <p:inputText
+                                    class="w-100"
+                                    value="#{admissionController.occupationForSearch}" >
+                                </p:inputText>
+
+                                <p:outputLabel value="Insurance Company" ></p:outputLabel>
+                                <p:selectOneMenu
+                                    class="w-100"
+                                    value="#{admissionController.creditCompanyForSearch}"
+                                    filter="true"
+                                    autoWidth="false"
+                                    >
+                                    <f:selectItem itemLabel="All"></f:selectItem>
+                                    <f:selectItems value="#{institutionController.creditCompanies}" var="cc" itemLabel="#{cc.name}" itemValue="#{cc}" />
+                                </p:selectOneMenu>
+
                                 <p:outputLabel value="Status" ></p:outputLabel>
                                 <p:selectOneMenu
                                     class="w-100"


### PR DESCRIPTION
## Summary
Adds three new search filters to the Inward Admission Search page (`/inward/inpatient_search.xhtml`):

1. **Referring Doctor** — Wire the existing autocomplete field into JPQL queries (fixes bug where the UI field was present but ignored)
2. **Occupation** — New free-text filter on the patient's occupation (`c.patient.person.occupation.name`)
3. **Insurance Company (Credit Company)** — New dropdown filter using `EncounterCreditCompany` subquery to find admissions linked to a specific credit company

## Changes
- **AdmissionController.java**: 
  - Add `occupationForSearch` and `creditCompanyForSearch` fields
  - Wire all 3 filters into both `searchAdmissions()` and `searchAdmissionsWithoutRoom()` JPQL
  - Clear new fields in `clearSearchValues()`
  - Add getters/setters
- **inpatient_search.xhtml**: Add Occupation text input and Insurance Company dropdown after Referring Doctor

## Testing
- Search with Occupation filter should match patients whose occupation `Item.name` contains the text
- Search with Insurance Company filter should find admissions linked to that credit company via `EncounterCreditCompany`
- Referring Doctor filter now actually filters results (was previously ignored)

Closes #21550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added patient occupation filter to the admission search form for refined queries
  * Insurance company filtering now available to help locate patient admissions by coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->