### PR TITLE
feat(api): add Staff CRUD API, user-staff link, and multi-dept grant-all privileges

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/user/UserUpsertRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/user/UserUpsertRequestDTO.java
@@ -40,4 +40,8 @@ public class UserUpsertRequestDTO {
     public void setPassword(String password) { this.password = password; }
     public String getLoginPage() { return loginPage; }
     public void setLoginPage(String loginPage) { this.loginPage = loginPage; }
+
+    private Long staffId;
+    public Long getStaffId() { return staffId; }
+    public void setStaffId(Long staffId) { this.staffId = staffId; }
 }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1046,17 +1046,52 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject manageStaffTool = Json.createObjectBuilder()
+                .add("name", "manage_staff")
+                .add("description",
+                        "CRUD for HMIS Staff records.\n\n"
+                        + "method: LIST | GET | POST | PUT | DELETE | LINK_TO_USER\n\n"
+                        + "LIST: search staff (query, departmentId, size).\n"
+                        + "GET: get a single staff record by id.\n"
+                        + "POST: create staff — required: name; optional: code, designation (string label), departmentId, institutionId. Creates linked Person automatically.\n"
+                        + "PUT: partial update (name, code, designation, departmentId, institutionId — only supplied fields change).\n"
+                        + "DELETE: soft-retire. Supply retireComments.\n"
+                        + "LINK_TO_USER: link an existing Staff to a WebUser — requires id (userId) and staffId.\n\n"
+                        + "Always confirm with the user before POST, PUT, DELETE, or LINK_TO_USER.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder().add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("LIST").add("GET").add("POST").add("PUT").add("DELETE").add("LINK_TO_USER")))
+                                .add("id", Json.createObjectBuilder().add("type", "string").add("description", "Staff ID (or User ID for LINK_TO_USER)"))
+                                .add("staffId", Json.createObjectBuilder().add("type", "string").add("description", "Staff ID to link to a user (LINK_TO_USER only)"))
+                                .add("query", Json.createObjectBuilder().add("type", "string").add("description", "Name or code search term"))
+                                .add("departmentId", Json.createObjectBuilder().add("type", "string"))
+                                .add("institutionId", Json.createObjectBuilder().add("type", "string"))
+                                .add("size", Json.createObjectBuilder().add("type", "string"))
+                                .add("name", Json.createObjectBuilder().add("type", "string").add("description", "Person name for the staff member"))
+                                .add("code", Json.createObjectBuilder().add("type", "string"))
+                                .add("designation", Json.createObjectBuilder().add("type", "string").add("description", "Free-text designation label"))
+                                .add("retireComments", Json.createObjectBuilder().add("type", "string")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
         JsonObject manageUsersTool = Json.createObjectBuilder()
                 .add("name", "manage_users")
                 .add("description",
                         "Manage HMIS users, passwords, loggable departments, and department-scoped privileges.\n\n"
                         + "method: LIST | GET | POST | PUT | DELETE | RESET_PASSWORD | CHANGE_PASSWORD | "
                         + "LIST_PRIVILEGES | ASSIGN_PRIVILEGES | REVOKE_PRIVILEGE | LIST_DEPARTMENTS | ASSIGN_DEPARTMENTS | "
-                        + "LIST_AVAILABLE_PRIVILEGES | BULK_ASSIGN_PRIVILEGES | ASSIGN_PRIVILEGE_CATEGORIES\n\n"
+                        + "LIST_AVAILABLE_PRIVILEGES | BULK_ASSIGN_PRIVILEGES | ASSIGN_PRIVILEGE_CATEGORIES | "
+                        + "ASSIGN_ALL_PRIVILEGES_MULTI_DEPT\n\n"
                         + "Privilege assignment requires departmentId; category assignment uses /users/{id}/departments/{departmentId}/privileges/category. "
+                        + "ASSIGN_ALL_PRIVILEGES_MULTI_DEPT grants every privilege across supplied departmentIds (or all user's loggable depts if omitted). "
+                        + "POST supports optional staffId to pre-link a Staff record at creation. "
                         + "Use LIST_AVAILABLE_PRIVILEGES before assigning explicit privilege names. "
                         + "Always confirm with the user before POST, PUT, DELETE, RESET_PASSWORD, CHANGE_PASSWORD, "
-                        + "ASSIGN_PRIVILEGES, REVOKE_PRIVILEGE, ASSIGN_DEPARTMENTS, BULK_ASSIGN_PRIVILEGES, or ASSIGN_PRIVILEGE_CATEGORIES.")
+                        + "ASSIGN_PRIVILEGES, REVOKE_PRIVILEGE, ASSIGN_DEPARTMENTS, BULK_ASSIGN_PRIVILEGES, "
+                        + "ASSIGN_PRIVILEGE_CATEGORIES, or ASSIGN_ALL_PRIVILEGES_MULTI_DEPT.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")
                         .add("properties", Json.createObjectBuilder()
@@ -1067,7 +1102,8 @@ public class AnthropicApiService implements Serializable {
                                                 .add("LIST_PRIVILEGES").add("ASSIGN_PRIVILEGES").add("REVOKE_PRIVILEGE")
                                                 .add("LIST_DEPARTMENTS").add("ASSIGN_DEPARTMENTS")
                                                 .add("LIST_AVAILABLE_PRIVILEGES").add("BULK_ASSIGN_PRIVILEGES")
-                                                .add("ASSIGN_PRIVILEGE_CATEGORIES")))
+                                                .add("ASSIGN_PRIVILEGE_CATEGORIES")
+                                                .add("ASSIGN_ALL_PRIVILEGES_MULTI_DEPT")))
                                 .add("id", Json.createObjectBuilder().add("type", "string").add("description", "User ID for user-specific operations"))
                                 .add("privilegeId", Json.createObjectBuilder().add("type", "string").add("description", "Privilege assignment ID for REVOKE_PRIVILEGE"))
                                 .add("query", Json.createObjectBuilder().add("type", "string").add("description", "User list/search query"))
