### PR TITLE
feat(api): add department remove and bulk privilege endpoints to User Management API

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3271,7 +3271,10 @@ public class AnthropicApiService implements Serializable {
         // ── Users / Roles / Privileges ────────────────────────────────────────
         appendModule(sb, "User Management", "/users",
                 "Create, read, update, and retire HMIS web users. Manage passwords, loggable departments, "
-                + "and individual privilege assignments. Use /users/privileges/available to discover valid privilege names.",
+                + "and individual or bulk privilege assignments. Use /users/privileges/available to discover valid privilege names. "
+                + "DELETE /{id}/departments/{assignmentId} removes one loggable department. "
+                + "DELETE /{id}/departments/{deptId}/privileges bulk-revokes all privileges for a department. "
+                + "POST /{id}/departments/{deptId}/privileges/all grants every privilege for a department.",
                 githubUrl(branch, "developer_docs/API_USER_MANAGEMENT.md"),
                 new String[][]{
                     {"GET",    "/users",                          "List users. Filters: query, departmentId, page, size"},
@@ -3287,7 +3290,10 @@ public class AnthropicApiService implements Serializable {
                     {"GET",    "/users/{id}/departments",         "List loggable departments for a user"},
                     {"POST",   "/users/{id}/departments",         "Assign a loggable department to a user"},
                     {"GET",    "/users/privileges/available",     "List all valid privilege enum names"},
-                    {"POST",   "/users/bulk-privileges",          "Bulk-assign privileges to multiple users at once"}
+                    {"POST",   "/users/bulk-privileges",                              "Bulk-assign privileges to multiple users at once"},
+                    {"DELETE", "/users/{id}/departments/{assignmentId}",             "Revoke a loggable department assignment (by WebUserDepartment id)"},
+                    {"DELETE", "/users/{id}/departments/{departmentId}/privileges",  "Bulk-revoke all active privileges for a user scoped to a department"},
+                    {"POST",   "/users/{id}/departments/{departmentId}/privileges/all", "Assign every Privileges enum value to a user for a department (skips duplicates)"}
                 });
 
         appendModule(sb, "User Roles", "/user-roles",

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -259,7 +259,10 @@ public class CapabilityStatementResource {
                 .add(resource("Users", "/api/users",
                         "User CRUD, password reset/change, loggable department assignment, "
                         + "and per-user privilege assignment with department scope. "
-                        + "Supports filtering by departmentId and query string.",
+                        + "Supports filtering by departmentId and query string. "
+                        + "DELETE /{id}/departments/{assignmentId} revokes one loggable department. "
+                        + "DELETE /{id}/departments/{departmentId}/privileges bulk-revokes all privileges for a department. "
+                        + "POST /{id}/departments/{departmentId}/privileges/all assigns every privilege for a department.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("User Bulk Privileges", "/api/users/bulk-privileges",

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -442,16 +442,11 @@ public class UserManagementApi {
         Map<String, Object> m = new HashMap<>();
         m.put("u", u);
         m.put("d", dept);
-        List<WebUserPrivilege> active = webUserPrivilegeFacade.findByJpql(
-                "select wp from WebUserPrivilege wp where wp.retired=false and wp.webUser=:u and wp.department=:d", m);
-        int revoked = 0;
-        for (WebUserPrivilege wp : active) {
-            wp.setRetired(true);
-            wp.setRetirer(apiUser);
-            wp.setRetiredAt(new Date());
-            webUserPrivilegeFacade.edit(wp);
-            revoked++;
-        }
+        m.put("retirer", apiUser);
+        m.put("retiredAt", new Date());
+        int revoked = webUserPrivilegeFacade.updateByJpql(
+                "update WebUserPrivilege wp set wp.retired=true, wp.retirer=:retirer, wp.retiredAt=:retiredAt "
+                + "where wp.retired=false and wp.webUser=:u and wp.department=:d", m);
         Map<String, Object> result = new HashMap<>();
         result.put("privilegesRevoked", revoked);
         return successResponse(result);

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -408,6 +408,97 @@ public class UserManagementApi {
         }
     }
 
+    @DELETE
+    @Path("/{id}/departments/{assignmentId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response revokeUserDepartment(@PathParam("id") Long id, @PathParam("assignmentId") Long assignmentId) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        WebUser u = webUserFacade.find(id);
+        if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+        WebUserDepartment wud = webUserDepartmentFacade.find(assignmentId);
+        if (wud == null || wud.isRetired() || wud.getWebUser() == null || !wud.getWebUser().getId().equals(id)) {
+            return errorResponse("Department assignment not found", 404);
+        }
+        wud.setRetired(true);
+        wud.setRetirer(apiUser);
+        wud.setRetiredAt(new Date());
+        webUserDepartmentFacade.edit(wud);
+        return successResponse("Department assignment revoked");
+    }
+
+    @DELETE
+    @Path("/{id}/departments/{departmentId}/privileges")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response revokeAllDepartmentPrivileges(@PathParam("id") Long id, @PathParam("departmentId") Long departmentId) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        WebUser u = webUserFacade.find(id);
+        if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+        Department dept = departmentFacade.find(departmentId);
+        if (dept == null) return errorResponse("Department not found", 404);
+        Map<String, Object> m = new HashMap<>();
+        m.put("u", u);
+        m.put("d", dept);
+        List<WebUserPrivilege> active = webUserPrivilegeFacade.findByJpql(
+                "select wp from WebUserPrivilege wp where wp.retired=false and wp.webUser=:u and wp.department=:d", m);
+        int revoked = 0;
+        for (WebUserPrivilege wp : active) {
+            wp.setRetired(true);
+            wp.setRetirer(apiUser);
+            wp.setRetiredAt(new Date());
+            webUserPrivilegeFacade.edit(wp);
+            revoked++;
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("privilegesRevoked", revoked);
+        return successResponse(result);
+    }
+
+    @POST
+    @Path("/{id}/departments/{departmentId}/privileges/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response assignAllDepartmentPrivileges(@PathParam("id") Long id, @PathParam("departmentId") Long departmentId) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        WebUser u = webUserFacade.find(id);
+        if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+        Department dept = departmentFacade.find(departmentId);
+        if (dept == null) return errorResponse("Department not found", 404);
+        Map<String, Object> existing = new HashMap<>();
+        existing.put("u", u);
+        existing.put("d", dept);
+        List<WebUserPrivilege> currentPrivileges = webUserPrivilegeFacade.findByJpql(
+                "select wp from WebUserPrivilege wp where wp.retired=false and wp.webUser=:u and wp.department=:d", existing);
+        Set<Privileges> alreadyAssigned = new HashSet<>();
+        for (WebUserPrivilege wp : currentPrivileges) {
+            if (wp.getPrivilege() != null) alreadyAssigned.add(wp.getPrivilege());
+        }
+        int added = 0;
+        int skipped = 0;
+        for (Privileges p : Privileges.values()) {
+            if (alreadyAssigned.contains(p)) {
+                skipped++;
+                continue;
+            }
+            WebUserPrivilege wp = new WebUserPrivilege();
+            wp.setWebUser(u);
+            wp.setPrivilege(p);
+            wp.setDepartment(dept);
+            wp.setCreater(apiUser);
+            wp.setCreatedAt(new Date());
+            webUserPrivilegeFacade.create(wp);
+            added++;
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("privilegesAdded", added);
+        result.put("privilegesSkipped", skipped);
+        return successResponse(result);
+    }
+
     @GET
     @Path("/privileges/available")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -51,7 +51,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -52,7 +52,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
## Summary

Adds three missing endpoints to `UserManagementApi` (`/api/users`) to complete user-department management via REST:

- **`DELETE /api/users/{id}/departments/{assignmentId}`** — Soft-retires the `WebUserDepartment` record identified by its assignment ID (mirrors the existing `DELETE /api/users/{id}/privileges/{privilegeId}` pattern). Returns 404 if not found, already retired, or belonging to a different user.
- **`DELETE /api/users/{id}/departments/{departmentId}/privileges`** — Bulk-retires all active `WebUserPrivilege` records for the given user scoped to the given department. Returns `{ privilegesRevoked: N }`. Eliminates the need for hundreds of individual DELETE calls (e.g. removing 977 privileges one by one).
- **`POST /api/users/{id}/departments/{departmentId}/privileges/all`** — Assigns every `Privileges` enum value to the user for the given department, skipping any already assigned. Returns `{ privilegesAdded: N, privilegesSkipped: M }`.

All three require the `Finance` API key header and Admin privilege. Registered in `CapabilityStatementResource` and `AnthropicApiService`.

## Context

Discovered managing user `irani` (userId 14229): removing "Matara - Pharmacy" as a loggable department was impossible via API, and revoking 977 associated privileges required a client-side loop of 977 individual DELETE calls.

## Test plan

- [x] Maven build passes (117 tests, 0 failures)
- [ ] `DELETE /api/users/{id}/departments/{assignmentId}` → 200 + "Department assignment revoked"; same call again → 404
- [ ] `DELETE /api/users/{id}/departments/{departmentId}/privileges` → 200 + `{"privilegesRevoked": N}`
- [ ] `POST /api/users/{id}/departments/{departmentId}/privileges/all` → 200 + `{"privilegesAdded": N, "privilegesSkipped": 0}` on first call; second call → all skipped
- [ ] All endpoints return 401 with invalid key, 403 for non-admin user

Closes #21557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three admin-only endpoints for department-level privilege management: revoke a specific department assignment, revoke all privileges for a user within a department, and grant all privileges for a user within a department.
  * Supports bulk privilege operations while avoiding duplicate privilege creation.
* **Documentation**
  * Expanded the Users resource capability description and the module’s system prompt text to reflect the new privilege management operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->