### PR TITLE
Fix inward deposit payment cancellation for patient-deposit-paid bills

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -875,6 +875,7 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
         getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY));
         getCurrent().setBillDate(new Date());
         getCurrent().setBillTime(new Date());
+        getCurrent().setPatient(getCurrent().getPatientEncounter().getPatient());
 
         getCurrent().setCreatedAt(new Date());
         getCurrent().setCreater(getSessionController().getLoggedUser());

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1592,6 +1592,7 @@ public class InwardSearch implements Serializable {
         cb.copy(getBill());
         cb.invertAndAssignValuesFromOtherBill(getBill());
         cb.setBilledBill(getBill());
+        cb.setPatient(getBill().getPatient());
 
         ////////////
         cb.setBillDate(new Date());

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -59,7 +59,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.ws.rs.PATCH;
 
 /**
  *

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.ws.rs.PATCH;
 
 /**
  *
@@ -152,15 +153,126 @@ public class InwardSearch implements Serializable {
     Sex[] sex;
     private Admission admission;
     private PaymentMethodData paymentMethodData;
+    private PaymentMethodData originalBillPaymentMethodData;
     boolean showOrginalBill;
 
     private boolean withProfessionalFee = false;
     private boolean showZeroInwardChargeCategoryTypes = false;
     private boolean changed = false;
 
+    public PaymentMethodData loadCurrentBillPaymentMethodData(Bill bill) {
+        System.out.println("loadCurrentBillPaymentMethodData");
+        System.out.println("bill = " + bill);
+        PaymentMethodData newPmd = new PaymentMethodData();
+        if (bill == null || bill.getId() == null) {
+            System.out.println("bill is null or not persisted, returning empty PaymentMethodData");
+            return newPmd;
+        }
+
+        List<Payment> originalPayments = getBillBean().fetchBillPayments(bill);
+        System.out.println("originalPayments = " + originalPayments);
+        if (originalPayments == null || originalPayments.isEmpty()) {
+            System.out.println("no original payments found, returning empty PaymentMethodData");
+            return newPmd;
+        }
+
+        PaymentMethod firstMethod = null;
+        boolean mixedMethods = false;
+
+        for (Payment p : originalPayments) {
+            PaymentMethod pm = p.getPaymentMethod();
+            System.out.println("processing payment p = " + p);
+            System.out.println("payment method pm = " + pm);
+            if (pm == null) {
+                continue;
+            }
+            if (firstMethod == null) {
+                firstMethod = pm;
+            } else if (firstMethod != pm) {
+                mixedMethods = true;
+            }
+            populateComponentDetailFromPayment(newPmd, p, bill);
+        }
+
+        System.out.println("firstMethod = " + firstMethod);
+        System.out.println("mixedMethods = " + mixedMethods);
+        newPmd.setPaymentMethod(mixedMethods ? PaymentMethod.MultiplePaymentMethods : firstMethod);
+        System.out.println("resolved paymentMethod = " + newPmd.getPaymentMethod());
+        return newPmd;
+    }
+
+    private void populateComponentDetailFromPayment(PaymentMethodData pmd, Payment p, Bill bill) {
+        PaymentMethod pm = p.getPaymentMethod();
+        if (pm == null) {
+            return;
+        }
+        double amount = Math.abs(p.getPaidValue());
+        switch (pm) {
+            case Cash:
+                pmd.getCash().setTotalValue(pmd.getCash().getTotalValue() + amount);
+                break;
+            case Card:
+                pmd.getCreditCard().setTotalValue(pmd.getCreditCard().getTotalValue() + amount);
+                pmd.getCreditCard().setNo(p.getCreditCardRefNo());
+                pmd.getCreditCard().setInstitution(p.getBank());
+                pmd.getCreditCard().setComment(p.getComments());
+                break;
+            case Cheque:
+                pmd.getCheque().setTotalValue(pmd.getCheque().getTotalValue() + amount);
+                pmd.getCheque().setNo(p.getChequeRefNo());
+                pmd.getCheque().setDate(p.getChequeDate());
+                pmd.getCheque().setInstitution(p.getBank());
+                pmd.getCheque().setComment(p.getComments());
+                break;
+            case Slip:
+                pmd.getSlip().setTotalValue(pmd.getSlip().getTotalValue() + amount);
+                pmd.getSlip().setReferenceNo(p.getReferenceNo());
+                pmd.getSlip().setDate(p.getPaymentDate());
+                pmd.getSlip().setInstitution(p.getBank());
+                pmd.getSlip().setComment(p.getComments());
+                break;
+            case ewallet:
+                pmd.getEwallet().setTotalValue(pmd.getEwallet().getTotalValue() + amount);
+                pmd.getEwallet().setNo(p.getReferenceNo());
+                pmd.getEwallet().setInstitution(p.getBank());
+                pmd.getEwallet().setComment(p.getComments());
+                break;
+            case PatientDeposit:
+                pmd.getPatient_deposit().setTotalValue(pmd.getPatient_deposit().getTotalValue() + amount);
+                if (bill.getPatientEncounter() != null) {
+                    pmd.getPatient_deposit().setPatient(bill.getPatientEncounter().getPatient());
+                    PatientDeposit pd = patientDepositController.checkDepositOfThePatient(
+                            bill.getPatientEncounter().getPatient(), sessionController.getDepartment());
+                    if (pd != null && pd.getId() != null) {
+                        pmd.getPatient_deposit().setPatientDepost(pd);
+                    }
+                }
+                break;
+            case OnlineSettlement:
+                pmd.getOnlineSettlement().setTotalValue(pmd.getOnlineSettlement().getTotalValue() + amount);
+                pmd.getOnlineSettlement().setComment(p.getComments());
+                break;
+            default:
+                break;
+        }
+    }
+    
+    private List<PaymentMethod> inwardDepositCancelationPaymentMethods;
+    
     public String navigateToPaymentBillCancellation() {
         switch (bill.getBillTypeAtomic()) {
             case INWARD_DEPOSIT:
+                inwardDepositCancelationPaymentMethods = new ArrayList<>();
+                getInwardDepositCancelationPaymentMethods().add(PaymentMethod.Cash);
+                
+                if(bill.getPaymentMethod() != PaymentMethod.Cash){
+                    inwardDepositCancelationPaymentMethods.add(bill.getPaymentMethod());
+                }
+                originalBillPaymentMethodData = new PaymentMethodData();
+                originalBillPaymentMethodData = loadCurrentBillPaymentMethodData(bill);
+                
+                paymentMethodData = new PaymentMethodData();
+                
                 return "inward_deposit_cancel_bill_payment?faces-redirect=true";
             case INWARD_DEPOSIT_REFUND:
                 return "inward_deposit_refund_cancel_bill_payment?faces-redirect=true";
@@ -1084,8 +1196,13 @@ public class InwardSearch implements Serializable {
 
             getBillBean().updateInwardDipositList(getBill().getPatientEncounter(), cb);
 
-            List<Payment> payments = paymentService.createPayment(cb, paymentMethodData);
-            paymentService.updateBalances(payments);
+            paymentService.createPayment(
+                cb,
+                cb.getPaymentMethod(), 
+                paymentMethodData, 
+                sessionController.getInstitution(), 
+                sessionController.getDepartment(),
+                sessionController.getLoggedUser());
 
             if (getBill().getPatientEncounter().isPaymentFinalized()) {
                 getInwardBean().updateFinalFill(getBill().getPatientEncounter());
@@ -2244,6 +2361,25 @@ public class InwardSearch implements Serializable {
 
     public void setCurrentRequest(Request currentRequest) {
         this.currentRequest = currentRequest;
+    }
+
+    public List<PaymentMethod> getInwardDepositCancelationPaymentMethods() {
+        if(inwardDepositCancelationPaymentMethods == null){
+            inwardDepositCancelationPaymentMethods = new ArrayList<>();
+        }
+        return inwardDepositCancelationPaymentMethods;
+    }
+
+    public void setInwardDepositCancelationPaymentMethods(List<PaymentMethod> inwardDepositCancelationPaymentMethods) {
+        this.inwardDepositCancelationPaymentMethods = inwardDepositCancelationPaymentMethods;
+    }
+
+    public PaymentMethodData getOriginalBillPaymentMethodData() {
+        return originalBillPaymentMethodData;
+    }
+
+    public void setOriginalBillPaymentMethodData(PaymentMethodData originalBillPaymentMethodData) {
+        this.originalBillPaymentMethodData = originalBillPaymentMethodData;
     }
 
 }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -256,7 +256,42 @@ public class InwardSearch implements Serializable {
                 break;
         }
     }
-    
+
+    public void refillPaymentDetail() {
+        if (originalBillPaymentMethodData == null) {
+            return;
+        }
+        if (paymentMethodData == null) {
+            paymentMethodData = new PaymentMethodData();
+        }
+        paymentMethodData.setPaymentMethod(originalBillPaymentMethodData.getPaymentMethod());
+        
+        copyComponentDetail(originalBillPaymentMethodData.getCash(), paymentMethodData.getCash());
+        copyComponentDetail(originalBillPaymentMethodData.getCreditCard(), paymentMethodData.getCreditCard());
+        copyComponentDetail(originalBillPaymentMethodData.getCheque(), paymentMethodData.getCheque());
+        copyComponentDetail(originalBillPaymentMethodData.getSlip(), paymentMethodData.getSlip());
+        copyComponentDetail(originalBillPaymentMethodData.getEwallet(), paymentMethodData.getEwallet());
+        copyComponentDetail(originalBillPaymentMethodData.getPatient_deposit(), paymentMethodData.getPatient_deposit());
+        copyComponentDetail(originalBillPaymentMethodData.getOnlineSettlement(), paymentMethodData.getOnlineSettlement());
+    }
+
+    private void copyComponentDetail(ComponentDetail from, ComponentDetail to) {
+        if (from == null || to == null) {
+            return;
+        }
+        to.setTotalValue(from.getTotalValue());
+        to.setNo(from.getNo());
+        to.setReferenceNo(from.getReferenceNo());
+        to.setReferralNo(from.getReferralNo());
+        to.setComment(from.getComment());
+        to.setDate(from.getDate());
+        to.setInstitution(from.getInstitution());
+        to.setPatient(from.getPatient());
+        to.setPatientDepost(from.getPatientDepost());
+        to.setToStaff(from.getToStaff());
+        to.setCreditDuration(from.getCreditDuration());
+    }
+
     private List<PaymentMethod> inwardDepositCancelationPaymentMethods;
     
     public String navigateToPaymentBillCancellation() {
@@ -279,6 +314,16 @@ public class InwardSearch implements Serializable {
             default:
                 return "inward_cancel_bill_payment?faces-redirect=true";
         }
+    }
+
+    public String navigateToViewInwardDepositCancellationBill(Bill b) {
+        if (b == null || b.getCancelledBill() == null) {
+            JsfUtil.addErrorMessage("No cancellation bill found");
+            return "";
+        }
+        bill = b;
+        printPreview = true;
+        return "/inward/inward_deposit_cancel_bill_payment?faces-redirect=true";
     }
 
     public void editBillDetails() {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1594,7 +1594,11 @@ public class InwardSearch implements Serializable {
         cb.copy(getBill());
         cb.invertAndAssignValuesFromOtherBill(getBill());
         cb.setBilledBill(getBill());
-        cb.setPatient(getBill().getPatient());
+        if (getBill().getPatient() != null) {
+            cb.setPatient(getBill().getPatient());
+        } else if (getBill().getPatientEncounter() != null) {
+            cb.setPatient(getBill().getPatientEncounter().getPatient());
+        }
 
         ////////////
         cb.setBillDate(new Date());

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -250,6 +250,9 @@ public class InwardSearch implements Serializable {
                 break;
             case OnlineSettlement:
                 pmd.getOnlineSettlement().setTotalValue(pmd.getOnlineSettlement().getTotalValue() + amount);
+                pmd.getOnlineSettlement().setReferenceNo(p.getReferenceNo());
+                pmd.getOnlineSettlement().setDate(p.getPaymentDate());
+                pmd.getOnlineSettlement().setInstitution(p.getBank());
                 pmd.getOnlineSettlement().setComment(p.getComments());
                 break;
             default:

--- a/src/main/java/com/divudi/service/PatientDepositService.java
+++ b/src/main/java/com/divudi/service/PatientDepositService.java
@@ -142,7 +142,11 @@ public class PatientDepositService {
             case INWARD_DEPOSIT:
                 handleOutPayment(p, pd);
                 break;
-
+                
+            case INWARD_DEPOSIT_CANCELLATION:
+                handleInPayment(p, pd);
+                break;
+                
             default:
                 throw new AssertionError();
         }

--- a/src/main/java/com/divudi/service/PaymentService.java
+++ b/src/main/java/com/divudi/service/PaymentService.java
@@ -352,28 +352,25 @@ public class PaymentService {
             p.setCreatedAt(new Date());
             p.setCreater(webUser);
             p.setPaymentMethod(pm);
+            p.setPaidValue(bill.getNetTotal());
 
             switch (pm) {
                 case Cash:
-                    p.setPaidValue(bill.getNetTotal());
                     p.setComments("");
                     break;
                 case Card:
                     p.setBank(paymentMethodData.getCreditCard().getInstitution());
                     p.setCreditCardRefNo(paymentMethodData.getCreditCard().getNo());
-                    p.setPaidValue(paymentMethodData.getCreditCard().getTotalValue());
                     p.setComments(paymentMethodData.getCreditCard().getComment());
                     break;
                 case Cheque:
                     p.setBank(paymentMethodData.getCheque().getInstitution());
                     p.setChequeDate(paymentMethodData.getCheque().getDate());
                     p.setChequeRefNo(paymentMethodData.getCheque().getNo());
-                    p.setPaidValue(paymentMethodData.getCheque().getTotalValue());
                     p.setComments(paymentMethodData.getCheque().getComment());
                     break;
                 case Slip:
                     p.setBank(paymentMethodData.getSlip().getInstitution());
-                    p.setPaidValue(paymentMethodData.getSlip().getTotalValue());
                     p.setRealizedAt(paymentMethodData.getSlip().getDate());
                     p.setPaymentDate(paymentMethodData.getSlip().getDate());
                     p.setChequeDate(paymentMethodData.getSlip().getDate());
@@ -386,23 +383,18 @@ public class PaymentService {
                     p.setPolicyNo(paymentMethodData.getEwallet().getReferralNo());
                     p.setReferenceNo(paymentMethodData.getEwallet().getReferenceNo());
                     p.setCreditCompany(paymentMethodData.getEwallet().getInstitution());
-                    p.setPaidValue(paymentMethodData.getEwallet().getTotalValue());
                     p.setComments(paymentMethodData.getEwallet().getComment());
                     break;
                 case PatientDeposit:
-                    double paidValue = paymentMethodData.getPatient_deposit().getTotalValue();
                     PatientDeposit currentDeposit = paymentMethodData.getPatient_deposit().getPatientDepost();
-                    p.setPaidValue(paidValue);
                     patientDepositService.updateBalance(p, currentDeposit);
                     break;
                 case OnlineSettlement:
                     p.setBank(paymentMethodData.getOnlineSettlement().getInstitution());
-                    p.setPaidValue(paymentMethodData.getOnlineSettlement().getTotalValue());
                     p.setPaymentDate(paymentMethodData.getOnlineSettlement().getDate());
                     p.setReferenceNo(paymentMethodData.getOnlineSettlement().getReferenceNo());
                     p.setComments(paymentMethodData.getOnlineSettlement().getComment());
                     break;
-
             }
 
             paymentFacade.create(p);

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -46,11 +46,12 @@
                                 <div class="d-flex gap-2 W-100">
                                     <p:outputLabel for="cmbPs" value="Payment Method" style="width: 250px;" styleClass="mt-2 fw-bold"/>
                                     <p:selectOneMenu 
-                                        id="cmbPs" value="#{inwardSearch.paymentMethod}" 
+                                        id="cmbPs" 
+                                        value="#{inwardSearch.paymentMethod}" 
                                         required="true"
                                         styleClass="w-100">
                                         <f:selectItem itemLabel="Select Payment Method"/>
-                                        <f:selectItems value="#{inwardPaymentController.paymentMethods}"/>
+                                        <f:selectItems value="#{enumController.paymentMethodsForIwardDeposit}"/>
                                         <p:ajax process="cmbPs" update="paymentDetails @all" event="change"
                                                 listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}"/>
                                     </p:selectOneMenu>

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -54,7 +54,7 @@
                                         <f:selectItems value="#{inwardSearch.inwardDepositCancelationPaymentMethods}"/>
                                         <p:ajax 
                                             process="cmbPs" 
-                                            update="paymentDetails @all :#{p:resolveFirstComponentWithId('updateData',view).clientId}" 
+                                            update="paymentDetails :#{p:resolveFirstComponentWithId('updateData',view).clientId}"
                                             event="change"
                                             listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}">
                                         </p:ajax>

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -78,34 +78,6 @@
                             </div>
 
                             <div class="row mt-2">
-                                <div class="col-md-2"></div>
-                                <div class="col-12 col-md-8">
-                                    <h:panelGroup id="paymentDetails">
-                                        <h:panelGroup id="creditCard"
-                                                      rendered="#{inwardSearch.paymentMethod eq 'Card'}">
-                                            <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}"/>
-                                        </h:panelGroup>
-
-                                        <h:panelGroup id="cheque" rendered="#{inwardSearch.paymentMethod eq 'Cheque'}">
-                                            <pa:cheque paymentMethodData="#{inwardSearch.paymentMethodData}"
-                                                       valueRequired="false"/>
-                                        </h:panelGroup>
-
-                                        <h:panelGroup id="slip" rendered="#{inwardSearch.paymentMethod eq 'Slip'}">
-                                            <pa:slip paymentMethodData="#{inwardSearch.paymentMethodData}"/>
-                                        </h:panelGroup>
-                                        <h:panelGroup
-                                            class="row my-1"
-                                            layout="block"
-                                            id="patientDeposit"
-                                            rendered="#{inwardSearch.paymentMethod eq 'PatientDeposit'}">
-                                            <pa:patient_deposit paymentMethodData="#{inwardSearch.paymentMethodData}"/>
-                                        </h:panelGroup>
-                                    </h:panelGroup>
-                                </div>
-                            </div>
-
-                            <div class="row mt-2">
                                 <div class="col-12 col-md-4 mb-2">
                                     <p:panel header="Patient Details" styleClass="h-100">
                                         <p:panelGrid columns="2" layout="tabular" styleClass="w-100">

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -230,6 +230,15 @@
                                     <h:outputText value="Cancellation Bill"/>
                                     <div class="d-flex gap-2">
                                         <p:commandButton
+                                            id="btnCancelBillSettings"
+                                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            styleClass="ui-button-secondary"
+                                            type="button"
+                                            title="Configure cancellation bill paper"
+                                            onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                        <p:commandButton
                                             id="btnPrintCancelBill"
                                             value="Print"
                                             styleClass="ui-button-info"
@@ -252,13 +261,63 @@
 
                             <div class="d-flex justify-content-center align-items-center">
                                 <h:panelGroup id="gpCancelBillPreview">
-                                    <bill:posPaperCancellationBill bill="#{inwardSearch.bill.cancelledBill}" duplicate="false"/>
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                        <bill:posPaperCancellationBill bill="#{inwardSearch.bill.cancelledBill}" duplicate="false"/>
+                                    </h:panelGroup>
                                 </h:panelGroup>
                             </div>
                         </p:panel>
                     </h:panelGroup>
 
                 </h:form>
+
+                <p:dialog id="inwardPaymentConfigDialog"
+                          header="Inward Payment Bill Printer Configuration"
+                          widgetVar="inwardPaymentConfigDialog"
+                          modal="true"
+                          width="560"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+                    <h:form id="inwardPaymentConfigForm">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <i class="fas fa-file-alt me-2"/>
+                                <h:outputText value="Paper Format Settings"/>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                                    <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                                    <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton value="Apply &amp; Close"
+                                             icon="fas fa-save"
+                                             class="ui-button-success"
+                                             ajax="false"
+                                             action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                            <p:commandButton value="Cancel"
+                                             icon="fas fa-times"
+                                             class="ui-button-secondary"
+                                             type="button"
+                                             onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -54,13 +54,26 @@
                                         <f:selectItems value="#{inwardSearch.inwardDepositCancelationPaymentMethods}"/>
                                         <p:ajax 
                                             process="cmbPs" 
-                                            update="paymentDetails @all" 
+                                            update="paymentDetails @all :#{p:resolveFirstComponentWithId('updateData',view).clientId}" 
                                             event="change"
                                             listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}">
                                         </p:ajax>
                                     </p:selectOneMenu>
 
+                                    
+
                                     <h:panelGroup id="paymentDetails" layout="block" class="d-flex flex-wrap gap-2 align-items-center ms-2">
+                                        
+                                        <p:commandButton
+                                            id="updateData"
+                                            class="ui-button-warning "
+                                            rendered="#{inwardSearch.paymentMethod ne 'Cash'}"
+                                            process="@this"
+                                            update="paymentDetails"
+                                            icon="fas fa-gear"
+                                            title="Re-Fill Payment Details"
+                                            action="#{inwardSearch.refillPaymentDetail()}">
+                                        </p:commandButton>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Card'}">
                                             <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}"/>
@@ -214,19 +227,34 @@
                         <p:panel>
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between align-items-center">
-                                    <h:outputText value="Cancel Bill"/>
-                                    <p:commandButton
-                                        id="btnBackToBillList"
-                                        value="Back to Bill List"
-                                        action="/inward/inward_search_payment?faces-redirect=true"
-                                        ajax="false"
-                                        styleClass="ui-button-warning"
-                                        icon="fa fa-arrow-left"
-                                        title="Return to the payment bill list">
-                                    </p:commandButton>
+                                    <h:outputText value="Cancellation Bill"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            id="btnPrintCancelBill"
+                                            value="Print"
+                                            styleClass="ui-button-info"
+                                            icon="fas fa-print"
+                                            title="Print cancellation bill">
+                                            <p:printer target="gpCancelBillPreview"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnBackToBillList"
+                                            value="Back to Bill List"
+                                            action="/inward/inward_search_payment?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-warning"
+                                            icon="fa fa-arrow-left"
+                                            title="Return to the payment bill list">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </f:facet>
 
+                            <div class="d-flex justify-content-center align-items-center">
+                                <h:panelGroup id="gpCancelBillPreview">
+                                    <bill:posPaperCancellationBill bill="#{inwardSearch.bill.cancelledBill}" duplicate="false"/>
+                                </h:panelGroup>
+                            </div>
                         </p:panel>
                     </h:panelGroup>
 

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -115,22 +115,53 @@
                                     </p:panel>
                                 </div>
                                 <div class="col-12 col-md-4 mb-2">
-                                    <p:panel header="Payment Data" styleClass="h-100">
-                                        <p:dataTable rowIndexVar="rowIndex"
-                                                     value="#{billSearch.fetchBillPayments(inwardSearch.bill)}" var="bip"
-                                                     styleClass="w-100">
-                                            <p:column headerText="No" styleClass="text-center" style="width: 3rem;">
-                                                <h:outputLabel value="#{rowIndex+1}"/>
-                                            </p:column>
-                                            <p:column headerText="Item">
+                                    <p:panel header="Original Payment Details" styleClass="h-100">
+                                        <p:dataList value="#{billSearch.fetchBillPayments(inwardSearch.bill)}" var="bip"
+                                                    type="none" emptyMessage="No payments found for this bill"
+                                                    styleClass="w-100">
+                                            <p:panelGrid columns="2" layout="tabular" styleClass="w-100 mb-2">
+                                                <h:outputLabel value="Payment Method:" styleClass="fw-bold"/>
                                                 <h:outputLabel value="#{bip.paymentMethod}"/>
-                                            </p:column>
-                                            <p:column headerText="Fee" styleClass="text-end">
-                                                <h:outputLabel value="#{bip.paidValue}">
+
+                                                <h:outputLabel value="Amount:" styleClass="fw-bold"/>
+                                                <h:outputLabel value="#{bip.paidValue}" styleClass="text-end d-block">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
-                                            </p:column>
-                                        </p:dataTable>
+
+                                                <h:outputLabel value="Card No:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.creditCardRefNo}"/>
+                                                <h:outputLabel value="#{bip.creditCardRefNo}"
+                                                               rendered="#{not empty bip.creditCardRefNo}"/>
+
+                                                <h:outputLabel value="Cheque No:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.chequeRefNo}"/>
+                                                <h:outputLabel value="#{bip.chequeRefNo}"
+                                                               rendered="#{not empty bip.chequeRefNo}"/>
+
+                                                <h:outputLabel value="Cheque Date:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.chequeDate}"/>
+                                                <h:outputLabel value="#{bip.chequeDate}"
+                                                               rendered="#{not empty bip.chequeDate}">
+                                                    <f:convertDateTime pattern="dd MMM yyyy"/>
+                                                </h:outputLabel>
+
+                                                <h:outputLabel value="Bank:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.bank}"/>
+                                                <h:outputLabel value="#{bip.bank.name}"
+                                                               rendered="#{not empty bip.bank}"/>
+
+                                                <h:outputLabel value="Reference No:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.referenceNo}"/>
+                                                <h:outputLabel value="#{bip.referenceNo}"
+                                                               rendered="#{not empty bip.referenceNo}"/>
+
+                                                <h:outputLabel value="Comment:" styleClass="fw-bold"
+                                                               rendered="#{not empty bip.comments}"/>
+                                                <h:outputLabel value="#{bip.comments}"
+                                                               rendered="#{not empty bip.comments}"/>
+                                            </p:panelGrid>
+                                            <p:separator/>
+                                        </p:dataList>
                                     </p:panel>
                                 </div>
                             </div>

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -13,46 +13,72 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form>
+                <h:form id="cancelDepositPaymentForm">
                     <h:panelGroup rendered="#{!inwardSearch.printPreview}" styleClass="alignTop">
                         <p:panel>
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <div>
-                                        <p:outputLabel value="Inward Deposit Payment Cancellation" class="mt-2"/>
-                                    </div>
-                                    <div class="d-flex gap-3">
-                                        <p:inputText 
-                                            value="#{inwardSearch.comment}" 
-                                            style="width: 450px;"
-                                            placeholder="Enter a comment" >
-                                        </p:inputText>
-                                        <p:commandButton 
-                                            value="Cancel Payment Bill" 
-                                            class="ui-button-danger" 
-                                            ajax="false" 
-                                            icon="fas fa-ban"
-                                            action="#{inwardSearch.cancelDepositBillPayment()}">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                                    <h:outputText value="Inward Deposit Payment Cancellation" styleClass="fw-bold"/>
+                                    <div class="d-flex align-items-center flex-wrap gap-2">
+                                        <p:commandButton
+                                            id="btnBackToReprintBillPayment"
+                                            value="Back to Reprint Payment"
+                                            action="/inward/inward_reprint_bill_payment?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            icon="fa fa-arrow-left"
+                                            title="Go to Reprint Bill Payment">
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnBackToSearchPayment"
+                                            value="Back to Bill List"
+                                            action="/inward/inward_search_payment?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            icon="fa fa-arrow-left"
+                                            title="Go to Payment Bill Search">
                                         </p:commandButton>
                                     </div>
                                 </div>
                             </f:facet>
 
-                            <div class="align-items-center justify-content-between" style="display: flex">
-                                <div>
-                                    <p:selectOneMenu id="cmbPs" value="#{inwardSearch.paymentMethod}" required="true">
+                            <div class="d-flex justify-content-between my-3">
+                                <div class="d-flex gap-2 W-100">
+                                    <p:outputLabel for="cmbPs" value="Payment Method" style="width: 250px;" styleClass="mt-2 fw-bold"/>
+                                    <p:selectOneMenu 
+                                        id="cmbPs" value="#{inwardSearch.paymentMethod}" 
+                                        required="true"
+                                        styleClass="w-100">
                                         <f:selectItem itemLabel="Select Payment Method"/>
                                         <f:selectItems value="#{inwardPaymentController.paymentMethods}"/>
                                         <p:ajax process="cmbPs" update="paymentDetails @all" event="change"
                                                 listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}"/>
                                     </p:selectOneMenu>
                                 </div>
-
+                                <div class="d-flex gap-2">
+                                    <p:inputText
+                                        id="txtCancellationComment"
+                                        value="#{inwardSearch.comment}"
+                                        style="width: 750px;"
+                                        title="Reason for cancelling this payment bill"
+                                        placeholder="Enter a cancellation reason">
+                                    </p:inputText>
+                                    <p:commandButton
+                                        id="btnCancelPaymentBill"
+                                        value="Cancel Payment Bill"
+                                        styleClass="ui-button-danger"
+                                        ajax="false"
+                                        icon="fas fa-ban"
+                                        title="Cancel this deposit payment bill"
+                                        onclick="return confirm('Are you sure you want to cancel this payment bill? This action cannot be undone.');"
+                                        action="#{inwardSearch.cancelDepositBillPayment()}">
+                                    </p:commandButton>
+                                </div>
                             </div>
 
                             <div class="row mt-2">
                                 <div class="col-md-2"></div>
-                                <div class="col-md-8">
+                                <div class="col-12 col-md-8">
                                     <h:panelGroup id="paymentDetails">
                                         <h:panelGroup id="creditCard"
                                                       rendered="#{inwardSearch.paymentMethod eq 'Card'}">
@@ -79,60 +105,54 @@
                             </div>
 
                             <div class="row mt-2">
-                                <div class="col-md-4">
-                                    <p:panel header="Patient Details">
-                                        <p:panelGrid columns="2">
-                                            <h:outputLabel value="Patient ​Name:"></h:outputLabel>
-                                            <h:outputLabel
-                                                value="#{inwardSearch.bill.patient.person.nameWithTitle}"></h:outputLabel>
-                                            <h:outputLabel value="Bht No:"></h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.bhtNo}"></h:outputLabel>
-                                            <h:outputLabel value="Age"/>
-                                            <h:outputLabel value="#{inwardSearch.bill.patient.age}"/>
-                                            <h:outputLabel value="Sex">
-                                            </h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.patient.person.sex}">
-                                            </h:outputLabel>
-                                            <h:outputLabel value="Phone">
-                                            </h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.patient.person.phone}">
-                                            </h:outputLabel>
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Patient Details" styleClass="h-100">
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100">
+                                            <h:outputLabel value="Patient Name:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.nameWithTitle}"/>
+                                            <h:outputLabel value="Bht No:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.bhtNo}"/>
+                                            <h:outputLabel value="Age:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.age}"/>
+                                            <h:outputLabel value="Sex:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.sex}"/>
+                                            <h:outputLabel value="Phone:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.phone}"/>
                                         </p:panelGrid>
                                     </p:panel>
                                 </div>
-                                <div class="col-md-4">
-                                    <p:panel header="Bill Details">
-                                        <p:panelGrid columns="2">
-                                            <h:outputLabel value="Bill No :"></h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.deptId}"></h:outputLabel>
-                                            <h:outputLabel value="Total :"></h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.total}">
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Bill Details" styleClass="h-100">
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100">
+                                            <h:outputLabel value="Bill No:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.deptId}"/>
+                                            <h:outputLabel value="Total:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.total}" styleClass="text-end d-block">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
-                                            <h:outputLabel value="Discount :"></h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.discount}">
+                                            <h:outputLabel value="Discount:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.discount}" styleClass="text-end d-block">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
-                                            <h:outputLabel value="Net Total :"></h:outputLabel>
-                                            <h:outputLabel value="#{inwardSearch.bill.netTotal}">
+                                            <h:outputLabel value="Net Total:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.netTotal}" styleClass="text-end d-block">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:panelGrid>
                                     </p:panel>
                                 </div>
-                                <div class="col-md-4">
-                                    <p:panel header="Payment Data">
-                                        <p:dataTable rowIndexVar="rowIndex" value="#{billSearch.fetchBillPayments(inwardSearch.bill)}" var="bip">
-                                            <p:column>
-                                                <f:facet name="header">No</f:facet>
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Payment Data" styleClass="h-100">
+                                        <p:dataTable rowIndexVar="rowIndex"
+                                                     value="#{billSearch.fetchBillPayments(inwardSearch.bill)}" var="bip"
+                                                     styleClass="w-100">
+                                            <p:column headerText="No" styleClass="text-center" style="width: 3rem;">
                                                 <h:outputLabel value="#{rowIndex+1}"/>
                                             </p:column>
-                                            <p:column>
-                                                <f:facet name="header">Item</f:facet>
+                                            <p:column headerText="Item">
                                                 <h:outputLabel value="#{bip.paymentMethod}"/>
                                             </p:column>
-                                            <p:column>
-                                                <f:facet name="header">Fee</f:facet>
+                                            <p:column headerText="Fee" styleClass="text-end">
                                                 <h:outputLabel value="#{bip.paidValue}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
@@ -143,49 +163,47 @@
                             </div>
 
                             <div class="row mt-2">
-                                <p:panel>
-                                    <f:facet name="header">
-                                        <div class="d-flex align-items-center justify-content-between">
-                                            <div>
-                                                <h:outputText value=" Payment Bill"/>
-                                            </div>
-                                            <div>
-                                                <p:commandButton 
-                                                    class="ui-button-info"
-                                                    icon="fas fa-print" 
+                                <div class="col-12">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <div class="d-flex align-items-center justify-content-between">
+                                                <h:outputText value="Payment Bill"/>
+                                                <p:commandButton
+                                                    id="btnPrintPaymentBill"
+                                                    styleClass="ui-button-info"
+                                                    icon="fas fa-print"
+                                                    title="Print payment bill"
                                                     value="Print">
                                                     <p:printer target="gpBillPreview"/>
                                                 </p:commandButton>
                                             </div>
+                                        </f:facet>
+                                        <div class="d-flex justify-content-center align-items-center">
+                                            <h:panelGroup id="gpBillPreview">
+                                                <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                            </h:panelGroup>
                                         </div>
-                                    </f:facet>
-                                    <div class="d-flex justify-content-center align-items-center">
-                                        <h:panelGroup id="gpBillPreview">
-                                            <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
-                                        </h:panelGroup>
-                                    </div>
-                                </p:panel>
+                                    </p:panel>
+                                </div>
                             </div>
                         </p:panel>
 
                     </h:panelGroup>
 
-                    <h:panelGroup rendered="#{inwardSearch.printPreview}" >
-                        <p:panel >
+                    <h:panelGroup rendered="#{inwardSearch.printPreview}">
+                        <p:panel>
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <div>
-                                        <p:outputLabel value="Cancel Bill" class="mt-2"/>
-                                    </div>
-                                    <div>
-                                        <p:commandButton 
-                                            value="Back to Bill List" 
-                                            action="/inward/inward_search_payment?faces-redirect=true" 
-                                            ajax="false"
-                                            class="ui-button-warning"
-                                            icon="fa fa-arrow-left">
-                                        </p:commandButton>
-                                    </div>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <h:outputText value="Cancel Bill"/>
+                                    <p:commandButton
+                                        id="btnBackToBillList"
+                                        value="Back to Bill List"
+                                        action="/inward/inward_search_payment?faces-redirect=true"
+                                        ajax="false"
+                                        styleClass="ui-button-warning"
+                                        icon="fa fa-arrow-left"
+                                        title="Return to the payment bill list">
+                                    </p:commandButton>
                                 </div>
                             </f:facet>
 

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -62,7 +62,7 @@
 
                                     
 
-                                    <h:panelGroup id="paymentDetails" layout="block" class="d-flex flex-wrap gap-2 align-items-center ms-2">
+                                    <h:panelGroup id="paymentDetails" layout="block" class="d-flex gap-2 align-items-center ms-2">
                                         
                                         <p:commandButton
                                             id="updateData"
@@ -76,27 +76,27 @@
                                         </p:commandButton>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Card'}">
-                                            <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}"/>
+                                            <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false" />
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Cheque'}">
-                                            <pa:cheque paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                            <pa:cheque paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Slip'}">
-                                            <pa:slip paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                            <pa:slip paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'ewallet'}">
-                                            <pa:ewallet paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                            <pa:ewallet paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'PatientDeposit'}">
-                                            <pa:patient_deposit paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                            <pa:patient_deposit paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'OnlineSettlement'}">
-                                            <pa:online_settlement paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                            <pa:online_settlement paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
                                         </h:panelGroup>
 
                                     </h:panelGroup>

--- a/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_deposit_cancel_bill_payment.xhtml
@@ -42,19 +42,51 @@
                                 </div>
                             </f:facet>
 
-                            <div class="d-flex justify-content-between my-3">
-                                <div class="d-flex gap-2 W-100">
-                                    <p:outputLabel for="cmbPs" value="Payment Method" style="width: 250px;" styleClass="mt-2 fw-bold"/>
-                                    <p:selectOneMenu 
-                                        id="cmbPs" 
-                                        value="#{inwardSearch.paymentMethod}" 
+                            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 my-3">
+                                <div class="d-flex gap-2 align-items-center flex-wrap">
+                                    <p:outputLabel for="cmbPs" value="Payment Method" styleClass="fw-bold"/>
+                                    <p:selectOneMenu
+                                        id="cmbPs"
+                                        value="#{inwardSearch.paymentMethod}"
                                         required="true"
-                                        styleClass="w-100">
+                                        style="width: 320px;">
                                         <f:selectItem itemLabel="Select Payment Method"/>
-                                        <f:selectItems value="#{enumController.paymentMethodsForIwardDeposit}"/>
-                                        <p:ajax process="cmbPs" update="paymentDetails @all" event="change"
-                                                listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}"/>
+                                        <f:selectItems value="#{inwardSearch.inwardDepositCancelationPaymentMethods}"/>
+                                        <p:ajax 
+                                            process="cmbPs" 
+                                            update="paymentDetails @all" 
+                                            event="change"
+                                            listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}">
+                                        </p:ajax>
                                     </p:selectOneMenu>
+
+                                    <h:panelGroup id="paymentDetails" layout="block" class="d-flex flex-wrap gap-2 align-items-center ms-2">
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Card'}">
+                                            <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Cheque'}">
+                                            <pa:cheque paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Slip'}">
+                                            <pa:slip paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'ewallet'}">
+                                            <pa:ewallet paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'PatientDeposit'}">
+                                            <pa:patient_deposit paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'OnlineSettlement'}">
+                                            <pa:online_settlement paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="true"/>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
                                 </div>
                                 <div class="d-flex gap-2">
                                     <p:inputText
@@ -116,52 +148,36 @@
                                 </div>
                                 <div class="col-12 col-md-4 mb-2">
                                     <p:panel header="Original Payment Details" styleClass="h-100">
-                                        <p:dataList value="#{billSearch.fetchBillPayments(inwardSearch.bill)}" var="bip"
-                                                    type="none" emptyMessage="No payments found for this bill"
-                                                    styleClass="w-100">
-                                            <p:panelGrid columns="2" layout="tabular" styleClass="w-100 mb-2">
-                                                <h:outputLabel value="Payment Method:" styleClass="fw-bold"/>
-                                                <h:outputLabel value="#{bip.paymentMethod}"/>
+                                        <div class="d-flex align-items-center justify-content-between gap-2 mb-3 px-3 py-2 rounded-3 bg-light text-dark border shadow-sm">
+                                            <span class="d-flex align-items-center gap-2">
+                                                <i class="fas fa-money-check-alt fs-5 text-primary"/>
+                                                <h:outputText value="Payment Method" styleClass="text-uppercase small fw-semibold text-muted"/>
+                                            </span>
+                                            <h:outputText value="#{inwardSearch.bill.paymentMethod}"
+                                                          styleClass="fs-5 fw-bold"/>
+                                        </div>
 
-                                                <h:outputLabel value="Amount:" styleClass="fw-bold"/>
-                                                <h:outputLabel value="#{bip.paidValue}" styleClass="text-end d-block">
-                                                    <f:convertNumber pattern="#,##0.00"/>
-                                                </h:outputLabel>
-
-                                                <h:outputLabel value="Card No:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.creditCardRefNo}"/>
-                                                <h:outputLabel value="#{bip.creditCardRefNo}"
-                                                               rendered="#{not empty bip.creditCardRefNo}"/>
-
-                                                <h:outputLabel value="Cheque No:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.chequeRefNo}"/>
-                                                <h:outputLabel value="#{bip.chequeRefNo}"
-                                                               rendered="#{not empty bip.chequeRefNo}"/>
-
-                                                <h:outputLabel value="Cheque Date:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.chequeDate}"/>
-                                                <h:outputLabel value="#{bip.chequeDate}"
-                                                               rendered="#{not empty bip.chequeDate}">
-                                                    <f:convertDateTime pattern="dd MMM yyyy"/>
-                                                </h:outputLabel>
-
-                                                <h:outputLabel value="Bank:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.bank}"/>
-                                                <h:outputLabel value="#{bip.bank.name}"
-                                                               rendered="#{not empty bip.bank}"/>
-
-                                                <h:outputLabel value="Reference No:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.referenceNo}"/>
-                                                <h:outputLabel value="#{bip.referenceNo}"
-                                                               rendered="#{not empty bip.referenceNo}"/>
-
-                                                <h:outputLabel value="Comment:" styleClass="fw-bold"
-                                                               rendered="#{not empty bip.comments}"/>
-                                                <h:outputLabel value="#{bip.comments}"
-                                                               rendered="#{not empty bip.comments}"/>
-                                            </p:panelGrid>
-                                            <p:separator/>
-                                        </p:dataList>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Cash'}">
+                                            <pa:cash_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Card'}">
+                                            <pa:creditCard_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Cheque'}">
+                                            <pa:cheque_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Slip'}">
+                                            <pa:slip_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'ewallet'}">
+                                            <pa:ewallet_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'PatientDeposit'}">
+                                            <pa:patient_deposit_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'OnlineSettlement'}">
+                                            <pa:online_settlement_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
                                     </p:panel>
                                 </div>
                             </div>

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -21,33 +21,50 @@
                             <div class=" d-flex justify-content-between ">
                                 <div><h:outputLabel value="Payment Reprint" class="mt-2"></h:outputLabel></div>
                                 <div class="d-flex gap-2">
-                                    <p:commandButton ajax="false" value="To Cancel"
-                                                     class="ui-button-danger"
-                                                     icon="fa fa-ban"
-                                                     action="#{inwardSearch.navigateToPaymentBillCancellation()}"
-                                                     disabled="#{inwardSearch.bill.cancelled}"  >                           
+                                    
+                                    <p:commandButton 
+                                        ajax="false" value="To Cancel"
+                                        class="ui-button-danger"
+                                        icon="fa fa-ban"
+                                        action="#{inwardSearch.navigateToPaymentBillCancellation()}"
+                                        disabled="#{inwardSearch.bill.cancelled}"  >                           
                                     </p:commandButton>
 
-                                    <p:commandButton value="Print" ajax="false" action="#" class="ui-button-info"
-                                                     icon="fas fa-print">
+                                    <p:commandButton 
+                                        value="Print" 
+                                        ajax="false" 
+                                        action="#" 
+                                        class="ui-button-info"
+                                        icon="fas fa-print">
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
-                                    <p:commandButton ajax="false" value="Mark As Checked"
-                                                     icon="fa fa-check-square"
-                                                     class="ui-button-success"
-                                                     action="#{inwardSearch.markAsChecked()}"
-                                                     rendered="#{webUserController.hasPrivilege('InwardCheck')}"  />
-                                    <p:commandButton ajax="false" value="Mark As Un Check"
-                                                     icon="fa fa-square"
-                                                     class="ui-button-warning"
-                                                     action="#{inwardSearch.markAsUnChecked()}"
-                                                     rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  />
+                                    
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Mark As Checked"
+                                        icon="fa fa-check-square"
+                                        class="ui-button-success"
+                                        action="#{inwardSearch.markAsChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardCheck')}"  >
+                                    </p:commandButton>
+                                    
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Mark As Un Check"
+                                        icon="fa fa-square"
+                                        class="ui-button-warning"
+                                        action="#{inwardSearch.markAsUnChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  >
+                                    </p:commandButton>
 
-                                    <p:commandButton ajax="false" value="Back To Interim"
-                                                     icon="fa fa-backward"
-                                                     action="/inward/inward_bill_intrim" 
-                                                     actionListener="#{bhtSummeryController.createTables()}"
-                                                     />
+                                    <p:commandButton 
+                                        ajax="false" 
+                                        value="Back To Interim"
+                                        icon="fa fa-backward"
+                                        action="/inward/inward_bill_intrim" 
+                                        actionListener="#{bhtSummeryController.createTables()}"
+                                        >
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>
@@ -99,7 +116,7 @@
                                             class="w-100"
                                             value="#{inwardSearch.bill.comments}">
                                         </p:inputText>
-                                        
+
                                         <p:commandButton 
                                             id="saveBillComment"
                                             value="Save Comment"
@@ -111,7 +128,7 @@
                                         </p:commandButton>
                                     </div>
                                 </p:panel>
-                                
+
                             </div>
                         </div>
 

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -22,34 +22,38 @@
                                 <div><h:outputLabel value="Payment Reprint" class="mt-2"></h:outputLabel></div>
                                 <div class="d-flex gap-2">
                                     
-                                    <p:commandButton 
+                                    <p:commandButton
+                                        id="btnToCancel"
                                         ajax="false" value="To Cancel"
                                         class="ui-button-danger"
                                         icon="fa fa-ban"
                                         action="#{inwardSearch.navigateToPaymentBillCancellation()}"
-                                        disabled="#{inwardSearch.bill.cancelled}"  >                           
+                                        disabled="#{inwardSearch.bill.cancelled}"  >
                                     </p:commandButton>
 
-                                    <p:commandButton 
-                                        value="Print" 
-                                        ajax="false" 
-                                        action="#" 
+                                    <p:commandButton
+                                        id="btnPrintBill"
+                                        value="Print"
+                                        ajax="false"
+                                        action="#"
                                         class="ui-button-info"
                                         icon="fas fa-print">
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
-                                    
-                                    <p:commandButton 
-                                        ajax="false" 
+
+                                    <p:commandButton
+                                        id="btnMarkAsChecked"
+                                        ajax="false"
                                         value="Mark As Checked"
                                         icon="fa fa-check-square"
                                         class="ui-button-success"
                                         action="#{inwardSearch.markAsChecked()}"
                                         rendered="#{webUserController.hasPrivilege('InwardCheck')}"  >
                                     </p:commandButton>
-                                    
-                                    <p:commandButton 
-                                        ajax="false" 
+
+                                    <p:commandButton
+                                        id="btnMarkAsUnChecked"
+                                        ajax="false"
                                         value="Mark As Un Check"
                                         icon="fa fa-square"
                                         class="ui-button-warning"
@@ -57,11 +61,12 @@
                                         rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  >
                                     </p:commandButton>
 
-                                    <p:commandButton 
-                                        ajax="false" 
+                                    <p:commandButton
+                                        id="btnBackToInterim"
+                                        ajax="false"
                                         value="Back To Interim"
                                         icon="fa fa-backward"
-                                        action="/inward/inward_bill_intrim" 
+                                        action="/inward/inward_bill_intrim?faces-redirect=true"
                                         actionListener="#{bhtSummeryController.createTables()}"
                                         >
                                     </p:commandButton>

--- a/src/main/webapp/inward/inward_search_payment.xhtml
+++ b/src/main/webapp/inward/inward_search_payment.xhtml
@@ -76,7 +76,7 @@
                                         <h:outputLabel value="#{i+1}" ></h:outputLabel>
                                     </p:column>
 
-                                    <p:column headerText="Bill No" width="8em;" style="padding: 12px;">
+                                    <p:column headerText="Bill No" width="10em;" style="padding: 12px;">
                                         <p:commandLink
                                             value="#{bb.deptId}"
                                             ajax="false"
@@ -95,7 +95,7 @@
                                         </h:panelGroup>
                                     </p:column>
 
-                                    <p:column headerText="BHT No" width="6em;" style="padding: 12px;">
+                                    <p:column headerText="BHT No" width="10em;" style="padding: 12px;">
                                         <h:outputLabel value="#{bb.patientEncounter.bhtNo}" ></h:outputLabel>
                                     </p:column>
 
@@ -123,17 +123,17 @@
 
                                     <p:column headerText="Patient" style="padding: 12px;">
                                         <h:outputLabel value="#{bb.patientEncounter.patient.person.nameWithTitle}" ></h:outputLabel>
-                                    </p:column>  
+                                    </p:column>
                                     
-                                    <p:column headerText="Payment Method" width="10em;" style="padding: 12px;">                            
+                                    <p:column headerText="Payment Method" width="12em;" style="padding: 12px;">                            
                                         <h:outputLabel value="#{bb.paymentMethod}" ></h:outputLabel>                                   
                                     </p:column>
                                     
-                                    <p:column headerText="Value" width="8em;" style="padding: 12px;">                              
-                                        <h:outputLabel value="#{bb.netTotal}" >
+                                    <p:column headerText="Value" width="8em;" style="padding: 12px;" class="text-end">                              
+                                        <h:outputLabel value="#{bb.netTotal}" class="text-end" >
                                             <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>                                  
-                                    </p:column>  
+                                        </h:outputLabel>
+                                    </p:column>
                                     
                                     <p:column headerText="Comments" width="16em;" style="padding: 12px;">
                                         <h:outputLabel rendered="#{bb.refundedBill ne null}" value="#{bb.refundedBill.comments}" >

--- a/src/main/webapp/inward/inward_search_payment.xhtml
+++ b/src/main/webapp/inward/inward_search_payment.xhtml
@@ -77,12 +77,22 @@
                                     </p:column>
 
                                     <p:column headerText="Bill No" width="8em;" style="padding: 12px;">
-                                        <p:commandLink 
+                                        <p:commandLink
                                             value="#{bb.deptId}"
-                                            ajax="false" 
+                                            ajax="false"
                                             action="inward_reprint_bill_payment?faces-redirect=true">
                                             <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
                                         </p:commandLink>
+                                        <h:panelGroup rendered="#{bb.cancelled and bb.cancelledBill ne null}" layout="block" class="mt-1">
+                                            <h:outputLabel style="color: red;" value="Cancel Bill : "/>
+                                            <p:commandLink
+                                                style="color: red;"
+                                                value="#{bb.cancelledBill.deptId}"
+                                                ajax="false"
+                                                title="View cancellation bill preview"
+                                                action="#{inwardSearch.navigateToViewInwardDepositCancellationBill(bb)}">
+                                            </p:commandLink>
+                                        </h:panelGroup>
                                     </p:column>
 
                                     <p:column headerText="BHT No" width="6em;" style="padding: 12px;">

--- a/src/main/webapp/resources/inward/bill/payment/FiveFivePaymentBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/FiveFivePaymentBill.xhtml
@@ -88,7 +88,7 @@
                         <td >:</td>
                         <td style="width: 5px;"></td>
                         <td>
-                            <h:outputLabel value="#{cc.attrs.bill.patient.person.nameWithTitle}" class="billDetailsFiveFive" >
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" class="billDetailsFiveFive" >
                             </h:outputLabel>
 
                         </td>
@@ -101,7 +101,7 @@
                         </td>
 
                         <td>
-                            <h:outputLabel value="#{cc.attrs.bill.patient.age}" class="billDetailsFiveFive">
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.age}" class="billDetailsFiveFive">
                             </h:outputLabel>
                         </td>
 
@@ -116,7 +116,7 @@
                         <td >:</td>
                         <td style="width: 5px;"></td>
                         <td>
-                            <h:outputLabel value="#{cc.attrs.bill.patient.person.sex}" class="billDetailsFiveFive" >
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.sex}" class="billDetailsFiveFive" >
                             </h:outputLabel>
 
                         </td>
@@ -144,7 +144,7 @@
                         <td >:</td>
                         <td style="width: 5px;"></td>
                         <td>
-                            <h:outputLabel value="#{cc.attrs.bill.patient.person.phone}" class="billDetailsFiveFive" >
+                            <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.phone}" class="billDetailsFiveFive" >
                             </h:outputLabel>
 
                         </td>

--- a/src/main/webapp/resources/inward/bill/payment/posPaperCancellationBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/posPaperCancellationBill.xhtml
@@ -1,0 +1,286 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" class="com.divudi.entitity.Bill"  />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbillBreak" style="page-break-after: always">
+
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Phone : #{cc.attrs.bill.department.telephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : #{cc.attrs.bill.department.fax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value=" Email : #{cc.attrs.bill.department.email}"/>
+                </div>
+            </div>
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Deposit Cancellation Receipt" style="font-size: 20px;" /><br/>
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div >
+                <table style="width: 100%; margin-left:0.5cm;" >
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Name"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 70%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Age / Sex"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <div class="d-flex gap-2">
+                                <h:outputLabel
+                                    value="#{cc.attrs.bill.patientEncounter.patient.age}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="/"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="#{cc.attrs.bill.patientEncounter.patient.person.sex}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Admission Type"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.patientEncounter.admissionType.name}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="BHT No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.patientEncounter.bhtNo}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Cancelled At"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.billDate}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Cancellation Bill No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.deptId}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Payment Method"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.bill.paymentMethod.label}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.comments ne null and cc.attrs.bill.comments ne ''}">
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel
+                                    value="Cancellation Reason"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel
+                                    value="#{cc.attrs.bill.comments}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div  >
+                <table style="width: 100%; margin-left:0.5cm; ">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Amount" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}" style="font-size: 13px!important; font-weight: bolder!important;" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <br/>
+
+            <div class="d-flex justify-content-start mb-3" style="font-size: 12px; margin-left: 0.5cm;">
+                <h:outputLabel value="Original Bill No : #{cc.attrs.bill.billedBill.deptId}"
+                               rendered="#{cc.attrs.bill.billedBill.deptId ne null}">
+                </h:outputLabel>
+            </div>
+
+            <div class=" d-flex justify-content-center">
+                <h:outputLabel
+                    value="Cashier : #{cc.attrs.bill.creater.webUserPerson.nameWithTitle}">
+                </h:outputLabel>
+            </div>
+
+            <div class="footer">
+                <br/>
+                The Greatest Wealth is Health!
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+                <br/>
+                <h:outputLabel value="Powered by CareCode (Pvt) Ltd" style="font-size: 10px;"></h:outputLabel>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/posPaperCancellationBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/posPaperCancellationBill.xhtml
@@ -8,7 +8,7 @@
 
     <!-- INTERFACE -->
     <cc:interface>
-        <cc:attribute name="bill" class="com.divudi.entitity.Bill"  />
+        <cc:attribute name="bill" class="com.divudi.core.entity.Bill"  />
         <cc:attribute name="duplicate" />
     </cc:interface>
 
@@ -168,7 +168,7 @@
                                 style="text-align: center!important;
                                 font-size: 12px!important;
                                 font-family:Arial, Helvetica, sans-serif!important;">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
                             </h:outputLabel>
                         </td>
                     </tr>

--- a/src/main/webapp/resources/paymentMethod/cash_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/cash_view.xhtml
@@ -14,13 +14,10 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cash.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cash.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>

--- a/src/main/webapp/resources/paymentMethod/cheque.xhtml
+++ b/src/main/webapp/resources/paymentMethod/cheque.xhtml
@@ -16,16 +16,22 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
         <div class="d-flex flex-wrap align-items-end gap-2 mt-2">
-            <div class="col-auto">
-                <p:outputLabel for="txtVal" value="Total Value:" />
-                <p:inputText id="txtVal" value="#{cc.attrs.paymentMethodData.cheque.totalValue}" style="width: auto; max-width: 200px;" class="form-control" autocomplete="off"
-                             required="true"
-                             requiredMessage="Total Value is required">
-                    <p:tooltip value="Enter the total value of the cheque."/>
-                    <f:convertNumber pattern="#,##0.00" />
-                    <p:ajax event="keyup" process="@this" />
-                </p:inputText>
-            </div>
+            <h:panelGroup rendered="#{cc.attrs.valueRequired}" class="" layout="block"  >
+                <div class="col-auto">
+                    <p:outputLabel for="txtVal" value="Total Value:" />
+                    <p:inputText 
+                        id="txtVal" 
+                        value="#{cc.attrs.paymentMethodData.cheque.totalValue}" 
+                        style="width: auto; max-width: 200px;" 
+                        class="form-control" autocomplete="off"
+                        required="true"
+                        requiredMessage="Total Value is required">
+                        <p:tooltip value="Enter the total value of the cheque."/>
+                        <f:convertNumber pattern="#,##0.00" />
+                        <p:ajax event="keyup" process="@this" />
+                    </p:inputText>
+                </div>
+            </h:panelGroup>
 
             <div class="col-auto">
                 <p:outputLabel for="chequeNo" value="Cheque Number:"/>

--- a/src/main/webapp/resources/paymentMethod/cheque_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/cheque_view.xhtml
@@ -14,50 +14,39 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cheque.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cheque.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Cheque No:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cheque.no}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.cheque.no}">
+                <p:outputLabel value="Cheque No" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cheque.no}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Bank:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cheque.institution.name}"
-                    styleClass="form-control-plaintext fw-semibold"
-                    style="width: 180px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.cheque.institution}">
+                <p:outputLabel value="Bank" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cheque.institution.name}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Date:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cheque.date}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;">
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.cheque.date}">
+                <p:outputLabel value="Date" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cheque.date}" styleClass="fw-semibold">
                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                 </h:outputText>
-            </div>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.cheque.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.cheque.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.cheque.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/paymentMethod/creditCard.xhtml
+++ b/src/main/webapp/resources/paymentMethod/creditCard.xhtml
@@ -16,9 +16,13 @@
     <cc:implementation>
         <div class="d-flex gap-2 mt-2" >
             <h:panelGroup rendered="#{cc.attrs.valueRequired}" class="" layout="block"  >
-                <p:inputText autocomplete="off"   value="#{cc.attrs.paymentMethodData.creditCard.totalValue}" style="width: 7em!important;" class="w-100" id="txtVal"
-                             required="true"
-                             requiredMessage="Value is required" >
+                <p:inputText 
+                    autocomplete="off"   
+                    value="#{cc.attrs.paymentMethodData.creditCard.totalValue}" 
+                    style="width: 7em!important;" 
+                    class="w-100" id="txtVal"
+                    required="true"
+                    requiredMessage="Value is required" >
                     <p:ajax process="@this" ></p:ajax>
                     <f:convertNumber pattern="#,##0.00" />
                 </p:inputText>

--- a/src/main/webapp/resources/paymentMethod/creditCard_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/creditCard_view.xhtml
@@ -14,40 +14,31 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.creditCard.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.creditCard.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Last 4 Digits:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.creditCard.no}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.creditCard.no}">
+                <p:outputLabel value="Last 4 Digits" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.creditCard.no}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Bank:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.creditCard.institution.name}"
-                    styleClass="form-control-plaintext fw-semibold"
-                    style="width: 180px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.creditCard.institution}">
+                <p:outputLabel value="Bank" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.creditCard.institution.name}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.creditCard.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.creditCard.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.creditCard.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/paymentMethod/ewallet_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/ewallet_view.xhtml
@@ -14,48 +14,37 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.ewallet.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.ewallet.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="E-wallet No:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.ewallet.no}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.ewallet.no}">
+                <p:outputLabel value="E-wallet No" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.ewallet.no}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Bank/Institution:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.ewallet.institution.name}"
-                    styleClass="form-control-plaintext"
-                    style="width: 150px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.ewallet.institution}">
+                <p:outputLabel value="Bank / Institution" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.ewallet.institution.name}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Reference No:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.ewallet.referenceNo}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.ewallet.referenceNo}">
+                <p:outputLabel value="Reference No" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.ewallet.referenceNo}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.ewallet.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.ewallet.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.ewallet.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/paymentMethod/online_settlement.xhtml
+++ b/src/main/webapp/resources/paymentMethod/online_settlement.xhtml
@@ -28,6 +28,7 @@
                     <f:convertNumber pattern="#,##0.00" />
                 </p:inputText>
             </h:panelGroup>
+            
             <p:selectOneMenu value="#{cc.attrs.paymentMethodData.onlineSettlement.institution}" style="width: 10em;"
                              required="true"
                              requiredMessage="Bank is required">
@@ -35,16 +36,19 @@
                 <f:selectItems value="#{institutionController.banks}" var="inst" itemLabel="#{inst.name}" itemValue="#{inst}"/>
                 <p:ajax process="@this" />
             </p:selectOneMenu>
+            
             <p:calendar value="#{cc.attrs.paymentMethodData.onlineSettlement.date}" placeholder="Select date" pattern="#{sessionController.applicationPreference.longDateFormat}" id="date"
                         required="true"
                         requiredMessage="Date is required">
                 <p:ajax process="@this" />
             </p:calendar>
+            
             <p:inputText value="#{cc.attrs.paymentMethodData.onlineSettlement.referenceNo}" placeholder="Reference No" class="w-100" style="width:7rem!important"
                          required="true"
                          requiredMessage="Reference No is required">
                 <p:ajax process="@this" />
             </p:inputText>
+            
             <p:inputText value="#{cc.attrs.paymentMethodData.onlineSettlement.comment}" placeholder="Comments" class="w-100" style="width:7rem!important"
                          required="true"
                          requiredMessage="Comments are required">

--- a/src/main/webapp/resources/paymentMethod/online_settlement_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/online_settlement_view.xhtml
@@ -14,40 +14,31 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.onlineSettlement.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.onlineSettlement.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Reference No:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.onlineSettlement.referenceNo}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.onlineSettlement.referenceNo}">
+                <p:outputLabel value="Reference No" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.onlineSettlement.referenceNo}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Institution:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.onlineSettlement.institution.name}"
-                    styleClass="form-control-plaintext fw-semibold"
-                    style="width: 180px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.onlineSettlement.institution}">
+                <p:outputLabel value="Institution" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.onlineSettlement.institution.name}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.onlineSettlement.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.onlineSettlement.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.onlineSettlement.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/paymentMethod/patient_deposit_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/patient_deposit_view.xhtml
@@ -14,32 +14,25 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.patient_deposit.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.patient_deposit.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Patient:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.patient_deposit.patient.person.nameWithTitle}"
-                    styleClass="form-control-plaintext fw-semibold"
-                    style="width: 200px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.patient_deposit.patient}">
+                <p:outputLabel value="Patient" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.patient_deposit.patient.person.nameWithTitle}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.patient_deposit.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.patient_deposit.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.patient_deposit.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/paymentMethod/slip_view.xhtml
+++ b/src/main/webapp/resources/paymentMethod/slip_view.xhtml
@@ -14,50 +14,39 @@
 
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Amount:" styleClass="form-label mb-0" style="min-width: 80px;"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.slip.totalValue}"
-                    styleClass="form-control-plaintext fw-bold"
-                    style="width: 150px;">
+        <div class="d-flex flex-wrap align-items-stretch gap-3 py-1">
+            <div class="d-flex flex-column border rounded-3 bg-light px-3 py-2">
+                <p:outputLabel value="Amount" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.slip.totalValue}" styleClass="fs-5 fw-bold text-primary">
                     <f:convertNumber pattern="#,##0.00" />
                 </h:outputText>
             </div>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Bank:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.slip.institution.name}"
-                    styleClass="form-control-plaintext fw-semibold"
-                    style="width: 180px;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.slip.referenceNo}">
+                <p:outputLabel value="Reference No" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.slip.referenceNo}" styleClass="fw-semibold"/>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Date:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.slip.date}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;">
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.slip.institution}">
+                <p:outputLabel value="Bank" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.slip.institution.name}" styleClass="fw-semibold"/>
+            </h:panelGroup>
+
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2"
+                          rendered="#{not empty cc.attrs.paymentMethodData.slip.date}">
+                <p:outputLabel value="Date" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.slip.date}" styleClass="fw-semibold">
                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                 </h:outputText>
-            </div>
+            </h:panelGroup>
 
-            <div class="d-flex align-items-center gap-2">
-                <p:outputLabel value="Reference No:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.slip.referenceNo}"
-                    styleClass="form-control-plaintext"
-                    style="width: 120px;"/>
-            </div>
-
-            <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <p:outputLabel value="Comment:" styleClass="form-label mb-0"/>
-                <h:outputText
-                    value="#{cc.attrs.paymentMethodData.slip.comment}"
-                    styleClass="form-control-plaintext"
-                    style="flex-grow: 1;"/>
-            </div>
+            <h:panelGroup layout="block" styleClass="d-flex flex-column border rounded-3 bg-light px-3 py-2 flex-grow-1"
+                          rendered="#{not empty cc.attrs.paymentMethodData.slip.comment}">
+                <p:outputLabel value="Comment" styleClass="text-muted text-uppercase small mb-1"/>
+                <h:outputText value="#{cc.attrs.paymentMethodData.slip.comment}"/>
+            </h:panelGroup>
         </div>
     </cc:implementation>
 </html>


### PR DESCRIPTION
## Summary

Fixes **#17354 — "Can't Cancel Inward Payment Bill Done Using Patient Deposit."**

Inward deposit payment bills could not be cancelled when they had been paid using a patient deposit, because the deposit balance was never reversed. This PR fixes the core cancellation flow and reworks the **Inward Deposit Payment Cancellation** page so the original payment is displayed, refillable, and printed on a proper POS cancellation receipt.

## Core fix

- **Reverse the patient deposit on cancellation** so a deposit-paid inward payment can be cancelled and the balance is credited back (`PatientDepositService`, `InwardSearch`).
- **Set `patient` on the inward payment and cancellation bills** from the patient encounter, so cancelled deposit records are linked to the correct patient.
- **Uniform `paidValue`** in `PaymentService` — the bill net total is now recorded consistently for every payment method, including cancellation payments.

## Cancellation page workflow

- Reworked the cancellation page UI and navigation (back-to-reprint / back-to-list buttons).
- **Restricts the cancellation payment methods** to the valid inward-deposit options.
- **Loads and displays the original payment details** of the selected bill (amount, card/cheque/slip/online-settlement fields, bank, comment) using read-only `_view` composites.
- **Re-Fill button** copies the original payment method data into the cancellation form (`refillPaymentDetail()`), and the editable composites no longer force the amount field (`valueRequired=false`).
- Fixed online-settlement refill so **Bank, Date and Reference No** are read from the original Payment (previously only amount and comment were loaded).

## Printing

- New **POS-format inward deposit cancellation receipt** (`posPaperCancellationBill.xhtml`) with patient details, cancellation bill no, original bill no, payment method, reason and amount.
- Added a **print paper Settings (config) button + dialog** to the cancellation preview, gated by the `ChangeReceiptPrintingPaperTypes` privilege and the `Inward Payment Bill POS Paper` config key — mirroring the reprint page.
- Cancellation bill is now reachable from the **payment search page** (link to the cancellation preview).

## Supporting / collateral changes

- Modernized the shared payment-method `_view` composites (cash, cheque, credit card, ewallet, online settlement, patient deposit, slip) into a consistent card-chip style.
- Made the cheque composite's Total Value field respect the `valueRequired` flag (as other composites already do).
- Minor polish: reprint-page button layout, search-table column widths / value alignment, and the FiveFive payment bill now sources patient details via the patient encounter.

## Testing

- `InwardSearch` / `PaymentService` / `PatientDepositService` compile cleanly (`mvn -o compile`).
- Verified cancel of a deposit-paid inward payment reverses the deposit balance and produces the POS cancellation receipt.
- Remaining XHTML changes are JSF-only.

Closes #17354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inward-deposit cancellation with payment-method selection, “original payment details” viewing, and receipt/print preview navigation.
  * Added paper-format configuration dialog for inward deposit cancellation bills (POS, custom sizes, A4).
* **Bug Fixes**
  * Corrected patient data assignment during inward deposit cancellation bill creation.
  * Improved inward-deposit cancellation payment balance/payment processing for consistent amounts.
* **UI Improvements**
  * Rebuilt the cancellation payment screen and refilled payment details for non-cash methods.
  * Refreshed payment method views into clearer card-style layouts and added conditional field rendering.
  * Enhanced bill/payment list with cancellation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->