### PR TITLE
fix(pharmacy): block new pharmacy issues after nursing discharge is confirmed

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -176,6 +176,11 @@ public class PharmacyRequestForBhtController implements Serializable {
             return;
         }
 
+        if (getBatchBill().getPatientEncounter().isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
+            return;
+        }
+
         if (getBatchBill().getPatientEncounter().isDischarged()) {
             JsfUtil.addErrorMessage("Sorry Patient is Discharged!!!");
             return;
@@ -915,6 +920,11 @@ public class PharmacyRequestForBhtController implements Serializable {
             return;
         }
 
+        if (getPatientEncounter().isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
+            return;
+        }
+
         if (getPatientEncounter().isDischarged()) {
             JsfUtil.addErrorMessage("Sorry Patient is Discharged!!!");
             return;
@@ -1018,6 +1028,11 @@ public class PharmacyRequestForBhtController implements Serializable {
 
         if (getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge() == null) {
             JsfUtil.addErrorMessage("Please Set Room");
+            return true;
+        }
+
+        if (getPatientEncounter().isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
             return true;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -309,6 +309,10 @@ public class PharmacySaleBhtController implements Serializable {
         if (patientEncounter == null) {
             patientEncounter = getBatchBill().getPatientEncounter();
         }
+        if (patientEncounter.isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
+            return;
+        }
         if (patientEncounter.isDischarged()) {
             JsfUtil.addErrorMessage("Sorry Patient is Discharged!!!");
             return;
@@ -1687,6 +1691,11 @@ public class PharmacySaleBhtController implements Serializable {
                 return true;
             }
 
+        }
+
+        if (getPatientEncounter().isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
+            return true;
         }
 
         if (getPatientEncounter().isDischarged()) {


### PR DESCRIPTION
## Description

Once nursing discharge is confirmed (`PatientEncounter.nursingDischarged = true`), users could still initiate new medicine issuances and ward pharmacy requests — only administrative discharge was checked.

## Fix

Added `isNursingDischarged()` guard alongside every existing `isDischarged()` check in both pharmacy controllers:

- **PharmacySaleBhtController** (Direct Issue to BHT) — 2 guard locations
- **PharmacyRequestForBhtController** (Ward Pharmacy Request) — 3 guard locations

Error message: *"Cannot issue medicines: nursing discharge has already been confirmed for this patient."*

The new guard is placed before the `isDischarged()` check, following the chronological discharge workflow (Nursing → Administrative).

Closes #21566

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pharmacy BHT/direct-issue settlements are now blocked for patients with confirmed nursing discharge, preventing invalid medicine issuance transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->