### PR TITLE
feat(api): inward billing margin diagnostic endpoint (#21545)

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -57,18 +57,18 @@ public class PriceMatrixController implements Serializable {
     private transient Map<String, Double> discountPercentCache;
 
     public PriceMatrix fetchInwardMargin(BillItem billItem, double serviceValue, Department department, PaymentMethod paymentMethod) {
-        PriceMatrix inwardPriceAdjustment;
-        Category category;
+        return fetchInwardMargin(billItem.getItem(), serviceValue, department, paymentMethod);
+    }
+
+    /**
+     * Item-based inward-margin lookup. The BillItem overload delegates here.
+     * Exposed so read-only callers (e.g. the inward margin diagnostic API) can
+     * run the exact same lookup without constructing a BillItem.
+     */
+    public PriceMatrix fetchInwardMargin(Item item, double serviceValue, Department department, PaymentMethod paymentMethod) {
         boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
-        if (billItem.getItem() instanceof Investigation) {
-            if (configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
-                category = ((Investigation) billItem.getItem()).getCategory();
-            } else {
-                category = ((Investigation) billItem.getItem()).getInvestigationCategory();
-            }
-        } else {
-            category = billItem.getItem().getCategory();
-        }
+        Category category = resolveInwardMatrixCategory(item);
+        PriceMatrix inwardPriceAdjustment;
         if (isPaymentMethodAllowedInInwardMatrix) {
             inwardPriceAdjustment = getInwardPriceAdjustment(department, serviceValue, category, paymentMethod);
         } else {
@@ -81,35 +81,26 @@ public class PriceMatrixController implements Serializable {
                 inwardPriceAdjustment = getInwardPriceAdjustment(department, serviceValue, category.getParentCategory());
             }
         }
-//        if (inwardPriceAdjustment == null) {
-//            return null;
-//        }
         return inwardPriceAdjustment;
-
     }
 
     public PriceMatrix fetchInwardMargin(BillItem billItem, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
+        return fetchInwardMargin(billItem.getItem(), serviceValue, department, paymentMethod, creditCompany);
+    }
+
+    public PriceMatrix fetchInwardMargin(Item item, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
         if (creditCompany != null) {
-            PriceMatrix result = fetchInwardMarginWithCreditCompany(billItem, serviceValue, department, paymentMethod, creditCompany);
+            PriceMatrix result = fetchInwardMarginWithCreditCompany(item, serviceValue, department, paymentMethod, creditCompany);
             if (result != null) {
                 return result;
             }
         }
-        return fetchInwardMargin(billItem, serviceValue, department, paymentMethod);
+        return fetchInwardMargin(item, serviceValue, department, paymentMethod);
     }
 
-    private PriceMatrix fetchInwardMarginWithCreditCompany(BillItem billItem, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
+    private PriceMatrix fetchInwardMarginWithCreditCompany(Item item, double serviceValue, Department department, PaymentMethod paymentMethod, Institution creditCompany) {
         boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
-        Category category;
-        if (billItem.getItem() instanceof Investigation) {
-            if (configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
-                category = ((Investigation) billItem.getItem()).getCategory();
-            } else {
-                category = ((Investigation) billItem.getItem()).getInvestigationCategory();
-            }
-        } else {
-            category = billItem.getItem().getCategory();
-        }
+        Category category = resolveInwardMatrixCategory(item);
         PriceMatrix result;
         if (isPaymentMethodAllowedInInwardMatrix) {
             result = getInwardPriceAdjustment(department, serviceValue, category, paymentMethod, creditCompany);
@@ -124,6 +115,19 @@ public class PriceMatrixController implements Serializable {
             }
         }
         return result;
+    }
+
+    /**
+     * The category the inward price-matrix lookup uses for an item: the
+     * investigation category for investigations (unless the config flag swaps
+     * it for the plain category), otherwise the item's category.
+     */
+    private Category resolveInwardMatrixCategory(Item item) {
+        if (item instanceof Investigation
+                && !configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
+            return ((Investigation) item).getInvestigationCategory();
+        }
+        return item.getCategory();
     }
 
     public PriceMatrix fetchInwardMargin(Item item, double serviceValue, Department department) {

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3587,7 +3587,8 @@ public class AnthropicApiService implements Serializable {
                     {"GET",    "/inward-price-adjustment/categories/search?scope=X&query=",       "Category name → id lookup (requires scope)"},
                     {"GET",    "/inward-price-adjustment/departments/search?query=",              "Department name → id lookup"},
                     {"GET",    "/inward-price-adjustment/payment-methods",                         "List PaymentMethod enum values"},
-                    {"GET",    "/inward-price-adjustment/credit-companies/search?query=",          "Credit company name → id lookup"}
+                    {"GET",    "/inward-price-adjustment/credit-companies/search?query=",          "Credit company name → id lookup"},
+                    {"GET",    "/inward-price-adjustment/diagnose?itemId=&departmentId=&paymentMethod=&patientEncounterId=&price=", "Explain whether inward service-charge margin will be applied for an item, with a per-condition pass/fail breakdown"}
                 });
 
         appendModule(sb, "Inward Room Management", "/inward/room-categories, /inward/rooms, /inward/room-facility-charges",

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -151,6 +151,8 @@ public class CapabilityStatementResource {
                         + "Price range lookup: fromPrice/toPrice define the gross value range to which the margin applies. "
                         + "Lookup sub-paths: /categories/search?scope=service|pharmacy, /departments/search, "
                         + "/payment-methods, /credit-companies/search. "
+                        + "Diagnostic sub-path: /diagnose?itemId=&departmentId=&paymentMethod=&patientEncounterId=&price= "
+                        + "explains whether inward service-charge margin will be applied for an item, with a per-condition breakdown. "
                         + "POST returns HTTP 409 with existing id when a duplicate combination exists.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -6,22 +6,36 @@
 package com.divudi.ws.inward;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.PriceMatrixController;
+import com.divudi.core.data.FeeType;
 import com.divudi.core.data.InstitutionType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.ItemFee;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.ServiceCategory;
 import com.divudi.core.entity.ServiceSubCategory;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.InwardPriceAdjustment;
+import com.divudi.core.entity.lab.Investigation;
 import com.divudi.core.entity.lab.InvestigationCategory;
 import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
 import com.divudi.core.facade.CategoryFacade;
 import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.EncounterCreditCompanyFacade;
 import com.divudi.core.facade.InstitutionFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.ItemFeeFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PriceMatrixFacade;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -86,6 +100,27 @@ public class InwardPriceAdjustmentApi {
 
     @EJB
     private InstitutionFacade institutionFacade;
+
+    @EJB
+    private ItemFacade itemFacade;
+
+    @EJB
+    private ItemFeeFacade itemFeeFacade;
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+
+    @EJB
+    private EncounterCreditCompanyFacade encounterCreditCompanyFacade;
+
+    @Inject
+    private PriceMatrixController priceMatrixController;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    private static final java.util.logging.Logger LOGGER =
+            java.util.logging.Logger.getLogger(InwardPriceAdjustmentApi.class.getName());
 
     private static final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
@@ -856,6 +891,194 @@ public class InwardPriceAdjustmentApi {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid numeric value: '" + o + "'");
         }
+    }
+
+    // =========================================================================
+    // Margin diagnostic
+    // =========================================================================
+
+    /**
+     * Diagnose whether inward service-charge margin will be applied for an item,
+     * and if not, which condition fails. Mirrors the eligibility logic in
+     * {@code InwardBeanController.setBillFeeMargin(...)} and the price-matrix
+     * lookup in {@code PriceMatrixController.fetchInwardMargin(...)} so the
+     * result matches real billing behaviour.
+     *
+     * GET /api/inward-price-adjustment/diagnose
+     *   ?itemId=&departmentId=&paymentMethod=&patientEncounterId=&price=
+     */
+    @GET
+    @Path("/diagnose")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response diagnoseInwardMargin() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Long itemId = longParam("itemId");
+            Long departmentId = longParam("departmentId");
+            String paymentMethodStr = param("paymentMethod");
+            Long patientEncounterId = longParam("patientEncounterId");
+            Double priceParam = asDouble(param("price"));
+
+            if (itemId == null || departmentId == null
+                    || paymentMethodStr == null || paymentMethodStr.trim().isEmpty()
+                    || patientEncounterId == null) {
+                return errorResponse("itemId, departmentId, paymentMethod and patientEncounterId are required", 400);
+            }
+
+            PaymentMethod paymentMethod;
+            try {
+                paymentMethod = PaymentMethod.valueOf(paymentMethodStr.trim());
+            } catch (IllegalArgumentException e) {
+                return errorResponse("Invalid paymentMethod: " + paymentMethodStr, 400);
+            }
+
+            Item item = itemFacade.find(itemId);
+            if (item == null) {
+                return errorResponse("Item not found with ID: " + itemId, 404);
+            }
+            Department department = departmentFacade.find(departmentId);
+            if (department == null) {
+                return errorResponse("Department not found with ID: " + departmentId, 404);
+            }
+            PatientEncounter encounter = patientEncounterFacade.find(patientEncounterId);
+            if (encounter == null) {
+                return errorResponse("PatientEncounter not found with ID: " + patientEncounterId, 404);
+            }
+
+            double price = priceParam != null ? priceParam : item.getTotal();
+            AdmissionType admissionType = encounter.getAdmissionType();
+            Institution creditCompany = resolveSingleCreditCompany(encounter);
+
+            // The category actually used by the price-matrix lookup: for an
+            // Investigation it is the investigation category (unless the config
+            // flag swaps it for the plain category), matching fetchInwardMargin.
+            Category effectiveCategory;
+            if (item instanceof Investigation
+                    && !configOptionApplicationController.getBooleanValueByKey("Get Category Instead of Investigation Category In Price Matrix")) {
+                effectiveCategory = ((Investigation) item).getInvestigationCategory();
+            } else {
+                effectiveCategory = item.getCategory();
+            }
+
+            // Price-matrix lookup: reuse the exact cascade + config gating used in billing.
+            BillItem probe = new BillItem();
+            probe.setItem(item);
+            PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(probe, price, department, paymentMethod, creditCompany);
+
+            // The OwnInstitution fee carries the hospital-portion margin flag.
+            ItemFee ownFee = findOwnInstitutionFee(item);
+
+            boolean configPaymentMethodUsed = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
+
+            List<Map<String, Object>> checks = new ArrayList<>();
+
+            boolean matrixFound = priceMatrix != null;
+            checks.add(check("PriceMatrix row found", matrixFound,
+                    matrixFound
+                            ? "ID " + priceMatrix.getId() + ", margin=" + priceMatrix.getMargin() + "%"
+                            : "No matching InwardPriceAdjustment for dept=" + departmentId
+                                    + ", category=" + (effectiveCategory != null ? effectiveCategory.getId() : "null")
+                                    + ", price=" + price
+                                    + (configPaymentMethodUsed ? ", paymentMethod=" + paymentMethod : "")));
+
+            boolean itemMarginOk = !item.isMarginNotAllowed();
+            checks.add(check("item.marginNotAllowed", itemMarginOk,
+                    "marginNotAllowed=" + item.isMarginNotAllowed()));
+
+            boolean feeMarginOk = ownFee != null && !Boolean.FALSE.equals(ownFee.getMarginAllowed());
+            checks.add(check("fee.marginAllowed (OwnInstitution)", feeMarginOk,
+                    ownFee == null
+                            ? "No OwnInstitution fee found for this item"
+                            : "marginAllowed=" + ownFee.getMarginAllowed() + " (fee ID " + ownFee.getId() + ")"));
+
+            boolean admissionOk = admissionType != null && admissionType.isAllowToCalculateMargin();
+            checks.add(check("admissionType.allowToCalculateMargin", admissionOk,
+                    admissionType == null
+                            ? "Encounter has no admission type"
+                            : admissionType.getName() + " (ID " + admissionType.getId()
+                                    + ") allowToCalculateMargin=" + admissionType.isAllowToCalculateMargin()));
+
+            boolean notStaff = ownFee != null && ownFee.getFeeType() != FeeType.Staff;
+            checks.add(check("feeType is not Staff", notStaff,
+                    ownFee == null ? "No OwnInstitution fee found" : "FeeType=" + ownFee.getFeeType()));
+
+            // Informational: the config flag changes the lookup, it is not itself a pass/fail blocker.
+            checks.add(check("Config: paymentMethod used in lookup", true,
+                    "Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation = " + configPaymentMethodUsed));
+
+            boolean marginWillBeApplied = matrixFound && itemMarginOk && feeMarginOk && admissionOk && notStaff;
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("itemId", item.getId());
+            data.put("itemName", item.getName());
+            data.put("categoryId", effectiveCategory != null ? effectiveCategory.getId() : null);
+            data.put("categoryName", effectiveCategory != null ? effectiveCategory.getName() : null);
+            data.put("departmentId", department.getId());
+            data.put("departmentName", department.getName());
+            data.put("paymentMethod", paymentMethod.toString());
+            data.put("patientEncounterId", encounter.getId());
+            data.put("admissionTypeId", admissionType != null ? admissionType.getId() : null);
+            data.put("creditCompanyId", creditCompany != null ? creditCompany.getId() : null);
+            data.put("price", price);
+            data.put("marginWillBeApplied", marginWillBeApplied);
+            data.put("expectedMarginPercent", matrixFound ? priceMatrix.getMargin() : null);
+            data.put("expectedMarginValue",
+                    (marginWillBeApplied && priceMatrix.getMargin() != null) ? (price * priceMatrix.getMargin()) / 100.0 : null);
+            data.put("checks", checks);
+
+            LOGGER.log(java.util.logging.Level.INFO,
+                    "INWARD_MARGIN_DIAGNOSE item={0} dept={1} pm={2} encounter={3} marginWillBeApplied={4}",
+                    new Object[]{itemId, departmentId, paymentMethod, patientEncounterId, marginWillBeApplied});
+
+            return successResponse(data);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    private Map<String, Object> check(String name, boolean passed, String detail) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("check", name);
+        m.put("passed", passed);
+        m.put("detail", detail);
+        return m;
+    }
+
+    /**
+     * The single credit company on an encounter, or null when none/ambiguous —
+     * mirrors InwardBeanController.resolveSingleCreditCompany.
+     */
+    private Institution resolveSingleCreditCompany(PatientEncounter encounter) {
+        if (encounter == null) {
+            return null;
+        }
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("enc", encounter);
+        List<EncounterCreditCompany> list = encounterCreditCompanyFacade.findByJpql(
+                "select e from EncounterCreditCompany e where e.retired = false and e.patientEncounter = :enc", hm, 2);
+        if (list != null && list.size() == 1) {
+            return list.get(0).getInstitution();
+        }
+        return null;
+    }
+
+    /**
+     * The item's active OwnInstitution fee — the hospital-portion fee whose
+     * marginAllowed flag gates the inward margin.
+     */
+    private ItemFee findOwnInstitutionFee(Item item) {
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("item", item);
+        hm.put("ft", FeeType.OwnInstitution);
+        return itemFeeFacade.findFirstByJpql(
+                "select f from ItemFee f where f.retired = false and f.item = :item and f.feeType = :ft order by f.id", hm);
     }
 
     // -------- auth + response helpers --------

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -12,7 +12,6 @@ import com.divudi.core.data.FeeType;
 import com.divudi.core.data.InstitutionType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.entity.ApiKey;
-import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.EncounterCreditCompany;
@@ -929,6 +928,10 @@ public class InwardPriceAdjustmentApi {
                 return errorResponse("itemId, departmentId, paymentMethod and patientEncounterId are required", 400);
             }
 
+            if (priceParam != null && !Double.isFinite(priceParam)) {
+                return errorResponse("price must be a finite number", 400);
+            }
+
             PaymentMethod paymentMethod;
             try {
                 paymentMethod = PaymentMethod.valueOf(paymentMethodStr.trim());
@@ -965,9 +968,7 @@ public class InwardPriceAdjustmentApi {
             }
 
             // Price-matrix lookup: reuse the exact cascade + config gating used in billing.
-            BillItem probe = new BillItem();
-            probe.setItem(item);
-            PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(probe, price, department, paymentMethod, creditCompany);
+            PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(item, price, department, paymentMethod, creditCompany);
 
             // Margin is applied to every non-Staff fee on the item: BillBhtController
             // creates a BillFee per item fee and calls setBillFeeMargin, whose

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -969,8 +969,23 @@ public class InwardPriceAdjustmentApi {
             probe.setItem(item);
             PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(probe, price, department, paymentMethod, creditCompany);
 
-            // The OwnInstitution fee carries the hospital-portion margin flag.
-            ItemFee ownFee = findOwnInstitutionFee(item);
+            // Margin is applied to every non-Staff fee on the item: BillBhtController
+            // creates a BillFee per item fee and calls setBillFeeMargin, whose
+            // eligibility only excludes FeeType.Staff and marginAllowed=false. So
+            // evaluate all non-Staff fees rather than assuming OwnInstitution.
+            List<ItemFee> nonStaffFees = findNonStaffFees(item);
+            boolean anyFeeAllowsMargin = false;
+            StringBuilder feeDetail = new StringBuilder();
+            for (ItemFee f : nonStaffFees) {
+                if (!Boolean.FALSE.equals(f.getMarginAllowed())) {
+                    anyFeeAllowsMargin = true;
+                }
+                if (feeDetail.length() > 0) {
+                    feeDetail.append("; ");
+                }
+                feeDetail.append(f.getFeeType()).append(" marginAllowed=").append(f.getMarginAllowed())
+                        .append(" (fee ID ").append(f.getId()).append(")");
+            }
 
             boolean configPaymentMethodUsed = configOptionApplicationController.getBooleanValueByKey(
                     "Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
@@ -990,11 +1005,10 @@ public class InwardPriceAdjustmentApi {
             checks.add(check("item.marginNotAllowed", itemMarginOk,
                     "marginNotAllowed=" + item.isMarginNotAllowed()));
 
-            boolean feeMarginOk = ownFee != null && !Boolean.FALSE.equals(ownFee.getMarginAllowed());
-            checks.add(check("fee.marginAllowed (OwnInstitution)", feeMarginOk,
-                    ownFee == null
-                            ? "No OwnInstitution fee found for this item"
-                            : "marginAllowed=" + ownFee.getMarginAllowed() + " (fee ID " + ownFee.getId() + ")"));
+            checks.add(check("fee.marginAllowed (billable non-Staff fee)", anyFeeAllowsMargin,
+                    nonStaffFees.isEmpty()
+                            ? "No non-Staff (billable) fee found for this item"
+                            : feeDetail.toString()));
 
             boolean admissionOk = admissionType != null && admissionType.isAllowToCalculateMargin();
             checks.add(check("admissionType.allowToCalculateMargin", admissionOk,
@@ -1003,15 +1017,15 @@ public class InwardPriceAdjustmentApi {
                             : admissionType.getName() + " (ID " + admissionType.getId()
                                     + ") allowToCalculateMargin=" + admissionType.isAllowToCalculateMargin()));
 
-            boolean notStaff = ownFee != null && ownFee.getFeeType() != FeeType.Staff;
-            checks.add(check("feeType is not Staff", notStaff,
-                    ownFee == null ? "No OwnInstitution fee found" : "FeeType=" + ownFee.getFeeType()));
+            boolean hasBillableFee = !nonStaffFees.isEmpty();
+            checks.add(check("has a billable (non-Staff) fee", hasBillableFee,
+                    "non-Staff fee count=" + nonStaffFees.size()));
 
             // Informational: the config flag changes the lookup, it is not itself a pass/fail blocker.
             checks.add(check("Config: paymentMethod used in lookup", true,
                     "Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation = " + configPaymentMethodUsed));
 
-            boolean marginWillBeApplied = matrixFound && itemMarginOk && feeMarginOk && admissionOk && notStaff;
+            boolean marginWillBeApplied = matrixFound && itemMarginOk && anyFeeAllowsMargin && admissionOk;
 
             Map<String, Object> data = new LinkedHashMap<>();
             data.put("itemId", item.getId());
@@ -1070,15 +1084,17 @@ public class InwardPriceAdjustmentApi {
     }
 
     /**
-     * The item's active OwnInstitution fee — the hospital-portion fee whose
-     * marginAllowed flag gates the inward margin.
+     * The item's active non-Staff fees — these are the billable fees the inward
+     * margin can apply to (Staff fees are excluded by setBillFeeMargin). A null
+     * fee type is treated as non-Staff, matching {@code getFeeType() != Staff}.
      */
-    private ItemFee findOwnInstitutionFee(Item item) {
+    private List<ItemFee> findNonStaffFees(Item item) {
         Map<String, Object> hm = new HashMap<>();
         hm.put("item", item);
-        hm.put("ft", FeeType.OwnInstitution);
-        return itemFeeFacade.findFirstByJpql(
-                "select f from ItemFee f where f.retired = false and f.item = :item and f.feeType = :ft order by f.id", hm);
+        hm.put("staff", FeeType.Staff);
+        return itemFeeFacade.findByJpql(
+                "select f from ItemFee f where f.retired = false and f.item = :item"
+                        + " and (f.feeType is null or f.feeType <> :staff) order by f.id", hm);
     }
 
     // -------- auth + response helpers --------


### PR DESCRIPTION
## Summary

Adds `GET /api/inward-price-adjustment/diagnose` — a read-only endpoint that explains, in one call, whether inward service-charge margin will be applied for an item and, if not, exactly which condition is blocking it. Closes #21545.

**Params:** `itemId`, `departmentId`, `paymentMethod`, `patientEncounterId` (required); `price` (optional, defaults to `item.total`). Auth: `Finance` header.

It runs the same six conditions the billing path enforces (`InwardBeanController.setBillFeeMargin` + `PriceMatrixController.fetchInwardMargin`) and returns a per-check pass/fail breakdown plus `marginWillBeApplied`, `expectedMarginPercent`, `expectedMarginValue`:

1. PriceMatrix (`InwardPriceAdjustment`) row found
2. `item.marginNotAllowed` is false
3. OwnInstitution `fee.marginAllowed` is not false
4. `admissionType.allowToCalculateMargin` is true
5. fee type is not `Staff`
6. config `Inward Matrix - Allow PaymentMethod...` (informational — gates whether payment method is used in the lookup)

### Implementation notes
- **Reuses the real lookup:** the price-matrix resolution calls `PriceMatrixController.fetchInwardMargin(...)` (via a transient probe `BillItem`), so it honours the exact cascade — credit-company-specific rows first, category→parent fallback, and the config-gated payment-method matching — and therefore matches actual billing behaviour rather than reimplementing it.
- **Effective category:** for an `Investigation` the lookup uses the investigation category (unless the config flag swaps it); the response's `categoryId/categoryName` reflect the category the lookup *actually* used, not just `item.getCategory()`.
- Injecting the `@SessionScoped` `PriceMatrixController` into this `@RequestScoped` resource follows the existing pattern (the `@SessionScoped` `ApiKeyController` is injected the same way across the API layer).
- Read-only; logs an `INWARD_MARGIN_DIAGNOSE` info line. Lives on the existing `inward-price-adjustment` resource rather than the issue's aspirational `/api/price-matrix/inward/diagnose`. Documented in the AI system-prompt module listing.

## Verification (local Payara `rh`, real DB)
Seeded one `InwardPriceAdjustment` row (category 24, dept 9209, 12%) and used encounter 4427040 (admission type "Classic Range", `allowToCalculateMargin=1`, Cash); all seed data removed afterward.

| Scenario | Result |
|---|---|
| Service item 13251, fee `marginAllowed=false` | `marginWillBeApplied=false`; only **fee.marginAllowed (OwnInstitution)** fails; matrix found (12%) — reproduces the issue's real blocker |
| Same item, fee flipped to `marginAllowed=true` | `marginWillBeApplied=true`, `expectedMarginPercent=12.0`, `expectedMarginValue=120.0`, all six checks pass |
| Investigation item with null investigation category | matrix-not-found detail shows the effective (investigation) category, not `getCategory()` |
| missing required param / bad paymentMethod | `400` |
| unknown item / department / encounter | `404` |
| no `Finance` key | `401` |

Closes #21545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic endpoint to evaluate inward service-charge margin eligibility for a given item and context.
  * Returns a structured JSON response showing whether a margin will be applied, expected margin values (when applicable), and a condition-by-condition pass/fail breakdown for easier troubleshooting.
  
* **Improvements**
  * Enhanced operational logging to capture key request identifiers and the computed eligibility outcome for faster support and investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->