### PR TITLE
feat(inward): add 5 missing user icons and unified teal SVG theme for all inpatient icons

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -171,7 +171,21 @@ public enum Icon {
     Request_Medicines_From_Pharmacy("Request Medicines from Pharmacy", INPATIENT_SERVICES),
     View_Pharmacy_Requests("View Pharmacy Requests", INPATIENT_SERVICES),
     Inward_Analytics("Inward Analytics", INPATIENT_ANALYTICS),
-    Bed_Board("Bed Board", INPATIENT_ROOMS);
+    Bed_Board("Bed Board", INPATIENT_ROOMS),
+    Patient_Lookup_Registration("Patient Lookup & Registration", INPATIENT_ADMISSIONS),
+    Initiate_Transfer("Initiate Transfer", INPATIENT_ROOMS),
+    Accept_Patients("Accept Patients", INPATIENT_ROOMS),
+    Accept_Returns_from_Ward("Accept Returns from Ward", INPATIENT_DIRECT_ISSUES),
+    Nursing_Work_Bench("Nursing WorkBench", INPATIENT_SERVICES);
+
+    private static final java.util.Set<IconGroup> INPATIENT_GROUPS = java.util.EnumSet.of(
+            IconGroup.INPATIENT_ADMISSIONS,
+            IconGroup.INPATIENT_ROOMS,
+            IconGroup.INPATIENT_SERVICES,
+            IconGroup.INPATIENT_BILLING,
+            IconGroup.INPATIENT_ANALYTICS,
+            IconGroup.INPATIENT_DIRECT_ISSUES
+    );
 
     private final String label;
     private final IconGroup iconGroup;
@@ -191,12 +205,13 @@ public enum Icon {
 
     /**
      * Returns the image filename for this icon.
-     * Icons from Patient_Deposit_Management onwards use .svg extension.
-     * Earlier icons use .png extension (legacy format).
-     *
-     * @return Image filename with extension (e.g., "Patient_Lookup.png" or "Patient_Deposit_Management.svg")
+     * All inpatient-group icons use .svg; icons from Patient_Deposit_Management
+     * onwards also use .svg; all others use .png (legacy format).
      */
     public String getImage() {
+        if (iconGroup != null && INPATIENT_GROUPS.contains(iconGroup)) {
+            return this.name() + ".svg";
+        }
         if (this.ordinal() >= Patient_Deposit_Management.ordinal()) {
             return this.name() + ".svg";
         }

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -2146,6 +2146,61 @@
                     </h:form>
                 </h:panelGroup>
 
+                <!-- Patient Lookup & Registration -->
+                <h:panelGroup rendered="#{ui.icon eq 'Patient_Lookup_Registration' and webUserController.hasPrivilege('OpdPreBilling')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Patient_Lookup_Registration" value="Patient Lookup &amp; Registration" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Patient_Lookup_Registration" ajax="false" action="#{opdBillController.navigateToSearchPatients()}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search-patient.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Patient Lookup &amp; Registration"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Initiate Transfer -->
+                <h:panelGroup rendered="#{ui.icon eq 'Initiate_Transfer' and webUserController.hasPrivilege('InwardRoomTransferInitiate')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Initiate_Transfer" value="Initiate Transfer" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Initiate_Transfer" ajax="false" action="#{patientTransferController.navigateToInitiateTransfer()}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/transfer.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Initiate Transfer"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Accept Patients -->
+                <h:panelGroup rendered="#{ui.icon eq 'Accept_Patients' and webUserController.hasPrivilege('InwardRoomPatientAccept')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Accept_Patients" value="Accept Patients" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Accept_Patients" ajax="false" action="#{patientTransferController.navigateToPatientAccept()}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/add-patient.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Accept Patients"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Accept Returns from Ward -->
+                <h:panelGroup rendered="#{ui.icon eq 'Accept_Returns_from_Ward' and webUserController.hasPrivilege('PharmacyBHTIssueAccept')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Accept_Returns_from_Ward" value="Accept Returns from Ward" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Accept_Returns_from_Ward" ajax="false" action="#{pharmacyReturnFromWardReceiveController.navigateToPendingList}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/truck-solid.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Accept Returns from Ward"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Nursing WorkBench -->
+                <h:panelGroup rendered="#{ui.icon eq 'Nursing_Work_Bench' and webUserController.hasPrivilege('NursingWorkBench')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Nursing_Work_Bench" value="Nursing WorkBench" showDelay="0" hideDelay="0"/>
+                        <p:commandLink id="Nursing_Work_Bench" ajax="false" action="#{nursingWorkBenchController.navigatetoNursingWorkBench()}" styleClass="svg-link">
+                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/health-worker-form.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Nursing WorkBench"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
                     </ui:repeat>
                 </div>
             </p:panel>

--- a/src/main/webapp/resources/icons/Accept_Patients.svg
+++ b/src/main/webapp/resources/icons/Accept_Patients.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad16a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad16" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad16)">
+    <!-- Person -->
+    <circle cx="88" cy="72" r="22" fill="url(#grad16a)"/>
+    <path d="M65 100 Q88 90 111 100 L114 145 Q114 151 109 151 L67 151 Q62 151 62 145 Z" fill="url(#grad16a)"/>
+    <!-- White highlight on person -->
+    <circle cx="80" cy="65" r="7" fill="white" opacity="0.2"/>
+    <!-- Large checkmark badge -->
+    <circle cx="148" cy="68" r="30" fill="white"/>
+    <circle cx="148" cy="68" r="26" fill="url(#grad16a)"/>
+    <path d="M133 68 L144 79 L163 56" fill="none" stroke="#22D3EE" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Arrow pointing to person -->
+    <path d="M118 120 L130 120" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <polygon points="125,114 132,120 125,126" fill="#22D3EE"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Accept_Returns_from_Ward.svg
+++ b/src/main/webapp/resources/icons/Accept_Returns_from_Ward.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad33a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad33" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad33)">
+    <!-- Delivery truck (left) -->
+    <!-- Truck body -->
+    <rect x="18" y="90" width="90" height="55" rx="5" fill="url(#grad33a)"/>
+    <!-- Truck cab -->
+    <rect x="95" y="105" width="40" height="40" rx="5" fill="#155E75"/>
+    <!-- Windshield -->
+    <rect x="98" y="108" width="25" height="18" rx="3" fill="#22D3EE" opacity="0.7"/>
+    <!-- Wheels -->
+    <circle cx="42" cy="148" r="13" fill="#155E75"/>
+    <circle cx="42" cy="148" r="7" fill="#F0FDFA"/>
+    <circle cx="118" cy="148" r="13" fill="#155E75"/>
+    <circle cx="118" cy="148" r="7" fill="#F0FDFA"/>
+    <!-- Cargo box on truck -->
+    <rect x="22" y="75" width="68" height="18" rx="3" fill="url(#grad33a)" opacity="0.8"/>
+    <!-- Return curved arrow (pointing left/back) -->
+    <path d="M150 75 Q172 55 172 90 Q172 115 148 115" fill="none" stroke="#22D3EE" stroke-width="7" stroke-linecap="round"/>
+    <polygon points="154,107 146,116 158,121" fill="#22D3EE"/>
+    <!-- Checkmark (accept) -->
+    <circle cx="158" cy="60" r="18" fill="white"/>
+    <circle cx="158" cy="60" r="14" fill="url(#grad33a)"/>
+    <path d="M148 60 L155 67 L168 52" fill="none" stroke="#22D3EE" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Estimated_Professional_Fee.svg
+++ b/src/main/webapp/resources/icons/Add_Estimated_Professional_Fee.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad21a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad21" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad21)">
+    <!-- Stethoscope (smaller, left) -->
+    <circle cx="60" cy="85" r="22" fill="url(#grad21a)"/>
+    <circle cx="60" cy="85" r="15" fill="#F0FDFA"/>
+    <circle cx="60" cy="85" r="8" fill="url(#grad21a)" opacity="0.4"/>
+    <path d="M74 85 Q98 85 98 68 Q98 50 114 50" fill="none" stroke="url(#grad21a)" stroke-width="7" stroke-linecap="round"/>
+    <circle cx="108" cy="47" r="6" fill="url(#grad21a)"/>
+    <circle cx="120" cy="47" r="6" fill="url(#grad21a)"/>
+    <line x1="108" y1="47" x2="120" y2="47" stroke="url(#grad21a)" stroke-width="5"/>
+    <!-- Clock (right, overlapping stethoscope bottom) -->
+    <circle cx="138" cy="140" r="34" fill="white"/>
+    <circle cx="138" cy="140" r="30" fill="url(#grad21a)"/>
+    <circle cx="138" cy="140" r="22" fill="none" stroke="#22D3EE" stroke-width="2"/>
+    <!-- Clock hands -->
+    <line x1="138" y1="140" x2="138" y2="123" stroke="white" stroke-width="3" stroke-linecap="round"/>
+    <line x1="138" y1="140" x2="150" y2="147" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="138" cy="140" r="3" fill="white"/>
+    <!-- Clock ticks -->
+    <line x1="138" y1="112" x2="138" y2="116" stroke="white" stroke-width="2"/>
+    <line x1="138" y1="164" x2="138" y2="168" stroke="white" stroke-width="2"/>
+    <line x1="110" y1="140" x2="114" y2="140" stroke="white" stroke-width="2"/>
+    <line x1="162" y1="140" x2="166" y2="140" stroke="white" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Outside_Charges.svg
+++ b/src/main/webapp/resources/icons/Add_Outside_Charges.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad19a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad19" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad19)">
+    <!-- Receipt/paper -->
+    <rect x="42" y="40" width="95" height="130" rx="5" fill="url(#grad19a)"/>
+    <!-- Receipt zigzag bottom -->
+    <path d="M42 162 L53 152 L64 162 L75 152 L86 162 L97 152 L108 162 L119 152 L130 162 L137 152 L137 170 L42 170 Z" fill="url(#grad19a)"/>
+    <!-- Receipt lines -->
+    <rect x="52" y="55" width="75" height="5" rx="2" fill="white" opacity="0.8"/>
+    <line x1="52" y1="70" x2="127" y2="70" stroke="white" stroke-width="1" opacity="0.3"/>
+    <rect x="52" y="76" width="55" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="88" width="60" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="100" width="50" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="112" width="65" height="4" rx="2" fill="white" opacity="0.55"/>
+    <line x1="52" y1="123" x2="127" y2="123" stroke="white" stroke-width="1" opacity="0.3"/>
+    <rect x="52" y="129" width="75" height="5" rx="2" fill="#22D3EE" opacity="0.9"/>
+    <!-- Plus sign badge -->
+    <circle cx="150" cy="55" width="0" r="24" fill="white"/>
+    <circle cx="150" cy="55" r="24" fill="white"/>
+    <circle cx="150" cy="55" r="20" fill="#22D3EE"/>
+    <rect x="142" y="52" width="16" height="6" rx="3" fill="white"/>
+    <rect x="147" y="47" width="6" height="16" rx="3" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Professional_Fee.svg
+++ b/src/main/webapp/resources/icons/Add_Professional_Fee.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad20a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad20" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad20)">
+    <!-- Stethoscope head disc -->
+    <circle cx="72" cy="90" r="28" fill="url(#grad20a)"/>
+    <circle cx="72" cy="90" r="20" fill="#F0FDFA"/>
+    <circle cx="72" cy="90" r="12" fill="url(#grad20a)" opacity="0.4"/>
+    <!-- Stethoscope tube -->
+    <path d="M90 90 Q120 90 120 70 Q120 48 140 48" fill="none" stroke="url(#grad20a)" stroke-width="8" stroke-linecap="round"/>
+    <!-- Earpieces -->
+    <circle cx="133" cy="45" r="7" fill="url(#grad20a)"/>
+    <circle cx="147" cy="45" r="7" fill="url(#grad20a)"/>
+    <line x1="133" y1="45" x2="147" y2="45" stroke="url(#grad20a)" stroke-width="5"/>
+    <!-- Dollar coin -->
+    <circle cx="142" cy="145" r="28" fill="white"/>
+    <circle cx="142" cy="145" r="24" fill="url(#grad20a)"/>
+    <circle cx="142" cy="145" r="17" fill="none" stroke="#22D3EE" stroke-width="2"/>
+    <text x="142" y="153" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="white" text-anchor="middle">$</text>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Services_Investigations.svg
+++ b/src/main/webapp/resources/icons/Add_Services_Investigations.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad17a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad17" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad17)">
+    <!-- Clipboard body -->
+    <rect x="42" y="52" width="116" height="135" rx="7" fill="url(#grad17a)"/>
+    <!-- Clipboard top -->
+    <rect x="70" y="42" width="60" height="22" rx="5" fill="#155E75"/>
+    <rect x="80" y="44" width="40" height="14" rx="4" fill="url(#grad17a)"/>
+    <!-- Lines on clipboard -->
+    <rect x="56" y="80" width="88" height="6" rx="3" fill="white" opacity="0.7"/>
+    <rect x="56" y="95" width="75" height="6" rx="3" fill="white" opacity="0.5"/>
+    <rect x="56" y="110" width="82" height="6" rx="3" fill="white" opacity="0.5"/>
+    <rect x="56" y="125" width="68" height="6" rx="3" fill="white" opacity="0.5"/>
+    <!-- Plus sign (add) -->
+    <circle cx="148" cy="155" r="22" fill="white"/>
+    <circle cx="148" cy="155" r="18" fill="#22D3EE"/>
+    <rect x="140" y="152" width="16" height="6" rx="3" fill="white"/>
+    <rect x="145" y="147" width="6" height="16" rx="3" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Services_With_Payments.svg
+++ b/src/main/webapp/resources/icons/Add_Services_With_Payments.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad18a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad18" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad18)">
+    <!-- Clipboard -->
+    <rect x="30" y="48" width="100" height="125" rx="7" fill="url(#grad18a)"/>
+    <rect x="55" y="38" width="50" height="20" rx="5" fill="#155E75"/>
+    <rect x="63" y="40" width="34" height="12" rx="4" fill="url(#grad18a)"/>
+    <rect x="42" y="74" width="76" height="5" rx="2" fill="white" opacity="0.7"/>
+    <rect x="42" y="88" width="62" height="5" rx="2" fill="white" opacity="0.5"/>
+    <rect x="42" y="102" width="70" height="5" rx="2" fill="white" opacity="0.5"/>
+    <rect x="42" y="116" width="55" height="5" rx="2" fill="white" opacity="0.5"/>
+    <rect x="42" y="130" width="65" height="5" rx="2" fill="white" opacity="0.5"/>
+    <!-- Currency coin -->
+    <circle cx="152" cy="135" r="32" fill="white"/>
+    <circle cx="152" cy="135" r="27" fill="url(#grad18a)"/>
+    <circle cx="152" cy="135" r="20" fill="none" stroke="#22D3EE" stroke-width="2.5"/>
+    <text x="152" y="143" font-family="Arial, sans-serif" font-size="26" font-weight="bold" fill="white" text-anchor="middle">$</text>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Add_Timed_Services.svg
+++ b/src/main/webapp/resources/icons/Add_Timed_Services.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad22a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad22" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad22)">
+    <!-- Large clock -->
+    <circle cx="95" cy="105" r="65" fill="white"/>
+    <circle cx="95" cy="105" r="60" fill="url(#grad22a)"/>
+    <circle cx="95" cy="105" r="48" fill="none" stroke="#22D3EE" stroke-width="3"/>
+    <!-- Clock hands -->
+    <line x1="95" y1="105" x2="95" y2="68" stroke="white" stroke-width="5" stroke-linecap="round"/>
+    <line x1="95" y1="105" x2="120" y2="118" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="95" cy="105" r="6" fill="white"/>
+    <!-- Clock hour marks -->
+    <line x1="95" y1="57" x2="95" y2="65" stroke="white" stroke-width="3"/>
+    <line x1="95" y1="145" x2="95" y2="153" stroke="white" stroke-width="3"/>
+    <line x1="47" y1="105" x2="55" y2="105" stroke="white" stroke-width="3"/>
+    <line x1="135" y1="105" x2="143" y2="105" stroke="white" stroke-width="3"/>
+    <!-- Plus sign badge top-right -->
+    <circle cx="155" cy="52" r="22" fill="white"/>
+    <circle cx="155" cy="52" r="18" fill="#22D3EE"/>
+    <rect x="147" y="49" width="16" height="6" rx="3" fill="white"/>
+    <rect x="152" y="44" width="6" height="16" rx="3" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Admit.svg
+++ b/src/main/webapp/resources/icons/Admit.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad1)">
+    <!-- Door frame -->
+    <rect x="115" y="55" width="45" height="100" rx="3" fill="url(#grad1a)"/>
+    <rect x="118" y="58" width="39" height="94" rx="2" fill="#F0FDFA"/>
+    <!-- Door knob -->
+    <circle cx="125" cy="108" r="4" fill="#22D3EE"/>
+    <!-- Person body -->
+    <circle cx="75" cy="75" r="14" fill="url(#grad1a)"/>
+    <path d="M60 95 Q75 88 90 95 L93 135 Q93 140 88 140 L62 140 Q57 140 57 135 Z" fill="url(#grad1a)"/>
+    <!-- Walking leg lines -->
+    <line x1="68" y1="140" x2="63" y2="158" stroke="url(#grad1a)" stroke-width="7" stroke-linecap="round"/>
+    <line x1="82" y1="140" x2="87" y2="158" stroke="url(#grad1a)" stroke-width="7" stroke-linecap="round"/>
+    <!-- Plus sign (admission) -->
+    <rect x="95" y="62" width="16" height="6" rx="3" fill="#22D3EE"/>
+    <rect x="100" y="57" width="6" height="16" rx="3" fill="#22D3EE"/>
+    <!-- Arrow pointing to door -->
+    <path d="M96 108 L110 108" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+    <path d="M105 103 L111 108 L105 113" fill="none" stroke="#22D3EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Admit_Room.svg
+++ b/src/main/webapp/resources/icons/Admit_Room.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad12a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad12" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad12)">
+    <!-- Door frame (arch) -->
+    <rect x="60" y="55" width="80" height="115" rx="5" fill="url(#grad12a)"/>
+    <!-- Door panel -->
+    <rect x="65" y="60" width="70" height="105" rx="4" fill="#F0FDFA"/>
+    <!-- Door inner panel detail -->
+    <rect x="72" y="70" width="25" height="38" rx="3" fill="url(#grad11a)" opacity="0.12"/>
+    <rect x="103" y="70" width="25" height="38" rx="3" fill="url(#grad11a)" opacity="0.12"/>
+    <rect x="72" y="116" width="56" height="38" rx="3" fill="url(#grad11a)" opacity="0.12"/>
+    <!-- Doorknob -->
+    <circle cx="76" cy="122" r="5" fill="#22D3EE"/>
+    <!-- Plus sign on door (admit) -->
+    <rect x="93" y="95" width="14" height="5" rx="2" fill="#22D3EE"/>
+    <rect x="97" y="91" width="5" height="14" rx="2" fill="#22D3EE"/>
+    <!-- Threshold line -->
+    <line x1="60" y1="170" x2="140" y2="170" stroke="url(#grad12a)" stroke-width="5" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Appointment_Admission.svg
+++ b/src/main/webapp/resources/icons/Appointment_Admission.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad7a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad7" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad7)">
+    <!-- Calendar -->
+    <rect x="30" y="50" width="100" height="85" rx="7" fill="url(#grad7a)"/>
+    <rect x="30" y="50" width="100" height="26" rx="7" fill="#155E75"/>
+    <rect x="30" y="64" width="100" height="12" fill="#155E75"/>
+    <rect x="52" y="42" width="9" height="18" rx="4" fill="white" opacity="0.9"/>
+    <rect x="99" y="42" width="9" height="18" rx="4" fill="white" opacity="0.9"/>
+    <!-- Calendar grid -->
+    <rect x="40" y="86" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="59" y="86" width="12" height="10" rx="2" fill="#22D3EE"/>
+    <rect x="78" y="86" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="97" y="86" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="40" y="103" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="59" y="103" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="78" y="103" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <rect x="97" y="103" width="12" height="10" rx="2" fill="white" opacity="0.7"/>
+    <!-- Walking person (right side) -->
+    <circle cx="155" cy="100" r="14" fill="url(#grad7a)"/>
+    <path d="M143 120 Q155 114 167 120 L169 148 Q169 153 164 153 L146 153 Q141 153 141 148 Z" fill="url(#grad7a)"/>
+    <!-- Arrow from calendar to person -->
+    <path d="M133 108 L141 108" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+    <polygon points="138,104 143,108 138,112" fill="#22D3EE"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/BHT_issue_requests.svg
+++ b/src/main/webapp/resources/icons/BHT_issue_requests.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad28a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad28" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad28)">
+    <!-- Notepad/clipboard body -->
+    <rect x="38" y="48" width="124" height="135" rx="7" fill="url(#grad28a)"/>
+    <!-- Spiral holes -->
+    <circle cx="65" cy="48" r="6" fill="#F0FDFA"/>
+    <circle cx="100" cy="48" r="6" fill="#F0FDFA"/>
+    <circle cx="135" cy="48" r="6" fill="#F0FDFA"/>
+    <!-- Lines on notepad -->
+    <rect x="52" y="68" width="96" height="5" rx="2" fill="white" opacity="0.7"/>
+    <rect x="52" y="82" width="80" height="5" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="96" width="88" height="5" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="110" width="74" height="5" rx="2" fill="white" opacity="0.55"/>
+    <rect x="52" y="124" width="82" height="5" rx="2" fill="white" opacity="0.55"/>
+    <!-- Medical cross badge (bottom-right of notepad) -->
+    <circle cx="144" cy="155" r="22" fill="white"/>
+    <circle cx="144" cy="155" r="18" fill="#22D3EE"/>
+    <rect x="136" y="152" width="16" height="6" rx="3" fill="white"/>
+    <rect x="141" y="147" width="6" height="16" rx="3" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Bed_Board.svg
+++ b/src/main/webapp/resources/icons/Bed_Board.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gradBBa" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shadBB" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shadBB)">
+    <!-- Bed board grid: 3x2 beds -->
+    <!-- Row 1 -->
+    <rect x="28" y="50" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <rect x="79" y="50" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <rect x="130" y="50" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <!-- Row 2 -->
+    <rect x="28" y="92" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <rect x="79" y="92" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <rect x="130" y="92" width="42" height="34" rx="4" fill="url(#gradBBa)"/>
+    <!-- Bed icons inside cells (pillow + mattress) -->
+    <!-- Cell 1,1 -->
+    <rect x="33" y="56" width="10" height="7" rx="2" fill="white" opacity="0.9"/>
+    <rect x="33" y="65" width="32" height="12" rx="2" fill="white" opacity="0.6"/>
+    <!-- Cell 1,2 - occupied (cyan patient) -->
+    <rect x="84" y="56" width="10" height="7" rx="2" fill="#22D3EE"/>
+    <rect x="84" y="65" width="32" height="12" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <!-- Cell 1,3 -->
+    <rect x="135" y="56" width="10" height="7" rx="2" fill="white" opacity="0.9"/>
+    <rect x="135" y="65" width="32" height="12" rx="2" fill="white" opacity="0.6"/>
+    <!-- Cell 2,1 - occupied -->
+    <rect x="33" y="98" width="10" height="7" rx="2" fill="#22D3EE"/>
+    <rect x="33" y="107" width="32" height="12" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <!-- Cell 2,2 -->
+    <rect x="84" y="98" width="10" height="7" rx="2" fill="white" opacity="0.9"/>
+    <rect x="84" y="107" width="32" height="12" rx="2" fill="white" opacity="0.6"/>
+    <!-- Cell 2,3 - occupied -->
+    <rect x="135" y="98" width="10" height="7" rx="2" fill="#22D3EE"/>
+    <rect x="135" y="107" width="32" height="12" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <!-- Legend row -->
+    <rect x="28" y="140" width="14" height="10" rx="2" fill="url(#gradBBa)"/>
+    <rect x="45" y="142" width="22" height="6" rx="2" fill="#22D3EE" opacity="0.8"/>
+    <rect x="80" y="140" width="14" height="10" rx="2" fill="url(#gradBBa)"/>
+    <rect x="97" y="142" width="22" height="6" rx="2" fill="white" opacity="0.7"/>
+    <!-- Occupied/Vacant text lines -->
+    <rect x="45" y="152" width="30" height="4" rx="2" fill="#0E7490" opacity="0.5"/>
+    <rect x="97" y="152" width="30" height="4" rx="2" fill="#0E7490" opacity="0.5"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Change_Patient_for_Admission.svg
+++ b/src/main/webapp/resources/icons/Change_Patient_for_Admission.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad5a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad5" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad5)">
+    <!-- Person 1 (left) -->
+    <circle cx="58" cy="72" r="18" fill="url(#grad5a)"/>
+    <path d="M38 98 Q58 88 78 98 L80 130 Q80 135 75 135 L41 135 Q36 135 36 130 Z" fill="url(#grad5a)"/>
+    <!-- Person 2 (right) -->
+    <circle cx="142" cy="72" r="18" fill="url(#grad5a)"/>
+    <path d="M122 98 Q142 88 162 98 L164 130 Q164 135 159 135 L125 135 Q120 135 120 130 Z" fill="url(#grad5a)"/>
+    <!-- Swap arrows -->
+    <path d="M85 108 Q100 95 115 108" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="110,100 118,108 108,112" fill="#22D3EE"/>
+    <path d="M115 118 Q100 131 85 118" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="90,126 82,118 92,114" fill="#22D3EE"/>
+    <!-- White highlights on heads -->
+    <circle cx="51" cy="66" r="5" fill="white" opacity="0.25"/>
+    <circle cx="135" cy="66" r="5" fill="white" opacity="0.25"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Edit_Admission_Details.svg
+++ b/src/main/webapp/resources/icons/Edit_Admission_Details.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad4a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad4" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad4)">
+    <!-- Document -->
+    <rect x="35" y="45" width="95" height="120" rx="6" fill="url(#grad4a)"/>
+    <rect x="45" y="65" width="75" height="5" rx="2" fill="white" opacity="0.8"/>
+    <rect x="45" y="80" width="62" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="45" y="95" width="70" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="45" y="110" width="55" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="45" y="125" width="65" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="45" y="140" width="48" height="5" rx="2" fill="white" opacity="0.6"/>
+    <!-- Document top fold -->
+    <path d="M110 45 L130 45 L130 65 L110 65 Z" fill="#155E75" opacity="0.6"/>
+    <path d="M110 45 L130 65 L110 65 Z" fill="#0E7490" opacity="0.8"/>
+    <!-- Pencil -->
+    <g transform="rotate(-40 148 118)">
+      <rect x="138" y="78" width="14" height="55" rx="3" fill="#22D3EE"/>
+      <polygon points="138,133 152,133 145,152" fill="#0E7490"/>
+      <rect x="138" y="78" width="14" height="10" rx="2" fill="white" opacity="0.9"/>
+      <rect x="140" y="145" width="10" height="5" fill="#F0FDFA" opacity="0.7"/>
+    </g>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Guardian_Room_Change.svg
+++ b/src/main/webapp/resources/icons/Guardian_Room_Change.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad14a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad14" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad14)">
+    <!-- Guardian (taller, left) -->
+    <circle cx="55" cy="65" r="16" fill="url(#grad14a)"/>
+    <path d="M40 88 Q55 80 70 88 L72 118 Q72 123 67 123 L43 123 Q38 123 38 118 Z" fill="url(#grad14a)"/>
+    <!-- Patient (smaller, right of guardian) -->
+    <circle cx="92" cy="70" r="11" fill="url(#grad14a)" opacity="0.75"/>
+    <path d="M80 87 Q92 81 104 87 L105 110 Q105 114 101 114 L83 114 Q79 114 79 110 Z" fill="url(#grad14a)" opacity="0.75"/>
+    <!-- Arrow pointing right -->
+    <path d="M108 100 L130 100" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="124,93 132,100 124,107" fill="#22D3EE"/>
+    <!-- Bed (right side) -->
+    <rect x="132" y="115" width="55" height="38" rx="5" fill="url(#grad14a)"/>
+    <rect x="132" y="108" width="9" height="45" rx="4" fill="#155E75"/>
+    <rect x="179" y="115" width="7" height="38" rx="4" fill="#155E75"/>
+    <rect x="136" y="119" width="40" height="28" rx="3" fill="white" opacity="0.8"/>
+    <rect x="138" y="122" width="16" height="14" rx="4" fill="#22D3EE" opacity="0.8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Initiate_Transfer.svg
+++ b/src/main/webapp/resources/icons/Initiate_Transfer.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad15a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad15" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad15)">
+    <!-- Person -->
+    <circle cx="62" cy="75" r="19" fill="url(#grad15a)"/>
+    <path d="M44 100 Q62 92 80 100 L83 138 Q83 144 78 144 L46 144 Q41 144 41 138 Z" fill="url(#grad15a)"/>
+    <!-- Large arrow pointing right -->
+    <rect x="85" y="93" width="65" height="14" rx="7" fill="#22D3EE"/>
+    <polygon points="140,78 168,100 140,122" fill="#22D3EE"/>
+    <!-- Destination marker -->
+    <rect x="162" y="55" width="18" height="25" rx="4" fill="url(#grad15a)"/>
+    <rect x="158" y="78" width="26" height="32" rx="3" fill="url(#grad15a)"/>
+    <rect x="166" y="82" width="10" height="24" rx="2" fill="#F0FDFA"/>
+    <!-- White highlight on person head -->
+    <circle cx="55" cy="68" r="6" fill="white" opacity="0.2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Inpatient_Appointments.svg
+++ b/src/main/webapp/resources/icons/Inpatient_Appointments.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad2a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad2" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad2)">
+    <!-- Calendar body -->
+    <rect x="40" y="60" width="110" height="90" rx="8" fill="url(#grad2a)"/>
+    <rect x="40" y="60" width="110" height="28" rx="8" fill="#155E75"/>
+    <rect x="40" y="76" width="110" height="12" fill="#155E75"/>
+    <!-- Calendar binding tabs -->
+    <rect x="62" y="50" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
+    <rect x="118" y="50" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
+    <!-- Calendar grid lines -->
+    <line x1="40" y1="102" x2="150" y2="102" stroke="white" stroke-width="0.8" opacity="0.3"/>
+    <line x1="40" y1="120" x2="150" y2="120" stroke="white" stroke-width="0.8" opacity="0.3"/>
+    <line x1="40" y1="138" x2="150" y2="138" stroke="white" stroke-width="0.8" opacity="0.3"/>
+    <!-- Calendar day dots -->
+    <circle cx="60" cy="111" r="4" fill="white" opacity="0.8"/>
+    <circle cx="80" cy="111" r="4" fill="white" opacity="0.8"/>
+    <circle cx="100" cy="111" r="4" fill="#22D3EE"/>
+    <circle cx="120" cy="111" r="4" fill="white" opacity="0.8"/>
+    <circle cx="60" cy="129" r="4" fill="white" opacity="0.8"/>
+    <circle cx="80" cy="129" r="4" fill="white" opacity="0.8"/>
+    <!-- Clock overlay -->
+    <circle cx="138" cy="140" r="20" fill="white"/>
+    <circle cx="138" cy="140" r="17" fill="url(#grad2a)"/>
+    <line x1="138" y1="140" x2="138" y2="128" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="138" y1="140" x2="147" y2="145" stroke="#22D3EE" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="138" cy="140" r="2" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Interim_Bill.svg
+++ b/src/main/webapp/resources/icons/Interim_Bill.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad34a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad34" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad34)">
+    <!-- Invoice/paper -->
+    <rect x="38" y="32" width="124" height="148" rx="6" fill="url(#grad34a)"/>
+    <!-- Header bar -->
+    <rect x="38" y="32" width="124" height="28" rx="6" fill="#155E75"/>
+    <rect x="38" y="48" width="124" height="12" fill="#155E75"/>
+    <!-- Invoice lines with running total style -->
+    <rect x="50" y="70" width="100" height="5" rx="2" fill="white" opacity="0.7"/>
+    <rect x="50" y="83" width="78" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="50" y="93" width="88" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="50" y="103" width="70" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="50" y="113" width="82" height="4" rx="2" fill="white" opacity="0.5"/>
+    <!-- Subtotal line -->
+    <line x1="50" y1="123" x2="150" y2="123" stroke="white" stroke-width="1" opacity="0.4"/>
+    <rect x="50" y="127" width="100" height="4" rx="2" fill="white" opacity="0.5"/>
+    <!-- Running total amounts (right-aligned ticks) -->
+    <rect x="110" y="70" width="38" height="5" rx="2" fill="#22D3EE" opacity="0.9"/>
+    <rect x="110" y="83" width="38" height="4" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <rect x="110" y="93" width="38" height="4" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <rect x="110" y="103" width="38" height="4" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <rect x="110" y="113" width="38" height="4" rx="2" fill="#22D3EE" opacity="0.7"/>
+    <!-- Total box -->
+    <rect x="50" y="138" width="100" height="26" rx="5" fill="#22D3EE" opacity="0.85"/>
+    <rect x="55" y="143" width="90" height="16" rx="4" fill="url(#grad34a)" opacity="0.5"/>
+    <!-- Zigzag bottom -->
+    <path d="M38 172 L49 160 L60 172 L71 160 L82 172 L93 160 L104 172 L115 160 L126 172 L137 160 L148 172 L162 160 L162 180 L38 180 Z" fill="url(#grad34a)"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Interim_Bill_Estimated.svg
+++ b/src/main/webapp/resources/icons/Interim_Bill_Estimated.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad35a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad35" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad35)">
+    <!-- Invoice (left, slightly smaller) -->
+    <rect x="25" y="35" width="100" height="130" rx="6" fill="url(#grad35a)"/>
+    <rect x="25" y="35" width="100" height="24" rx="6" fill="#155E75"/>
+    <rect x="25" y="49" width="100" height="10" fill="#155E75"/>
+    <rect x="37" y="68" width="76" height="4" rx="2" fill="white" opacity="0.7"/>
+    <rect x="37" y="80" width="60" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="37" y="90" width="68" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="37" y="100" width="55" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="37" y="110" width="64" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="37" y="125" width="76" height="18" rx="4" fill="#22D3EE" opacity="0.8"/>
+    <!-- Zigzag bottom -->
+    <path d="M25 158 L35 147 L45 158 L55 147 L65 158 L75 147 L85 158 L95 147 L105 158 L115 147 L125 158 L125 165 L25 165 Z" fill="url(#grad35a)"/>
+    <!-- Clock overlay (right, larger) -->
+    <circle cx="148" cy="140" r="40" fill="white"/>
+    <circle cx="148" cy="140" r="35" fill="url(#grad35a)"/>
+    <circle cx="148" cy="140" r="26" fill="none" stroke="#22D3EE" stroke-width="2.5"/>
+    <line x1="148" y1="140" x2="148" y2="118" stroke="white" stroke-width="4" stroke-linecap="round"/>
+    <line x1="148" y1="140" x2="164" y2="150" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="148" cy="140" r="4" fill="white"/>
+    <line x1="148" y1="108" x2="148" y2="114" stroke="white" stroke-width="2.5"/>
+    <line x1="148" y1="166" x2="148" y2="172" stroke="white" stroke-width="2.5"/>
+    <line x1="118" y1="140" x2="124" y2="140" stroke="white" stroke-width="2.5"/>
+    <line x1="172" y1="140" x2="178" y2="140" stroke="white" stroke-width="2.5"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Interim_Bill_Search.svg
+++ b/src/main/webapp/resources/icons/Interim_Bill_Search.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad36a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad36" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad36)">
+    <!-- Invoice (left) -->
+    <rect x="22" y="35" width="92" height="118" rx="6" fill="url(#grad36a)"/>
+    <rect x="22" y="35" width="92" height="22" rx="6" fill="#155E75"/>
+    <rect x="22" y="48" width="92" height="9" fill="#155E75"/>
+    <rect x="32" y="65" width="72" height="4" rx="2" fill="white" opacity="0.7"/>
+    <rect x="32" y="76" width="58" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="86" width="65" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="96" width="52" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="106" width="60" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="118" width="72" height="16" rx="4" fill="#22D3EE" opacity="0.8"/>
+    <!-- Zigzag -->
+    <path d="M22 146 L31 136 L40 146 L49 136 L58 146 L67 136 L76 146 L85 136 L94 146 L103 136 L114 146 L114 153 L22 153 Z" fill="url(#grad36a)"/>
+    <!-- Magnifying glass (right) -->
+    <circle cx="148" cy="120" r="38" fill="none" stroke="url(#grad36a)" stroke-width="12"/>
+    <circle cx="148" cy="120" r="26" fill="#F0FDFA"/>
+    <circle cx="148" cy="120" r="14" fill="url(#grad36a)" opacity="0.2"/>
+    <line x1="172" y1="144" x2="185" y2="157" stroke="url(#grad36a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Investigation_Trace.svg
+++ b/src/main/webapp/resources/icons/Investigation_Trace.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad43a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad43" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad43)">
+    <!-- Test tube (left, angled) -->
+    <g transform="rotate(20 65 110)">
+      <rect x="54" y="50" width="22" height="80" rx="4" fill="url(#grad43a)"/>
+      <rect x="50" y="44" width="30" height="14" rx="4" fill="#155E75"/>
+      <!-- Liquid in tube -->
+      <rect x="54" y="108" width="22" height="22" rx="0" fill="#22D3EE" opacity="0.85"/>
+      <ellipse cx="65" cy="130" rx="11" ry="4" fill="#22D3EE"/>
+      <!-- Bubble -->
+      <circle cx="60" cy="118" r="3" fill="white" opacity="0.5"/>
+    </g>
+    <!-- Microscope (center-right) -->
+    <!-- Base -->
+    <rect x="100" y="152" width="68" height="12" rx="5" fill="url(#grad43a)"/>
+    <!-- Column -->
+    <rect x="128" y="90" width="12" height="65" rx="4" fill="url(#grad43a)"/>
+    <!-- Stage arm -->
+    <rect x="100" y="110" width="40" height="10" rx="4" fill="url(#grad43a)"/>
+    <!-- Objective -->
+    <rect x="125" y="65" width="18" height="32" rx="5" fill="#155E75"/>
+    <circle cx="134" cy="98" r="8" fill="url(#grad43a)"/>
+    <!-- Eyepiece -->
+    <rect x="130" y="48" width="8" height="20" rx="4" fill="url(#grad43a)"/>
+    <!-- Magnifying glass overlay -->
+    <circle cx="110" cy="78" r="22" fill="none" stroke="#22D3EE" stroke-width="5"/>
+    <circle cx="110" cy="78" r="14" fill="#F0FDFA" opacity="0.6"/>
+    <line x1="126" y1="94" x2="134" y2="102" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Inward_Analytics.svg
+++ b/src/main/webapp/resources/icons/Inward_Analytics.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad44a" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="grad44b" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#22D3EE;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0E7490;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad44" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad44)">
+    <!-- Axes -->
+    <line x1="35" y1="155" x2="172" y2="155" stroke="url(#grad44a)" stroke-width="5" stroke-linecap="round"/>
+    <line x1="35" y1="40" x2="35" y2="155" stroke="url(#grad44a)" stroke-width="5" stroke-linecap="round"/>
+    <!-- Bar 1 (short) -->
+    <rect x="50" y="125" width="24" height="30" rx="4" fill="url(#grad44a)"/>
+    <!-- Bar 2 (medium) -->
+    <rect x="84" y="100" width="24" height="55" rx="4" fill="url(#grad44a)"/>
+    <!-- Bar 3 (tall) -->
+    <rect x="118" y="72" width="24" height="83" rx="4" fill="url(#grad44b)"/>
+    <!-- Trend line -->
+    <path d="M62 120 Q96 92 130 68" fill="none" stroke="#22D3EE" stroke-width="4" stroke-linecap="round" stroke-dasharray="6,3"/>
+    <!-- Upward arrow -->
+    <path d="M148 58 L160 38 L172 58" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="160" y1="38" x2="160" y2="72" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <!-- White highlights on tallest bar -->
+    <rect x="121" y="76" width="8" height="12" rx="3" fill="white" opacity="0.25"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Manage_Appointment.svg
+++ b/src/main/webapp/resources/icons/Manage_Appointment.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad8a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad8" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad8)">
+    <!-- Calendar body -->
+    <rect x="35" y="48" width="130" height="110" rx="8" fill="url(#grad8a)"/>
+    <rect x="35" y="48" width="130" height="30" rx="8" fill="#155E75"/>
+    <rect x="35" y="65" width="130" height="13" fill="#155E75"/>
+    <!-- Binding tabs -->
+    <rect x="60" y="38" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
+    <rect x="130" y="38" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
+    <!-- Calendar rows -->
+    <line x1="35" y1="98" x2="165" y2="98" stroke="white" stroke-width="0.8" opacity="0.25"/>
+    <line x1="35" y1="118" x2="165" y2="118" stroke="white" stroke-width="0.8" opacity="0.25"/>
+    <line x1="35" y1="138" x2="165" y2="138" stroke="white" stroke-width="0.8" opacity="0.25"/>
+    <!-- Day cells with checkmarks -->
+    <rect x="50" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
+    <rect x="78" y="104" width="18" height="14" rx="3" fill="#22D3EE"/>
+    <rect x="106" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
+    <rect x="134" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
+    <!-- Checkmark on highlighted cell -->
+    <path d="M81 111 L85 115 L91 108" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Large checkmark overlay -->
+    <circle cx="148" cy="148" r="22" fill="white"/>
+    <circle cx="148" cy="148" r="18" fill="#22D3EE"/>
+    <path d="M137 148 L145 156 L160 140" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Nursing_Work_Bench.svg
+++ b/src/main/webapp/resources/icons/Nursing_Work_Bench.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad45a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad45" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad45)">
+    <!-- Nurse cap (top) -->
+    <path d="M62 72 Q100 42 138 72 L130 85 Q100 70 70 85 Z" fill="url(#grad45a)"/>
+    <!-- Red cross on nurse cap -->
+    <rect x="92" y="52" width="16" height="6" rx="3" fill="#22D3EE"/>
+    <rect x="97" y="47" width="6" height="16" rx="3" fill="#22D3EE"/>
+    <!-- Clipboard (below hat) -->
+    <rect x="52" y="95" width="96" height="90" rx="7" fill="url(#grad45a)"/>
+    <!-- Clipboard top clip -->
+    <rect x="78" y="85" width="44" height="20" rx="5" fill="#155E75"/>
+    <rect x="86" y="87" width="28" height="13" rx="3" fill="url(#grad45a)"/>
+    <!-- Lines on clipboard -->
+    <rect x="64" y="115" width="72" height="5" rx="2" fill="white" opacity="0.75"/>
+    <rect x="64" y="128" width="58" height="5" rx="2" fill="white" opacity="0.55"/>
+    <rect x="64" y="141" width="65" height="5" rx="2" fill="white" opacity="0.55"/>
+    <rect x="64" y="154" width="50" height="5" rx="2" fill="white" opacity="0.55"/>
+    <!-- Medical cross badge bottom-right -->
+    <circle cx="148" cy="168" r="16" fill="white"/>
+    <circle cx="148" cy="168" r="13" fill="#22D3EE"/>
+    <rect x="141" y="165" width="14" height="6" rx="3" fill="white"/>
+    <rect x="145" y="161" width="6" height="14" rx="3" fill="white"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Patient_Lookup_Registration.svg
+++ b/src/main/webapp/resources/icons/Patient_Lookup_Registration.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad6a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad6" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad6)">
+    <!-- Person silhouette -->
+    <circle cx="80" cy="78" r="22" fill="url(#grad6a)"/>
+    <path d="M55 108 Q80 96 105 108 L108 148 Q108 154 103 154 L57 154 Q52 154 52 148 Z" fill="url(#grad6a)"/>
+    <!-- White highlight on head -->
+    <circle cx="72" cy="71" r="7" fill="white" opacity="0.2"/>
+    <!-- Magnifying glass overlapping -->
+    <circle cx="135" cy="95" r="30" fill="none" stroke="url(#grad6a)" stroke-width="11"/>
+    <circle cx="135" cy="95" r="19" fill="#F0FDFA"/>
+    <!-- Person inside magnifier (small) -->
+    <circle cx="135" cy="88" r="7" fill="#22D3EE"/>
+    <path d="M124 100 Q135 95 146 100 L147 107 Q147 110 144 110 L126 110 Q123 110 123 107 Z" fill="#22D3EE"/>
+    <!-- Handle -->
+    <line x1="157" y1="117" x2="172" y2="132" stroke="url(#grad6a)" stroke-width="11" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Request_Medicines_From_Pharmacy.svg
+++ b/src/main/webapp/resources/icons/Request_Medicines_From_Pharmacy.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad23a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad23" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad23)">
+    <!-- Pill bottle -->
+    <rect x="55" y="75" width="60" height="90" rx="8" fill="url(#grad23a)"/>
+    <!-- Bottle cap -->
+    <rect x="50" y="58" width="70" height="22" rx="6" fill="#155E75"/>
+    <!-- Bottle label -->
+    <rect x="60" y="95" width="50" height="52" rx="5" fill="white" opacity="0.85"/>
+    <!-- Medical cross on label -->
+    <rect x="77" y="108" width="16" height="6" rx="3" fill="#22D3EE"/>
+    <rect x="82" y="103" width="6" height="16" rx="3" fill="#22D3EE"/>
+    <!-- Pills inside visible area -->
+    <ellipse cx="75" cy="80" rx="8" ry="5" fill="#22D3EE" opacity="0.7"/>
+    <ellipse cx="93" cy="80" rx="8" ry="5" fill="#22D3EE" opacity="0.7"/>
+    <!-- Arrow pointing right -->
+    <rect x="122" y="107" width="48" height="12" rx="6" fill="#22D3EE"/>
+    <polygon points="158,95 176,113 158,131" fill="#22D3EE"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Room_Change.svg
+++ b/src/main/webapp/resources/icons/Room_Change.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad13a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad13" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad13)">
+    <!-- Bed 1 (left, smaller) -->
+    <rect x="15" y="115" width="70" height="45" rx="5" fill="url(#grad13a)" opacity="0.7"/>
+    <rect x="15" y="108" width="10" height="52" rx="4" fill="#155E75" opacity="0.7"/>
+    <rect x="77" y="115" width="8" height="45" rx="4" fill="#155E75" opacity="0.7"/>
+    <rect x="20" y="119" width="50" height="36" rx="3" fill="white" opacity="0.6"/>
+    <rect x="22" y="122" width="20" height="18" rx="4" fill="#22D3EE" opacity="0.6"/>
+    <!-- Bed 2 (right, smaller) -->
+    <rect x="115" y="115" width="70" height="45" rx="5" fill="url(#grad13a)"/>
+    <rect x="115" y="108" width="10" height="52" rx="4" fill="#155E75"/>
+    <rect x="177" y="115" width="8" height="45" rx="4" fill="#155E75"/>
+    <rect x="120" y="119" width="50" height="36" rx="3" fill="white" opacity="0.8"/>
+    <rect x="122" y="122" width="20" height="18" rx="4" fill="#22D3EE" opacity="0.8"/>
+    <!-- Transfer arrows between beds -->
+    <path d="M89 125 Q100 115 111 125" fill="none" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <polygon points="107,118 114,125 106,129" fill="#22D3EE"/>
+    <path d="M111 143 Q100 153 89 143" fill="none" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <polygon points="93,150 86,143 94,139" fill="#22D3EE"/>
+    <!-- Person being moved (above arrows) -->
+    <circle cx="100" cy="78" r="14" fill="url(#grad13a)"/>
+    <path d="M87 98 Q100 92 113 98 L114 112 Q114 117 110 117 L90 117 Q86 117 86 112 Z" fill="url(#grad13a)"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Room_Occupancy.svg
+++ b/src/main/webapp/resources/icons/Room_Occupancy.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad10a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad10" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad10)">
+    <!-- Bed frame -->
+    <rect x="25" y="105" width="150" height="65" rx="6" fill="url(#grad10a)"/>
+    <!-- Mattress -->
+    <rect x="32" y="111" width="136" height="52" rx="4" fill="white" opacity="0.85"/>
+    <!-- Headboard -->
+    <rect x="25" y="95" width="16" height="75" rx="5" fill="#155E75"/>
+    <!-- Footboard -->
+    <rect x="159" y="105" width="16" height="65" rx="5" fill="#155E75"/>
+    <!-- Pillow -->
+    <rect x="36" y="116" width="32" height="26" rx="6" fill="#22D3EE" opacity="0.9"/>
+    <!-- Patient lying in bed (person under covers) -->
+    <!-- Head (on pillow area) -->
+    <circle cx="52" cy="107" r="13" fill="url(#grad10a)"/>
+    <circle cx="47" cy="103" r="4" fill="white" opacity="0.2"/>
+    <!-- Body under blanket -->
+    <rect x="68" y="115" width="95" height="36" rx="8" fill="url(#grad10a)" opacity="0.7"/>
+    <!-- Blanket fold line -->
+    <line x1="68" y1="124" x2="163" y2="124" stroke="white" stroke-width="2" opacity="0.5"/>
+    <!-- IV stand -->
+    <line x1="155" y1="55" x2="155" y2="108" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <line x1="140" y1="55" x2="170" y2="55" stroke="#22D3EE" stroke-width="4" stroke-linecap="round"/>
+    <rect x="148" y="58" width="14" height="22" rx="5" fill="#F0FDFA" stroke="#22D3EE" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Room_Reservations.svg
+++ b/src/main/webapp/resources/icons/Room_Reservations.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad9a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad9" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad9)">
+    <!-- Calendar small top-left -->
+    <rect x="28" y="35" width="80" height="68" rx="6" fill="url(#grad9a)"/>
+    <rect x="28" y="35" width="80" height="20" rx="6" fill="#155E75"/>
+    <rect x="28" y="47" width="80" height="8" fill="#155E75"/>
+    <rect x="43" y="28" width="8" height="16" rx="4" fill="white" opacity="0.9"/>
+    <rect x="77" y="28" width="8" height="16" rx="4" fill="white" opacity="0.9"/>
+    <rect x="36" y="60" width="10" height="8" rx="2" fill="white" opacity="0.6"/>
+    <rect x="52" y="60" width="10" height="8" rx="2" fill="#22D3EE"/>
+    <rect x="68" y="60" width="10" height="8" rx="2" fill="white" opacity="0.6"/>
+    <rect x="84" y="60" width="10" height="8" rx="2" fill="white" opacity="0.6"/>
+    <rect x="36" y="74" width="10" height="8" rx="2" fill="white" opacity="0.6"/>
+    <rect x="52" y="74" width="10" height="8" rx="2" fill="white" opacity="0.6"/>
+    <!-- Bed (bottom-right) -->
+    <!-- Frame -->
+    <rect x="78" y="110" width="95" height="60" rx="5" fill="url(#grad9a)"/>
+    <!-- Mattress -->
+    <rect x="83" y="115" width="85" height="45" rx="4" fill="white" opacity="0.85"/>
+    <!-- Pillow -->
+    <rect x="88" y="119" width="28" height="22" rx="5" fill="#22D3EE" opacity="0.85"/>
+    <!-- Headboard -->
+    <rect x="78" y="105" width="12" height="65" rx="4" fill="#155E75"/>
+    <!-- Footboard -->
+    <rect x="163" y="110" width="10" height="60" rx="4" fill="#155E75"/>
+    <!-- Sheet lines -->
+    <line x1="120" y1="118" x2="160" y2="118" stroke="#0E7490" stroke-width="1.5" opacity="0.3"/>
+    <line x1="120" y1="128" x2="160" y2="128" stroke="#0E7490" stroke-width="1.5" opacity="0.3"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Room_Vacancy.svg
+++ b/src/main/webapp/resources/icons/Room_Vacancy.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad11a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad11" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad11)">
+    <!-- Empty bed frame outline -->
+    <rect x="25" y="105" width="150" height="65" rx="6" fill="none" stroke="url(#grad11a)" stroke-width="7"/>
+    <!-- Mattress outline -->
+    <rect x="35" y="113" width="130" height="49" rx="4" fill="#F0FDFA" stroke="#0E7490" stroke-width="2" opacity="0.7"/>
+    <!-- Headboard -->
+    <rect x="25" y="95" width="16" height="75" rx="5" fill="url(#grad11a)"/>
+    <!-- Footboard -->
+    <rect x="159" y="105" width="16" height="65" rx="5" fill="url(#grad11a)"/>
+    <!-- Empty pillow outline -->
+    <rect x="38" y="117" width="34" height="26" rx="6" fill="none" stroke="#22D3EE" stroke-width="3" stroke-dasharray="4,3"/>
+    <!-- Sheet wrinkle lines (empty bed) -->
+    <line x1="80" y1="120" x2="155" y2="120" stroke="#0E7490" stroke-width="2" opacity="0.3"/>
+    <line x1="80" y1="130" x2="155" y2="130" stroke="#0E7490" stroke-width="2" opacity="0.3"/>
+    <line x1="80" y1="140" x2="155" y2="140" stroke="#0E7490" stroke-width="2" opacity="0.3"/>
+    <!-- "Available" indicator - green-ish cyan circle top -->
+    <circle cx="100" cy="68" r="22" fill="url(#grad11a)"/>
+    <path d="M88 68 L96 76 L113 60" fill="none" stroke="#22D3EE" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Admissions.svg
+++ b/src/main/webapp/resources/icons/Search_Admissions.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad3a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad3" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad3)">
+    <!-- Patient list / document -->
+    <rect x="40" y="48" width="90" height="115" rx="6" fill="url(#grad3a)"/>
+    <rect x="48" y="68" width="74" height="5" rx="2" fill="white" opacity="0.8"/>
+    <rect x="48" y="82" width="60" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="48" y="96" width="68" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="48" y="110" width="55" height="5" rx="2" fill="white" opacity="0.6"/>
+    <rect x="48" y="124" width="64" height="5" rx="2" fill="white" opacity="0.6"/>
+    <!-- Patient icon on document -->
+    <circle cx="63" cy="57" r="7" fill="#22D3EE"/>
+    <path d="M55 68 Q63 62 71 68" fill="#22D3EE" opacity="0.7"/>
+    <!-- Magnifying glass -->
+    <circle cx="138" cy="138" r="26" fill="none" stroke="url(#grad3a)" stroke-width="10"/>
+    <circle cx="138" cy="138" r="16" fill="#F0FDFA"/>
+    <line x1="158" y1="158" x2="172" y2="172" stroke="url(#grad3a)" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="138" cy="138" r="8" fill="url(#grad3a)" opacity="0.3"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Estimated_Professional_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Estimated_Professional_Bill.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad39a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad39" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad39)">
+    <!-- Magnifying glass (left) -->
+    <circle cx="72" cy="78" r="42" fill="none" stroke="url(#grad39a)" stroke-width="11"/>
+    <circle cx="72" cy="78" r="31" fill="#F0FDFA"/>
+    <!-- Stethoscope inside -->
+    <circle cx="63" cy="78" r="11" fill="url(#grad39a)"/>
+    <circle cx="63" cy="78" r="7" fill="#F0FDFA"/>
+    <path d="M72 78 Q83 78 83 68 Q83 58 90 56" fill="none" stroke="url(#grad39a)" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="87" cy="54" r="4" fill="url(#grad39a)"/>
+    <circle cx="94" cy="54" r="4" fill="url(#grad39a)"/>
+    <line x1="87" y1="54" x2="94" y2="54" stroke="url(#grad39a)" stroke-width="3.5"/>
+    <!-- Handle -->
+    <line x1="105" y1="111" x2="122" y2="128" stroke="url(#grad39a)" stroke-width="11" stroke-linecap="round"/>
+    <!-- Clock (right) -->
+    <circle cx="152" cy="145" r="34" fill="white"/>
+    <circle cx="152" cy="145" r="30" fill="url(#grad39a)"/>
+    <circle cx="152" cy="145" r="22" fill="none" stroke="#22D3EE" stroke-width="2"/>
+    <line x1="152" y1="145" x2="152" y2="127" stroke="white" stroke-width="3.5" stroke-linecap="round"/>
+    <line x1="152" y1="145" x2="165" y2="153" stroke="#22D3EE" stroke-width="3.5" stroke-linecap="round"/>
+    <circle cx="152" cy="145" r="3.5" fill="white"/>
+    <line x1="152" y1="117" x2="152" y2="121" stroke="white" stroke-width="2"/>
+    <line x1="152" y1="169" x2="152" y2="173" stroke="white" stroke-width="2"/>
+    <line x1="124" y1="145" x2="128" y2="145" stroke="white" stroke-width="2"/>
+    <line x1="176" y1="145" x2="180" y2="145" stroke="white" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Final_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Final_Bill.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad41a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad41" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad41)">
+    <!-- Final bill paper with checkmark -->
+    <rect x="22" y="35" width="95" height="125" rx="6" fill="url(#grad41a)"/>
+    <rect x="22" y="35" width="95" height="22" rx="6" fill="#155E75"/>
+    <rect x="22" y="48" width="95" height="9" fill="#155E75"/>
+    <rect x="32" y="66" width="75" height="4" rx="2" fill="white" opacity="0.7"/>
+    <rect x="32" y="78" width="62" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="88" width="68" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="98" width="55" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="32" y="108" width="72" height="4" rx="2" fill="white" opacity="0.5"/>
+    <!-- Final / approved total row -->
+    <rect x="32" y="120" width="75" height="20" rx="5" fill="#22D3EE" opacity="0.9"/>
+    <!-- Large checkmark on paper -->
+    <circle cx="88" cy="148" r="14" fill="white"/>
+    <circle cx="88" cy="148" r="11" fill="#22D3EE"/>
+    <path d="M80 148 L86 154 L97 141" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Magnifying glass -->
+    <circle cx="150" cy="125" r="36" fill="none" stroke="url(#grad41a)" stroke-width="12"/>
+    <circle cx="150" cy="125" r="24" fill="#F0FDFA"/>
+    <circle cx="150" cy="125" r="13" fill="url(#grad41a)" opacity="0.2"/>
+    <line x1="172" y1="147" x2="183" y2="158" stroke="url(#grad41a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Final_Bill_By_Discharge_Date.svg
+++ b/src/main/webapp/resources/icons/Search_Final_Bill_By_Discharge_Date.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad42a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad42" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad42)">
+    <!-- Paper/bill (top-left) -->
+    <rect x="18" y="25" width="75" height="90" rx="5" fill="url(#grad42a)"/>
+    <rect x="18" y="25" width="75" height="18" rx="5" fill="#155E75"/>
+    <rect x="18" y="36" width="75" height="7" fill="#155E75"/>
+    <rect x="27" y="52" width="57" height="4" rx="2" fill="white" opacity="0.7"/>
+    <rect x="27" y="62" width="46" height="3" rx="2" fill="white" opacity="0.5"/>
+    <rect x="27" y="71" width="52" height="3" rx="2" fill="white" opacity="0.5"/>
+    <rect x="27" y="80" width="40" height="3" rx="2" fill="white" opacity="0.5"/>
+    <rect x="27" y="90" width="57" height="12" rx="3" fill="#22D3EE" opacity="0.85"/>
+    <!-- Checkmark on paper -->
+    <circle cx="76" cy="104" r="11" fill="white"/>
+    <circle cx="76" cy="104" r="8" fill="#22D3EE"/>
+    <path d="M69 104 L74 109 L83 98" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Calendar (middle) -->
+    <rect x="75" y="95" width="65" height="55" rx="5" fill="url(#grad42a)"/>
+    <rect x="75" y="95" width="65" height="18" rx="5" fill="#155E75"/>
+    <rect x="75" y="106" width="65" height="7" fill="#155E75"/>
+    <rect x="84" y="88" width="7" height="14" rx="3" fill="white" opacity="0.9"/>
+    <rect x="122" y="88" width="7" height="14" rx="3" fill="white" opacity="0.9"/>
+    <rect x="82" y="120" width="10" height="8" rx="2" fill="white" opacity="0.7"/>
+    <rect x="98" y="120" width="10" height="8" rx="2" fill="#22D3EE"/>
+    <rect x="114" y="120" width="10" height="8" rx="2" fill="white" opacity="0.7"/>
+    <rect x="82" y="134" width="10" height="8" rx="2" fill="white" opacity="0.7"/>
+    <rect x="98" y="134" width="10" height="8" rx="2" fill="white" opacity="0.7"/>
+    <!-- Magnifying glass -->
+    <circle cx="152" cy="150" r="32" fill="none" stroke="url(#grad42a)" stroke-width="11"/>
+    <circle cx="152" cy="150" r="21" fill="#F0FDFA"/>
+    <circle cx="152" cy="150" r="11" fill="url(#grad42a)" opacity="0.2"/>
+    <line x1="170" y1="168" x2="180" y2="178" stroke="url(#grad42a)" stroke-width="11" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Professional_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Professional_Bill.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad38a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad38" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad38)">
+    <!-- Magnifying glass -->
+    <circle cx="82" cy="82" r="50" fill="none" stroke="url(#grad38a)" stroke-width="13"/>
+    <circle cx="82" cy="82" r="37" fill="#F0FDFA"/>
+    <!-- Stethoscope inside magnifier -->
+    <circle cx="72" cy="82" r="14" fill="url(#grad38a)"/>
+    <circle cx="72" cy="82" r="9" fill="#F0FDFA"/>
+    <circle cx="72" cy="82" r="4" fill="url(#grad38a)" opacity="0.5"/>
+    <path d="M82 82 Q96 82 96 70 Q96 58 105 56" fill="none" stroke="url(#grad38a)" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="101" cy="54" r="5" fill="url(#grad38a)"/>
+    <circle cx="109" cy="54" r="5" fill="url(#grad38a)"/>
+    <line x1="101" y1="54" x2="109" y2="54" stroke="url(#grad38a)" stroke-width="4"/>
+    <!-- Handle -->
+    <line x1="120" y1="120" x2="148" y2="148" stroke="url(#grad38a)" stroke-width="13" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Provisional_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Provisional_Bill.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad40a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad40" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad40)">
+    <!-- Draft/provisional paper (dashed border) -->
+    <rect x="25" y="35" width="95" height="120" rx="6" fill="url(#grad40a)" opacity="0.85"/>
+    <rect x="30" y="40" width="85" height="110" rx="4" fill="none" stroke="white" stroke-width="2.5" stroke-dasharray="6,4" opacity="0.7"/>
+    <!-- Draft lines -->
+    <rect x="40" y="58" width="65" height="5" rx="2" fill="white" opacity="0.7"/>
+    <rect x="40" y="72" width="52" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="40" y="84" width="58" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="40" y="96" width="45" height="4" rx="2" fill="white" opacity="0.5"/>
+    <rect x="40" y="108" width="55" height="4" rx="2" fill="white" opacity="0.5"/>
+    <!-- Diagonal "draft" pattern on paper -->
+    <line x1="25" y1="75" x2="55" y2="35" stroke="white" stroke-width="1" opacity="0.12"/>
+    <line x1="25" y1="105" x2="85" y2="35" stroke="white" stroke-width="1" opacity="0.12"/>
+    <line x1="25" y1="135" x2="115" y2="35" stroke="white" stroke-width="1" opacity="0.12"/>
+    <line x1="35" y1="155" x2="120" y2="55" stroke="white" stroke-width="1" opacity="0.12"/>
+    <!-- Total row dashed -->
+    <rect x="40" y="122" width="65" height="18" rx="4" fill="none" stroke="#22D3EE" stroke-width="2" stroke-dasharray="4,3"/>
+    <!-- Magnifying glass -->
+    <circle cx="148" cy="130" r="38" fill="none" stroke="url(#grad40a)" stroke-width="12"/>
+    <circle cx="148" cy="130" r="26" fill="#F0FDFA"/>
+    <circle cx="148" cy="130" r="13" fill="url(#grad40a)" opacity="0.2"/>
+    <line x1="170" y1="152" x2="183" y2="165" stroke="url(#grad40a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Service_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Service_Bill.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad37a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad37" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad37)">
+    <!-- Magnifying glass -->
+    <circle cx="85" cy="85" r="52" fill="none" stroke="url(#grad37a)" stroke-width="13"/>
+    <circle cx="85" cy="85" r="39" fill="#F0FDFA"/>
+    <!-- Wrench / service tool inside magnifier -->
+    <g transform="rotate(45 85 85)">
+      <rect x="79" y="60" width="12" height="50" rx="4" fill="url(#grad37a)"/>
+      <circle cx="85" cy="62" r="12" fill="url(#grad37a)"/>
+      <circle cx="85" cy="62" r="6" fill="#F0FDFA"/>
+      <circle cx="85" cy="108" r="12" fill="url(#grad37a)"/>
+      <circle cx="85" cy="108" r="6" fill="#F0FDFA"/>
+    </g>
+    <!-- Handle -->
+    <line x1="124" y1="124" x2="150" y2="150" stroke="url(#grad37a)" stroke-width="13" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/View_Pharmacy_Requests.svg
+++ b/src/main/webapp/resources/icons/View_Pharmacy_Requests.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad24a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad24" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad24)">
+    <!-- Pill bottle (left) -->
+    <rect x="35" y="75" width="55" height="85" rx="7" fill="url(#grad24a)"/>
+    <rect x="30" y="58" width="65" height="21" rx="6" fill="#155E75"/>
+    <rect x="40" y="93" width="45" height="48" rx="4" fill="white" opacity="0.82"/>
+    <!-- Cross on bottle -->
+    <rect x="53" y="107" width="14" height="5" rx="2" fill="#22D3EE"/>
+    <rect x="57" y="103" width="5" height="14" rx="2" fill="#22D3EE"/>
+    <!-- Magnifying glass (right) -->
+    <circle cx="138" cy="105" r="40" fill="none" stroke="url(#grad24a)" stroke-width="12"/>
+    <circle cx="138" cy="105" r="28" fill="#F0FDFA"/>
+    <!-- Pill inside magnifier -->
+    <rect x="118" y="100" width="40" height="14" rx="7" fill="url(#grad24a)" opacity="0.8"/>
+    <line x1="138" y1="100" x2="138" y2="114" stroke="white" stroke-width="2"/>
+    <!-- Handle -->
+    <line x1="166" y1="133" x2="178" y2="145" stroke="url(#grad24a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/direct_issue_to_BHTs.svg
+++ b/src/main/webapp/resources/icons/direct_issue_to_BHTs.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad25a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad25" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad25)">
+    <!-- Capsule pill (large, left) -->
+    <rect x="28" y="88" width="90" height="34" rx="17" fill="url(#grad25a)"/>
+    <rect x="28" y="88" width="45" height="34" rx="17" fill="#22D3EE"/>
+    <line x1="73" y1="88" x2="73" y2="122" stroke="white" stroke-width="2"/>
+    <!-- Arrow pointing right (to bed) -->
+    <line x1="124" y1="105" x2="148" y2="105" stroke="#22D3EE" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="143,96 155,105 143,114" fill="#22D3EE"/>
+    <!-- Bed silhouette (right) -->
+    <rect x="125" y="125" width="52" height="35" rx="5" fill="url(#grad25a)"/>
+    <rect x="125" y="118" width="9" height="42" rx="4" fill="#155E75"/>
+    <rect x="168" y="125" width="9" height="35" rx="4" fill="#155E75"/>
+    <rect x="130" y="129" width="38" height="25" rx="3" fill="white" opacity="0.8"/>
+    <rect x="132" y="132" width="15" height="12" rx="4" fill="#22D3EE" opacity="0.8"/>
+    <!-- BHT label lines -->
+    <rect x="28" y="135" width="85" height="5" rx="2" fill="url(#grad25a)" opacity="0.5"/>
+    <rect x="28" y="145" width="65" height="5" rx="2" fill="url(#grad25a)" opacity="0.4"/>
+    <rect x="28" y="155" width="75" height="5" rx="2" fill="url(#grad25a)" opacity="0.4"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/direct_issue_to_BHTs_native.svg
+++ b/src/main/webapp/resources/icons/direct_issue_to_BHTs_native.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad26a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad26" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad26)">
+    <!-- Capsule pill -->
+    <rect x="25" y="82" width="88" height="32" rx="16" fill="url(#grad26a)"/>
+    <rect x="25" y="82" width="44" height="32" rx="16" fill="#22D3EE"/>
+    <line x1="69" y1="82" x2="69" y2="114" stroke="white" stroke-width="2"/>
+    <!-- Lightning bolt (fast/native) -->
+    <polygon points="118,40 98,105 113,105 93,165 140,85 122,85 145,40" fill="#22D3EE"/>
+    <polygon points="118,40 98,105 113,105 93,165 140,85 122,85 145,40" fill="none" stroke="url(#grad26a)" stroke-width="2"/>
+    <!-- Bed small (bottom-right) -->
+    <rect x="115" y="135" width="55" height="35" rx="5" fill="url(#grad26a)"/>
+    <rect x="115" y="128" width="9" height="42" rx="4" fill="#155E75"/>
+    <rect x="161" y="135" width="9" height="35" rx="4" fill="#155E75"/>
+    <rect x="120" y="139" width="39" height="25" rx="3" fill="white" opacity="0.8"/>
+    <rect x="122" y="141" width="14" height="12" rx="4" fill="#22D3EE" opacity="0.8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/direct_issue_to_theatre.svg
+++ b/src/main/webapp/resources/icons/direct_issue_to_theatre.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad27a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad27" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad27)">
+    <!-- Capsule pill (top-left) -->
+    <rect x="20" y="55" width="80" height="28" rx="14" fill="url(#grad27a)"/>
+    <rect x="20" y="55" width="40" height="28" rx="14" fill="#22D3EE"/>
+    <line x1="60" y1="55" x2="60" y2="83" stroke="white" stroke-width="2"/>
+    <!-- Arrow -->
+    <line x1="105" y1="69" x2="125" y2="69" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="120,62 128,69 120,76" fill="#22D3EE"/>
+    <!-- Scalpel / surgical blade -->
+    <g transform="rotate(-35 145 125)">
+      <!-- Handle -->
+      <rect x="133" y="88" width="10" height="50" rx="3" fill="url(#grad27a)"/>
+      <!-- Blade -->
+      <path d="M133 88 L143 88 L155 70 L148 65 Z" fill="url(#grad27a)"/>
+      <path d="M143 88 L155 70 L148 65 L138 80 Z" fill="#22D3EE" opacity="0.8"/>
+      <!-- Blade shine -->
+      <line x1="142" y1="87" x2="153" y2="69" stroke="white" stroke-width="1.5" opacity="0.6"/>
+    </g>
+    <!-- Theatre cross -->
+    <rect x="28" y="105" width="65" height="65" rx="6" fill="url(#grad27a)" opacity="0.2"/>
+    <rect x="42" y="105" width="65" height="65" rx="6" fill="none" stroke="url(#grad27a)" stroke-width="3" opacity="0.6"/>
+    <rect x="55" y="120" width="32" height="10" rx="4" fill="url(#grad27a)"/>
+    <rect x="66" y="110" width="10" height="30" rx="4" fill="url(#grad27a)"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/search_inpatint_direct_issue_by_bill.svg
+++ b/src/main/webapp/resources/icons/search_inpatint_direct_issue_by_bill.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad29a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad29" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad29)">
+    <!-- Receipt/bill -->
+    <rect x="30" y="38" width="88" height="120" rx="5" fill="url(#grad29a)"/>
+    <path d="M30 150 L41 140 L52 150 L63 140 L74 150 L85 140 L96 150 L107 140 L118 150 L118 158 L30 158 Z" fill="url(#grad29a)"/>
+    <rect x="40" y="52" width="68" height="5" rx="2" fill="white" opacity="0.8"/>
+    <line x1="40" y1="66" x2="108" y2="66" stroke="white" stroke-width="1" opacity="0.3"/>
+    <rect x="40" y="72" width="48" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="40" y="84" width="55" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="40" y="96" width="45" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="40" y="108" width="52" height="4" rx="2" fill="white" opacity="0.55"/>
+    <line x1="40" y1="120" x2="108" y2="120" stroke="white" stroke-width="1" opacity="0.3"/>
+    <rect x="40" y="126" width="68" height="5" rx="2" fill="#22D3EE" opacity="0.9"/>
+    <!-- Magnifying glass -->
+    <circle cx="147" cy="125" r="35" fill="none" stroke="url(#grad29a)" stroke-width="11"/>
+    <circle cx="147" cy="125" r="24" fill="#F0FDFA"/>
+    <circle cx="147" cy="125" r="12" fill="url(#grad29a)" opacity="0.25"/>
+    <line x1="170" y1="148" x2="182" y2="160" stroke="url(#grad29a)" stroke-width="11" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/search_inpatint_direct_issue_by_item.svg
+++ b/src/main/webapp/resources/icons/search_inpatint_direct_issue_by_item.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad30a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad30" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad30)">
+    <!-- Magnifying glass (large, center) -->
+    <circle cx="90" cy="90" r="55" fill="none" stroke="url(#grad30a)" stroke-width="13"/>
+    <circle cx="90" cy="90" r="42" fill="#F0FDFA"/>
+    <!-- Pill inside magnifier -->
+    <rect x="62" y="83" width="56" height="20" rx="10" fill="url(#grad30a)"/>
+    <rect x="62" y="83" width="28" height="20" rx="10" fill="#22D3EE"/>
+    <line x1="90" y1="83" x2="90" y2="103" stroke="white" stroke-width="2"/>
+    <!-- Handle -->
+    <line x1="132" y1="132" x2="156" y2="156" stroke="url(#grad30a)" stroke-width="13" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/search_inpatint_direct_issue_returns_by_bill.svg
+++ b/src/main/webapp/resources/icons/search_inpatint_direct_issue_returns_by_bill.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad31a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad31" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad31)">
+    <!-- Receipt/bill (left) -->
+    <rect x="22" y="38" width="80" height="105" rx="5" fill="url(#grad31a)"/>
+    <path d="M22 136 L31 126 L40 136 L49 126 L58 136 L67 126 L76 136 L85 126 L94 136 L102 126 L102 143 L22 143 Z" fill="url(#grad31a)"/>
+    <rect x="32" y="52" width="60" height="4" rx="2" fill="white" opacity="0.8"/>
+    <rect x="32" y="64" width="48" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="32" y="76" width="55" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="32" y="88" width="44" height="4" rx="2" fill="white" opacity="0.55"/>
+    <rect x="32" y="100" width="60" height="4" rx="2" fill="#22D3EE" opacity="0.9"/>
+    <!-- Return arrow (curved) -->
+    <path d="M106 100 Q130 80 152 100" fill="none" stroke="#22D3EE" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="147,92 155,100 146,106" fill="#22D3EE"/>
+    <path d="M106 115 Q130 135 152 115" fill="none" stroke="#22D3EE" stroke-width="6" stroke-linecap="round"/>
+    <polygon points="109,107 102,115 111,120" fill="#22D3EE"/>
+    <!-- Magnifying glass (right) -->
+    <circle cx="152" cy="150" r="28" fill="none" stroke="url(#grad31a)" stroke-width="9"/>
+    <circle cx="152" cy="150" r="19" fill="#F0FDFA"/>
+    <circle cx="152" cy="150" r="10" fill="url(#grad31a)" opacity="0.25"/>
+    <line x1="170" y1="168" x2="180" y2="178" stroke="url(#grad31a)" stroke-width="9" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/search_inpatint_direct_issue_returns_by_item.svg
+++ b/src/main/webapp/resources/icons/search_inpatint_direct_issue_returns_by_item.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad32a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad32" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
+  <g filter="url(#shad32)">
+    <!-- Pill (left) -->
+    <rect x="22" y="78" width="80" height="28" rx="14" fill="url(#grad32a)"/>
+    <rect x="22" y="78" width="40" height="28" rx="14" fill="#22D3EE"/>
+    <line x1="62" y1="78" x2="62" y2="106" stroke="white" stroke-width="2"/>
+    <!-- Return arrow -->
+    <path d="M106 85 Q130 65 152 85" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="147,77 155,85 146,91" fill="#22D3EE"/>
+    <path d="M106 115 Q130 135 152 115" fill="none" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+    <polygon points="109,107 101,115 110,120" fill="#22D3EE"/>
+    <!-- Magnifying glass (bottom) -->
+    <circle cx="100" cy="155" r="30" fill="none" stroke="url(#grad32a)" stroke-width="10"/>
+    <circle cx="100" cy="155" r="20" fill="#F0FDFA"/>
+    <!-- Mini pill inside magnifier -->
+    <rect x="84" y="150" width="32" height="11" rx="5" fill="url(#grad32a)" opacity="0.7"/>
+    <rect x="84" y="150" width="16" height="11" rx="5" fill="#22D3EE" opacity="0.7"/>
+    <line x1="127" y1="178" x2="138" y2="189" stroke="url(#grad32a)" stroke-width="10" stroke-linecap="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Added 5 missing `Icon` enum values for inward menu items that previously could not be assigned to User Icons
- Updated `Icon.getImage()` to return `.svg` for all inpatient `IconGroup`s rather than relying on ordinal position
- Added 46 teal-themed SVG files covering every inpatient-group icon, including the previously missing `Bed_Board.svg`
- Added 5 new tile handlers in `home.xhtml` for the new icons

