### PR TITLE
feat(api): add safe retire-bill capability to Bill Data Correction API

### DIFF
--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -81,7 +81,7 @@ public class BillDataCorrectionService {
 
         switch (normalizedType) {
             case "BILL":
-                parentBill = updateBill(targetId, fields, previousValues, newValues);
+                parentBill = updateBill(targetId, fields, previousValues, newValues, apiUser);
                 break;
             case "BILL_ITEM":
                 parentBill = updateBillItem(targetId, fields, previousValues, newValues);
@@ -123,7 +123,7 @@ public class BillDataCorrectionService {
         return result;
     }
 
-    private Bill updateBill(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
+    private Bill updateBill(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues, WebUser apiUser) {
         Bill entity = billFacade.find(id);
         if (entity == null) {
             throw new IllegalArgumentException("Bill not found for id " + id);
@@ -158,12 +158,18 @@ public class BillDataCorrectionService {
             if (requestedRetire) {
                 guardEmptyBillForRetire(entity, originalNetTotal, originalTotal);
                 previousValues.put("retired", entity.isRetired());
+                previousValues.put("retiredAt", entity.getRetiredAt());
+                previousValues.put("retireComments", entity.getRetireComments());
                 String retireComments = fields.containsKey("retireComments")
                         ? toStringValue(fields.get("retireComments")) : null;
+                Date retiredAt = new Date();
                 entity.setRetired(true);
-                entity.setRetiredAt(new Date());
+                entity.setRetiredAt(retiredAt);
                 entity.setRetireComments(retireComments);
+                entity.setRetirer(apiUser);
                 newValues.put("retired", true);
+                newValues.put("retiredAt", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(retiredAt));
+                newValues.put("retireComments", retireComments);
             }
         }
 

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -45,7 +45,7 @@ public class BillDataCorrectionService {
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
 
-    private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments"));
+    private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments", "retired", "retireComments"));
     private static final Set<String> BILL_ITEM_FIELDS = new HashSet<>(Arrays.asList("qty", "rate", "grossValue", "netValue", "discount"));
     private static final Set<String> BILL_FINANCE_FIELDS = new HashSet<>(Arrays.asList("totalRetailSaleValue", "totalCostValue", "totalPurchaseValue", "netTotal", "grossTotal", "billExpensesConsideredForCosting", "billExpensesNotConsideredForCosting", "totalBillValue"));
     private static final Set<String> BILL_FEE_FIELDS = new HashSet<>(Arrays.asList("feeValue", "grossValue"));
@@ -144,9 +144,47 @@ public class BillDataCorrectionService {
             entity.setComments(value);
             newValues.put("comments", entity.getComments());
         }
+        if (fields.containsKey("retired")) {
+            boolean requestedRetire = toBooleanValue(fields.get("retired"), "retired");
+            if (requestedRetire) {
+                guardEmptyBillForRetire(entity);
+                previousValues.put("retired", entity.isRetired());
+                String retireComments = fields.containsKey("retireComments")
+                        ? toStringValue(fields.get("retireComments")) : null;
+                entity.setRetired(true);
+                entity.setRetiredAt(new Date());
+                entity.setRetireComments(retireComments);
+                newValues.put("retired", true);
+            }
+        }
 
         billFacade.edit(entity);
         return entity;
+    }
+
+    private void guardEmptyBillForRetire(Bill bill) {
+        Map<String, Object> params = new java.util.HashMap<>();
+        params.put("b", bill);
+
+        long itemCount = billItemFacade.findLongByJpql(
+                "SELECT COUNT(bi) FROM BillItem bi WHERE bi.bill = :b AND bi.retired = false", params);
+        if (itemCount > 0) {
+            throw new IllegalStateException(
+                    "Bill " + bill.getId() + " has " + itemCount + " active bill items — retire them first");
+        }
+
+        long feeCount = billFeeFacade.findLongByJpql(
+                "SELECT COUNT(bf) FROM BillFee bf WHERE bf.bill = :b AND bf.retired = false", params);
+        if (feeCount > 0) {
+            throw new IllegalStateException(
+                    "Bill " + bill.getId() + " has " + feeCount + " active bill fees — retire them first");
+        }
+
+        if (bill.getNetTotal() != 0.0 || bill.getTotal() != 0.0) {
+            throw new IllegalStateException(
+                    "Bill " + bill.getId() + " has non-zero totals (net=" + bill.getNetTotal()
+                    + ", gross=" + bill.getTotal() + ") — only zero-value bills may be retired via this API");
+        }
     }
 
     private Bill updateBillItem(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues) {
@@ -429,5 +467,18 @@ public class BillDataCorrectionService {
 
     private String toStringValue(Object value) {
         return value == null ? null : value.toString();
+    }
+
+    private boolean toBooleanValue(Object value, String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException("Field '" + fieldName + "' cannot be null");
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String s = value.toString().trim().toLowerCase();
+        if ("true".equals(s) || "1".equals(s)) return true;
+        if ("false".equals(s) || "0".equals(s)) return false;
+        throw new IllegalArgumentException("Field '" + fieldName + "' must be a boolean (true/false)");
     }
 }

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -12,6 +12,7 @@ import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillFinanceDetailsFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BillItemFinanceDetailsFacade;
+import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
@@ -41,6 +42,9 @@ public class BillDataCorrectionService {
 
     @EJB
     private BillItemFinanceDetailsFacade billItemFinanceDetailsFacade;
+
+    @EJB
+    private PaymentFacade paymentFacade;
 
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
@@ -126,6 +130,11 @@ public class BillDataCorrectionService {
         }
         validateAllowedFields(fields, BILL_FIELDS, "BILL");
 
+        // Capture original persisted totals before any in-memory mutations so the retire guard
+        // always checks the true DB values, not values already changed in this same request.
+        final double originalNetTotal = entity.getNetTotal();
+        final double originalTotal = entity.getTotal();
+
         if (fields.containsKey("netTotal")) {
             previousValues.put("netTotal", entity.getNetTotal());
             double value = toDouble(fields.get("netTotal"), "netTotal");
@@ -147,7 +156,7 @@ public class BillDataCorrectionService {
         if (fields.containsKey("retired")) {
             boolean requestedRetire = toBooleanValue(fields.get("retired"), "retired");
             if (requestedRetire) {
-                guardEmptyBillForRetire(entity);
+                guardEmptyBillForRetire(entity, originalNetTotal, originalTotal);
                 previousValues.put("retired", entity.isRetired());
                 String retireComments = fields.containsKey("retireComments")
                         ? toStringValue(fields.get("retireComments")) : null;
@@ -162,7 +171,7 @@ public class BillDataCorrectionService {
         return entity;
     }
 
-    private void guardEmptyBillForRetire(Bill bill) {
+    private void guardEmptyBillForRetire(Bill bill, double originalNetTotal, double originalTotal) {
         Map<String, Object> params = new java.util.HashMap<>();
         params.put("b", bill);
 
@@ -180,10 +189,17 @@ public class BillDataCorrectionService {
                     "Bill " + bill.getId() + " has " + feeCount + " active bill fees — retire them first");
         }
 
-        if (bill.getNetTotal() != 0.0 || bill.getTotal() != 0.0) {
+        long paymentCount = paymentFacade.findLongByJpql(
+                "SELECT COUNT(p) FROM Payment p WHERE p.bill = :b AND p.retired = false", params);
+        if (paymentCount > 0) {
             throw new IllegalStateException(
-                    "Bill " + bill.getId() + " has non-zero totals (net=" + bill.getNetTotal()
-                    + ", gross=" + bill.getTotal() + ") — only zero-value bills may be retired via this API");
+                    "Bill " + bill.getId() + " has " + paymentCount + " active payments — retire them first");
+        }
+
+        if (originalNetTotal != 0.0 || originalTotal != 0.0) {
+            throw new IllegalStateException(
+                    "Bill " + bill.getId() + " has non-zero totals (net=" + originalNetTotal
+                    + ", gross=" + originalTotal + ") — only zero-value bills may be retired via this API");
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `retired` and `retireComments` to the `BILL` target type allowed fields in `BillDataCorrectionService`
- When `retired=true`: stamps `retiredAt=now`, sets `retireComments`, marks bill retired
- **Guardrails**: rejects if bill has active `BillItem`s, active `BillFee`s, or non-zero `netTotal`/`grossTotal` — prevents using this to reverse settlements
- Full audit trail via existing `appendAuditLog()` mechanism (previousValues/newValues recorded)
- No API signature change — passes through the existing `PATCH /api/bill_data_correction` endpoint

## Test plan
- [x] `PATCH /api/bill_data_correction` with `targetType=BILL`, `fields.retired=true` on empty zero-value bill → returns success with `{retired: false→true}` in previousValues/newValues
- [x] Same on a bill with 31 active BillItems → rejected with 500 "has 31 active bill items — retire them first"
- [x] Compile clean

## Usage
```json
PATCH /api/bill_data_correction
{
  "targetType": "BILL",
  "targetId": 131785,
  "fields": {"retired": true, "retireComments": "orphan duplicate pre-bill — no items, zero value"},
  "auditComment": "retire orphan duplicate",
  "approvedBy": "admin"
}
```

Closes #21154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced bill retirement capability through the correction API. Bills can be retired only when all associated line items, fees, and payments are cleared and the balance equals zero. Retirement comments can be recorded to provide documentation and audit trail information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->