### PR TITLE
fix(qb): count split-payment bills in QB Import Daily Return [ruhunu-prod hotfix]

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -1754,14 +1754,24 @@ public class BillBeanController implements Serializable {
     public List<Object[]> fetchDepartmentSale(Date fromDate, Date toDate, Institution institution, BillType billType) {
         PaymentMethod[] pms = new PaymentMethod[]{PaymentMethod.Cash, PaymentMethod.Card, PaymentMethod.Cheque, PaymentMethod.Slip};
 
+        // Sum from the child Payment rows (p.paidValue) instead of filtering whole bills by the
+        // bill-level paymentMethod. A bill settled with more than one method has
+        // bill.paymentMethod = MultiplePaymentMethods; filtering on the bill-level method dropped
+        // such bills entirely, even though their actual payments were Cash/Card/Cheque/Slip. The
+        // Daily Return report sums child payments and therefore counts them, which caused the QB
+        // Import figure to fall short. Filtering on p.paymentMethod captures the individual
+        // components of split-payment bills while still excluding credit/deposit portions.
+        // See hmislk/hmis#21639.
         String sql = "Select b.referenceBill.department,"
-                + " sum(b.netTotal) "
-                + " from Bill b "
+                + " sum(p.paidValue) "
+                + " from Payment p "
+                + " join p.bill b "
                 + " where b.retired=false"
+                + " and p.retired=false"
                 + " and  b.billType=:bType"
                 + " and b.referenceBill.department.institution=:ins "
                 + " and b.createdAt between :fromDate and :toDate "
-                + " and b.paymentMethod in :pm"
+                + " and p.paymentMethod in :pm"
                 + " and type(b)!=:cl "
                 + " group by b.referenceBill.department"
                 + " order by b.referenceBill.department.name";


### PR DESCRIPTION
**Hotfix → `ruhunu-prod`.** Cherry-pick of `development` commit d9d1de4 (PR #21642, issue #21639).

## Problem

The **QB Import → Daily Return** report under-reported pharmacy collection compared to the **Daily Return** report. A customer observed a fixed difference between the two reports for a pharmacy department over a one-month period.

## Root cause

`BillBeanController.fetchDepartmentSale(...)` summed `b.netTotal` filtered by the **bill-level** `paymentMethod IN (Cash, Card, Cheque, Slip)`. A bill settled with more than one method has `bill.paymentMethod = MultiplePaymentMethods`, so it failed the filter and was **excluded entirely** — even though its child `Payment` rows were plain cash/card. The Daily Return report sums child `Payment.paidValue`, so it counted these bills, producing the gap.

## Fix

Sum from the child `Payment.paidValue` rows, filtering on the **payment-level** method (`p.paymentMethod IN (Cash, Card, Cheque, Slip)`) instead of the bill-level method. This captures the individual components of split-payment bills while still excluding any credit/deposit portions. The grouping (`referenceBill.department`), `PreBill` exclusion, and return contract (`[Department, Double]`) are unchanged.

## Verification

Verified on staging against a production data snapshot: the QB Import Daily Return figure now matches the Collection of the Day exactly for the affected pharmacy department/day, including the split-payment bills that the previous version dropped.

## Scope

- Single-file change: `BillBeanController.java`.
- `fetchDepartmentSale` is shared by all non-credit QB Import sections, so every section benefits.
- The credit counterpart `fetchDepartmentSaleCredit` was intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
