### PR TITLE
feat(inward): display inward deposit comments on final bill and payment prints (#21393)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -614,6 +614,8 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
             finalBillDeptId = pe.getFinalBill().getDeptId();
         }
 
+        boolean showInwardDepositComment = configOptionApplicationController.getBooleanValueByKey("Show Comment on Inward Deposit Bill", false);
+
         String output;
         output = template
                 .replace("{dept_id}", bill.getDeptId() != null ? String.valueOf(bill.getDeptId()) : "")
@@ -649,7 +651,9 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
                 .replace("{bill_date}", bill.getBillDate() != null ? formatDate(bill.getBillDate(), sessionController) : "")
                 .replace("{bill_time}", bill.getBillTime() != null ? formatTime(bill.getBillTime(), sessionController) : "")
                 .replace("{time_of_admission}", pe.getDateOfAdmission() != null ? formatDate(pe.getDateOfAdmission(), sessionController) : "")
-                .replace("{time_of_discharge}", pe.getDateOfDischarge() != null ? formatTime(pe.getDateOfDischarge(), sessionController) : "");
+                .replace("{time_of_discharge}", pe.getDateOfDischarge() != null ? formatTime(pe.getDateOfDischarge(), sessionController) : "")
+                .replace("{comment}", showInwardDepositComment && bill.getComments() != null ? bill.getComments() : "")
+                .replace("{bill_comment}", showInwardDepositComment && bill.getComments() != null ? bill.getComments() : "");
 
         return output;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1866,6 +1866,15 @@ public class InwardSearch implements Serializable {
         JsfUtil.addErrorMessage("Successfully Cheked");
     }
 
+    public void updateBillComments() {
+        if (bill == null || bill.getId() == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return;
+        }
+        getBillFacade().edit(bill);
+        JsfUtil.addSuccessMessage("Comment Updated");
+    }
+
     public void selectBillItem(BillItem billItem) {
         makeNull();
         BillItem tmp = billItemFacede.find(billItem.getId());

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -86,8 +86,35 @@
 
                                     </p:dataTable>
                                 </p:panel>
+
+                                <p:panel class="mt-2">
+                                    <f:facet name="header">
+                                        <h:outputText styleClass="fas fa-comment-dots"></h:outputText>
+                                        <h:outputLabel value="Bill Comment" class="mx-2"></h:outputLabel>
+                                    </f:facet>
+
+                                    <div class="d-flex gap-2 justify-content-between">
+                                        <p:inputText 
+                                            id="billComment"
+                                            class="w-100"
+                                            value="#{inwardSearch.bill.comments}">
+                                        </p:inputText>
+                                        
+                                        <p:commandButton 
+                                            id="saveBillComment"
+                                            value="Save Comment"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            style="width: 200px;"
+                                            action="#{inwardSearch.updateBillComments()}"
+                                            update="billComment gpBillPreview">
+                                        </p:commandButton>
+                                    </div>
+                                </p:panel>
+                                
                             </div>
                         </div>
+
                         <p:panel >
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between">
@@ -118,10 +145,10 @@
                                     <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
                                         <bill:posPaperPaymentBill bill="#{inwardSearch.bill}"/> 
                                     </h:panelGroup>
-                                    
-                                     <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
-                                         <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
-                                </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
+                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                    </h:panelGroup>
 
                                 </h:panelGroup>
                             </div>
@@ -129,53 +156,53 @@
                     </p:panel>
                 </h:form>
 
-        <p:dialog id="inwardPaymentConfigDialog"
-                  header="Inward Payment Bill Printer Configuration"
-                  widgetVar="inwardPaymentConfigDialog"
-                  modal="true"
-                  width="560"
-                  resizable="false"
-                  closeOnEscape="true">
-            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
-            <h:form id="inwardPaymentConfigForm">
-                <div class="card config-section">
-                    <div class="card-header">
-                        <i class="fas fa-file-alt me-2"/>
-                        <h:outputText value="Paper Format Settings"/>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
-                            <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                <p:dialog id="inwardPaymentConfigDialog"
+                          header="Inward Payment Bill Printer Configuration"
+                          widgetVar="inwardPaymentConfigDialog"
+                          modal="true"
+                          width="560"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+                    <h:form id="inwardPaymentConfigForm">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <i class="fas fa-file-alt me-2"/>
+                                <h:outputText value="Paper Format Settings"/>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                                    <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                                    <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                                </div>
+                            </div>
                         </div>
-                        <div class="mb-3">
-                            <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
-                            <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton value="Apply &amp; Close"
+                                             icon="fas fa-save"
+                                             class="ui-button-success"
+                                             ajax="false"
+                                             action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                            <p:commandButton value="Cancel"
+                                             icon="fas fa-times"
+                                             class="ui-button-secondary"
+                                             type="button"
+                                             onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
                         </div>
-                        <div class="mb-3">
-                            <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
-                            <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
-                        </div>
-                        <div class="mb-3">
-                            <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
-                            <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
-                        </div>
-                    </div>
-                </div>
-                <div class="d-flex gap-2 mt-3">
-                    <p:commandButton value="Apply &amp; Close"
-                                     icon="fas fa-save"
-                                     class="ui-button-success"
-                                     ajax="false"
-                                     action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
-                    <p:commandButton value="Cancel"
-                                     icon="fas fa-times"
-                                     class="ui-button-secondary"
-                                     type="button"
-                                     onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
-                </div>
-            </h:form>
-        </p:dialog>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward_payments.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward_payments.xhtml
@@ -222,6 +222,15 @@
                         </h:panelGroup>
                     </tr>
 
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.bill.comments ne null and cc.attrs.bill.comments ne '' and !configOptionApplicationController.getBooleanValueByKey('Show Payment Type on Inward Deposit Bill',false)}" >
+                        <tr>
+                            <td style="padding: 2px;">Comment :</td>
+                            <td style="padding: 2px;" colspan="4">
+                                <h:outputLabel value="#{cc.attrs.bill.comments}"/>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
                     <h:panelGroup rendered="#{cc.attrs.bill.referredBy ne null}" >
                         <tr>
                             <td style="padding: 2px;">Ref. Doctor :</td>

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -816,7 +816,7 @@
                                         </td>
                                         <td>
                                             <table>
