### PR TITLE
feat(api): expose bed-board SVGs via institution/department/room APIs + AI chat

### DIFF
--- a/developer_docs/API_INSTITUTION_DEPARTMENT_MANAGEMENT.md
+++ b/developer_docs/API_INSTITUTION_DEPARTMENT_MANAGEMENT.md
@@ -2482,6 +2482,52 @@ def verify_config_update(manager, dept_id, config_key, expected_value):
     return False
 ```
 
+## Bed-board SVG (issue #21592)
+
+Institutions and departments each store two SVG drawings used by the Inpatient
+Bed Board page, on a shared `viewBox="0 0 1000 600"` grid:
+
+- **`svgParentView`** — the entity's own empty floor-plan canvas, shown when you
+  navigate *into* it.
+- **`svgChildView`** — the small shape showing how this entity looks as a tile
+  *inside its parent's* canvas.
+
+Both fields are accepted on the normal `POST`/`PUT` bodies and returned by `GET`
+for both `/api/institutions` and `/api/departments`. SVG is stored **verbatim**
+(create/update → read back identical); it is sanitised at render time on the bed
+board. See the wiki page
+[Inpatient — Bed Board](https://github.com/hmislk/hmis/wiki/Inpatient-Bed-Board)
+for authoring guidance and copy-paste examples.
+
+> The bed-board navigation hierarchy is Site → Building → Floor → Unit → Room.
+> Sites live under `/api/sites` (see `API_SITES.md`); buildings/floors/units are
+> `Department`s; rooms (leaves, `svgChildView` only) live under
+> `/api/inward/rooms` (see `API_INWARD_ROOM.md`).
+
+### `/api/institutions/{id}/svg` and `/api/departments/{id}/svg`
+
+Dedicated sub-resources read/set just the drawings without round-tripping the
+whole entity (mirroring `/{id}/config` and `/{id}/preferences`).
+
+**GET** returns the two fields:
+
+```json
+{ "status": "success", "code": 200,
+  "data": { "id": 42, "name": "Building One", "svgParentView": "<svg ...>", "svgChildView": "<svg ...>" } }
+```
+
+**PUT** changes only the fields present in the body; pass an empty string to clear
+a drawing:
+
+```bash
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X PUT "$BASE/api/departments/42/svg" \
+  -d '{
+        "svgParentView": "<svg viewBox=\"0 0 1000 600\"><rect width=\"1000\" height=\"600\" fill=\"#f5f5f5\"/></svg>",
+        "svgChildView":  "<svg viewBox=\"0 0 1000 600\"><rect x=\"50\" y=\"50\" width=\"300\" height=\"200\"/></svg>"
+      }'
+```
+
 ## Summary
 
 This API provides comprehensive institution, department, and site management capabilities for HMIS. Key features include:

--- a/developer_docs/API_INWARD_ROOM.md
+++ b/developer_docs/API_INWARD_ROOM.md
@@ -262,6 +262,40 @@ DELETE /api/inward/room-facility-charges/{id}?retireComments=reason
 
 ---
 
+## Bed-board SVG (issue #21592)
+
+A room is a **leaf** in the bed-board hierarchy (Site → Building → Floor → Unit →
+Room), so it stores only one drawing:
+
+- **`svgChildView`** — the small shape showing how the room looks as a tile
+  *inside its parent's* canvas, on the shared `viewBox="0 0 1000 600"` grid.
+  (Rooms have no `svgParentView` — you do not navigate *into* a room.)
+
+`svgChildView` is accepted on the normal room `POST`/`PUT` bodies and returned by
+the room `GET`. SVG is stored **verbatim** (create/update → read back identical);
+it is sanitised at render time on the bed board. See the wiki page
+[Inpatient — Bed Board](https://github.com/hmislk/hmis/wiki/Inpatient-Bed-Board)
+for authoring guidance and copy-paste examples.
+
+### GET `/api/inward/rooms/{id}/svg` — Read just the drawing
+
+```json
+{ "status": "success", "code": 200,
+  "data": { "id": 10, "name": "Room 101", "svgChildView": "<svg ...>" } }
+```
+
+### PUT `/api/inward/rooms/{id}/svg` — Set just the drawing
+
+Only `svgChildView` is changed when present; pass an empty string to clear it.
+
+```bash
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X PUT "$BASE/api/inward/rooms/10/svg" \
+  -d '{"svgChildView":"<svg viewBox=\"0 0 1000 600\"><rect x=\"100\" y=\"100\" width=\"200\" height=\"150\"/></svg>"}'
+```
+
+---
+
 ## Typical Workflow
 
 ```bash

--- a/developer_docs/API_SITES.md
+++ b/developer_docs/API_SITES.md
@@ -71,3 +71,44 @@ Same fields as POST — only supplied fields are updated.
 ### DELETE `/api/sites/{id}` — Retire (soft-delete) a site
 
 Returns `200` on success, `404` if not found.
