### PR TITLE
Restrict Sample Rejection and Analyzer Test Code panels by privilege on Lab Sample Management page

### DIFF
--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -66,10 +66,11 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
         resources.add(com.divudi.ws.inward.InwardDocumentTemplateApi.class);
         resources.add(com.divudi.ws.inward.InwardPriceAdjustmentApi.class);
-        resources.add(com.divudi.ws.inward.PriceMatrixInwardApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomCategoryApi.class);
         resources.add(com.divudi.ws.inward.InwardRoomFacilityChargeApi.class);
+        resources.add(com.divudi.ws.inward.PriceMatrixInwardApi.class);
+        resources.add(com.divudi.ws.inward.TimedItemApi.class);
         resources.add(com.divudi.ws.lims.AnalyzerTestApi.class);
         resources.add(com.divudi.ws.lims.Lims.class);
         resources.add(com.divudi.ws.lims.LimsMiddlewareController.class);
@@ -78,19 +79,18 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.lims.PatientSampleApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmaceuticalConfigApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmaceuticalItemApi.class);
-        resources.add(com.divudi.ws.pharmacy.PharmacyItemApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyAdjustmentApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyBatchApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyBfdBackfillApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyF15ReportApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyGrnBifdBackfillApi.class);
+        resources.add(com.divudi.ws.pharmacy.PharmacyItemApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacySearchApi.class);
         resources.add(com.divudi.ws.pharmacy.StockHistoryApi.class);
         resources.add(com.divudi.ws.pricing.CollectingCentreFeesApi.class);
         resources.add(com.divudi.ws.sap.SapBillingApi.class);
         resources.add(com.divudi.ws.sap.SapInventoryApi.class);
         resources.add(com.divudi.ws.service.ServiceApi.class);
-        resources.add(com.divudi.ws.inward.TimedItemApi.class);
     }
     
 }

--- a/src/main/webapp/lab/generate_barcode_p.xhtml
+++ b/src/main/webapp/lab/generate_barcode_p.xhtml
@@ -439,55 +439,60 @@
 
                                     <hr/>
 
-                                    <p:inputText 
-                                        class="w-100"
-                                        disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
-                                        placeholder="Sample Reject Reason"
-                                        value="#{patientInvestigationController.sampleRejectionComment}" >
-                                    </p:inputText>
+                                    <h:panelGrid columns="1" class="w-100" rendered="#{webUserController.hasPrivilege('LabSampleRejecting')}">
 
-                                    <h:panelGrid columns="3" class="my-2">
-                                        <p:toggleSwitch 
-                                            value="#{patientInvestigationController.requestReCollected}" 
-                                            onIcon="pi pi-check" 
-                                            offIcon="pi pi-times" 
-                                            disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}">
-                                        </p:toggleSwitch>
-                                        <p:spacer width="20"/>
-                                        <h:outputLabel value="Request Re-Collect Sample"/>
+                                        <p:inputText 
+                                            class="w-100"
+                                            disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
+                                            placeholder="Sample Reject Reason"
+                                            value="#{patientInvestigationController.sampleRejectionComment}" >
+                                        </p:inputText>
+
+                                        <h:panelGrid columns="3" class="my-2">
+                                            <p:toggleSwitch 
+                                                value="#{patientInvestigationController.requestReCollected}" 
+                                                onIcon="pi pi-check" 
+                                                offIcon="pi pi-times" 
+                                                disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}">
+                                            </p:toggleSwitch>
+                                            <p:spacer width="20"/>
+                                            <h:outputLabel value="Request Re-Collect Sample"/>
+                                        </h:panelGrid>
+
+                                        <p:commandButton 
+                                            disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
+                                            id="btnRejectSamples"
+                                            value="Reject Samples"
+                                            ajax="false"
+                                            action="#{patientInvestigationController.rejectSamples()}"
+                                            title="Reject Samples"
+                                            icon="pi pi-times-circle"
+                                            styleClass="w-100 ui-button-danger" >
+                                        </p:commandButton>
+
+                                        <hr/>
+
                                     </h:panelGrid>
 
-                                    <p:commandButton 
-                                        disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
-                                        id="btnRejectSamples"
-                                        value="Reject Samples"
-                                        ajax="false"
-                                        action="#{patientInvestigationController.rejectSamples()}"
-                                        title="Reject Samples"
-                                        icon="pi pi-times-circle"
-                                        styleClass="w-100 ui-button-danger" >
-                                    </p:commandButton>
+                                    <h:panelGrid columns="1" class="w-100" rendered="#{webUserController.hasPrivilege('Developers')}">
+                                        <p:commandButton 
+                                            disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
+                                            id="btnGenerateTestCodes"
+                                            value="Check Analyzer Test Codes"
+                                            ajax="false"
+                                            action="#{patientInvestigationController.generateSampleCodesSamples()}"
+                                            title="Reject Samples"
+                                            icon="pi pi-times-circle"
+                                            styleClass="w-100 ui-button-danger" >
+                                        </p:commandButton>
 
-                                    <hr/>
+                                        <p:inputTextarea 
+                                            class="w-100"
+                                            value="#{patientInvestigationController.testDetails}" >
+                                        </p:inputTextarea>
 
-                                    <p:commandButton 
-                                        disabled="#{patientInvestigationController.listingEntity ne 'PATIENT_SAMPLES'}"
-                                        id="btnGenerateTestCodes"
-                                        value="Check Analyzer Test Codes"
-                                        ajax="false"
-                                        action="#{patientInvestigationController.generateSampleCodesSamples()}"
-                                        title="Reject Samples"
-                                        icon="pi pi-times-circle"
-                                        styleClass="w-100 ui-button-danger" >
-                                    </p:commandButton>
-
-                                    <p:inputTextarea 
-                                        class="w-100"
-                                        value="#{patientInvestigationController.testDetails}" >
-                                    </p:inputTextarea>
-
-                                    <hr/>
-
+                                        <hr/>
+                                    </h:panelGrid>
                                 </h:panelGrid>
                             </div>
 


### PR DESCRIPTION
## Summary

Restricts two control groups on the Lab Sample Management barcode page (`lab/generate_barcode_p.xhtml`) so they only render for users with the appropriate privilege, and tidies the REST resource registration list.

## Changes

- **Sample Rejection panel** (reject-reason input, "Request Re-Collect Sample" toggle, **Reject Samples** button) is now wrapped in `rendered="#{webUserController.hasPrivilege('LabSampleRejecting')}"` — visible only to users who can reject samples.
- **Check Analyzer Test Codes** button and the test-details textarea are now wrapped in `rendered="#{webUserController.hasPrivilege('Developers')}"` — these are developer/debug aids and are hidden from regular users.
- **`ApplicationConfig.java`**: alphabetized the REST resource registrations (`PharmacyItemApi`, `PriceMatrixInwardApi`, `TimedItemApi`). No APIs added or removed — pure ordering cleanup.

## Notes

- Both privileges already exist in `Privileges` (`LabSampleRejecting`, `Developers`); no new privileges were introduced.
- `persistence.xml` is intentionally left out of this PR (local JNDI dev config).

## Testing

- JSF/XHTML rendering change — no Java logic change on the page; `ApplicationConfig` change is registration ordering only.

Closes #21640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal REST resource configuration

* **New Features**
  * Added privilege-based access controls to lab features: sample rejection functions now restricted to authorized users, analyzer test code tools limited to developers only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->