-                                                <ui:repeat value="#{cc.attrs.bill.backwardReferenceBills}" var="b">
+                                                <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
                                                     <h:panelGroup rendered="#{(b.netTotal ne 0 )
                                                                               and
                                                                               ((b.cancelled eq false
@@ -826,13 +826,14 @@
                                                                               and b.refundedBill eq null
                                                                               and b.billClass eq 'class com.divudi.core.entity.RefundBill')) and b.billTypeAtomic ne 'INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED'}">
                                                         <div class="d-flex gap-3" style="font-size: 11px;">
-                                                            <h:outputLabel value="#{b.comments}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comments of Payments on Final Bill On Final Bill Print',false)}"/>
                                                             <h:outputLabel value="#{b.deptId}"/>
                                                             <h:outputLabel value="#{b.paymentMethod}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Method on Payments on Final Bill On Final Bill Print',false)}"/>
                                                             <h:outputLabel value="#{b.netTotal}"
-                                                                           style="width: 30px; text-align: right;">
+                                                                           style="text-align: right;">
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputLabel>
+                                                            <h:outputLabel value="(#{b.comments})" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comments of Payments on Final Bill On Final Bill Print',false) and b.comments ne null and b.comments ne ''}"/>
+
                                                         </div>
 
                                                     </h:panelGroup>
@@ -858,7 +859,7 @@
                                         </td>
                                         <td>
                                             <table>
-                                                <ui:repeat value="#{cc.attrs.bill.backwardReferenceBills}" var="b">
+                                                <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
                                                     <h:panelGroup rendered="#{(b.netTotal ne 0 )
                                                                               and
                                                                               ((b.cancelled eq false

--- a/src/main/webapp/resources/inward/bill/payment/FiveFivePaymentBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/FiveFivePaymentBill.xhtml
@@ -286,6 +286,13 @@
 
 
             </div>
+
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.bill.comments ne null and cc.attrs.bill.comments ne ''}">
+                <div class="billDetailsFiveFive" style="margin-top: 10px; text-align: left;">
+                    <h:outputLabel value="Comment : #{cc.attrs.bill.comments}" class="billDetailsFiveFive"/>
+                </div>
+            </h:panelGroup>
+
             <div style="text-decoration: overline; margin-top: 20px;">
                 <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.webUserPerson.name}"/>
             </div>

--- a/src/main/webapp/resources/inward/bill/payment/posPaperPaymentBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/posPaperPaymentBill.xhtml
@@ -273,14 +273,36 @@
                         </td>
                         <td>:</td>
                         <td style="width: 30%;" >
