### PR TITLE
fix: Bed_Board Icon enum constant and mf.xhtml privilege gate

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -170,7 +170,8 @@ public enum Icon {
     Search_Final_Bill_By_Discharge_Date("Search Final Bill by Discharge Date", INPATIENT_BILLING),
     Request_Medicines_From_Pharmacy("Request Medicines from Pharmacy", INPATIENT_SERVICES),
     View_Pharmacy_Requests("View Pharmacy Requests", INPATIENT_SERVICES),
-    Inward_Analytics("Inward Analytics", INPATIENT_ANALYTICS);
+    Inward_Analytics("Inward Analytics", INPATIENT_ANALYTICS),
+    Bed_Board("Bed Board", INPATIENT_ROOMS);
 
     private final String label;
     private final IconGroup iconGroup;

--- a/src/main/webapp/mf.xhtml
+++ b/src/main/webapp/mf.xhtml
@@ -44,18 +44,11 @@
         <!-- Not migration pending: admin only -->
         <h:panelGroup rendered="#{not applicationController.databaseMigrationPending}">
 
-            <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+            <h:panelGroup >
                 <ez:midding_data_fields/>
             </h:panelGroup>
 
-            <h:panelGroup rendered="#{not webUserController.hasPrivilege('Admin')}">
-                <div class="container mt-5">
-                    <div class="alert alert-danger text-center" role="alert">
-                        <h:outputText value="Access Denied" styleClass="alert-heading h4"/>
-                        <p>This page is restricted to administrators. No database migration is currently pending.</p>
-                    </div>
-                </div>
-            </h:panelGroup>
+           
 
         </h:panelGroup>
 


### PR DESCRIPTION
## Summary

- **Icon enum**: adds the missing `Bed_Board` constant to `com.divudi.core.data.Icon`, which was referenced in `home.xhtml` but never declared — causing `IllegalArgumentException: No enum constant … Icon.Bed_Board` on every page load after the bed-board feature was merged (PR #21591).
- **mf.xhtml**: removes the `Admin`-only privilege check that was gating the missing-data-fields panel; any authenticated user who reaches that page should be able to complete mandatory fields, not just administrators.

## Test plan

- [ ] Load `home.xhtml` — no `IllegalArgumentException` thrown
- [ ] Bed Board navigation link renders and is clickable for users with `InwardRoomRoomOccupency` privilege
- [ ] Non-admin users can see and interact with missing-data-fields panel on `mf.xhtml`
- [ ] Admin users are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)