+
+---
+
+## Bed-board SVG (issue #21592)
+
+A site stores two SVG drawings used by the Inpatient Bed Board page, on a shared
+`viewBox="0 0 1000 600"` grid:
+
+- **`svgParentView`** — the site's own empty floor-plan canvas, shown when you
+  navigate *into* it.
+- **`svgChildView`** — the small shape showing how the site looks as a tile
+  *inside its parent's* canvas.
+
+Both fields are accepted on the normal `POST`/`PUT` bodies and returned by `GET`.
+SVG is stored **verbatim** (create/update → read back identical); it is sanitised
+at render time on the bed board. See the wiki page
+[Inpatient — Bed Board](https://github.com/hmislk/hmis/wiki/Inpatient-Bed-Board)
+for authoring guidance and copy-paste examples.
+
+### GET `/api/sites/{id}/svg` — Read just the drawings
+
+```json
+{ "status": "success", "code": 200,
+  "data": { "id": 5, "name": "Karapitiya", "svgParentView": "<svg ...>", "svgChildView": "<svg ...>" } }
+```
+
+### PUT `/api/sites/{id}/svg` — Set just the drawings
+
+Only the fields present in the body are changed; pass an empty string to clear a
+drawing.
+
+```json
+{ "svgParentView": "<svg viewBox=\"0 0 1000 600\">...</svg>",
+  "svgChildView":  "<svg viewBox=\"0 0 1000 600\"><ellipse cx=\"500\" cy=\"300\" rx=\"400\" ry=\"200\"/></svg>" }
+```
+
+```bash
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X PUT "$BASE/api/sites/5/svg" \
+  -d '{"svgChildView":"<svg viewBox=\"0 0 1000 600\"><rect width=\"1000\" height=\"600\"/></svg>"}'
+```

--- a/src/main/java/com/divudi/core/data/dto/bedboard/BedBoardSvgDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/bedboard/BedBoardSvgDTO.java
@@ -1,0 +1,83 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.bedboard;
+
+import java.io.Serializable;
+
+/**
+ * Lightweight DTO for the bed-board SVG sub-resources (issue #21592).
+ *
+ * Used by GET/PUT {@code /api/institutions/{id}/svg},
+ * {@code /api/sites/{id}/svg}, and {@code /api/departments/{id}/svg} so an
+ * agent can read and set the two SVG drawings without round-tripping the whole
+ * entity.
+ *
+ * <p>Each bed-board entity stores two drawings on a shared
+ * {@code viewBox="0 0 1000 600"} grid:
+ * <ul>
+ *   <li>{@code svgParentView} — the entity's own empty floor-plan canvas,
+ *       shown when you navigate <em>into</em> it.</li>
+ *   <li>{@code svgChildView} — the small shape showing how this entity looks as
+ *       a tile <em>inside its parent's</em> canvas.</li>
+ * </ul>
+ *
+ * <p>On a PUT, only fields present (non-null) are changed; pass an empty string
+ * to clear a drawing. SVG markup is stored verbatim (create/update → read back
+ * identical); the bed board sanitises it at render time.
+ *
+ * @author Buddhika
+ */
+public class BedBoardSvgDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String name;
+    private String svgParentView;
+    private String svgChildView;
+
+    public BedBoardSvgDTO() {
+    }
+
+    public BedBoardSvgDTO(Long id, String name, String svgParentView, String svgChildView) {
+        this.id = id;
+        this.name = name;
+        this.svgParentView = svgParentView;
+        this.svgChildView = svgChildView;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/department/DepartmentCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/department/DepartmentCreateRequestDTO.java
@@ -32,6 +32,9 @@ public class DepartmentCreateRequestDTO implements Serializable {
     private Long superDepartmentId; // Optional - parent department
     private Double margin; // Optional - department margin
     private Double pharmacyMarginFromPurchaseRate; // Optional
+    // Bed-board SVG fields (issue #21592). Optional; additive only.
+    private String svgParentView; // Optional - bed-board floor-plan canvas
+    private String svgChildView; // Optional - bed-board child tile shape
 
     public DepartmentCreateRequestDTO() {
     }
@@ -188,6 +191,22 @@ public class DepartmentCreateRequestDTO implements Serializable {
 
     public void setPharmacyMarginFromPurchaseRate(Double pharmacyMarginFromPurchaseRate) {
         this.pharmacyMarginFromPurchaseRate = pharmacyMarginFromPurchaseRate;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/department/DepartmentResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/department/DepartmentResponseDTO.java
@@ -41,6 +41,9 @@ public class DepartmentResponseDTO implements Serializable {
     private Boolean active;
     private Date createdAt;
     private String message;
+    // Bed-board SVG fields (issue #21592). Additive only — populated via setters.
+    private String svgParentView;
+    private String svgChildView;
 
     public DepartmentResponseDTO() {
     }
@@ -252,6 +255,22 @@ public class DepartmentResponseDTO implements Serializable {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/department/DepartmentUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/department/DepartmentUpdateRequestDTO.java
@@ -31,6 +31,9 @@ public class DepartmentUpdateRequestDTO implements Serializable {
     private Double margin; // Optional - update if provided
     private Double pharmacyMarginFromPurchaseRate; // Optional - update if provided
     private Boolean active; // Optional - update if provided
+    // Bed-board SVG fields (issue #21592). Optional; additive only.
+    private String svgParentView; // Optional - update if provided
+    private String svgChildView; // Optional - update if provided
 
     public DepartmentUpdateRequestDTO() {
     }
@@ -175,6 +178,22 @@ public class DepartmentUpdateRequestDTO implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/institution/InstitutionCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/institution/InstitutionCreateRequestDTO.java
@@ -30,6 +30,10 @@ public class InstitutionCreateRequestDTO implements Serializable {
     private String contactPersonName; // Optional
     private String ownerName; // Optional
     private String ownerEmail; // Optional
+    // Bed-board SVG fields (issue #21592). Optional; additive only — not part of
+    // any existing constructor signature.
+    private String svgParentView; // Optional - bed-board floor-plan canvas
+    private String svgChildView; // Optional - bed-board child tile shape
 
     public InstitutionCreateRequestDTO() {
     }
@@ -165,6 +169,22 @@ public class InstitutionCreateRequestDTO implements Serializable {
 
     public void setOwnerEmail(String ownerEmail) {
         this.ownerEmail = ownerEmail;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/institution/InstitutionResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/institution/InstitutionResponseDTO.java
@@ -37,6 +37,10 @@ public class InstitutionResponseDTO implements Serializable {
     private Boolean active;
     private Date createdAt;
     private String message;
+    // Bed-board SVG fields (issue #21592). Additive only — not part of any
+    // existing constructor signature; populated via setters.
+    private String svgParentView;
+    private String svgChildView;
 
     public InstitutionResponseDTO() {
     }
@@ -211,6 +215,22 @@ public class InstitutionResponseDTO implements Serializable {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/institution/InstitutionUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/institution/InstitutionUpdateRequestDTO.java
@@ -31,6 +31,10 @@ public class InstitutionUpdateRequestDTO implements Serializable {
     private String ownerName; // Optional - update if provided
     private String ownerEmail; // Optional - update if provided
     private Boolean active; // Optional - update if provided
+    // Bed-board SVG fields (issue #21592). Optional; additive only — not part of
+    // any existing constructor signature.
+    private String svgParentView; // Optional - update if provided
+    private String svgChildView; // Optional - update if provided
 
     public InstitutionUpdateRequestDTO() {
     }
@@ -174,6 +178,22 @@ public class InstitutionUpdateRequestDTO implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/site/SiteCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/site/SiteCreateRequestDTO.java
@@ -25,6 +25,9 @@ public class SiteCreateRequestDTO implements Serializable {
     private String email; // Optional
     private String fax; // Optional
     private Long parentInstitutionId; // Optional - main institution this site belongs to
+    // Bed-board SVG fields (issue #21592). Optional; additive only.
+    private String svgParentView; // Optional - bed-board floor-plan canvas
+    private String svgChildView; // Optional - bed-board child tile shape
 
     public SiteCreateRequestDTO() {
     }
@@ -113,6 +116,22 @@ public class SiteCreateRequestDTO implements Serializable {
 
     public void setParentInstitutionId(Long parentInstitutionId) {
         this.parentInstitutionId = parentInstitutionId;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/site/SiteResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/site/SiteResponseDTO.java
@@ -32,6 +32,9 @@ public class SiteResponseDTO implements Serializable {
     private Boolean active;
     private Date createdAt;
     private String message;
+    // Bed-board SVG fields (issue #21592). Additive only — populated via setters.
+    private String svgParentView;
+    private String svgChildView;
 
     public SiteResponseDTO() {
     }
@@ -159,6 +162,22 @@ public class SiteResponseDTO implements Serializable {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/site/SiteUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/site/SiteUpdateRequestDTO.java
@@ -26,6 +26,9 @@ public class SiteUpdateRequestDTO implements Serializable {
     private String email; // Optional - update if provided
     private String fax; // Optional - update if provided
     private Boolean active; // Optional - update if provided
+    // Bed-board SVG fields (issue #21592). Optional; additive only.
+    private String svgParentView; // Optional - update if provided
+    private String svgChildView; // Optional - update if provided
 
     public SiteUpdateRequestDTO() {
     }
@@ -123,6 +126,22 @@ public class SiteUpdateRequestDTO implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    public String getSvgParentView() {
+        return svgParentView;
+    }
+
+    public void setSvgParentView(String svgParentView) {
+        this.svgParentView = svgParentView;
+    }
+
+    public String getSvgChildView() {
+        return svgChildView;
+    }
+
+    public void setSvgChildView(String svgChildView) {
+        this.svgChildView = svgChildView;
     }
 
     @Override

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -636,8 +636,8 @@ public class AnthropicApiService implements Serializable {
                         + "viewBox=\"0 0 1000 600\" grid: svgParentView is the entity's own empty floor-plan "
                         + "canvas (shown when you navigate into it), and svgChildView is the small shape "
                         + "showing how this entity looks as a tile inside its parent's canvas. "
-                        + "Sites and departments have both views; a room (leaf) has only svgChildView. "
-                        + "Methods: GET_SITE, SET_SITE, GET_DEPARTMENT, SET_DEPARTMENT, GET_ROOM, SET_ROOM. "
+                        + "Sites, institutions, and departments have both views; a room (leaf) has only svgChildView. "
+                        + "Methods: GET_SITE, SET_SITE, GET_INSTITUTION, SET_INSTITUTION, GET_DEPARTMENT, SET_DEPARTMENT, GET_ROOM, SET_ROOM. "
                         + "On SET, only the fields you supply are changed; pass an empty string to clear a drawing. "
                         + "SVG is stored verbatim and sanitised when the bed board renders it. "
                         + "Authoring guidance (viewBox, copy-paste examples, draw-your-own primer) is on the "
@@ -649,9 +649,10 @@ public class AnthropicApiService implements Serializable {
                                         .add("type", "string")
                                         .add("enum", Json.createArrayBuilder()
                                                 .add("GET_SITE").add("SET_SITE")
+                                                .add("GET_INSTITUTION").add("SET_INSTITUTION")
                                                 .add("GET_DEPARTMENT").add("SET_DEPARTMENT")
                                                 .add("GET_ROOM").add("SET_ROOM"))
-                                        .add("description", "Operation to perform. SITE targets /api/sites, DEPARTMENT targets /api/departments, ROOM targets /api/inward/rooms."))
+                                        .add("description", "Operation to perform. SITE targets /api/sites, INSTITUTION targets /api/institutions, DEPARTMENT targets /api/departments, ROOM targets /api/inward/rooms."))
                                 .add("id", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Entity id (site/department/room). Required for all methods."))
@@ -1335,7 +1336,9 @@ public class AnthropicApiService implements Serializable {
                     String roomId         = toolInput.containsKey("roomId")                         ? toolInput.getString("roomId", "")                         : "";
                     String departmentId   = toolInput.containsKey("departmentId")                   ? toolInput.getString("departmentId", "")                   : "";
                     String filled         = toolInput.containsKey("filled")                         ? toolInput.getString("filled", "")                         : "";
-                    String svgChildView   = toolInput.containsKey("svgChildView")                   ? toolInput.getString("svgChildView", "")                   : "";
+                    // null = caller omitted the field (leave unchanged); a non-null
+                    // value, including "", is forwarded ("" clears the drawing).
+                    String svgChildView   = toolInput.containsKey("svgChildView")                   ? toolInput.getString("svgChildView", "")                   : null;
                     String roomCharge     = toolInput.containsKey("roomCharge")                     ? toolInput.getString("roomCharge", "")                     : "";
                     String maintCharge    = toolInput.containsKey("maintananceCharge")              ? toolInput.getString("maintananceCharge", "")              : "";
                     String linenCharge    = toolInput.containsKey("linenCharge")                    ? toolInput.getString("linenCharge", "")                    : "";
@@ -2431,7 +2434,7 @@ public class AnthropicApiService implements Serializable {
                     if (description != null && !description.isEmpty()) bodyMap.put("description", description);
                     if (roomCategoryId != null && !roomCategoryId.isEmpty()) bodyMap.put("roomCategoryId", Long.parseLong(roomCategoryId));
                     if (filled != null && !filled.isEmpty()) bodyMap.put("filled", Boolean.parseBoolean(filled));
-                    if (svgChildView != null && !svgChildView.isEmpty()) bodyMap.put("svgChildView", svgChildView);
+                    if (svgChildView != null) bodyMap.put("svgChildView", svgChildView);
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/rooms"))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -2447,7 +2450,7 @@ public class AnthropicApiService implements Serializable {
                     if (description != null && !description.isEmpty()) bodyMap.put("description", description);
                     if (roomCategoryId != null && !roomCategoryId.isEmpty()) bodyMap.put("roomCategoryId", Long.parseLong(roomCategoryId));
                     if (filled != null && !filled.isEmpty()) bodyMap.put("filled", Boolean.parseBoolean(filled));
-                    if (svgChildView != null && !svgChildView.isEmpty()) bodyMap.put("svgChildView", svgChildView);
+                    if (svgChildView != null) bodyMap.put("svgChildView", svgChildView);
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/rooms/" + id))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -2583,6 +2586,9 @@ public class AnthropicApiService implements Serializable {
             if (method.endsWith("_SITE")) {
                 entityPath = "/api/sites/";
                 isRoom = false;
+            } else if (method.endsWith("_INSTITUTION")) {
+                entityPath = "/api/institutions/";
+                isRoom = false;
             } else if (method.endsWith("_DEPARTMENT")) {
                 entityPath = "/api/departments/";
                 isRoom = false;
@@ -2601,13 +2607,22 @@ public class AnthropicApiService implements Serializable {
                         .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
             } else if (method.startsWith("SET_")) {
                 java.util.Map<String, Object> bodyMap = new java.util.LinkedHashMap<>();
-                // Only include fields the caller actually supplied (null = omit).
+                // Only include fields the caller actually supplied (null = omit, so
+                // the entity field is left unchanged). A non-null value — including
+                // an empty string, which clears the drawing — is forwarded.
                 // A room has no parent canvas, so svgParentView is ignored for rooms.
                 if (!isRoom && svgParentView != null) {
                     bodyMap.put("svgParentView", svgParentView);
                 }
                 if (svgChildView != null) {
                     bodyMap.put("svgChildView", svgChildView);
+                }
+                // Reject an empty SET so the tool can't silently report success
+                // without changing anything.
+                if (bodyMap.isEmpty()) {
+                    return isRoom
+                            ? "Error: svgChildView is required for " + method + " (rooms have no parent canvas)."
+                            : "Error: svgParentView or svgChildView is required for " + method + ".";
                 }
                 String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                 request = HttpRequest.newBuilder().uri(URI.create(url))
@@ -2621,6 +2636,9 @@ public class AnthropicApiService implements Serializable {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             return "HTTP " + response.statusCode() + ": " + response.body();
 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Bed Board SVG API call interrupted.";
         } catch (Exception e) {
             LOG.log(java.util.logging.Level.WARNING, "callBedBoardSvgApi error: {0}", e.getMessage());
             return "Error calling Bed Board SVG API: " + e.getMessage();
@@ -3478,8 +3496,9 @@ public class AnthropicApiService implements Serializable {
           .append("Methods: GET_SITE / SET_SITE / GET_DEPARTMENT / SET_DEPARTMENT / GET_ROOM / SET_ROOM (id required). ")
           .append("On SET, only the fields you pass are changed; pass an empty string to clear a drawing. ")
           .append("SVG is stored verbatim and sanitised when the bed board renders it. ")
-          .append("Before authoring drawings, read the wiki page 'Inpatient — Bed Board' (via fetch_wiki_file or web) — ")
-          .append("it documents the viewBox, the site→building→floor→unit hierarchy, copy-paste SVG examples, and a ")
+          .append("Before authoring drawings, consult the bed-board authoring guidance on the wiki page ")
+          .append("'Inpatient — Bed Board' (https://github.com/hmislk/hmis/wiki/Inpatient-Bed-Board); if you cannot reach it, ask the user to paste it. ")
+          .append("The guidance documents the viewBox, the site→building→floor→unit hierarchy, copy-paste SVG examples, and a ")
           .append("draw-your-own-shapes primer (rect / ellipse / text / polygon). The same SVG fields are also accepted on ")
           .append("the normal create/update bodies of /api/sites, /api/departments, and /api/inward/rooms, but this tool is the focused way to read or set just the drawings. ")
           .append("Always confirm with the user before any SET.\n\n");

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -580,6 +580,9 @@ public class AnthropicApiService implements Serializable {
                                 .add("filled", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Whether room is under construction (true/false). Optional for POST_ROOM/PUT_ROOM."))
+                                .add("svgChildView", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Bed-board child-tile SVG markup for the room (issue #21592). Optional for POST_ROOM/PUT_ROOM. A Room is a leaf in the bed-board hierarchy, so it has only this child view (no parent canvas). Or use the dedicated manage_bed_board_svg tool."))
                                 .add("roomCharge", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Room charge per block. Optional for POST_CHARGE/PUT_CHARGE."))
@@ -623,6 +626,42 @@ public class AnthropicApiService implements Serializable {
                                         .add("type", "string")
                                         .add("description", "Reason for retirement. Optional for DELETE methods.")))
                         .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
+        JsonObject bedBoardSvgTool = Json.createObjectBuilder()
+                .add("name", "manage_bed_board_svg")
+                .add("description",
+                        "Read and set the graphical bed-board SVG drawings (issue #21592) used by the "
+                        + "Inpatient Bed Board page. Each entity stores drawings on a shared "
+                        + "viewBox=\"0 0 1000 600\" grid: svgParentView is the entity's own empty floor-plan "
+                        + "canvas (shown when you navigate into it), and svgChildView is the small shape "
+                        + "showing how this entity looks as a tile inside its parent's canvas. "
+                        + "Sites and departments have both views; a room (leaf) has only svgChildView. "
+                        + "Methods: GET_SITE, SET_SITE, GET_DEPARTMENT, SET_DEPARTMENT, GET_ROOM, SET_ROOM. "
+                        + "On SET, only the fields you supply are changed; pass an empty string to clear a drawing. "
+                        + "SVG is stored verbatim and sanitised when the bed board renders it. "
+                        + "Authoring guidance (viewBox, copy-paste examples, draw-your-own primer) is on the "
+                        + "wiki page 'Inpatient — Bed Board'. Always confirm with the user before SET.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("GET_SITE").add("SET_SITE")
+                                                .add("GET_DEPARTMENT").add("SET_DEPARTMENT")
+                                                .add("GET_ROOM").add("SET_ROOM"))
+                                        .add("description", "Operation to perform. SITE targets /api/sites, DEPARTMENT targets /api/departments, ROOM targets /api/inward/rooms."))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Entity id (site/department/room). Required for all methods."))
+                                .add("svgParentView", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Parent-canvas SVG markup. Used by SET_SITE/SET_DEPARTMENT. Ignored for rooms (a room has no parent view). Pass an empty string to clear."))
+                                .add("svgChildView", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Child-tile SVG markup. Used by SET_SITE/SET_DEPARTMENT/SET_ROOM. Pass an empty string to clear.")))
+                        .add("required", Json.createArrayBuilder().add("method").add("id")))
                 .build();
 
         JsonObject manageInvestigationsTool = Json.createObjectBuilder()
@@ -1111,6 +1150,7 @@ public class AnthropicApiService implements Serializable {
                 .add(inwardDiscountMatrixTool)
                 .add(inwardPriceAdjustmentTool)
                 .add(inwardRoomsTool)
+                .add(bedBoardSvgTool)
                 .add(manageInvestigationsTool)
                 .add(manageInvestigationFormatTool)
                 .add(manageFormsTool)
@@ -1295,6 +1335,7 @@ public class AnthropicApiService implements Serializable {
                     String roomId         = toolInput.containsKey("roomId")                         ? toolInput.getString("roomId", "")                         : "";
                     String departmentId   = toolInput.containsKey("departmentId")                   ? toolInput.getString("departmentId", "")                   : "";
                     String filled         = toolInput.containsKey("filled")                         ? toolInput.getString("filled", "")                         : "";
+                    String svgChildView   = toolInput.containsKey("svgChildView")                   ? toolInput.getString("svgChildView", "")                   : "";
                     String roomCharge     = toolInput.containsKey("roomCharge")                     ? toolInput.getString("roomCharge", "")                     : "";
                     String maintCharge    = toolInput.containsKey("maintananceCharge")              ? toolInput.getString("maintananceCharge", "")              : "";
                     String linenCharge    = toolInput.containsKey("linenCharge")                    ? toolInput.getString("linenCharge", "")                    : "";
@@ -1310,10 +1351,17 @@ public class AnthropicApiService implements Serializable {
                     String size           = toolInput.containsKey("size")                           ? toolInput.getString("size", "")                           : "";
                     String retireComments = toolInput.containsKey("retireComments")                 ? toolInput.getString("retireComments", "")                 : "";
                     return callInwardRoomsApi(method, id, name, code, desc, roomCategoryId, roomId,
-                            departmentId, filled, roomCharge, maintCharge, linenCharge, nursingCharge,
+                            departmentId, filled, svgChildView, roomCharge, maintCharge, linenCharge, nursingCharge,
                             moCharge, moAfterCharge, adminCharge, medCareCharge,
                             durationHours, overShoot, durationDays,
                             query, size, retireComments, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_bed_board_svg": {
+                    String method        = toolInput.getString("method", "GET_SITE");
+                    String id            = toolInput.containsKey("id")            ? toolInput.getString("id", "")            : "";
+                    String svgParentView = toolInput.containsKey("svgParentView") ? toolInput.getString("svgParentView", "") : null;
+                    String svgChildView  = toolInput.containsKey("svgChildView")  ? toolInput.getString("svgChildView", "")  : null;
+                    return callBedBoardSvgApi(method, id, svgParentView, svgChildView, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_forms": {
                     String resourceType = toolInput.getString("resource_type", "TEMPLATE");
@@ -2287,7 +2335,7 @@ public class AnthropicApiService implements Serializable {
 
     private String callInwardRoomsApi(
             String method, String id, String name, String code, String description,
-            String roomCategoryId, String roomId, String departmentId, String filled,
+            String roomCategoryId, String roomId, String departmentId, String filled, String svgChildView,
             String roomCharge, String maintananceCharge, String linenCharge, String nursingCharge,
             String moCharge, String moChargeForAfterDuration, String adminstrationCharge, String medicalCareCharge,
             String timedItemFeeDurationHours, String timedItemFeeOverShootHours, String timedItemFeeDurationDaysForMoCharge,
@@ -2383,6 +2431,7 @@ public class AnthropicApiService implements Serializable {
                     if (description != null && !description.isEmpty()) bodyMap.put("description", description);
                     if (roomCategoryId != null && !roomCategoryId.isEmpty()) bodyMap.put("roomCategoryId", Long.parseLong(roomCategoryId));
                     if (filled != null && !filled.isEmpty()) bodyMap.put("filled", Boolean.parseBoolean(filled));
+                    if (svgChildView != null && !svgChildView.isEmpty()) bodyMap.put("svgChildView", svgChildView);
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/rooms"))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -2398,6 +2447,7 @@ public class AnthropicApiService implements Serializable {
                     if (description != null && !description.isEmpty()) bodyMap.put("description", description);
                     if (roomCategoryId != null && !roomCategoryId.isEmpty()) bodyMap.put("roomCategoryId", Long.parseLong(roomCategoryId));
                     if (filled != null && !filled.isEmpty()) bodyMap.put("filled", Boolean.parseBoolean(filled));
+                    if (svgChildView != null && !svgChildView.isEmpty()) bodyMap.put("svgChildView", svgChildView);
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/rooms/" + id))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -2499,6 +2549,81 @@ public class AnthropicApiService implements Serializable {
         } catch (Exception e) {
             LOG.log(java.util.logging.Level.WARNING, "callInwardRoomsApi error: {0}", e.getMessage());
             return "Error calling Inward Rooms API: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Read/set the bed-board SVG drawings of a site, department, or room (issue
+     * #21592) via the dedicated /{id}/svg sub-resources. SVG is sent verbatim;
+     * the bed board sanitises it at render time.
+     */
+    private String callBedBoardSvgApi(String method, String id, String svgParentView, String svgChildView,
+            String hmisBaseUrl, String hmisApiKey) {
+
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        if (id == null || id.isEmpty()) {
+            return "Error: id is required for " + method + ".";
+        }
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String baseUrl = hmisBaseUrl.endsWith("/") ? hmisBaseUrl.substring(0, hmisBaseUrl.length() - 1) : hmisBaseUrl;
+
+            // Resolve the entity path from the method.
+            String entityPath;
+            boolean isRoom;
+            if (method.endsWith("_SITE")) {
+                entityPath = "/api/sites/";
+                isRoom = false;
+            } else if (method.endsWith("_DEPARTMENT")) {
+                entityPath = "/api/departments/";
+                isRoom = false;
+            } else if (method.endsWith("_ROOM")) {
+                entityPath = "/api/inward/rooms/";
+                isRoom = true;
+            } else {
+                return "Unknown method: " + method;
+            }
+
+            String url = baseUrl + entityPath + id + "/svg";
+            HttpRequest request;
+
+            if (method.startsWith("GET_")) {
+                request = HttpRequest.newBuilder().uri(URI.create(url))
+                        .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
+            } else if (method.startsWith("SET_")) {
+                java.util.Map<String, Object> bodyMap = new java.util.LinkedHashMap<>();
+                // Only include fields the caller actually supplied (null = omit).
+                // A room has no parent canvas, so svgParentView is ignored for rooms.
+                if (!isRoom && svgParentView != null) {
+                    bodyMap.put("svgParentView", svgParentView);
+                }
+                if (svgChildView != null) {
+                    bodyMap.put("svgChildView", svgChildView);
+                }
+                String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
+                request = HttpRequest.newBuilder().uri(URI.create(url))
+                        .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(bodyJson)).build();
+            } else {
+                return "Unknown method: " + method;
+            }
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + ": " + response.body();
+
+        } catch (Exception e) {
+            LOG.log(java.util.logging.Level.WARNING, "callBedBoardSvgApi error: {0}", e.getMessage());
+            return "Error calling Bed Board SVG API: " + e.getMessage();
         }
     }
 
@@ -3344,6 +3469,20 @@ public class AnthropicApiService implements Serializable {
           .append("PUT_CATEGORY / PUT_ROOM / PUT_CHARGE to update. ")
           .append("DELETE_CATEGORY / DELETE_ROOM / DELETE_CHARGE to soft-retire. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live inward room billing.\n\n");
+        sb.append("### manage_bed_board_svg\n");
+        sb.append("Read and set the graphical bed-board SVG drawings used by the Inpatient Bed Board page. ")
+          .append("Every bed-board entity stores two drawings on a shared viewBox=\"0 0 1000 600\" grid: ")
+          .append("svgParentView (the entity's own empty floor-plan canvas, shown when you navigate into it) and ")
+          .append("svgChildView (the small shape showing how this entity looks as a tile inside its parent's canvas). ")
+          .append("Sites and departments have both; a room is a leaf and has only svgChildView. ")
+          .append("Methods: GET_SITE / SET_SITE / GET_DEPARTMENT / SET_DEPARTMENT / GET_ROOM / SET_ROOM (id required). ")
+          .append("On SET, only the fields you pass are changed; pass an empty string to clear a drawing. ")
+          .append("SVG is stored verbatim and sanitised when the bed board renders it. ")
+          .append("Before authoring drawings, read the wiki page 'Inpatient — Bed Board' (via fetch_wiki_file or web) — ")
+          .append("it documents the viewBox, the site→building→floor→unit hierarchy, copy-paste SVG examples, and a ")
+          .append("draw-your-own-shapes primer (rect / ellipse / text / polygon). The same SVG fields are also accepted on ")
+          .append("the normal create/update bodies of /api/sites, /api/departments, and /api/inward/rooms, but this tool is the focused way to read or set just the drawings. ")
+          .append("Always confirm with the user before any SET.\n\n");
         sb.append("### manage_forms\n");
         sb.append("Design and manage dynamic clinical form templates end-to-end. ")
           .append("resource_type: TEMPLATE | FIELD | CHOICE | ENTRY | VALUE. ")

--- a/src/main/java/com/divudi/service/institution/DepartmentApiService.java
+++ b/src/main/java/com/divudi/service/institution/DepartmentApiService.java
@@ -8,6 +8,7 @@ package com.divudi.service.institution;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.InstitutionType;
 import com.divudi.core.data.ItemListingStrategy;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.department.DepartmentCreateRequestDTO;
 import com.divudi.core.data.dto.department.DepartmentPreferenceDTO;
 import com.divudi.core.data.dto.department.DepartmentRelationshipUpdateDTO;
@@ -151,6 +152,15 @@ public class DepartmentApiService implements Serializable {
         department.setFax(request.getFax());
         department.setEmail(request.getEmail());
 
+        // Bed-board SVG fields (issue #21592) — stored verbatim; sanitised at
+        // render time by BedBoardController.sanitizeSvg().
+        if (request.getSvgParentView() != null) {
+            department.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            department.setSvgChildView(request.getSvgChildView());
+        }
+
         // Set site if provided
         if (request.getSiteId() != null) {
             Institution site = loadAndValidateSite(request.getSiteId());
@@ -250,6 +260,14 @@ public class DepartmentApiService implements Serializable {
 
         if (request.getPharmacyMarginFromPurchaseRate() != null) {
             department.setPharmacyMarginFromPurchaseRate(request.getPharmacyMarginFromPurchaseRate());
+        }
+
+        // Bed-board SVG fields (issue #21592) — stored verbatim.
+        if (request.getSvgParentView() != null) {
+            department.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            department.setSvgChildView(request.getSvgChildView());
         }
 
         // Save updated department and flush so response reflects persisted state
@@ -584,6 +602,9 @@ public class DepartmentApiService implements Serializable {
         response.setPharmacyMarginFromPurchaseRate(department.getPharmacyMarginFromPurchaseRate());
         response.setActive(!department.isRetired());
         response.setCreatedAt(department.getCreatedAt());
+        // Bed-board SVG fields (issue #21592) — returned verbatim.
+        response.setSvgParentView(department.getSvgParentView());
+        response.setSvgChildView(department.getSvgChildView());
 
         // Set institution details
         if (department.getInstitution() != null) {
@@ -605,5 +626,39 @@ public class DepartmentApiService implements Serializable {
 
         response.setMessage(message);
         return response;
+    }
+
+    /**
+     * Read just the bed-board SVG fields of a department (issue #21592).
+     * Returned verbatim — sanitisation happens at render time on the bed board.
+     */
+    public BedBoardSvgDTO getDepartmentSvg(Long id) throws Exception {
+        Department department = loadAndValidateDepartment(id);
+        return new BedBoardSvgDTO(department.getId(), department.getName(),
+                department.getSvgParentView(), department.getSvgChildView());
+    }
+
+    /**
+     * Update just the bed-board SVG fields of a department (issue #21592).
+     * Only the fields present (non-null) in the request are changed; pass an
+     * empty string to clear a drawing. SVG is stored verbatim.
+     */
+    public BedBoardSvgDTO updateDepartmentSvg(Long id, BedBoardSvgDTO request, WebUser user) throws Exception {
+        if (request == null) {
+            throw new Exception("Request body is required");
+        }
+        if (user == null) {
+            throw new Exception("User is required for updating department SVG");
+        }
+        Department department = loadAndValidateDepartment(id);
+        if (request.getSvgParentView() != null) {
+            department.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            department.setSvgChildView(request.getSvgChildView());
+        }
+        departmentFacade.editAndFlush(department);
+        return new BedBoardSvgDTO(department.getId(), department.getName(),
+                department.getSvgParentView(), department.getSvgChildView());
     }
 }

--- a/src/main/java/com/divudi/service/institution/InstitutionApiService.java
+++ b/src/main/java/com/divudi/service/institution/InstitutionApiService.java
@@ -6,6 +6,7 @@
 package com.divudi.service.institution;
 
 import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.institution.InstitutionCreateRequestDTO;
 import com.divudi.core.data.dto.institution.InstitutionRelationshipUpdateDTO;
 import com.divudi.core.data.dto.institution.InstitutionResponseDTO;
@@ -123,6 +124,15 @@ public class InstitutionApiService implements Serializable {
         institution.setOwnerName(request.getOwnerName());
         institution.setOwnerEmail(request.getOwnerEmail());
 
+        // Bed-board SVG fields (issue #21592) — stored verbatim; sanitised at
+        // render time by BedBoardController.sanitizeSvg().
+        if (request.getSvgParentView() != null) {
+            institution.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            institution.setSvgChildView(request.getSvgChildView());
+        }
+
         // Set parent institution if provided
         if (request.getParentInstitutionId() != null) {
             Institution parentInstitution = loadAndValidateInstitution(request.getParentInstitutionId());
@@ -207,6 +217,14 @@ public class InstitutionApiService implements Serializable {
 
         if (request.getOwnerEmail() != null) {
             institution.setOwnerEmail(request.getOwnerEmail());
+        }
+
+        // Bed-board SVG fields (issue #21592) — stored verbatim.
+        if (request.getSvgParentView() != null) {
+            institution.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            institution.setSvgChildView(request.getSvgChildView());
         }
 
         // Save updated institution and flush so response reflects persisted state
@@ -400,6 +418,9 @@ public class InstitutionApiService implements Serializable {
         response.setOwnerEmail(institution.getOwnerEmail());
         response.setActive(!institution.isRetired());
         response.setCreatedAt(institution.getCreatedAt());
+        // Bed-board SVG fields (issue #21592) — returned verbatim.
+        response.setSvgParentView(institution.getSvgParentView());
+        response.setSvgChildView(institution.getSvgChildView());
 
         // Set parent institution details if exists
         if (institution.getInstitution() != null) {
@@ -409,5 +430,45 @@ public class InstitutionApiService implements Serializable {
 
         response.setMessage(message);
         return response;
+    }
+
+    /**
+     * Read just the bed-board SVG fields of an institution (issue #21592).
+     * Returned verbatim — sanitisation happens at render time on the bed board.
+     */
+    public BedBoardSvgDTO getInstitutionSvg(Long id) throws Exception {
+        if (id == null) {
+            throw new Exception("Institution ID is required");
+        }
+        Institution institution = loadAndValidateInstitution(id);
+        return new BedBoardSvgDTO(institution.getId(), institution.getName(),
+                institution.getSvgParentView(), institution.getSvgChildView());
+    }
+
+    /**
+     * Update just the bed-board SVG fields of an institution (issue #21592).
+     * Only the fields present (non-null) in the request are changed; pass an
+     * empty string to clear a drawing. SVG is stored verbatim.
+     */
+    public BedBoardSvgDTO updateInstitutionSvg(Long id, BedBoardSvgDTO request, WebUser user) throws Exception {
+        if (id == null) {
+            throw new Exception("Institution ID is required");
+        }
+        if (request == null) {
+            throw new Exception("Request body is required");
+        }
+        if (user == null) {
+            throw new Exception("User is required for updating institution SVG");
+        }
+        Institution institution = loadAndValidateInstitution(id);
+        if (request.getSvgParentView() != null) {
+            institution.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            institution.setSvgChildView(request.getSvgChildView());
+        }
+        institutionFacade.editAndFlush(institution);
+        return new BedBoardSvgDTO(institution.getId(), institution.getName(),
+                institution.getSvgParentView(), institution.getSvgChildView());
     }
 }

--- a/src/main/java/com/divudi/service/institution/SiteApiService.java
+++ b/src/main/java/com/divudi/service/institution/SiteApiService.java
@@ -6,6 +6,7 @@
 package com.divudi.service.institution;
 
 import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.search.SiteDTO;
 import com.divudi.core.data.dto.site.SiteCreateRequestDTO;
 import com.divudi.core.data.dto.site.SiteResponseDTO;
@@ -122,6 +123,15 @@ public class SiteApiService implements Serializable {
         site.setEmail(request.getEmail());
         site.setFax(request.getFax());
 
+        // Bed-board SVG fields (issue #21592) — stored verbatim; sanitised at
+        // render time by BedBoardController.sanitizeSvg().
+        if (request.getSvgParentView() != null) {
+            site.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            site.setSvgChildView(request.getSvgChildView());
+        }
+
         // Set parent institution if provided
         if (request.getParentInstitutionId() != null) {
             Institution parentInstitution = loadAndValidateInstitution(request.getParentInstitutionId());
@@ -185,6 +195,14 @@ public class SiteApiService implements Serializable {
 
         if (request.getFax() != null) {
             site.setFax(request.getFax());
+        }
+
+        // Bed-board SVG fields (issue #21592) — stored verbatim.
+        if (request.getSvgParentView() != null) {
+            site.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            site.setSvgChildView(request.getSvgChildView());
         }
 
         // Save updated site
@@ -339,6 +357,9 @@ public class SiteApiService implements Serializable {
         response.setFax(site.getFax());
         response.setActive(!site.isRetired());
         response.setCreatedAt(site.getCreatedAt());
+        // Bed-board SVG fields (issue #21592) — returned verbatim.
+        response.setSvgParentView(site.getSvgParentView());
+        response.setSvgChildView(site.getSvgChildView());
 
         // Set parent institution details if exists
         if (site.getInstitution() != null) {
@@ -348,5 +369,45 @@ public class SiteApiService implements Serializable {
 
         response.setMessage(message);
         return response;
+    }
+
+    /**
+     * Read just the bed-board SVG fields of a site (issue #21592).
+     * Returned verbatim — sanitisation happens at render time on the bed board.
+     */
+    public BedBoardSvgDTO getSiteSvg(Long id) throws Exception {
+        if (id == null) {
+            throw new Exception("Site ID is required");
+        }
+        Institution site = loadAndValidateSite(id);
+        return new BedBoardSvgDTO(site.getId(), site.getName(),
+                site.getSvgParentView(), site.getSvgChildView());
+    }
+
+    /**
+     * Update just the bed-board SVG fields of a site (issue #21592).
+     * Only the fields present (non-null) in the request are changed; pass an
+     * empty string to clear a drawing. SVG is stored verbatim.
+     */
+    public BedBoardSvgDTO updateSiteSvg(Long id, BedBoardSvgDTO request, WebUser user) throws Exception {
+        if (id == null) {
+            throw new Exception("Site ID is required");
+        }
+        if (request == null) {
+            throw new Exception("Request body is required");
+        }
+        if (user == null) {
+            throw new Exception("User is required for updating site SVG");
+        }
+        Institution site = loadAndValidateSite(id);
+        if (request.getSvgParentView() != null) {
+            site.setSvgParentView(request.getSvgParentView());
+        }
+        if (request.getSvgChildView() != null) {
+            site.setSvgChildView(request.getSvgChildView());
+        }
+        institutionFacade.edit(site);
+        return new BedBoardSvgDTO(site.getId(), site.getName(),
+                site.getSvgParentView(), site.getSvgChildView());
     }
 }

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -119,15 +119,27 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET"))
                 .add(resource("Departments", "/api/departments",
-                        "Department management",
+                        "Department management. Create/update bodies and GET responses include the "
+                        + "bed-board SVG fields svgParentView and svgChildView (issue #21592). "
+                        + "Dedicated sub-resource: GET/PUT /api/departments/{id}/svg "
+                        + "(body { svgParentView, svgChildView }) reads/sets just the drawings. "
+                        + "SVG is stored verbatim; it is sanitised at render time on the bed board.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Institutions", "/api/institutions",
-                        "Institution management",
+                        "Institution management. Create/update bodies and GET responses include the "
+                        + "bed-board SVG fields svgParentView and svgChildView (issue #21592). "
+                        + "Dedicated sub-resource: GET/PUT /api/institutions/{id}/svg "
+                        + "(body { svgParentView, svgChildView }) reads/sets just the drawings. "
+                        + "SVG is stored verbatim; it is sanitised at render time on the bed board.",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))
                 .add(resource("Sites", "/api/sites",
-                        "Site management",
+                        "Site management. Create/update bodies and GET responses include the "
+                        + "bed-board SVG fields svgParentView and svgChildView (issue #21592). "
+                        + "Dedicated sub-resource: GET/PUT /api/sites/{id}/svg "
+                        + "(body { svgParentView, svgChildView }) reads/sets just the drawings. "
+                        + "SVG is stored verbatim; it is sanitised at render time on the bed board.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Inward", "/api/apiInward",
@@ -164,7 +176,12 @@ public class CapabilityStatementResource {
                 .add(resource("Inward Rooms", "/api/inward/rooms",
                         "Manage inward rooms (backs /inward/inward_room.xhtml). "
                         + "Supports optional filter roomCategoryId. "
-                        + "POST returns HTTP 409 with existing id when a duplicate name already exists.",
+                        + "POST returns HTTP 409 with existing id when a duplicate name already exists. "
+                        + "Create/update bodies and GET responses include the bed-board child-tile field "
+                        + "svgChildView (a Room is a leaf, so it has no svgParentView) (issue #21592). "
+                        + "Dedicated sub-resource: GET/PUT /api/inward/rooms/{id}/svg "
+                        + "(body { svgChildView }) reads/sets just the drawing. "
+                        + "SVG is stored verbatim; it is sanitised at render time on the bed board.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Inward Document Templates", "/api/inward/document-templates",

--- a/src/main/java/com/divudi/ws/institution/DepartmentApi.java
+++ b/src/main/java/com/divudi/ws/institution/DepartmentApi.java
@@ -576,6 +576,10 @@ public class DepartmentApi {
             if (request == null) {
                 return errorResponse("Request body is required", 400);
             }
+            // Reject a payload id that contradicts the path id (mirrors updateDepartment)
+            if (request.getId() != null && !request.getId().equals(id)) {
+                return errorResponse("Path id and payload id mismatch", 400);
+            }
             BedBoardSvgDTO response = departmentService.updateDepartmentSvg(id, request, user);
             return successResponse(response);
         } catch (Exception e) {

--- a/src/main/java/com/divudi/ws/institution/DepartmentApi.java
+++ b/src/main/java/com/divudi/ws/institution/DepartmentApi.java
@@ -7,6 +7,7 @@ package com.divudi.ws.institution;
 
 import com.divudi.bean.common.ApiKeyController;
 import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.config.DepartmentConfigDTO;
 import com.divudi.core.data.dto.config.DepartmentConfigUpdateDTO;
 import com.divudi.core.data.dto.department.DepartmentCreateRequestDTO;
@@ -513,6 +514,73 @@ public class DepartmentApi {
             }
             if (e.getMessage() != null && e.getMessage().startsWith("Invalid ")) {
                 return errorResponse(e.getMessage(), 400);
+            }
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get the bed-board SVG drawings of a department (issue #21592)
+     * GET /api/departments/{id}/svg
+     */
+    @GET
+    @Path("/{id}/svg")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getDepartmentSvg(@PathParam("id") Long id) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Department ID is required", 400);
+            }
+            BedBoardSvgDTO result = departmentService.getDepartmentSvg(id);
+            return successResponse(result);
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+                return errorResponse(e.getMessage(), 404);
+            }
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Set the bed-board SVG drawings of a department (issue #21592).
+     * Only fields present in the body are changed; pass an empty string to clear
+     * a drawing. SVG is stored verbatim.
+     * PUT /api/departments/{id}/svg
+     * Body: { "svgParentView": "...", "svgChildView": "..." }
+     */
+    @PUT
+    @Path("/{id}/svg")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateDepartmentSvg(@PathParam("id") Long id, String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Department ID is required", 400);
+            }
+            BedBoardSvgDTO request;
+            try {
+                request = gson.fromJson(requestBody, BedBoardSvgDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            BedBoardSvgDTO response = departmentService.updateDepartmentSvg(id, request, user);
+            return successResponse(response);
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+                return errorResponse(e.getMessage(), 404);
             }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
         }

--- a/src/main/java/com/divudi/ws/institution/InstitutionApi.java
+++ b/src/main/java/com/divudi/ws/institution/InstitutionApi.java
@@ -7,6 +7,7 @@ package com.divudi.ws.institution;
 
 import com.divudi.bean.common.ApiKeyController;
 import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.institution.InstitutionCreateRequestDTO;
 import com.divudi.core.data.dto.institution.InstitutionRelationshipUpdateDTO;
 import com.divudi.core.data.dto.institution.InstitutionResponseDTO;
@@ -310,6 +311,75 @@ public class InstitutionApi {
             InstitutionResponseDTO response = institutionService.changeParentInstitution(request, user);
             return successResponse(response);
 
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Get the bed-board SVG drawings of an institution (issue #21592)
+     * GET /api/institutions/{id}/svg
+     */
+    @GET
+    @Path("/{id}/svg")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getInstitutionSvg(@PathParam("id") Long id) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Institution ID is required", 400);
+            }
+            BedBoardSvgDTO result = institutionService.getInstitutionSvg(id);
+            return successResponse(result);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Set the bed-board SVG drawings of an institution (issue #21592).
+     * Only fields present in the body are changed; pass an empty string to clear
+     * a drawing. SVG is stored verbatim.
+     * PUT /api/institutions/{id}/svg
+     * Body: { "svgParentView": "...", "svgChildView": "..." }
+     */
+    @PUT
+    @Path("/{id}/svg")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateInstitutionSvg(@PathParam("id") Long id, String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Institution ID is required", 400);
+            }
+            BedBoardSvgDTO request;
+            try {
+                request = gson.fromJson(requestBody, BedBoardSvgDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            BedBoardSvgDTO response = institutionService.updateInstitutionSvg(id, request, user);
+            return successResponse(response);
         } catch (Exception e) {
             String msg = e.getMessage();
             if (msg != null && msg.contains("not found")) {

--- a/src/main/java/com/divudi/ws/institution/InstitutionApi.java
+++ b/src/main/java/com/divudi/ws/institution/InstitutionApi.java
@@ -378,6 +378,10 @@ public class InstitutionApi {
             if (request == null) {
                 return errorResponse("Request body is required", 400);
             }
+            // Reject a payload id that contradicts the path id (mirrors updateDepartment)
+            if (request.getId() != null && !request.getId().equals(id)) {
+                return errorResponse("Path id and payload id mismatch", 400);
+            }
             BedBoardSvgDTO response = institutionService.updateInstitutionSvg(id, request, user);
             return successResponse(response);
         } catch (Exception e) {

--- a/src/main/java/com/divudi/ws/institution/SiteApi.java
+++ b/src/main/java/com/divudi/ws/institution/SiteApi.java
@@ -314,6 +314,10 @@ public class SiteApi {
             if (request == null) {
                 return errorResponse("Request body is required", 400);
             }
+            // Reject a payload id that contradicts the path id (mirrors updateDepartment)
+            if (request.getId() != null && !request.getId().equals(id)) {
+                return errorResponse("Path id and payload id mismatch", 400);
+            }
             BedBoardSvgDTO response = siteService.updateSiteSvg(id, request, user);
             return successResponse(response);
         } catch (Exception e) {

--- a/src/main/java/com/divudi/ws/institution/SiteApi.java
+++ b/src/main/java/com/divudi/ws/institution/SiteApi.java
@@ -6,6 +6,7 @@
 package com.divudi.ws.institution;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.bedboard.BedBoardSvgDTO;
 import com.divudi.core.data.dto.search.SiteDTO;
 import com.divudi.core.data.dto.site.SiteCreateRequestDTO;
 import com.divudi.core.data.dto.site.SiteResponseDTO;
@@ -252,6 +253,75 @@ public class SiteApi {
                 return errorResponse(e.getMessage(), 404);
             }
             return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Get the bed-board SVG drawings of a site (issue #21592)
+     * GET /api/sites/{id}/svg
+     */
+    @GET
+    @Path("/{id}/svg")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getSiteSvg(@PathParam("id") Long id) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Site ID is required", 400);
+            }
+            BedBoardSvgDTO result = siteService.getSiteSvg(id);
+            return successResponse(result);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && (msg.contains("not found") || msg.contains("not a site"))) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Set the bed-board SVG drawings of a site (issue #21592).
+     * Only fields present in the body are changed; pass an empty string to clear
+     * a drawing. SVG is stored verbatim.
+     * PUT /api/sites/{id}/svg
+     * Body: { "svgParentView": "...", "svgChildView": "..." }
+     */
+    @PUT
+    @Path("/{id}/svg")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateSiteSvg(@PathParam("id") Long id, String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (id == null) {
+                return errorResponse("Site ID is required", 400);
+            }
+            BedBoardSvgDTO request;
+            try {
+                request = gson.fromJson(requestBody, BedBoardSvgDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            BedBoardSvgDTO response = siteService.updateSiteSvg(id, request, user);
+            return successResponse(response);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && (msg.contains("not found") || msg.contains("not a site"))) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
         }
     }
 

--- a/src/main/java/com/divudi/ws/inward/InwardRoomApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomApi.java
@@ -212,9 +212,15 @@ public class InwardRoomApi {
                 room.setFilled(filledVal);
             }
             // Bed-board child-tile SVG (issue #21592) — stored verbatim; sanitised
-            // at render time by BedBoardController.sanitizeSvg().
+            // at render time by BedBoardController.sanitizeSvg(). Non-string is rejected.
             if (body.containsKey("svgChildView")) {
-                room.setSvgChildView(asString(body.get("svgChildView")));
+                Object raw = body.get("svgChildView");
+                if (raw != null && !(raw instanceof String)) {
+                    return errorResponse("Invalid value for 'svgChildView': must be a string", 400);
+                }
+                if (raw != null) {
+                    room.setSvgChildView((String) raw);
+                }
             }
             room.setCreatedAt(new Date());
             room.setCreater(user);
@@ -306,8 +312,16 @@ public class InwardRoomApi {
                 room.setFilled(filledVal);
             }
             // Bed-board child-tile SVG (issue #21592) — stored verbatim.
+            // JSON null = no-op (leave unchanged, matching the service partial-update
+            // semantics); an empty string clears the drawing; non-string is rejected.
             if (body.containsKey("svgChildView")) {
-                room.setSvgChildView(asString(body.get("svgChildView")));
+                Object raw = body.get("svgChildView");
+                if (raw != null && !(raw instanceof String)) {
+                    return errorResponse("Invalid value for 'svgChildView': must be a string", 400);
+                }
+                if (raw != null) {
+                    room.setSvgChildView((String) raw);
+                }
             }
 
             roomFacade.edit(room);
@@ -416,8 +430,15 @@ public class InwardRoomApi {
             if (body == null) {
                 return errorResponse("Request body is required", 400);
             }
+            // JSON null = no-op (leave unchanged); empty string clears; non-string rejected.
             if (body.containsKey("svgChildView")) {
-                room.setSvgChildView(asString(body.get("svgChildView")));
+                Object raw = body.get("svgChildView");
+                if (raw != null && !(raw instanceof String)) {
+                    return errorResponse("Invalid value for 'svgChildView': must be a string", 400);
+                }
+                if (raw != null) {
+                    room.setSvgChildView((String) raw);
+                }
             }
             roomFacade.edit(room);
             return successResponse(svgDto(room));

--- a/src/main/java/com/divudi/ws/inward/InwardRoomApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomApi.java
@@ -211,6 +211,11 @@ public class InwardRoomApi {
                 }
                 room.setFilled(filledVal);
             }
+            // Bed-board child-tile SVG (issue #21592) — stored verbatim; sanitised
+            // at render time by BedBoardController.sanitizeSvg().
+            if (body.containsKey("svgChildView")) {
+                room.setSvgChildView(asString(body.get("svgChildView")));
+            }
             room.setCreatedAt(new Date());
             room.setCreater(user);
             roomFacade.create(room);
@@ -300,6 +305,10 @@ public class InwardRoomApi {
                 }
                 room.setFilled(filledVal);
             }
+            // Bed-board child-tile SVG (issue #21592) — stored verbatim.
+            if (body.containsKey("svgChildView")) {
+                room.setSvgChildView(asString(body.get("svgChildView")));
+            }
 
             roomFacade.edit(room);
             return successResponse(toDto(room));
@@ -352,9 +361,82 @@ public class InwardRoomApi {
         }
     }
 
+    /**
+     * Get the bed-board child-tile SVG of a room (issue #21592).
+     * A Room only has svgChildView (no parent canvas) — it is always a leaf in
+     * the bed-board hierarchy.
+     * GET /api/inward/rooms/{id}/svg
+     */
+    @GET
+    @Path("/{id}/svg")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getRoomSvg(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            Room room = roomFacade.find(id);
+            if (room == null || room.isRetired()) {
+                return errorResponse("Room not found: " + id, 404);
+            }
+            return successResponse(svgDto(room));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Set the bed-board child-tile SVG of a room (issue #21592).
+     * Only svgChildView present in the body is changed; pass an empty string to
+     * clear the drawing. SVG is stored verbatim.
+     * PUT /api/inward/rooms/{id}/svg
+     * Body: { "svgChildView": "..." }
+     */
+    @PUT
+    @Path("/{id}/svg")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateRoomSvg(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            Room room = roomFacade.find(id);
+            if (room == null || room.isRetired()) {
+                return errorResponse("Room not found: " + id, 404);
+            }
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            if (body.containsKey("svgChildView")) {
+                room.setSvgChildView(asString(body.get("svgChildView")));
+            }
+            roomFacade.edit(room);
+            return successResponse(svgDto(room));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
     // =========================================================================
     // Helpers
     // =========================================================================
+
+    private Map<String, Object> svgDto(Room r) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", r.getId());
+        row.put("name", r.getName());
+        row.put("svgChildView", r.getSvgChildView());
+        return row;
+    }
 
     private Map<String, Object> toDto(Room r) {
         Map<String, Object> row = new LinkedHashMap<>();
@@ -364,6 +446,8 @@ public class InwardRoomApi {
         row.put("description", r.getDescription());
         row.put("filled", r.isFilled());
         row.put("retired", r.isRetired());
+        // Bed-board child-tile SVG (issue #21592) — returned verbatim.
+        row.put("svgChildView", r.getSvgChildView());
         if (r.getParentCategory() != null) {
             Map<String, Object> cat = new LinkedHashMap<>();
             cat.put("id", r.getParentCategory().getId());


### PR DESCRIPTION
## Summary

Exposes the bed-board SVG fields (`svgParentView` / `svgChildView`) introduced in #21580 / PR #21591 through the **existing** management APIs and the **AI chat**, so an AI agent (or any API client) can read and write the bed-board drawings programmatically and "draw" a hospital map.

Parent epic: #21589. Builds on #21580 / PR #21591.

## Design decisions

- **Both** DTO fields *and* a dedicated `GET/PUT /{id}/svg` sub-resource (mirrors the existing `/{id}/config` and `/{id}/preferences` sub-resources). The sub-resource lets an agent set drawings without round-tripping the whole entity.
- **SVG stored verbatim** on the write path so create/update → read-back is byte-identical (acceptance criterion). The bed board already sanitises stored SVG **at render time** with the jsoup allowlist (`BedBoardController.sanitizeSvg`) — its code comment names this #21592 write path as the input surface it defends. No sanitisation on write (would reserialize and break the identical round-trip).
- **Additive only** — no existing DTO constructor signatures were changed; new fields use plain getters/setters.

## Changes

- **`BedBoardSvgDTO`** — new shared DTO (`com.divudi.core.data.dto.bedboard`) for the `/svg` sub-resources.
- **Institution / Site / Department** — added `svgParentView` + `svgChildView` to the Create/Update/Response DTOs; mapped in `InstitutionApiService` / `SiteApiService` / `DepartmentApiService` on create, update and build; added `GET/PUT /{id}/svg`.
- **Room** (leaf — `svgChildView` only) — added to `InwardRoomApi` create/update/`toDto` and a `GET/PUT /inward/rooms/{id}/svg` sub-resource.
- **`CapabilityStatementResource`** — Departments / Institutions / Sites / Inward Rooms entries now advertise the SVG fields and `/svg` endpoints.
- **`AnthropicApiService`** — new `manage_bed_board_svg` tool (`GET_/SET_` × `SITE`/`DEPARTMENT`/`ROOM`) with handler (`callBedBoardSvgApi`) and a system-prompt module block; `svgChildView` also threaded through the existing `manage_inward_rooms` ROOM operations.
- **Developer docs** — Bed-board SVG sections added to `API_SITES.md`, `API_INWARD_ROOM.md`, `API_INSTITUTION_DEPARTMENT_MANAGEMENT.md`, each pointing to the [Inpatient — Bed Board](https://github.com/hmislk/hmis/wiki/Inpatient-Bed-Board) wiki page.

All 4 REST-registration steps are satisfied (ApplicationConfig unchanged — existing resources were extended, not added; CapabilityStatement; system prompt; tools + handler).

## Endpoints added

| Method | Path | Body |
|--------|------|------|
| GET    | `/api/institutions/{id}/svg` | — |
| PUT    | `/api/institutions/{id}/svg` | `{ svgParentView, svgChildView }` |
| GET    | `/api/sites/{id}/svg` | — |
| PUT    | `/api/sites/{id}/svg` | `{ svgParentView, svgChildView }` |
| GET    | `/api/departments/{id}/svg` | — |
| PUT    | `/api/departments/{id}/svg` | `{ svgParentView, svgChildView }` |
| GET    | `/api/inward/rooms/{id}/svg` | — |
| PUT    | `/api/inward/rooms/{id}/svg` | `{ svgChildView }` |

The SVG fields are also accepted on the existing create/update bodies and returned by the existing GET of each resource.

## Testing

- `mvn -o compile` → **BUILD SUCCESS** (2010 source files).
- Round-trip / AI-chat validation against a running deployment to follow.

## Acceptance criteria

- [x] API client can GET and PUT `svgParentView`/`svgChildView` on sites, institutions, departments, and `svgChildView` on rooms, via `/api`.
- [x] Full SVG markup round-trips intact (stored verbatim).
- [x] `/api/capabilities` lists the new SVG fields/endpoints.
- [x] AI chat can read an entity's current bed-board SVG and set a new one (`manage_bed_board_svg` tool).
- [x] No existing DTO constructor signatures changed; only additive changes.
- [ ] AI agent can build a small site→building→floor→unit map using only the wiki page (to validate against a running app; wiki updated if gaps found).

Closes #21592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bed-board SVG drawing support (`svgParentView`, `svgChildView`) for institutions, departments, sites, and `svgChildView` for inward rooms (leaf tiles).
  * Added dedicated `GET/PUT .../{id}/svg` sub-resources to read/update SVGs separately from main entity updates.
  * SVG updates are partial: omit fields to leave unchanged; send empty strings to clear drawings.
  * Added an AI tool to manage bed-board SVGs across these levels.

* **Documentation**
  * Updated API documentation and capability statements with the new SVG fields, sub-resources, and clear behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->