## Missing icons added

| Enum value | Group | Menu item |
|---|---|---|
| `Patient_Lookup_Registration` | `INPATIENT_ADMISSIONS` | Patient Lookup & Registration |
| `Initiate_Transfer` | `INPATIENT_ROOMS` | Initiate Transfer |
| `Accept_Patients` | `INPATIENT_ROOMS` | Accept Patients |
| `Accept_Returns_from_Ward` | `INPATIENT_DIRECT_ISSUES` | Accept Returns from Ward |
| `Nursing_Work_Bench` | `INPATIENT_SERVICES` | Nursing WorkBench |

## Colour theme (all 46 SVGs)

| Role | Colour |
|---|---|
| Primary gradient | `#0E7490` → `#155E75` |
| Accent / highlights | `#22D3EE` |
| Background circle | `#F0FDFA` |

## Test plan

- [ ] Open User Icons admin page for an inward user — all 5 new icons appear in the INPATIENT_* tree nodes
- [ ] Assign a new icon (e.g. `Nursing_Work_Bench`) to a test user → home screen tile appears with the teal SVG
- [ ] Verify existing inpatient icons (e.g. `Room_Occupancy`, `Interim_Bill`) now load `.svg` in the user icon bar instead of missing `.png`
- [ ] Confirm `Bed_Board` icon renders correctly in the user icon bar

Closes #21608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded home page menu with new inpatient management options: patient lookup and registration, bed board, patient transfer workflows, patient acceptance, returns from ward processing, and nursing workbench access.
  * Menu items are dynamically displayed based on user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->