### PR TITLE
feat(api): config option read/write via REST (#21544)

### DIFF
--- a/developer_docs/API_CONFIG.md
+++ b/developer_docs/API_CONFIG.md
@@ -2,9 +2,12 @@
 
 Base path: `/api/config`
 Authentication: `Config` header (**not** `Finance` — this is a separate key)
-Content-Type: `text/plain`
 
-Used to set application configuration options at runtime without redeployment.
+Content types vary by endpoint:
+- The read/list/update endpoints (`GET /api/config`, `GET /api/config/{key}`, `PUT /api/config/{key}`) accept/return **`application/json`**.
+- The legacy `setBoolean`/`setLongText`/`setInteger` endpoints take the value in the path and return **`text/plain`**.
+
+Used to read and set application configuration options at runtime without redeployment.
 
 ## Endpoints
 
@@ -86,5 +89,5 @@ Header: Config: YOUR_CONFIG_API_KEY
 
 - The `{key}` is the config option name as stored in the database (URL-encode spaces as `%20`)
 - To discover valid config keys, query the database: `SELECT key_name FROM config_option_application`
-- Returns HTTP 200 plain text `"Success"` on success, 401 on invalid key
+- The legacy `setBoolean`/`setLongText`/`setInteger` endpoints return HTTP 200 plain text on success; the JSON read/update endpoints return a JSON body. All return 401 on an invalid/expired/retired key.
 - **Authentication header is `Config`, not `Finance`** — the Config API key is separate

--- a/developer_docs/API_CONFIG.md
+++ b/developer_docs/API_CONFIG.md
@@ -8,6 +8,51 @@ Used to set application configuration options at runtime without redeployment.
 
 ## Endpoints
 
+### GET `/api/config?scope={tag}` — List config options by scope tag
+
+```bash
+GET /api/config?scope=inward
+Header: Config: YOUR_CONFIG_API_KEY
+```
+
+`scope` is matched as a **case-insensitive substring** of the option key, so
+`scope=inward` returns every application-scoped option whose key contains
+"inward". Omit `scope` to return all application-scoped options. Returns a JSON
+array of `{key, type, scope, value}` (sensitive values are masked).
+
+---
+
+### GET `/api/config/{key}` — Read a single config option
+
+```bash
+GET /api/config/Enable%20Collecting%20Payments%20on%20Add%20Services%20%26%20Investigations%20on%20Inward
+Header: Config: YOUR_CONFIG_API_KEY
+```
+
+Returns `{key, type, scope, value}` for the exact key, or HTTP 404 if not found.
+
+---
+
+### PUT `/api/config/{key}` — Update a config option value
+
+```bash
+PUT /api/config/Enable%20Collecting%20Payments%20on%20Add%20Services%20%26%20Investigations%20on%20Inward
+Header: Config: YOUR_CONFIG_API_KEY
+Content-Type: application/json
+
+{"value":"true"}
+```
+
+Updates the option's value and immediately reloads the `@ApplicationScoped`
+config cache (`loadApplicationOptions()`) so the change takes effect without a
+restart. The option must already exist (this endpoint does not create new keys;
+returns 404 otherwise). The change is recorded in the server log as a
+`CONFIG_UPDATED` audit entry (user, key, old value, new value, timestamp).
+`value` may be a JSON string (`"true"`) or a raw JSON scalar (`true`, `5`);
+it is persisted as a string. Returns the updated `{key, type, scope, value}`.
+
+---
+
 ### POST `/api/config/setBoolean/{key}/{value}` — Set a boolean config value
 
 ```bash

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3626,6 +3626,9 @@ public class AnthropicApiService implements Serializable {
                 + "IMPORTANT: Uses the 'Config' header for authentication, not 'Finance'.",
                 githubUrl(branch, "developer_docs/API_CONFIG.md"),
                 new String[][]{
+                    {"GET",  "/config?scope={tag}",  "List config options whose key contains {tag} (e.g. scope=inward); omit scope for all"},
+                    {"GET",  "/config/{key}",  "Read a single config option by exact key (key, type, scope, current value)"},
+                    {"PUT",  "/config/{key}",  "Update a config option value by key. Body {\"value\":\"...\"}. Flushes the cache immediately"},
                     {"GET",  "/config/search?keyword={keyword}", "Search config options by keyword (returns key, type, current value)"},
                     {"POST", "/config/setBoolean/{key}/{value}",  "Set a boolean config option by key name"},
                     {"POST", "/config/setLongText/{key}/{value}", "Set a text config option by key name"},

--- a/src/main/java/com/divudi/ws/common/ConfigResource.java
+++ b/src/main/java/com/divudi/ws/common/ConfigResource.java
@@ -6,7 +6,9 @@ import com.divudi.core.data.ApiKeyType;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.ConfigOption;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.ConfigOptionFacade;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +16,9 @@ import javax.ejb.EJB;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -24,9 +28,13 @@ import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonException;
+import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -141,6 +149,183 @@ public class ConfigResource {
             arrayBuilder.add(obj);
         }
         return Response.ok(arrayBuilder.build().toString()).build();
+    }
+
+    /**
+     * List application-scoped config options, optionally filtered by a scope
+     * tag. {@code scope} is matched as a case-insensitive substring of the
+     * option key, so {@code scope=inward} returns every option whose key
+     * contains "inward" (e.g. the inward-billing flags). With no scope the
+     * full application option set is returned.
+     *
+     * GET /api/config?scope=inward
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listConfigOptions(@QueryParam("scope") String scope,
+            @Context HttpHeaders headers) {
+        if (validateConfigKey(headers) == null) {
+            return unauthorizedResponse();
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("scope", OptionScope.APPLICATION);
+        StringBuilder jpql = new StringBuilder(
+                "SELECT o FROM ConfigOption o WHERE o.retired = false AND o.scope = :scope ");
+        if (scope != null && !scope.trim().isEmpty()) {
+            jpql.append("AND LOWER(o.optionKey) LIKE :scopeTag ");
+            params.put("scopeTag", "%" + scope.toLowerCase().trim() + "%");
+        }
+        jpql.append("ORDER BY o.optionKey");
+
+        List<ConfigOption> options = configOptionFacade.findByJpql(jpql.toString(), params);
+
+        JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+        for (ConfigOption opt : options) {
+            arrayBuilder.add(toJson(opt));
+        }
+        return Response.ok(arrayBuilder.build().toString()).build();
+    }
+
+    /**
+     * Read a single config option by its exact key.
+     *
+     * GET /api/config/{key}
+     */
+    @GET
+    @Path("{key}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getConfigOption(@PathParam("key") String key,
+            @Context HttpHeaders headers) {
+        if (validateConfigKey(headers) == null) {
+            return unauthorizedResponse();
+        }
+        ConfigOption option = findApplicationOption(key);
+        if (option == null) {
+            return notFoundResponse(key);
+        }
+        return Response.ok(toJson(option).build().toString()).build();
+    }
+
+    /**
+     * Update a single config option's value by key. Body: {"value":"true"}.
+     *
+     * The in-memory {@code @ApplicationScoped} cache is reloaded via
+     * {@code loadApplicationOptions()} so the change takes effect immediately
+     * without a restart. The option must already exist (this endpoint does not
+     * create new keys).
+     *
+     * PUT /api/config/{key}
+     */
+    @PUT
+    @Path("{key}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateConfigOption(@PathParam("key") String key,
+            String requestBody,
+            @Context HttpHeaders headers) {
+        ApiKey apiKey = validateConfigKey(headers);
+        if (apiKey == null) {
+            return unauthorizedResponse();
+        }
+
+        String newValue;
+        try {
+            if (requestBody == null || requestBody.trim().isEmpty()) {
+                return badRequestResponse("Request body with a \"value\" field is required");
+            }
+            JsonReader reader = Json.createReader(new StringReader(requestBody));
+            JsonObject body = reader.readObject();
+            if (!body.containsKey("value") || body.isNull("value")) {
+                return badRequestResponse("\"value\" field is required");
+            }
+            // Accept a JSON string ("true") or a raw JSON scalar (true / 5);
+            // config values are persisted as strings regardless.
+            javax.json.JsonValue jv = body.get("value");
+            if (jv.getValueType() == javax.json.JsonValue.ValueType.STRING) {
+                newValue = body.getString("value");
+            } else {
+                newValue = jv.toString();
+            }
+        } catch (JsonException | IllegalStateException e) {
+            return badRequestResponse("Invalid JSON body: " + e.getMessage());
+        }
+
+        ConfigOption option = findApplicationOption(key);
+        if (option == null) {
+            return notFoundResponse(key);
+        }
+
+        String oldValue = option.getOptionValue();
+        option.setOptionValue(newValue);
+        configOptionFacade.edit(option);
+        // Flush the @ApplicationScoped cache so the change is effective immediately.
+        configOptionApplicationController.loadApplicationOptions();
+
+        // Audit trail: who changed which key, from what to what, and when.
+        WebUser user = apiKey.getWebUser();
+        LOGGER.log(Level.INFO, "CONFIG_UPDATED key=[{0}] oldValue=[{1}] newValue=[{2}] by user=[{3}] at=[{4}]",
+                new Object[]{key,
+                    maskSensitiveValue(key, oldValue),
+                    maskSensitiveValue(key, newValue),
+                    user != null ? user.getName() : "unknown",
+                    new java.util.Date()});
+
+        return Response.ok(toJson(option).build().toString()).build();
+    }
+
+    /**
+     * Find an application-scoped, non-retired config option by exact key.
+     */
+    private ConfigOption findApplicationOption(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("scope", OptionScope.APPLICATION);
+        params.put("k", key);
+        return configOptionFacade.findFirstByJpql(
+                "SELECT o FROM ConfigOption o WHERE o.retired = false AND o.scope = :scope AND o.optionKey = :k",
+                params);
+    }
+
+    /**
+     * Validate the Config API key from the request headers, returning the
+     * ApiKey when valid (active, Config type, not expired) or null otherwise.
+     */
+    private ApiKey validateConfigKey(HttpHeaders headers) {
+        String apiKeyValue = headers.getHeaderString("Config");
+        ApiKey apiKey = apiKeyController.findApiKey(apiKeyValue);
+        if (apiKey == null || apiKey.getKeyType() != ApiKeyType.Config
+                || apiKey.getDateOfExpiary() == null
+                || apiKey.getDateOfExpiary().before(new java.util.Date())) {
+            return null;
+        }
+        return apiKey;
+    }
+
+    /**
+     * Build a JSON representation of a config option with sensitive values masked.
+     */
+    private JsonObjectBuilder toJson(ConfigOption opt) {
+        String value = maskSensitiveValue(opt.getOptionKey(), opt.getOptionValue());
+        return Json.createObjectBuilder()
+                .add("key", opt.getOptionKey() != null ? opt.getOptionKey() : "")
+                .add("type", opt.getValueType() != null ? opt.getValueType().toString() : "")
+                .add("scope", opt.getScope() != null ? opt.getScope().toString() : "")
+                .add("value", value != null ? value : "");
+    }
+
+    private Response notFoundResponse(String key) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity("{\"error\":\"Config option not found: " + key + "\"}")
+                .build();
+    }
+
+    private Response badRequestResponse(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity("{\"error\":\"" + message + "\"}")
+                .build();
     }
 
     private String maskSensitiveValue(String key, String value) {

--- a/src/main/java/com/divudi/ws/common/ConfigResource.java
+++ b/src/main/java/com/divudi/ws/common/ConfigResource.java
@@ -4,6 +4,7 @@ import com.divudi.bean.common.ApiKeyController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.ApiKeyType;
 import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.OptionValueType;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.ConfigOption;
 import com.divudi.core.entity.WebUser;
@@ -36,6 +37,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 
 /**
  * REST Web Service
@@ -117,10 +120,7 @@ public class ConfigResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response searchConfigOptions(@QueryParam("keyword") String keyword,
             @Context HttpHeaders headers) {
-        String apiKeyValue = headers.getHeaderString("Config");
-        ApiKey apiKey = apiKeyController.findApiKey(apiKeyValue);
-        if (apiKey == null || apiKey.getKeyType() != ApiKeyType.Config
-                || apiKey.getDateOfExpiary().before(new java.util.Date())) {
+        if (validateConfigKey(headers) == null) {
             return unauthorizedResponse();
         }
         if (keyword == null || keyword.trim().isEmpty()) {
@@ -256,6 +256,14 @@ public class ConfigResource {
             return notFoundResponse(key);
         }
 
+        // Sanitize LONG_TEXT the same way ConfigOptionApplicationController
+        // .setLongTextValueByKey() does, since some LONG_TEXT options are
+        // rendered with escape="false" in JSF — an unsanitized value would be a
+        // stored-XSS vector.
+        if (option.getValueType() == OptionValueType.LONG_TEXT) {
+            newValue = Jsoup.clean(newValue, Safelist.basic());
+        }
+
         String oldValue = option.getOptionValue();
         option.setOptionValue(newValue);
         configOptionFacade.edit(option);
@@ -296,7 +304,8 @@ public class ConfigResource {
     private ApiKey validateConfigKey(HttpHeaders headers) {
         String apiKeyValue = headers.getHeaderString("Config");
         ApiKey apiKey = apiKeyController.findApiKey(apiKeyValue);
-        if (apiKey == null || apiKey.getKeyType() != ApiKeyType.Config
+        if (apiKey == null || apiKey.isRetired()
+                || apiKey.getKeyType() != ApiKeyType.Config
                 || apiKey.getDateOfExpiary() == null
                 || apiKey.getDateOfExpiary().before(new java.util.Date())) {
             return null;

--- a/src/main/java/com/divudi/ws/common/ConfigResource.java
+++ b/src/main/java/com/divudi/ws/common/ConfigResource.java
@@ -271,12 +271,14 @@ public class ConfigResource {
         configOptionApplicationController.loadApplicationOptions();
 
         // Audit trail: who changed which key, from what to what, and when.
+        // Fields are CR/LF-stripped so a crafted key/value cannot forge
+        // additional log lines.
         WebUser user = apiKey.getWebUser();
         LOGGER.log(Level.INFO, "CONFIG_UPDATED key=[{0}] oldValue=[{1}] newValue=[{2}] by user=[{3}] at=[{4}]",
-                new Object[]{key,
-                    maskSensitiveValue(key, oldValue),
-                    maskSensitiveValue(key, newValue),
-                    user != null ? user.getName() : "unknown",
+                new Object[]{sanitizeForLog(key),
+                    sanitizeForLog(maskSensitiveValue(key, oldValue)),
+                    sanitizeForLog(maskSensitiveValue(key, newValue)),
+                    sanitizeForLog(user != null ? user.getName() : "unknown"),
                     new java.util.Date()});
 
         return Response.ok(toJson(option).build().toString()).build();
@@ -326,15 +328,25 @@ public class ConfigResource {
     }
 
     private Response notFoundResponse(String key) {
-        return Response.status(Response.Status.NOT_FOUND)
-                .entity("{\"error\":\"Config option not found: " + key + "\"}")
-                .build();
+        String body = Json.createObjectBuilder()
+                .add("error", "Config option not found: " + (key != null ? key : ""))
+                .build().toString();
+        return Response.status(Response.Status.NOT_FOUND).entity(body).build();
     }
 
     private Response badRequestResponse(String message) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity("{\"error\":\"" + message + "\"}")
-                .build();
+        String body = Json.createObjectBuilder()
+                .add("error", message != null ? message : "")
+                .build().toString();
+        return Response.status(Response.Status.BAD_REQUEST).entity(body).build();
+    }
+
+    /**
+     * Strip CR/LF from a value before it is written to the audit log, so a
+     * crafted config key or value cannot inject forged log lines.
+     */
+    private static String sanitizeForLog(String value) {
+        return value == null ? null : value.replaceAll("[\\r\\n]", "_");
     }
 
     private String maskSensitiveValue(String key, String value) {


### PR DESCRIPTION
## Summary

Extends the `/config` API (uses the `Config` header) so config options can be read and updated over REST instead of via direct DB access, closing #21544.

- `GET /api/config?scope={tag}` — list application-scoped options whose key contains `{tag}` (case-insensitive substring). `scope=inward` returns every inward-billing flag; omit `scope` for all.
- `GET /api/config/{key}` — read a single option (`key, type, scope, value`); 404 if absent.
- `PUT /api/config/{key}` — update an option value. Body `{"value":"..."}` (JSON string or raw scalar, persisted as string).

### Design decisions (for review)
- **`scope` interpretation:** the issue's `scope=inward` is implemented as a case-insensitive substring match on the option key (all inward-billing keys contain "Inward"). This avoids hardcoding a key list and matches the stated example.
- **Cache flush:** `PUT` calls `ConfigOptionApplicationController.loadApplicationOptions()` so the `@ApplicationScoped` cache reflects the change immediately, per the issue's requirement.
- **Audit:** there is no existing API-layer audit-event entity, so the required audit trail is written as a structured `CONFIG_UPDATED` server-log line (user, key, old value, new value, timestamp). A persisted audit entity can be a follow-up if desired.
- **Update-only:** `PUT` does not create new keys (404 if the key doesn't exist), to avoid polluting config with arbitrary keys via the API.
- Sensitive values (password/secret/token/…) are masked in responses, reusing the existing `maskSensitiveValue` helper. `CapabilityStatement` already advertised `GET/PUT` on this resource.

## Verification (local Payara `rh`, real DB)
| Test | Result |
|---|---|
| `GET ?scope=inward` | `215` keys |
| `GET /{key}` (boolean flag) | `value=false` |
| `PUT /{key}` `{"value":"true"}` | `value=true`; DB row = `true` |
| `GET /{key}` after PUT | `value=true` (cache reloaded) |
| `PUT` raw scalar `{"value":false}` | `value=false` |
| `PUT` / `GET` unknown key | `404` |
| `PUT` missing `value` | `400` |
| Finance key on Config endpoint / no key | `401` |
| Server log | `CONFIG_UPDATED key=[…] oldValue=[false] newValue=[true] by user=[buddhika] at=[…]` |

Test key restored to its original value after testing.

Closes #21544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Configuration Management REST endpoints to list, read, and update application configuration options under `/api/config`
  * List supports case-insensitive scope filtering; sensitive values are masked in responses
  * Update validates the required `Config` API key, accepts a JSON `"value"` payload (persisted as a string), sanitizes long text, and records an audit entry
* **Bug Fixes**
  * Improved existing config search authorization by using shared API-key validation
* **Documentation**
  * Updated developer documentation with the new `/api/config` endpoint behaviors and conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->