@@ -1091,7 +1127,8 @@ public class AnthropicApiService implements Serializable {
                                 .add("privileges", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated privilege enum names"))
                                 .add("categories", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated Privileges.getCategory() names"))
                                 .add("userIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated user IDs for BULK_ASSIGN_PRIVILEGES"))
-                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs for ASSIGN_DEPARTMENTS"))
+                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs for ASSIGN_DEPARTMENTS or ASSIGN_ALL_PRIVILEGES_MULTI_DEPT"))
+                                .add("staffId", Json.createObjectBuilder().add("type", "string").add("description", "Staff ID to link to the user on POST or via PUT /{id}/staff"))
                                 .add("retireComments", Json.createObjectBuilder().add("type", "string")))
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
@@ -1318,6 +1355,7 @@ public class AnthropicApiService implements Serializable {
                 .add(manageInvestigationFormatTool)
                 .add(manageFormsTool)
                 .add(manageSubscriptionsTool)
+                .add(manageStaffTool)
                 .add(manageUsersTool)
                 .add(managePharmacyItemsTool)
                 .add(manageChannelBookingTool)
@@ -1591,6 +1629,9 @@ public class AnthropicApiService implements Serializable {
                     String applicationWide = toolInput.containsKey("applicationWide") ? toolInput.getString("applicationWide", "") : "";
                     return callSubscriptionApi(method, id, triggerType, userId, departmentId, applicationWide,
                             hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_staff": {
+                    return callStaffApi(toolInput, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_users": {
                     return callUsersApi(toolInput, hmisBaseUrl, hmisApiKey);
@@ -3564,6 +3605,78 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    private String callStaffApi(JsonObject input, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        String method = input.getString("method", "LIST").toUpperCase();
+        String id = jsonString(input, "id");
+        try {
+            String base = hmisBaseUrl.replaceAll("/$", "") + "/api/staff";
+            String url = base;
+            String httpMethod = "GET";
+            String body = null;
+            switch (method) {
+                case "LIST":
+                    url = base + "?" + queryParam("query", jsonString(input, "query"))
+                            + "&" + queryParam("departmentId", jsonString(input, "departmentId"))
+                            + "&" + queryParam("size", defaultString(jsonString(input, "size"), "50"));
+                    break;
+                case "GET":
+                    url = base + "/" + requireText(id, "id");
+                    break;
+                case "POST": {
+                    httpMethod = "POST";
+                    javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+                    addString(b, "name", jsonString(input, "name"));
+                    addString(b, "code", jsonString(input, "code"));
+                    addString(b, "designation", jsonString(input, "designation"));
+                    addLong(b, "departmentId", jsonString(input, "departmentId"));
+                    addLong(b, "institutionId", jsonString(input, "institutionId"));
+                    if (jsonString(input, "name").isEmpty()) throw new IllegalArgumentException("name is required for POST");
+                    body = b.build().toString();
+                    break;
+                }
+                case "PUT": {
+                    httpMethod = "PUT";
+                    url = base + "/" + requireText(id, "id");
+                    javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+                    addString(b, "name", jsonString(input, "name"));
+                    addString(b, "code", jsonString(input, "code"));
+                    addString(b, "designation", jsonString(input, "designation"));
+                    addLong(b, "departmentId", jsonString(input, "departmentId"));
+                    addLong(b, "institutionId", jsonString(input, "institutionId"));
+                    body = b.build().toString();
+                    break;
+                }
+                case "DELETE":
+                    httpMethod = "DELETE";
+                    url = base + "/" + requireText(id, "id");
+                    String retireComments = jsonString(input, "retireComments");
+                    if (!retireComments.isEmpty()) url += "?" + queryParam("retireComments", retireComments);
+                    break;
+                case "LINK_TO_USER": {
+                    // PUT /api/users/{userId}/staff  with body {staffId}
+                    httpMethod = "PUT";
+                    String usersBase = hmisBaseUrl.replaceAll("/$", "") + "/api/users";
+                    url = usersBase + "/" + requireText(id, "id") + "/staff";
+                    body = Json.createObjectBuilder()
+                            .add("staffId", Long.parseLong(requireText(jsonString(input, "staffId"), "staffId")))
+                            .build().toString();
+                    break;
+                }
+                default:
+                    return "Unknown method: " + method;
+            }
+            return callHmisApi(url, httpMethod, body, hmisApiKey);
+        } catch (Exception e) {
+            return "Staff API error: " + e.getMessage();
+        }
+    }
+
     private String callUsersApi(JsonObject input, String hmisBaseUrl, String hmisApiKey) {
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
             return "Error: HMIS base URL is not configured.";
@@ -3663,6 +3776,20 @@ public class AnthropicApiService implements Serializable {
                             .add("categories", csvArray(jsonString(input, "categories")))
                             .build().toString();
                     break;
+                case "ASSIGN_ALL_PRIVILEGES_MULTI_DEPT": {
+                    httpMethod = "POST";
+                    url = base + "/" + requireText(id, "id") + "/privileges/all";
+                    String deptIdsStr = jsonString(input, "departmentIds");
+                    if (!deptIdsStr.isEmpty()) {
+                        javax.json.JsonArrayBuilder deptArr = Json.createArrayBuilder();
+                        for (String d : deptIdsStr.split(",")) {
+                            d = d.trim();
+                            if (!d.isEmpty()) deptArr.add(Long.parseLong(d));
+                        }
+                        body = Json.createObjectBuilder().add("departmentIds", deptArr).build().toString();
+                    }
+                    break;
+                }
                 default:
                     return "Unknown method: " + method;
             }
@@ -3781,6 +3908,7 @@ public class AnthropicApiService implements Serializable {
         addBoolean(body, "activated", jsonString(input, "activated"));
         addString(body, "loginPage", jsonString(input, "loginPage"));
         addString(body, "password", jsonString(input, "password"));
+        addLong(body, "staffId", jsonString(input, "staffId"));
         if (create && jsonString(input, "password").isEmpty()) {
             throw new IllegalArgumentException("password is required for POST");
         }
@@ -4392,18 +4520,38 @@ public class AnthropicApiService implements Serializable {
                     {"POST", "/channel/cancellation",       "Cancel an existing booking"}
                 });
 
+        // ── Staff ─────────────────────────────────────────────────────────────
+        appendModule(sb, "Staff", "/staff",
+                "CRUD for HMIS Staff records. "
+                + "GET lists active staff (query, departmentId, size). "
+                + "POST creates a staff member (required: name; optional: code, designation label, departmentId, institutionId) and auto-creates a linked Person. "
+                + "PUT partial update (name, code, designation, departmentId, institutionId). "
+                + "DELETE soft-retires a staff record. "
+                + "Link staff to a user: PUT /users/{userId}/staff with body {staffId}. "
+                + "Create user with pre-linked staff: POST /users with optional staffId field.",
+                null,
+                new String[][]{
+                    {"GET",    "/staff",           "List active staff. Filters: query, departmentId, size"},
+                    {"GET",    "/staff/{id}",      "Get a single staff record by ID"},
+                    {"POST",   "/staff",           "Create staff (required: name; optional: code, designation, departmentId, institutionId)"},
+                    {"PUT",    "/staff/{id}",      "Partial update of staff (name, code, designation, departmentId, institutionId)"},
+                    {"DELETE", "/staff/{id}",      "Soft-retire a staff record"},
+                    {"PUT",    "/users/{id}/staff","Link an existing Staff to a WebUser (body: {staffId})"}
+                });
+
         // ── Users / Roles / Privileges ────────────────────────────────────────
         appendModule(sb, "User Management", "/users",
                 "Create, read, update, and retire HMIS web users. Manage passwords, loggable departments, "
-                + "and department-scoped privilege assignments. Create/update supports loginPage. "
+                + "and department-scoped privilege assignments. Create/update supports loginPage and optional staffId. "
                 + "Use /users/privileges/available to discover valid privilege names. "
                 + "DELETE /{id}/departments/{assignmentId} removes one loggable department. "
                 + "DELETE /{id}/departments/{deptId}/privileges bulk-revokes all privileges for a department. "
-                + "POST /{id}/departments/{deptId}/privileges/all grants every privilege for a department.",
+                + "POST /{id}/departments/{deptId}/privileges/all grants every privilege for a department. "
+                + "POST /{id}/privileges/all with optional body {departmentIds:[...]} grants every privilege across multiple departments at once.",
                 githubUrl(branch, "developer_docs/API_USER_MANAGEMENT.md"),
                 new String[][]{
                     {"GET",    "/users",                          "List users. Filters: query, departmentId, page, size"},
-                    {"POST",   "/users",                          "Create a new user"},
+                    {"POST",   "/users",                          "Create a new user (optional staffId links Staff at creation)"},
                     {"GET",    "/users/{id}",                     "Get user by ID"},
                     {"PUT",    "/users/{id}",                     "Update user details"},
                     {"DELETE", "/users/{id}",                     "Retire (soft-delete) a user"},
@@ -4419,7 +4567,9 @@ public class AnthropicApiService implements Serializable {
                     {"POST",   "/users/bulk-privileges",                              "Bulk-assign privileges to multiple users at once"},
                     {"DELETE", "/users/{id}/departments/{assignmentId}",             "Revoke a loggable department assignment (by WebUserDepartment id)"},
                     {"DELETE", "/users/{id}/departments/{departmentId}/privileges",  "Bulk-revoke all active privileges for a user scoped to a department"},
-                    {"POST",   "/users/{id}/departments/{departmentId}/privileges/all", "Assign every Privileges enum value to a user for a department (skips duplicates)"}
+                    {"POST",   "/users/{id}/departments/{departmentId}/privileges/all", "Assign every Privileges enum value to a user for a department (skips duplicates)"},
+                    {"PUT",    "/users/{id}/staff",               "Link an existing Staff record to the user (body: {staffId})"},
+                    {"POST",   "/users/{id}/privileges/all",      "Assign every privilege across supplied departmentIds (or all loggable depts). Returns per-dept summary"}
                 });
 
         appendModule(sb, "User Roles", "/user-roles",

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -45,6 +45,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.common.CapabilityStatementResource.class);
         resources.add(com.divudi.ws.common.ConfigResource.class);
         resources.add(com.divudi.ws.common.LoginHistoryApi.class);
+        resources.add(com.divudi.ws.common.StaffApi.class);
         resources.add(com.divudi.ws.common.SubscriptionApi.class);
         resources.add(com.divudi.ws.common.UserManagementApi.class);
         resources.add(com.divudi.ws.common.UserRoleApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -292,12 +292,27 @@ public class CapabilityStatementResource {
                         + "Also exposes /api/logins/last-per-user for the most recent login per unique user in a department.",
                         "API Key",
                         "GET"))
+                .add(resource("Staff", "/api/staff",
+                        "Staff CRUD. GET lists active staff (supports ?query=&departmentId=&size=). "
+                        + "GET /{id} returns a single staff record including personId, code, designation, and department. "
+                        + "POST creates a new staff member (required: name; optional: code, designation (string label), departmentId, institutionId). "
+                        + "Creates a linked Person automatically. "
+                        + "PUT /{id} updates name, code, designation, departmentId, or institutionId (partial update — only supplied fields change). "
+                        + "DELETE /{id}?retireComments=reason soft-retires a staff record. "
+                        + "Link an existing Staff to a WebUser via PUT /api/users/{id}/staff with body {staffId}. "
+                        + "POST /api/users supports optional staffId field to pre-link staff at user creation. "
+                        + "POST /api/users/{id}/privileges/all with optional body {departmentIds:[...]} assigns every privilege across specified (or all loggable) departments; "
+                        + "returns {privilegesAdded, privilegesSkipped, departments:[{departmentId, added, skipped}]}.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Users", "/api/users",
                         "User CRUD, password reset/change, loggable department assignment, "
                         + "and per-user privilege assignment with department scope. "
-                        + "Create/update accepts optional loginPage. "
+                        + "Create/update accepts optional loginPage and optional staffId. "
                         + "POST /{id}/privileges requires departmentId. "
                         + "POST /{id}/departments/{departmentId}/privileges/category assigns all privileges from named categories. "
+                        + "POST /{id}/privileges/all with optional body {departmentIds:[...]} assigns every privilege across specified or all loggable departments. "
+                        + "PUT /{id}/staff with body {staffId} links a Staff record to the user. "
                         + "Supports filtering by departmentId and query string. "
                         + "DELETE /{id}/departments/{assignmentId} revokes one loggable department. "
                         + "DELETE /{id}/departments/{departmentId}/privileges bulk-revokes all privileges for a department. "

--- a/src/main/java/com/divudi/ws/common/StaffApi.java
+++ b/src/main/java/com/divudi/ws/common/StaffApi.java
@@ -1,0 +1,368 @@
+package com.divudi.ws.common;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.Privileges;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Person;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.InstitutionFacade;
+import com.divudi.core.facade.PersonFacade;
+import com.divudi.core.facade.StaffFacade;
+import com.divudi.core.facade.WebUserPrivilegeFacade;
+import com.divudi.core.facade.WebUserRolePrivilegeFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * REST API for Staff CRUD operations.
+ * Auth: Finance header (same as UserManagementApi).
+ */
+@Path("staff")
+@RequestScoped
+public class StaffApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private StaffFacade staffFacade;
+    @EJB
+    private PersonFacade personFacade;
+    @EJB
+    private DepartmentFacade departmentFacade;
+    @EJB
+    private InstitutionFacade institutionFacade;
+    @EJB
+    private WebUserPrivilegeFacade webUserPrivilegeFacade;
+    @EJB
+    private WebUserRolePrivilegeFacade webUserRolePrivilegeFacade;
+
+    private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
+
+    // -------------------------------------------------------------------------
+    // GET /api/staff?query=&departmentId=&size=
+    // -------------------------------------------------------------------------
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listStaff() {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+
+            String q = value("query");
+            int size = Math.min(Math.max(parseInt(value("size"), 50), 1), 200);
+            String departmentIdStr = value("departmentId");
+
+            Map<String, Object> params = new HashMap<>();
+            String jpql;
+
+            if (departmentIdStr != null && !departmentIdStr.trim().isEmpty()) {
+                Long deptId = parseLong(departmentIdStr);
+                if (deptId == null) return errorResponse("Invalid departmentId", 400);
+                Department dept = departmentFacade.find(deptId);
+                if (dept == null) return errorResponse("Department not found", 404);
+                jpql = "select s from Staff s where s.retired=false and s.department=:dept";
+                params.put("dept", dept);
+                if (q != null && !q.trim().isEmpty()) {
+                    jpql += " and (upper(s.person.name) like :q or upper(s.code) like :q)";
+                    params.put("q", "%" + q.trim().toUpperCase() + "%");
+                }
+            } else {
+                jpql = "select s from Staff s where s.retired=false";
+                if (q != null && !q.trim().isEmpty()) {
+                    jpql += " and (upper(s.person.name) like :q or upper(s.code) like :q)";
+                    params.put("q", "%" + q.trim().toUpperCase() + "%");
+                }
+            }
+            jpql += " order by s.person.name";
+
+            List<Staff> staffList = staffFacade.findByJpql(jpql, params, size);
+            List<Map<String, Object>> out = new ArrayList<>();
+            for (Staff s : staffList) {
+                out.add(toStaffMap(s, false));
+            }
+            return successResponse(out);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/staff/{id}
+    // -------------------------------------------------------------------------
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getStaff(@PathParam("id") Long id) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        Staff s = staffFacade.find(id);
+        if (s == null || s.isRetired()) return errorResponse("Staff not found", 404);
+        return successResponse(toStaffMap(s, true));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/staff
+    // Body: {name, code, designation (string label), departmentId, institutionId}
+    // -------------------------------------------------------------------------
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createStaff(String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+
+            Map req = gson.fromJson(body, Map.class);
+            if (req == null) return errorResponse("Request body is required", 400);
+
+            String name = req.containsKey("name") ? (String) req.get("name") : null;
+            if (name == null || name.trim().isEmpty()) return errorResponse("name is required", 400);
+            name = name.trim();
+
+            String code = req.containsKey("code") ? (String) req.get("code") : null;
+            String designationLabel = req.containsKey("designation") ? (String) req.get("designation") : null;
+
+            Long departmentId = parseDoubleAsLong(req.get("departmentId"));
+            Long institutionId = parseDoubleAsLong(req.get("institutionId"));
+
+            Department dept = (departmentId != null) ? departmentFacade.find(departmentId) : null;
+            if (departmentId != null && dept == null) return errorResponse("Department not found", 404);
+
+            Institution inst = (institutionId != null) ? institutionFacade.find(institutionId) : null;
+            if (institutionId != null && inst == null) return errorResponse("Institution not found", 404);
+
+            // Create a Person for this staff member
+            Person person = new Person();
+            person.setName(name);
+            person.setCreatedAt(new Date());
+            person.setCreater(apiUser);
+            personFacade.create(person);
+
+            // Create the Staff record
+            Staff staff = new Staff();
+            staff.setPerson(person);
+            if (code != null && !code.trim().isEmpty()) staff.setCode(code.trim());
+            if (designationLabel != null && !designationLabel.trim().isEmpty()) {
+                staff.setDescription(designationLabel.trim());
+            }
+            if (dept != null) staff.setDepartment(dept);
+            if (inst != null) staff.setInstitution(inst);
+            staff.setCreatedAt(new Date());
+            staff.setCreater(apiUser);
+            staffFacade.create(staff);
+
+            return successResponse(toStaffMap(staff, true));
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PUT /api/staff/{id}
+    // Partial update — only supplied fields change (name, code, designation)
+    // -------------------------------------------------------------------------
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateStaff(@PathParam("id") Long id, String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+
+            Staff staff = staffFacade.find(id);
+            if (staff == null || staff.isRetired()) return errorResponse("Staff not found", 404);
+
+            Map req = gson.fromJson(body, Map.class);
+            if (req == null) return errorResponse("Request body is required", 400);
+
+            if (req.containsKey("name")) {
+                String name = (String) req.get("name");
+                if (name == null || name.trim().isEmpty()) return errorResponse("name cannot be empty", 400);
+                if (staff.getPerson() != null) {
+                    staff.getPerson().setName(name.trim());
+                    personFacade.edit(staff.getPerson());
+                }
+            }
+            if (req.containsKey("code")) {
+                String code = (String) req.get("code");
+                staff.setCode(code != null ? code.trim() : null);
+            }
+            if (req.containsKey("designation")) {
+                String designation = (String) req.get("designation");
+                staff.setDescription(designation != null ? designation.trim() : null);
+            }
+            if (req.containsKey("departmentId")) {
+                Long departmentId = parseDoubleAsLong(req.get("departmentId"));
+                if (departmentId != null) {
+                    Department dept = departmentFacade.find(departmentId);
+                    if (dept == null) return errorResponse("Department not found", 404);
+                    staff.setDepartment(dept);
+                } else {
+                    staff.setDepartment(null);
+                }
+            }
+            if (req.containsKey("institutionId")) {
+                Long institutionId = parseDoubleAsLong(req.get("institutionId"));
+                if (institutionId != null) {
+                    Institution inst = institutionFacade.find(institutionId);
+                    if (inst == null) return errorResponse("Institution not found", 404);
+                    staff.setInstitution(inst);
+                } else {
+                    staff.setInstitution(null);
+                }
+            }
+
+            staffFacade.edit(staff);
+            return successResponse(toStaffMap(staff, true));
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /api/staff/{id}?retireComments=reason  — soft-retire
+    // -------------------------------------------------------------------------
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retireStaff(@PathParam("id") Long id) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        Staff staff = staffFacade.find(id);
+        if (staff == null || staff.isRetired()) return errorResponse("Staff not found", 404);
+        staff.setRetired(true);
+        staff.setRetirer(apiUser);
+        staff.setRetiredAt(new Date());
+        staff.setRetireComments(value("retireComments"));
+        staffFacade.edit(staff);
+        return successResponse(toStaffMap(staff, false));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Map<String, Object> toStaffMap(Staff s, boolean full) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("id", s.getId());
+        m.put("code", s.getCodeRaw());
+        m.put("designation", s.getDescription());
+        m.put("retired", s.isRetired());
+        m.put("personId", s.getPerson() != null ? s.getPerson().getId() : null);
+        m.put("name", s.getPerson() != null ? s.getPerson().getName() : null);
+        m.put("departmentId", s.getDepartment() != null ? s.getDepartment().getId() : null);
+        m.put("departmentName", s.getDepartment() != null ? s.getDepartment().getName() : null);
+        m.put("institutionId", s.getInstitution() != null ? s.getInstitution().getId() : null);
+        if (full) {
+            m.put("createdAt", s.getCreatedAt());
+            m.put("retiredAt", s.getRetiredAt());
+            m.put("retireComments", s.getRetireComments());
+        }
+        return m;
+    }
+
+    private String value(String key) {
+        return uriInfo.getQueryParameters().getFirst(key);
+    }
+
+    private int parseInt(String v, int d) {
+        try { return v == null ? d : Integer.parseInt(v.trim()); } catch (Exception e) { return d; }
+    }
+
+    private Long parseLong(String v) {
+        try { return v == null ? null : Long.parseLong(v.trim()); } catch (Exception e) { return null; }
+    }
+
+    private Long parseDoubleAsLong(Object v) {
+        if (v == null) return null;
+        try {
+            if (v instanceof Number) return ((Number) v).longValue();
+            return Long.parseLong(v.toString().trim());
+        } catch (Exception e) { return null; }
+    }
+
+    private WebUser validateApiUser() {
+        String key = requestContext.getHeader("Finance");
+        if (key == null || key.trim().isEmpty()) return null;
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.getWebUser() == null
+                || apiKey.getDateOfExpiary() == null
+                || apiKey.getDateOfExpiary().before(new Date())) return null;
+        WebUser u = apiKey.getWebUser();
+        if (u.isRetired() || !u.isActivated()) return null;
+        return u;
+    }
+
+    private boolean isAdmin(WebUser user) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("u", user);
+        m.put("p", Privileges.Admin);
+        if (!webUserPrivilegeFacade.findByJpql(
+                "select wp from WebUserPrivilege wp where wp.retired=false and wp.webUser=:u and wp.privilege=:p", m).isEmpty()) {
+            return true;
+        }
+        if (user.getRole() == null) return false;
+        Map<String, Object> r = new HashMap<>();
+        r.put("r", user.getRole());
+        r.put("p", Privileges.Admin);
+        return !webUserRolePrivilegeFacade.findByJpql(
+                "select rp from WebUserRolePrivilege rp where rp.retired=false and rp.webUserRole=:r and rp.privilege=:p", r).isEmpty();
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.status(200).entity(gson.toJson(response)).build();
+    }
+}

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -57,6 +57,8 @@ public class UserManagementApi {
     private InstitutionFacade institutionFacade;
     @EJB
     private PersonFacade personFacade;
+    @EJB
+    private StaffFacade staffFacade;
 
     private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
 
@@ -162,6 +164,11 @@ public class UserManagementApi {
             p.setCreater(apiUser);
             personFacade.create(p);
             u.setWebUserPerson(p);
+            if (req.getStaffId() != null) {
+                Staff staff = staffFacade.find(req.getStaffId());
+                if (staff == null || staff.isRetired()) return errorResponse("Staff not found: " + req.getStaffId(), 404);
+                u.setStaff(staff);
+            }
             applyUserChanges(u, req, apiUser, true);
             webUserFacade.create(u);
             return successResponse(toUserMap(u));
@@ -576,6 +583,153 @@ public class UserManagementApi {
         result.put("privilegesAdded", added);
         result.put("privilegesSkipped", skipped);
         return successResponse(result);
+    }
+
+    /**
+     * POST /api/users/{id}/privileges/all
+     * Body: {"departmentIds": [481, 485]}  — optional; if omitted, uses all loggable departments.
+     * Assigns every Privileges enum value across the specified (or all loggable) departments.
+     * Returns {privilegesAdded, privilegesSkipped, departments: [{departmentId, added, skipped}]}.
+     */
+    @POST
+    @Path("/{id}/privileges/all")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response assignAllPrivilegesMultiDept(@PathParam("id") Long id, String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+            WebUser u = webUserFacade.find(id);
+            if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+
+            // Parse optional departmentIds from body
+            List<Long> requestedDeptIds = new ArrayList<>();
+            if (body != null && !body.trim().isEmpty()) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> req = gson.fromJson(body, Map.class);
+                    if (req != null && req.containsKey("departmentIds")) {
+                        Object deptIdsObj = req.get("departmentIds");
+                        if (deptIdsObj instanceof List) {
+                            for (Object item : (List<?>) deptIdsObj) {
+                                if (item instanceof Number) requestedDeptIds.add(((Number) item).longValue());
+                            }
+                        }
+                    }
+                } catch (JsonSyntaxException e) {
+                    return errorResponse("Invalid JSON format", 400);
+                }
+            }
+
+            // Determine target departments
+            List<Department> targetDepts = new ArrayList<>();
+            if (!requestedDeptIds.isEmpty()) {
+                for (Long deptId : requestedDeptIds) {
+                    Department dept = departmentFacade.find(deptId);
+                    if (dept == null) return errorResponse("Department not found: " + deptId, 404);
+                    targetDepts.add(dept);
+                }
+            } else {
+                List<WebUserDepartment> userDepts = webUserDepartmentFacade.findByJpql(
+                        "select d from WebUserDepartment d where d.retired=false and d.webUser=:u",
+                        Collections.singletonMap("u", u));
+                for (WebUserDepartment wud : userDepts) {
+                    if (wud.getDepartment() != null) targetDepts.add(wud.getDepartment());
+                }
+            }
+
+            int totalAdded = 0;
+            int totalSkipped = 0;
+            List<Map<String, Object>> deptResults = new ArrayList<>();
+
+            for (Department dept : targetDepts) {
+                Map<String, Object> existingParams = new HashMap<>();
+                existingParams.put("u", u);
+                existingParams.put("d", dept);
+                List<WebUserPrivilege> currentPrivileges = webUserPrivilegeFacade.findByJpql(
+                        "select wp from WebUserPrivilege wp where wp.retired=false and wp.webUser=:u and wp.department=:d",
+                        existingParams);
+                Set<Privileges> alreadyAssigned = new HashSet<>();
+                for (WebUserPrivilege wp : currentPrivileges) {
+                    if (wp.getPrivilege() != null) alreadyAssigned.add(wp.getPrivilege());
+                }
+                int deptAdded = 0;
+                int deptSkipped = 0;
+                for (Privileges p : Privileges.values()) {
+                    if (alreadyAssigned.contains(p)) {
+                        deptSkipped++;
+                        continue;
+                    }
+                    WebUserPrivilege wp = new WebUserPrivilege();
+                    wp.setWebUser(u);
+                    wp.setPrivilege(p);
+                    wp.setDepartment(dept);
+                    wp.setCreater(apiUser);
+                    wp.setCreatedAt(new Date());
+                    webUserPrivilegeFacade.create(wp);
+                    deptAdded++;
+                }
+                totalAdded += deptAdded;
+                totalSkipped += deptSkipped;
+                Map<String, Object> deptResult = new LinkedHashMap<>();
+                deptResult.put("departmentId", dept.getId());
+                deptResult.put("departmentName", dept.getName());
+                deptResult.put("added", deptAdded);
+                deptResult.put("skipped", deptSkipped);
+                deptResults.add(deptResult);
+            }
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("userId", u.getId());
+            result.put("privilegesAdded", totalAdded);
+            result.put("privilegesSkipped", totalSkipped);
+            result.put("departments", deptResults);
+            return successResponse(result);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    /**
+     * PUT /api/users/{id}/staff
+     * Body: {"staffId": 12345}
+     * Links an existing (non-retired) Staff to a WebUser.
+     */
+    @PUT
+    @Path("/{id}/staff")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response linkStaffToUser(@PathParam("id") Long id, String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+            WebUser u = webUserFacade.find(id);
+            if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+            if (body == null || body.trim().isEmpty()) return errorResponse("Request body is required", 400);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> req = gson.fromJson(body, Map.class);
+            if (req == null || !req.containsKey("staffId")) return errorResponse("staffId is required", 400);
+            Object staffIdObj = req.get("staffId");
+            Long staffId;
+            try {
+                staffId = ((Number) staffIdObj).longValue();
+            } catch (Exception e) {
+                return errorResponse("staffId must be a numeric ID", 400);
+            }
+            Staff staff = staffFacade.find(staffId);
+            if (staff == null || staff.isRetired()) return errorResponse("Staff not found: " + staffId, 404);
+
+            u.setStaff(staff);
+            webUserFacade.edit(u);
+            return successResponse(toUserMap(u));
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
     }
 
     @GET

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -156,6 +156,11 @@ public class UserManagementApi {
             if (!webUserFacade.findByJpql("select w from WebUser w where w.retired=false and lower(w.name)=:n", Collections.singletonMap("n", normalizedName.toLowerCase())).isEmpty()) {
                 return errorResponse("User name already exists", 400);
             }
+            Staff linkedStaff = null;
+            if (req.getStaffId() != null) {
+                linkedStaff = staffFacade.find(req.getStaffId());
+                if (linkedStaff == null || linkedStaff.isRetired()) return errorResponse("Staff not found: " + req.getStaffId(), 404);
+            }
             WebUser u = new WebUser();
             Person p = new Person();
             p.setName(req.getPersonName() != null ? req.getPersonName() : normalizedName);
@@ -164,10 +169,8 @@ public class UserManagementApi {
             p.setCreater(apiUser);
             personFacade.create(p);
             u.setWebUserPerson(p);
-            if (req.getStaffId() != null) {
-                Staff staff = staffFacade.find(req.getStaffId());
-                if (staff == null || staff.isRetired()) return errorResponse("Staff not found: " + req.getStaffId(), 404);
-                u.setStaff(staff);
+            if (linkedStaff != null) {
+                u.setStaff(linkedStaff);
             }
             applyUserChanges(u, req, apiUser, true);
             webUserFacade.create(u);
@@ -612,8 +615,13 @@ public class UserManagementApi {
                     if (req != null && req.containsKey("departmentIds")) {
                         Object deptIdsObj = req.get("departmentIds");
                         if (deptIdsObj instanceof List) {
-                            for (Object item : (List<?>) deptIdsObj) {
-                                if (item instanceof Number) requestedDeptIds.add(((Number) item).longValue());
+                            List<?> rawList = (List<?>) deptIdsObj;
+                            for (Object item : rawList) {
+                                if (item instanceof Number) {
+                                    requestedDeptIds.add(((Number) item).longValue());
+                                } else {
+                                    return errorResponse("departmentIds must be an array of integers, got: " + item, 400);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- New `GET/POST/PUT/DELETE /api/staff` endpoint for Staff master data management (creates Person + Staff together, supports soft-retire)
- `PUT /api/users/{id}/staff` — link an existing Staff record to a WebUser
- `POST /api/users` now accepts optional `staffId` to pre-link Staff at creation time
- `POST /api/users/{id}/privileges/all` — multi-department grant-all wrapper (body: `{"departmentIds":[...]}`, defaults to all user's loggable departments)
- Registered in `ApplicationConfig`, `CapabilityStatementResource`, and AI chat tool definitions

## Test plan
- [x] `GET /api/staff?query=Test&size=5` returns staff list
- [x] `POST /api/staff` creates Person + Staff, returns `{id, name, code, personId, departmentId}`
- [x] `PUT /api/staff/{id}` partial update (name only tested)
- [x] `DELETE /api/staff/{id}` soft-retires
- [x] `POST /api/users/{id}/privileges/all` with `{"departmentIds":[3]}` added 647 privileges
- [x] All endpoints return 401 without valid Finance key

Closes #20454
Closes #20450

🤖 Generated with [Claude Code](https://claude.com/claude-code)