### PR TITLE
fix(inward): scope service breakdown to Service-type items only (#21177)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -11,6 +11,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.FeeType;
+import static com.divudi.core.data.FeeType.Service;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.hr.ReportKeyWord;
 import com.divudi.core.data.inward.InwardChargeType;
@@ -40,6 +41,7 @@ import com.divudi.service.BillService;
 import com.divudi.core.data.dto.InpatientPharmacyIssueDTO;
 import com.divudi.core.data.dto.InpatientServiceIssueDTO;
 import com.divudi.core.data.dto.BillListReportDTO;
+import com.divudi.core.entity.Service;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -285,7 +287,7 @@ public class InwardReportControllerBht implements Serializable {
             serviceTypes.add(BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL);
             serviceTypes.add(BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL_CANCELLATION);
 
-            serviceIssueDtosToPatientEncounter = fetchServiceIssueDtos(serviceTypes);
+            serviceIssueDtosToPatientEncounter = fetchOnlyIPServiceIssueDtos(serviceTypes);
 
             for (InpatientServiceIssueDTO dto : serviceIssueDtosToPatientEncounter) {
                 double netValue = dto.getNetValue() != null ? dto.getNetValue() : 0.0;
@@ -386,6 +388,40 @@ public class InwardReportControllerBht implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("billTypeAtomics", billTypes);
         params.put("patientEncounter", patientEncounter);
+
+        if (department != null) {
+            jpql += "AND bi.bill.department = :department ";
+            params.put("department", department);
+        }
+
+        jpql += "ORDER BY bi.bill.createdAt, bi.id";
+
+        List<InpatientServiceIssueDTO> result = (List<InpatientServiceIssueDTO>) billItemFacade.findLightsByJpql(jpql, params);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    
+    private List<InpatientServiceIssueDTO> fetchOnlyIPServiceIssueDtos(List<BillTypeAtomic> billTypes) {
+        String jpql = "SELECT new com.divudi.core.data.dto.InpatientServiceIssueDTO("
+                + "bi.id, "
+                + "bi.item.name, "
+                + "bi.qty, "
+                + "bi.netValue, "
+                + "bi.bill.createdAt, "
+                + "bi.bill.billTypeAtomic, "
+                + "COALESCE(bi.bill.department.name, 'N/A'), "
+                + "bi.bill.cancelled) "
+                + "FROM BillItem bi "
+                + "WHERE bi.bill.patientEncounter = :patientEncounter "
+                + "AND type(bi.item)=:btp "
+                + "AND bi.bill.billTypeAtomic IN :billTypeAtomics "
+                + "AND bi.retired = FALSE "
+                + "AND bi.bill.retired = FALSE ";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billTypeAtomics", billTypes);
+        params.put("patientEncounter", patientEncounter);
+        params.put("btp", Service.class);
 
         if (department != null) {
             jpql += "AND bi.bill.department = :department ";

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -1081,7 +1081,7 @@
                                 <div class="col-6">
                                     <p:commandButton
                                         id="btnServiceBills"
-                                        value="Inward Service Bills"
+                                        value="All Inward Service Bills"
                                         action="#{inwardReportControllerBht.navigateToInpatientServiceBillListDto()}"
                                         icon="fa fa-file-invoice"
                                         ajax="false"


### PR DESCRIPTION
## Summary

Fixes the inward **Drugs / Service / Lab** breakdown on the admission profile, where the *service* total was being inflated by pharmacy and lab items.

Closes #21177

## Problem

The encounter service breakdown previously called `fetchServiceIssueDtos(serviceTypes)`, which returned **all** `BillItem`s for the patient encounter matching the inward service bill types — including pharmacy (drugs) and lab items. As a result the "Service" figures mixed in drug and lab charges instead of showing service charges only.

## Fix

- Added `fetchOnlyIPServiceIssueDtos(...)` in `InwardReportControllerBht`, which restricts the JPQL to `type(bi.item) = Service` so only `Service` entities are counted in the service breakdown. Department scoping, retired filtering and ordering are preserved.
- Switched the breakdown population to use the new method.
- Relabelled the encounter button from "Inward Service Bills" to **"All Inward Service Bills"** for clarity.

## Files Changed

- `src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java`
- `src/main/webapp/inward/admission_profile.xhtml`

## Testing

Verified the service breakdown on an inpatient admission profile now reflects only service-type charges, with drugs and lab items excluded from the service totals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision of inpatient service bill filtering to properly distinguish service items in reports.

* **UI Updates**
  * Updated service bills report button label to "All Inward Service Bills" for improved clarity on report scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->