### PR TITLE
feat(api): add marginAllowed/discountAllowed flag management endpoints

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/service/ItemFeeDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ItemFeeDTO.java
@@ -18,6 +18,7 @@ public class ItemFeeDTO {
     private double fee;
     private double ffee;
     private boolean discountAllowed;
+    private Boolean marginAllowed;
     private boolean retired;
     private Long institutionId;
     private String institutionName;
@@ -77,6 +78,14 @@ public class ItemFeeDTO {
 
     public void setDiscountAllowed(boolean discountAllowed) {
         this.discountAllowed = discountAllowed;
+    }
+
+    public Boolean getMarginAllowed() {
+        return marginAllowed;
+    }
+
+    public void setMarginAllowed(Boolean marginAllowed) {
+        this.marginAllowed = marginAllowed;
     }
 
     public boolean isRetired() {

--- a/src/main/java/com/divudi/core/data/dto/service/ItemFeeUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ItemFeeUpdateRequestDTO.java
@@ -18,6 +18,7 @@ public class ItemFeeUpdateRequestDTO {
     private Double fee;
     private Double ffee;
     private Boolean discountAllowed;
+    private Boolean marginAllowed;
     private Long institutionId;
     private Long departmentId;
     private Long specialityId;
@@ -28,7 +29,8 @@ public class ItemFeeUpdateRequestDTO {
 
     public boolean isValid() {
         return name != null || feeType != null || fee != null || ffee != null
-                || discountAllowed != null || institutionId != null || departmentId != null
+                || discountAllowed != null || marginAllowed != null
+                || institutionId != null || departmentId != null
                 || specialityId != null || staffId != null;
     }
 
@@ -70,6 +72,14 @@ public class ItemFeeUpdateRequestDTO {
 
     public void setDiscountAllowed(Boolean discountAllowed) {
         this.discountAllowed = discountAllowed;
+    }
+
+    public Boolean getMarginAllowed() {
+        return marginAllowed;
+    }
+
+    public void setMarginAllowed(Boolean marginAllowed) {
+        this.marginAllowed = marginAllowed;
     }
 
     public Long getInstitutionId() {

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -683,9 +683,7 @@ public class ServiceApiService implements Serializable {
         int count = 0;
         Map<String, Object> changes = new HashMap<>();
         changes.put("categoryId", categoryId);
-        if (feeType != null) {
-            changes.put("feeType", feeType.name());
-        }
+        changes.put("feeType", feeType != null ? feeType.name() : "ALL_TYPES");
         if (marginAllowed != null) {
             changes.put("marginAllowed", marginAllowed);
         }

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -660,7 +660,7 @@ public class ServiceApiService implements Serializable {
             throw new Exception("At least one of marginAllowed or discountAllowed must be provided");
         }
 
-        FeeType feeType = FeeType.OwnInstitution;
+        FeeType feeType = null;
         if (feeTypeStr != null && !feeTypeStr.trim().isEmpty()) {
             try {
                 feeType = FeeType.valueOf(feeTypeStr.trim());
@@ -669,19 +669,23 @@ public class ServiceApiService implements Serializable {
             }
         }
 
-        String jpql = "SELECT f FROM ItemFee f "
+        StringBuilder jpqlBuilder = new StringBuilder("SELECT f FROM ItemFee f "
                 + "WHERE f.item.category.id = :catId "
-                + "AND f.feeType = :ft "
-                + "AND f.retired = false";
+                + "AND f.retired = false");
         Map<String, Object> params = new HashMap<>();
         params.put("catId", categoryId);
-        params.put("ft", feeType);
+        if (feeType != null) {
+            jpqlBuilder.append(" AND f.feeType = :ft");
+            params.put("ft", feeType);
+        }
 
-        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql, params);
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpqlBuilder.toString(), params);
         int count = 0;
         Map<String, Object> changes = new HashMap<>();
         changes.put("categoryId", categoryId);
-        changes.put("feeType", feeType.name());
+        if (feeType != null) {
+            changes.put("feeType", feeType.name());
+        }
         if (marginAllowed != null) {
             changes.put("marginAllowed", marginAllowed);
         }

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -34,6 +34,7 @@ import com.divudi.core.facade.ServiceFacade;
 import com.divudi.core.facade.SpecialityFacade;
 import com.divudi.core.facade.StaffFacade;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.service.AuditService;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -79,6 +80,9 @@ public class ServiceApiService implements Serializable {
 
     @EJB
     private StaffFacade staffFacade;
+
+    @EJB
+    private AuditService auditService;
 
     // =========================================================================
     // Service Search
@@ -531,6 +535,11 @@ public class ServiceApiService implements Serializable {
         Service service = loadAndValidateService(serviceId);
         ItemFee itemFee = loadAndValidateFee(feeId, service);
 
+        // Snapshot before-state for audit
+        Map<String, Object> beforeFlags = new HashMap<>();
+        beforeFlags.put("marginAllowed", itemFee.getMarginAllowed());
+        beforeFlags.put("discountAllowed", itemFee.isDiscountAllowed());
+
         if (request.getName() != null && !request.getName().trim().isEmpty()) {
             itemFee.setName(request.getName().trim());
         }
@@ -555,6 +564,9 @@ public class ServiceApiService implements Serializable {
         }
         if (request.getDiscountAllowed() != null) {
             itemFee.setDiscountAllowed(request.getDiscountAllowed());
+        }
+        if (request.getMarginAllowed() != null) {
+            itemFee.setMarginAllowed(request.getMarginAllowed());
         }
         if (request.getInstitutionId() != null) {
             Institution institution = institutionFacade.find(request.getInstitutionId());
@@ -589,6 +601,15 @@ public class ServiceApiService implements Serializable {
         itemFee.setEditedAt(Calendar.getInstance().getTime());
         itemFeeFacade.edit(itemFee);
 
+        // Audit flag changes
+        Map<String, Object> afterFlags = new HashMap<>();
+        afterFlags.put("marginAllowed", itemFee.getMarginAllowed());
+        afterFlags.put("discountAllowed", itemFee.isDiscountAllowed());
+        if (!java.util.Objects.equals(beforeFlags.get("marginAllowed"), afterFlags.get("marginAllowed"))
+                || !java.util.Objects.equals(beforeFlags.get("discountAllowed"), afterFlags.get("discountAllowed"))) {
+            auditService.logAudit(beforeFlags, afterFlags, user, "ItemFee", "FEE_FLAG_UPDATED", feeId);
+        }
+
         // Recalculate service totals
         recalculateServiceTotal(service);
 
@@ -617,6 +638,98 @@ public class ServiceApiService implements Serializable {
 
         List<ItemFee> fees = fetchFeesForItem(service);
         return buildServiceResponseDTO(service, fees, "Fee removed successfully");
+    }
+
+    // =========================================================================
+    // Fee Flag Bulk Operations
+    // =========================================================================
+
+    /**
+     * Bulk-update marginAllowed and/or discountAllowed on all non-retired fees
+     * for items in a given category with a given feeType.
+     */
+    public Map<String, Object> bulkUpdateMargin(Long categoryId, String feeTypeStr,
+            Boolean marginAllowed, Boolean discountAllowed, WebUser user) throws Exception {
+        if (categoryId == null) {
+            throw new Exception("categoryId is required");
+        }
+        if (user == null) {
+            throw new Exception("User is required for bulk update");
+        }
+        if (marginAllowed == null && discountAllowed == null) {
+            throw new Exception("At least one of marginAllowed or discountAllowed must be provided");
+        }
+
+        FeeType feeType = FeeType.OwnInstitution;
+        if (feeTypeStr != null && !feeTypeStr.trim().isEmpty()) {
+            try {
+                feeType = FeeType.valueOf(feeTypeStr.trim());
+            } catch (IllegalArgumentException e) {
+                throw new Exception("Invalid feeType: " + feeTypeStr);
+            }
+        }
+
+        String jpql = "SELECT f FROM ItemFee f "
+                + "WHERE f.item.category.id = :catId "
+                + "AND f.feeType = :ft "
+                + "AND f.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("catId", categoryId);
+        params.put("ft", feeType);
+
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql, params);
+        int count = 0;
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("categoryId", categoryId);
+        changes.put("feeType", feeType.name());
+        if (marginAllowed != null) {
+            changes.put("marginAllowed", marginAllowed);
+        }
+        if (discountAllowed != null) {
+            changes.put("discountAllowed", discountAllowed);
+        }
+
+        for (ItemFee fee : fees) {
+            if (marginAllowed != null) {
+                fee.setMarginAllowed(marginAllowed);
+            }
+            if (discountAllowed != null) {
+                fee.setDiscountAllowed(discountAllowed);
+            }
+            itemFeeFacade.edit(fee);
+            count++;
+        }
+
+        changes.put("count", count);
+        auditService.logAudit(null, changes, user, "ItemFee",
+                "FEE_FLAGS_BULK_UPDATED", null);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", count);
+        return result;
+    }
+
+    /**
+     * Find fees with marginAllowed disabled (false or null) for items in a category.
+     */
+    public List<ItemFeeDTO> findFeesWithMarginDisabled(Long categoryId) throws Exception {
+        if (categoryId == null) {
+            throw new Exception("categoryId is required");
+        }
+
+        String jpql = "SELECT f FROM ItemFee f "
+                + "WHERE f.item.category.id = :catId "
+                + "AND f.retired = false "
+                + "AND (f.marginAllowed = false OR f.marginAllowed IS NULL)";
+        Map<String, Object> params = new HashMap<>();
+        params.put("catId", categoryId);
+
+        List<ItemFee> fees = itemFeeFacade.findByJpql(jpql, params);
+        List<ItemFeeDTO> dtos = new ArrayList<>();
+        for (ItemFee fee : fees) {
+            dtos.add(buildItemFeeDTO(fee));
+        }
+        return dtos;
     }
 
     // =========================================================================
@@ -920,6 +1033,7 @@ public class ServiceApiService implements Serializable {
         dto.setFee(fee.getFee());
         dto.setFfee(fee.getFfee());
         dto.setDiscountAllowed(fee.isDiscountAllowed());
+        dto.setMarginAllowed(fee.getMarginAllowed());
         dto.setRetired(fee.isRetired());
         if (fee.getInstitution() != null) {
             dto.setInstitutionId(fee.getInstitution().getId());

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -341,7 +341,10 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Services", "/api/services",
-                        "OPD and Inward service management including fees and categories",
+                        "OPD and Inward service management including fees and categories. "
+                        + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "
+                        + "/fees/bulk-margin (POST bulk-update marginAllowed/discountAllowed on fees in a category). "
+                        + "/fees/margin-disabled?categoryId=X (GET diagnostic list of fees with marginAllowed=false/null).",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))
                 .add(resource("Timed Items", "/api/timed-items",

--- a/src/main/java/com/divudi/ws/service/ServiceApi.java
+++ b/src/main/java/com/divudi/ws/service/ServiceApi.java
@@ -469,8 +469,14 @@ public class ServiceApi {
                 return errorResponse("Request body is required", 400);
             }
 
-            Long categoryId = body.get("categoryId") instanceof Number
-                    ? ((Number) body.get("categoryId")).longValue() : null;
+            Long categoryId = null;
+            if (body.get("categoryId") instanceof Number) {
+                Number n = (Number) body.get("categoryId");
+                if (n.doubleValue() != Math.floor(n.doubleValue()) || Double.isInfinite(n.doubleValue())) {
+                    return errorResponse("categoryId must be a whole number", 400);
+                }
+                categoryId = n.longValue();
+            }
             String feeType = body.get("feeType") != null ? body.get("feeType").toString() : null;
 
             Boolean marginAllowed = null;

--- a/src/main/java/com/divudi/ws/service/ServiceApi.java
+++ b/src/main/java/com/divudi/ws/service/ServiceApi.java
@@ -440,6 +440,109 @@ public class ServiceApi {
         }
     }
 
+    /**
+     * Bulk-update marginAllowed and/or discountAllowed on fees in a category.
+     * POST /api/services/fees/bulk-margin
+     * Body: {"categoryId": 1054, "feeType": "OwnInstitution", "marginAllowed": true, "discountAllowed": null}
+     */
+    @POST
+    @Path("/fees/bulk-margin")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response bulkUpdateMargin(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            Long categoryId = body.get("categoryId") instanceof Number
+                    ? ((Number) body.get("categoryId")).longValue() : null;
+            String feeType = body.get("feeType") != null ? body.get("feeType").toString() : null;
+
+            Boolean marginAllowed = null;
+            if (body.get("marginAllowed") != null) {
+                if (body.get("marginAllowed") instanceof Boolean) {
+                    marginAllowed = (Boolean) body.get("marginAllowed");
+                } else {
+                    return errorResponse("marginAllowed must be a boolean", 400);
+                }
+            }
+
+            Boolean discountAllowed = null;
+            if (body.get("discountAllowed") != null) {
+                if (body.get("discountAllowed") instanceof Boolean) {
+                    discountAllowed = (Boolean) body.get("discountAllowed");
+                } else {
+                    return errorResponse("discountAllowed must be a boolean", 400);
+                }
+            }
+
+            Map<String, Object> result = serviceApiService.bulkUpdateMargin(
+                    categoryId, feeType, marginAllowed, discountAllowed, user);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && (msg.contains("required") || msg.contains("Invalid") || msg.contains("must be"))) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * List fees with marginAllowed disabled (false or null) in a category.
+     * GET /api/services/fees/margin-disabled?categoryId=X
+     */
+    @GET
+    @Path("/fees/margin-disabled")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listMarginDisabled() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String categoryIdStr = uriInfo.getQueryParameters().getFirst("categoryId");
+            if (categoryIdStr == null || categoryIdStr.trim().isEmpty()) {
+                return errorResponse("categoryId query parameter is required", 400);
+            }
+
+            Long categoryId;
+            try {
+                categoryId = Long.parseLong(categoryIdStr.trim());
+            } catch (NumberFormatException e) {
+                return errorResponse("Invalid categoryId format", 400);
+            }
+
+            List<ItemFeeDTO> fees = serviceApiService.findFeesWithMarginDisabled(categoryId);
+            return successResponse(fees);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("required")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
     // =========================================================================
     // Service Category CRUD
     // =========================================================================


### PR DESCRIPTION
## Summary
- Adds `marginAllowed` field to `ItemFeeDTO` and `ItemFeeUpdateRequestDTO`
- Extends `PUT /api/services/{id}/fees/{feeId}` to accept and audit `marginAllowed`
- Adds `POST /api/services/fees/bulk-margin` for category-wide bulk flag update (marginAllowed + discountAllowed)
- Adds `GET /api/services/fees/margin-disabled?categoryId=X` diagnostic listing of fees with marginAllowed=false/null
- Audit events: `FEE_FLAG_UPDATED` (individual), `FEE_FLAGS_BULK_UPDATED` (bulk)
- Updates `CapabilityStatementResource` with new sub-paths

## Test plan
- [x] `GET /api/services/fees/margin-disabled?categoryId=4` returns fees with `marginAllowed=false`
- [x] `POST /api/services/fees/bulk-margin` with `{"categoryId":1,"marginAllowed":true}` returns `{"count":N}`
- [x] Both endpoints return 401 without valid Finance header
- [x] Both endpoints return 400 when required params missing

Closes #21543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `POST /api/services/fees/bulk-margin` to bulk-update `marginAllowed` and/or `discountAllowed` for fees by category (optionally filtered by fee type).
  * Added `GET /api/services/fees/margin-disabled` to list fees where margin is disabled.
  * Added auditing and updated fee responses to include `marginAllowed`.
* **Bug Fixes**
  * Improved support for nullable `marginAllowed` by treating it as optional in fee update requests.
* **Documentation**
  * Updated capability/API documentation to describe the new fee endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->