### PR TITLE
feat(api): add includeArchived parameter to GET /stock_history (#20978)

### DIFF
--- a/developer_docs/API_STOCK_HISTORY.md
+++ b/developer_docs/API_STOCK_HISTORY.md
@@ -32,6 +32,7 @@ Finance: <your-api-key>
 | toDate | String | No | End timestamp (`yyyy-MM-dd HH:mm:ss`) |
 | historyType | String | No | Filter by `HistoryType` enum value |
 | limit | Integer | No | Max rows (default: 100) |
+| includeArchived | Boolean | No | When `true`, also search the `STOCKHISTORYARCHIVE` table and merge results (default: `false`) |
 
 **Example Request:**
 ```bash
@@ -92,3 +93,4 @@ curl -X GET \
 - `limit` defaults to 100 if omitted or invalid (<= 0). Maximum allowed value is 1000.
 - Date parsing requires exact format: `yyyy-MM-dd HH:mm:ss`.
 - `historyType` must match an enum value in `HistoryType`.
+- `includeArchived=true` queries the live `STOCKHISTORY` and the `STOCKHISTORYARCHIVE` tables separately (JPA has no UNION), merges them, re-orders by `id DESC`, and caps the combined result at `limit`. Archived rows keep their original id, so ordering stays consistent across both tables. Use it to retrieve history older than the archival retention window.

--- a/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
+++ b/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
@@ -9,6 +9,8 @@ package com.divudi.core.facade;
 import com.divudi.core.data.HistoryType;
 import com.divudi.core.data.dto.StockHistoryDTO;
 import com.divudi.core.entity.pharmacy.StockHistory;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.ejb.Stateless;
@@ -431,6 +433,48 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
 
     public List<StockHistoryDTO> findStockHistoryDtos(Long itemId, Long departmentId, Long billId, Date fromDate, Date toDate,
             HistoryType historyType, int maxResults) {
+        return findStockHistoryDtos(itemId, departmentId, billId, fromDate, toDate, historyType, maxResults, false);
+    }
+
+    /**
+     * Stock history lookup with optional inclusion of archived rows.
+     *
+     * When {@code includeArchived} is true, the live {@code StockHistory} table
+     * and the {@code StockHistoryArchive} table are each queried with the same
+     * JPQL projection, then merged, ordered by id descending, and capped at
+     * {@code maxResults}. JPA has no UNION operator, so the two entities are
+     * queried separately and combined in memory rather than via native SQL
+     * (per the project's JPQL-first rule). {@code StockHistoryArchive} keeps the
+     * original {@code StockHistory} id, so ids stay unique and comparable across
+     * both tables, preserving the same id-descending ordering as the live-only
+     * query.
+     */
+    public List<StockHistoryDTO> findStockHistoryDtos(Long itemId, Long departmentId, Long billId, Date fromDate, Date toDate,
+            HistoryType historyType, int maxResults, boolean includeArchived) {
+        List<StockHistoryDTO> results = queryStockHistoryDtos("StockHistory", itemId, departmentId, billId,
+                fromDate, toDate, historyType, maxResults);
+
+        if (!includeArchived) {
+            return results;
+        }
+
+        List<StockHistoryDTO> archived = queryStockHistoryDtos("StockHistoryArchive", itemId, departmentId, billId,
+                fromDate, toDate, historyType, maxResults);
+
+        List<StockHistoryDTO> combined = new ArrayList<>(results.size() + archived.size());
+        combined.addAll(results);
+        combined.addAll(archived);
+        // Match the live-only ORDER BY sh.id DESC across the merged set.
+        combined.sort(Comparator.comparing(StockHistoryDTO::getId, Comparator.nullsLast(Comparator.reverseOrder())));
+
+        if (combined.size() > maxResults) {
+            return new ArrayList<>(combined.subList(0, maxResults));
+        }
+        return combined;
+    }
+
+    private List<StockHistoryDTO> queryStockHistoryDtos(String entityName, Long itemId, Long departmentId, Long billId,
+            Date fromDate, Date toDate, HistoryType historyType, int maxResults) {
         StringBuilder jpql = new StringBuilder();
         jpql.append("SELECT new com.divudi.core.data.dto.StockHistoryDTO(")
                 .append("sh.id, sh.createdAt, sh.stockAt, sh.historyType, ")
@@ -445,7 +489,7 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
                 .append("sh.institutionBatchStockValueAtSaleRate, sh.institutionBatchStockValueAtPurchaseRate, sh.institutionBatchStockValueAtCostRate, ")
                 .append("sh.totalBatchStockValueAtSaleRate, sh.totalBatchStockValueAtPurchaseRate, sh.totalBatchStockValueAtCostRate")
                 .append(") ")
-                .append("FROM StockHistory sh ")
+                .append("FROM ").append(entityName).append(" sh ")
                 .append("LEFT JOIN sh.item item ")
                 .append("LEFT JOIN sh.itemBatch ib ")
                 .append("LEFT JOIN sh.department dept ")

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3183,7 +3183,7 @@ public class AnthropicApiService implements Serializable {
                 "Retrieve pharmacy stock movement and history records.",
                 githubUrl(branch, "developer_docs/API_STOCK_HISTORY.md"),
                 new String[][]{
-                    {"GET", "/stock_history", "Get stock history with date range, item, and department filters"}
+                    {"GET", "/stock_history", "Get stock history with date range, item, and department filters. Pass includeArchived=true to also search archived rows beyond the retention window."}
                 });
 
         appendModule(sb, "Pharmaceutical Items", "/pharmaceutical_items",

--- a/src/main/java/com/divudi/ws/pharmacy/StockHistoryApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/StockHistoryApi.java
@@ -57,7 +57,8 @@ public class StockHistoryApi {
             @QueryParam("fromDate") String fromDateStr,
             @QueryParam("toDate") String toDateStr,
             @QueryParam("historyType") String historyTypeStr,
-            @QueryParam("limit") Integer limit) {
+            @QueryParam("limit") Integer limit,
+            @QueryParam("includeArchived") boolean includeArchived) {
 
         try {
             String key = requestContext.getHeader("Finance");
@@ -101,7 +102,8 @@ public class StockHistoryApi {
                     fromDate,
                     toDate,
                     historyType,
-                    maxResults
+                    maxResults,
+                    includeArchived
             );
 
             return successResponse(results);


### PR DESCRIPTION
## Summary

Adds an optional `includeArchived` boolean query parameter to `GET /api/stock_history`, closing #20978. After the StockHistory archival job (#20726) moves rows older than the retention window into `STOCKHISTORYARCHIVE`, callers can now retrieve that older history.

- `includeArchived=false` (default): existing behaviour — queries the live `STOCKHISTORY` table only.
- `includeArchived=true`: queries `STOCKHISTORY` **and** `STOCKHISTORYARCHIVE` (same JPQL projection), merges the results, re-orders by `id DESC`, and caps the combined set at `limit`.

## Implementation notes
- **JPQL-first (rule #9):** JPA has no UNION operator, so rather than native SQL the two entities are queried separately and merged in memory. `StockHistoryArchive` keeps the original `StockHistory` id (no `@GeneratedValue`), so ids stay unique and comparable across both tables and the id-descending ordering is preserved across the merge.
- **No signature changes (rule #8):** the existing `findStockHistoryDtos(...)` method is unchanged and now delegates to a new overload with `includeArchived=false`. The shared query body was extracted into a private helper parameterised by entity name.
- Updated the AI system-prompt module listing and `developer_docs/API_STOCK_HISTORY.md`.

## Verification (local Payara `rh`, real DB)
Seeded 5 archive-only rows for item `3697323` (offset ids), exercised the endpoint, then removed the seed rows.

| Test | Result |
|---|---|
| `itemId=3697323&limit=1000` (default) | `375` rows (live only) |
| `&includeArchived=false` | `375` rows |
| `&includeArchived=true` | `380` rows; top 5 ids are the archive rows, id-DESC |
| `&includeArchived=true&limit=3` | the 3 highest ids across both tables |
| no `Finance` key | `401` |
| `includeArchived=notabool` | treated as `false` → `375` |

Closes #20978

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock History API now supports an optional `includeArchived` parameter to retrieve archived history records beyond the standard retention window.

* **Documentation**
  * Updated API documentation for the Stock History endpoint to reflect the new query parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->