### PR TITLE
feat(inward): add service-wise comment column to inward bill service

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -579,6 +579,11 @@
                                                             </p:selectOneMenu>
 
                                                         </p:column>
+                                                        
+                                                        <p:column width="8em">
+                                                            <f:facet name="header">Comment</f:facet>
+                                                            <h:outputLabel value="#{bi.billItem.descreption}"/>
+                                                        </p:column>
 
                                                         <p:column width="7em" class="text-end">
                                                             <f:facet name="header">Rate</f:facet>


### PR DESCRIPTION
## Summary

Adds a **Comment** column to the inward service billing table (`inward_bill_service.xhtml`) so that service-wise remarks are visible while billing.

The column displays the bill item description (`bi.billItem.descreption`) alongside each service line, addressing the request to show a service-wise remark.

## Issue

Closes #21179 — *"Service Wise remark Need to add."* (Inward / Ruhunu Hospital)

The inward service bill did not surface the per-service remark/description to the user. This adds a read-only **Comment** column rendering the existing bill item description.

## Changes

- `src/main/webapp/inward/inward_bill_service.xhtml` — new `Comment` column (`8em`) showing `#{bi.billItem.descreption}`.

## Type of change

JSF-only (XHTML) change — no Java compilation or migration required.

## Testing

- Verified the new column renders the service description in the inward service billing table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Comment column to the Bill Items table in the inward bill service view, enabling users to view description information for each item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->