-                            <h:outputLabel 
-                                value="#{cc.attrs.bill.paymentMethod.label}"  
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.paymentMethod.label}"
                                 style="text-align: center!important;
                                 font-size: 12px!important;
                                 font-family:Arial, Helvetica, sans-serif!important;">
                             </h:outputLabel>
                         </td>
                     </tr>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.bill.comments ne null and cc.attrs.bill.comments ne ''}">
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel
+                                    value="Comment"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel
+                                    value="#{cc.attrs.bill.comments}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
                 </table>
             </div>
 


### PR DESCRIPTION
## Summary

Fixes #21393 — inward deposit **comments** were not shown on the final bill next to the deposit amount. This PR displays the deposit comment on the final bill and across all inward deposit payment bill prints, behind a single configuration option, and adds the ability to edit the comment from the payment reprint page.

## Changes

### 1. Final bill — display deposit comment (`finalBill.xhtml`)
- The **Paid By Patient** / **Paid By Company** breakdown now reads its payment lines from the encounter's final bill (`patientEncounter.finalBill.backwardReferenceBills`) instead of the rendered bill's own `backwardReferenceBills`. Deposit payments are only linked (via `forwardReferenceBill`) to the actual `InwardFinalBill`, so previously the **Original / Hospital / Duplicate** copies showed the total but an **empty detail breakdown**. Now every copy shows the deposit lines.
- Each deposit payment **comment is printed in parentheses** beside the payment, gated by the existing `Show Comments of Payments on Final Bill On Final Bill Print` option. Empty/null comments print nothing.

### 2. Inward deposit payment bill prints — display comment behind one config option
All four deposit payment bill templates now show the comment, controlled by **one** new option:
- **A4** (`A4PaperPaymentBill` / `fillDataForInpatientsDepositBill`): new `{comment}` and `{bill_comment}` placeholders, resolved only when the option is on.
- **5×5** (`FiveFivePaymentBill`)
- **POS** (`posPaperPaymentBill`)
- **5×5 Custom 3** (`five_five_custom_3_inward_payments`) — suppressed when the existing `Show Payment Type on Inward Deposit Bill` row already prints the same value (avoids duplicate lines).

### 3. Payment reprint page — edit comment (`inward_reprint_bill_payment.xhtml`, `InwardSearch`)
- New **Bill Comment** section with an editable field and **Save Comment** action (`InwardSearch.updateBillComments()`) that persists the change and refreshes the bill preview.

## Configuration Option (new)

| Key | Type | Default | Effect |
|---|---|---|---|
| `Show Comment on Inward Deposit Bill` | Boolean | `false` | When enabled, the inward deposit comment is displayed on all four deposit payment bill prints (A4, 5×5, POS, 5×5 Custom 3). For A4 the `{comment}`/`{bill_comment}` placeholder must also be present in the department's `Inward Deposit Bill Template`. |

With the option off (default), payment-print behavior is unchanged. The final-bill comment display continues to use the pre-existing `Show Comments of Payments on Final Bill On Final Bill Print` option.

## Test Plan

1. **Setup**: Admit a patient (BHT), collect one or more inward deposits, entering a **comment** on each deposit.
2. **Final bill**
   - Enable `Show Comments of Payments on Final Bill On Final Bill Print`.
   - Settle/finalize the bill and open the final bill print. Under **Paid By Patient**, confirm each deposit shows its `deptId`, amount, and the **comment in parentheses**.
   - Switch to the **Original / Hospital / Duplicate** copies and confirm the deposit lines (and comments) now appear there too — not just the patient copy.
   - Set a deposit comment to empty and confirm no stray `()` is printed.
3. **Payment bill prints**
   - With `Show Comment on Inward Deposit Bill` **off**, reprint a deposit on each paper type (A4, 5×5, POS, 5×5 Custom 3) and confirm **no comment** is shown.
   - Turn the option **on** (for A4, also add `{comment}` to the deposit bill template) and reprint: confirm the comment appears on each format.
   - On 5×5 Custom 3 with `Show Payment Type on Inward Deposit Bill` on, confirm the comment is **not** duplicated.
4. **Edit comment**
   - On the payment **reprint** page, edit the Bill Comment, click **Save Comment**, confirm success message, the preview refreshes, and the new value persists and flows through to the final bill / payment prints.

## Notes
- Includes Java changes (`InwardPaymentController`, `InwardSearch`) — requires a rebuild + redeploy.
- `persistence.xml` local JNDI changes are intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to manage comments on inward deposit bills with a configurable option to enable/disable comment visibility
  * Introduced a new inward payment bill template format option for additional printing flexibility
  * Added "Bill Comment" section to the inward bill interface for editing and saving comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->