### PR TITLE
feat(emr): Graphical patient journey timeline on patient profile (#21652)

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -19,11 +19,11 @@ import com.divudi.core.data.SymanticType;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
 import com.divudi.core.data.clinical.DocumentTemplateType;
 import com.divudi.core.data.clinical.PrescriptionTemplateType;
-import com.divudi.core.data.EncounterType;
 import com.divudi.core.data.inward.PatientEncounterType;
 import com.divudi.core.data.lab.InvestigationResultForGraph;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.entity.Doctor;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
@@ -3587,6 +3587,7 @@ public class PatientEncounterController implements Serializable {
 
     public void setPatient(Patient patient) {
         this.patient = patient;
+        clearPatientJourneyTimeline();
     }
 
     public ClinicalFindingValueFacade getClinicalFindingValueFacade() {
@@ -4560,6 +4561,7 @@ public class PatientEncounterController implements Serializable {
     }
 
     // Patient Journey Timeline data
+    private Long patientJourneyTimelinePatientId;
     private Date patientRegistrationDate;
     private List<Object[]> opdVisitEvents = new ArrayList<>();
     private List<Object[]> admissionStartEvents = new ArrayList<>();
@@ -4567,42 +4569,45 @@ public class PatientEncounterController implements Serializable {
     private List<Object[]> labEvents = new ArrayList<>();
     private List<Object[]> surgeryEvents = new ArrayList<>();
 
-    public void generatePatientJourneyTimeline() {
+    private void clearPatientJourneyTimeline() {
+        patientJourneyTimelinePatientId = null;
         patientRegistrationDate = null;
         opdVisitEvents = new ArrayList<>();
         admissionStartEvents = new ArrayList<>();
         admissionEndEvents = new ArrayList<>();
         labEvents = new ArrayList<>();
         surgeryEvents = new ArrayList<>();
+    }
+
+    public void generatePatientJourneyTimeline() {
+        clearPatientJourneyTimeline();
 
         if (patient == null) {
             return;
         }
 
+        patientJourneyTimelinePatientId = patient.getId();
         patientRegistrationDate = patient.getCreatedAt();
 
-        Map<String, Object> params = new HashMap<>();
-        params.put("patient", patient);
+        Map<String, Object> patientOnlyParams = new HashMap<>();
+        patientOnlyParams.put("patient", patient);
 
-        params.put("encounterType", EncounterType.Opd);
+        Map<String, Object> opdParams = new HashMap<>(patientOnlyParams);
+        opdParams.put("patientEncounterType", PatientEncounterType.OpdVisit);
         String opdJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
-                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
-                + "AND e.retired = false ORDER BY e.encounterDate ASC";
-        List<Object[]> opd = ejbFacade.findObjectArrayByJpql(opdJpql, params, null);
+                + "WHERE e.patient = :patient AND e.patientEncounterType = :patientEncounterType "
+                + "AND e.retired = false AND e.encounterDate IS NOT NULL ORDER BY e.encounterDate ASC";
+        List<Object[]> opd = ejbFacade.findObjectArrayByJpql(opdJpql, opdParams, null);
         if (opd != null) {
             opdVisitEvents = opd;
         }
-        if (patientRegistrationDate == null && !opdVisitEvents.isEmpty() && opdVisitEvents.get(0)[0] != null) {
-            patientRegistrationDate = (Date) opdVisitEvents.get(0)[0];
-        }
 
-        params.put("encounterType", EncounterType.Admission);
-        String admJpql = "SELECT e.dateOfAdmission, e.timeOfAdmission, e.fromTime, "
-                + "e.dateOfDischarge, e.timeOfDischarge, e.toTime, e.bhtNo "
-                + "FROM PatientEncounter e "
-                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
-                + "AND e.retired = false ORDER BY coalesce(e.dateOfAdmission, e.timeOfAdmission, e.fromTime) ASC";
-        List<Object[]> admissions = ejbFacade.findObjectArrayByJpql(admJpql, params, null);
+        String admJpql = "SELECT a.dateOfAdmission, a.timeOfAdmission, a.fromTime, "
+                + "a.dateOfDischarge, a.timeOfDischarge, a.toTime, a.bhtNo "
+                + "FROM Admission a "
+                + "WHERE a.patient = :patient AND a.retired = false "
+                + "ORDER BY coalesce(a.dateOfAdmission, a.timeOfAdmission, a.fromTime) ASC";
+        List<Object[]> admissions = ejbFacade.findObjectArrayByJpql(admJpql, patientOnlyParams, null);
         if (admissions != null) {
             for (Object[] row : admissions) {
                 Date startDate = firstNonNullDate((Date) row[0], (Date) row[1], (Date) row[2]);
@@ -4617,23 +4622,61 @@ public class PatientEncounterController implements Serializable {
             }
         }
 
-        params.put("encounterType", EncounterType.Lab);
-        String labJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
-                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
-                + "AND e.retired = false ORDER BY e.encounterDate ASC";
-        List<Object[]> labs = ejbFacade.findObjectArrayByJpql(labJpql, params, null);
+        String labJpql = "SELECT pi.sampledAt, pi.orderedAt, pi.createdAt, pi.id "
+                + "FROM PatientInvestigation pi WHERE pi.patient = :patient AND pi.retired = false "
+                + "ORDER BY coalesce(pi.sampledAt, pi.orderedAt, pi.createdAt) ASC";
+        List<Object[]> labs = ejbFacade.findObjectArrayByJpql(labJpql, patientOnlyParams, null);
         if (labs != null) {
-            labEvents = labs;
+            for (Object[] row : labs) {
+                Date labDate = firstNonNullDate((Date) row[0], (Date) row[1], (Date) row[2]);
+                if (labDate != null) {
+                    labEvents.add(new Object[]{labDate, row[3]});
+                }
+            }
         }
 
-        params.put("encounterType", EncounterType.SurgicalProcedure);
-        String surgJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
-                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
-                + "AND e.retired = false ORDER BY e.encounterDate ASC";
-        List<Object[]> surgs = ejbFacade.findObjectArrayByJpql(surgJpql, params, null);
+        Map<String, Object> surgeryParams = new HashMap<>(patientOnlyParams);
+        surgeryParams.put("billType", BillType.SurgeryBill);
+        String surgJpql = "SELECT b.createdAt, b.id FROM Bill b "
+                + "WHERE b.patient = :patient AND b.billType = :billType "
+                + "AND b.retired = false AND b.cancelled = false AND b.createdAt IS NOT NULL "
+                + "ORDER BY b.createdAt ASC";
+        List<Object[]> surgs = ejbFacade.findObjectArrayByJpql(surgJpql, surgeryParams, null);
         if (surgs != null) {
             surgeryEvents = surgs;
         }
+
+        // Registration must be the earliest point on the timeline: clamp to the
+        // earliest dated event across all categories when createdAt is missing/later.
+        Date earliestEvent = minDate(
+                earliestEventDate(opdVisitEvents),
+                earliestEventDate(admissionStartEvents),
+                earliestEventDate(admissionEndEvents),
+                earliestEventDate(labEvents),
+                earliestEventDate(surgeryEvents));
+        if (earliestEvent != null && (patientRegistrationDate == null || earliestEvent.before(patientRegistrationDate))) {
+            patientRegistrationDate = earliestEvent;
+        }
+    }
+
+    private static Date earliestEventDate(List<Object[]> events) {
+        if (events == null || events.isEmpty() || events.get(0)[0] == null) {
+            return null;
+        }
+        return (Date) events.get(0)[0];
+    }
+
+    private static Date minDate(Date... dates) {
+        Date min = null;
+        if (dates == null) {
+            return null;
+        }
+        for (Date d : dates) {
+            if (d != null && (min == null || d.before(min))) {
+                min = d;
+            }
+        }
+        return min;
     }
 
     private static Date firstNonNullDate(Date... dates) {
@@ -4646,6 +4689,12 @@ public class PatientEncounterController implements Serializable {
             }
         }
         return null;
+    }
+
+    public boolean isPatientJourneyTimelineReadyForCurrentPatient() {
+        return patient != null && patient.getId() != null
+                && patient.getId().equals(patientJourneyTimelinePatientId)
+                && patientRegistrationDate != null;
     }
 
     public Date getPatientRegistrationDate() {

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -4624,6 +4624,7 @@ public class PatientEncounterController implements Serializable {
 
         String labJpql = "SELECT pi.sampledAt, pi.orderedAt, pi.createdAt, pi.id "
                 + "FROM PatientInvestigation pi WHERE pi.patient = :patient AND pi.retired = false "
+                + "AND (pi.cancelled = false OR pi.cancelled IS NULL) "
                 + "ORDER BY coalesce(pi.sampledAt, pi.orderedAt, pi.createdAt) ASC";
         List<Object[]> labs = ejbFacade.findObjectArrayByJpql(labJpql, patientOnlyParams, null);
         if (labs != null) {
@@ -4637,13 +4638,18 @@ public class PatientEncounterController implements Serializable {
 
         Map<String, Object> surgeryParams = new HashMap<>(patientOnlyParams);
         surgeryParams.put("billType", BillType.SurgeryBill);
-        String surgJpql = "SELECT b.createdAt, b.id FROM Bill b "
+        String surgJpql = "SELECT b.createdAt, b.billDate, b.id FROM Bill b "
                 + "WHERE b.patient = :patient AND b.billType = :billType "
-                + "AND b.retired = false AND b.cancelled = false AND b.createdAt IS NOT NULL "
-                + "ORDER BY b.createdAt ASC";
+                + "AND b.retired = false AND b.cancelled = false "
+                + "ORDER BY coalesce(b.createdAt, b.billDate) ASC";
         List<Object[]> surgs = ejbFacade.findObjectArrayByJpql(surgJpql, surgeryParams, null);
         if (surgs != null) {
-            surgeryEvents = surgs;
+            for (Object[] row : surgs) {
+                Date surgeryDate = firstNonNullDate((Date) row[0], (Date) row[1]);
+                if (surgeryDate != null) {
+                    surgeryEvents.add(new Object[]{surgeryDate, row[2]});
+                }
+            }
         }
 
         // Registration must be the earliest point on the timeline: clamp to the

--- a/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
+++ b/src/main/java/com/divudi/bean/clinical/PatientEncounterController.java
@@ -19,6 +19,7 @@ import com.divudi.core.data.SymanticType;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
 import com.divudi.core.data.clinical.DocumentTemplateType;
 import com.divudi.core.data.clinical.PrescriptionTemplateType;
+import com.divudi.core.data.EncounterType;
 import com.divudi.core.data.inward.PatientEncounterType;
 import com.divudi.core.data.lab.InvestigationResultForGraph;
 import com.divudi.core.entity.Bill;
@@ -4556,6 +4557,119 @@ public class PatientEncounterController implements Serializable {
 
     public void setSelectedInvestigationItem(InvestigationItem selectedInvestigationItem) {
         this.selectedInvestigationItem = selectedInvestigationItem;
+    }
+
+    // Patient Journey Timeline data
+    private Date patientRegistrationDate;
+    private List<Object[]> opdVisitEvents = new ArrayList<>();
+    private List<Object[]> admissionStartEvents = new ArrayList<>();
+    private List<Object[]> admissionEndEvents = new ArrayList<>();
+    private List<Object[]> labEvents = new ArrayList<>();
+    private List<Object[]> surgeryEvents = new ArrayList<>();
+
+    public void generatePatientJourneyTimeline() {
+        patientRegistrationDate = null;
+        opdVisitEvents = new ArrayList<>();
+        admissionStartEvents = new ArrayList<>();
+        admissionEndEvents = new ArrayList<>();
+        labEvents = new ArrayList<>();
+        surgeryEvents = new ArrayList<>();
+
+        if (patient == null) {
+            return;
+        }
+
+        patientRegistrationDate = patient.getCreatedAt();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("patient", patient);
+
+        params.put("encounterType", EncounterType.Opd);
+        String opdJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
+                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
+                + "AND e.retired = false ORDER BY e.encounterDate ASC";
+        List<Object[]> opd = ejbFacade.findObjectArrayByJpql(opdJpql, params, null);
+        if (opd != null) {
+            opdVisitEvents = opd;
+        }
+        if (patientRegistrationDate == null && !opdVisitEvents.isEmpty() && opdVisitEvents.get(0)[0] != null) {
+            patientRegistrationDate = (Date) opdVisitEvents.get(0)[0];
+        }
+
+        params.put("encounterType", EncounterType.Admission);
+        String admJpql = "SELECT e.dateOfAdmission, e.timeOfAdmission, e.fromTime, "
+                + "e.dateOfDischarge, e.timeOfDischarge, e.toTime, e.bhtNo "
+                + "FROM PatientEncounter e "
+                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
+                + "AND e.retired = false ORDER BY coalesce(e.dateOfAdmission, e.timeOfAdmission, e.fromTime) ASC";
+        List<Object[]> admissions = ejbFacade.findObjectArrayByJpql(admJpql, params, null);
+        if (admissions != null) {
+            for (Object[] row : admissions) {
+                Date startDate = firstNonNullDate((Date) row[0], (Date) row[1], (Date) row[2]);
+                Date endDate   = firstNonNullDate((Date) row[3], (Date) row[4], (Date) row[5]);
+                String bhtNo   = (String) row[6];
+                if (startDate != null) {
+                    admissionStartEvents.add(new Object[]{startDate, bhtNo});
+                }
+                if (endDate != null) {
+                    admissionEndEvents.add(new Object[]{endDate, bhtNo});
+                }
+            }
+        }
+
+        params.put("encounterType", EncounterType.Lab);
+        String labJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
+                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
+                + "AND e.retired = false ORDER BY e.encounterDate ASC";
+        List<Object[]> labs = ejbFacade.findObjectArrayByJpql(labJpql, params, null);
+        if (labs != null) {
+            labEvents = labs;
+        }
+
+        params.put("encounterType", EncounterType.SurgicalProcedure);
+        String surgJpql = "SELECT e.encounterDate, e.id FROM PatientEncounter e "
+                + "WHERE e.patient = :patient AND e.encounterType = :encounterType "
+                + "AND e.retired = false ORDER BY e.encounterDate ASC";
+        List<Object[]> surgs = ejbFacade.findObjectArrayByJpql(surgJpql, params, null);
+        if (surgs != null) {
+            surgeryEvents = surgs;
+        }
+    }
+
+    private static Date firstNonNullDate(Date... dates) {
+        if (dates == null) {
+            return null;
+        }
+        for (Date d : dates) {
+            if (d != null) {
+                return d;
+            }
+        }
+        return null;
+    }
+
+    public Date getPatientRegistrationDate() {
+        return patientRegistrationDate;
+    }
+
+    public List<Object[]> getOpdVisitEvents() {
+        return opdVisitEvents;
+    }
+
+    public List<Object[]> getAdmissionStartEvents() {
+        return admissionStartEvents;
+    }
+
+    public List<Object[]> getAdmissionEndEvents() {
+        return admissionEndEvents;
+    }
+
+    public List<Object[]> getLabEvents() {
+        return labEvents;
+    }
+
+    public List<Object[]> getSurgeryEvents() {
+        return surgeryEvents;
     }
 
     // Autocomplete for all InvestigationItems (not patient-specific)

--- a/src/main/webapp/emr/patient_profile.xhtml
+++ b/src/main/webapp/emr/patient_profile.xhtml
@@ -701,6 +701,152 @@
                                             </h:form>
 
                                         </p:tab>
+                                        <p:tab id="tabJourney" title="Journey">
+                                            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+                                            <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+                                            <h:form id="formJourney">
+                                                <div class="container-fluid p-2">
+                                                    <div class="d-flex justify-content-between align-items-center mb-2">
+                                                        <span class="fw-bold">Patient Journey Timeline</span>
+                                                        <p:commandButton id="btnGenerateJourney"
+                                                            value="Generate"
+                                                            action="#{patientEncounterController.generatePatientJourneyTimeline()}"
+                                                            ajax="true"
+                                                            update="journeyChartContainer"
+                                                            icon="pi pi-chart-bar"
+                                                            styleClass="ui-button-info ui-button-sm"
+                                                            title="Generate Patient Journey Timeline"/>
+                                                    </div>
+                                                    <h:panelGroup id="journeyChartContainer" layout="block">
+                                                        <h:panelGroup layout="block"
+                                                            rendered="#{patientEncounterController.patientRegistrationDate ne null}">
+                                                            <div style="width:100%; height:350px;">
+                                                                <canvas id="journeyCanvas"></canvas>
+                                                            </div>
+                                                            <script type="text/javascript">
+                                                                setTimeout(function() {
+                                                                    if (typeof Chart === 'undefined') { return; }
+                                                                    var existingChart = Chart.getChart('journeyCanvas');
+                                                                    if (existingChart) { existingChart.destroy(); }
+                                                                    var ctx = document.getElementById('journeyCanvas');
+                                                                    if (!ctx) { return; }
+                                                                    var categoryLabels = ['Registration', 'OPD Visit', 'Admission', 'Discharge', 'Lab', 'Surgery'];
+                                                                    new Chart(ctx, {
+                                                                        type: 'scatter',
+                                                                        data: {
+                                                                            datasets: [
+                                                                                {
+                                                                                    label: 'Registration',
+                                                                                    data: [{x: #{patientEncounterController.patientRegistrationDate.time}, y: 0}],
+                                                                                    backgroundColor: 'rgba(40,167,69,0.9)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                },
+                                                                                {
+                                                                                    label: 'OPD Visit',
+                                                                                    data: [
+                                                                                        <ui:repeat value="#{patientEncounterController.opdVisitEvents}" var="ev" varStatus="s">
+                                                                                            {x: #{ev[0].time}, y: 1}#{!s.last ? ',' : ''}
+                                                                                        </ui:repeat>
+                                                                                    ],
+                                                                                    backgroundColor: 'rgba(0,123,255,0.85)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                },
+                                                                                {
+                                                                                    label: 'Admission',
+                                                                                    data: [
+                                                                                        <ui:repeat value="#{patientEncounterController.admissionStartEvents}" var="ev" varStatus="s">
+                                                                                            {x: #{ev[0].time}, y: 2}#{!s.last ? ',' : ''}
+                                                                                        </ui:repeat>
+                                                                                    ],
+                                                                                    backgroundColor: 'rgba(255,140,0,0.9)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                },
+                                                                                {
+                                                                                    label: 'Discharge',
+                                                                                    data: [
+                                                                                        <ui:repeat value="#{patientEncounterController.admissionEndEvents}" var="ev" varStatus="s">
+                                                                                            {x: #{ev[0].time}, y: 3}#{!s.last ? ',' : ''}
+                                                                                        </ui:repeat>
+                                                                                    ],
+                                                                                    backgroundColor: 'rgba(108,99,255,0.9)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                },
+                                                                                {
+                                                                                    label: 'Lab',
+                                                                                    data: [
+                                                                                        <ui:repeat value="#{patientEncounterController.labEvents}" var="ev" varStatus="s">
+                                                                                            {x: #{ev[0].time}, y: 4}#{!s.last ? ',' : ''}
+                                                                                        </ui:repeat>
+                                                                                    ],
+                                                                                    backgroundColor: 'rgba(23,162,184,0.9)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                },
+                                                                                {
+                                                                                    label: 'Surgery',
+                                                                                    data: [
+                                                                                        <ui:repeat value="#{patientEncounterController.surgeryEvents}" var="ev" varStatus="s">
+                                                                                            {x: #{ev[0].time}, y: 5}#{!s.last ? ',' : ''}
+                                                                                        </ui:repeat>
+                                                                                    ],
+                                                                                    backgroundColor: 'rgba(220,53,69,0.9)',
+                                                                                    pointRadius: 10,
+                                                                                    pointHoverRadius: 14
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        options: {
+                                                                            responsive: true,
+                                                                            maintainAspectRatio: false,
+                                                                            plugins: {
+                                                                                legend: { display: true, position: 'top' },
+                                                                                title: { display: true, text: 'Patient Journey Timeline' },
+                                                                                tooltip: {
+                                                                                    callbacks: {
+                                                                                        label: function(context) {
+                                                                                            var d = new Date(context.parsed.x);
+                                                                                            var label = d.toLocaleDateString('en-GB', {day:'2-digit', month:'short', year:'numeric'});
+                                                                                            return context.dataset.label + ': ' + label;
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            scales: {
+                                                                                x: {
+                                                                                    type: 'time',
+                                                                                    time: { unit: 'month', displayFormats: { month: 'MMM yyyy' } },
+                                                                                    title: { display: true, text: 'Date' }
+                                                                                },
+                                                                                y: {
+                                                                                    min: -0.5,
+                                                                                    max: 5.5,
+                                                                                    title: { display: true, text: 'Event Type' },
+                                                                                    ticks: {
+                                                                                        stepSize: 1,
+                                                                                        callback: function(value) {
+                                                                                            var labels = ['Registration', 'OPD Visit', 'Admission', 'Discharge', 'Lab', 'Surgery'];
+                                                                                            return labels[value] || '';
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    });
+                                                                }, 500);
+                                                            </script>
+                                                        </h:panelGroup>
+                                                        <h:outputText
+                                                            value="Click 'Generate' to view the patient journey timeline."
+                                                            rendered="#{patientEncounterController.patientRegistrationDate eq null}"
+                                                            styleClass="text-muted d-block text-center mt-3"/>
+                                                    </h:panelGroup>
+                                                </div>
+                                            </h:form>
+                                        </p:tab>
                                     </p:tabView>
                                 </div>
                             </div>

--- a/src/main/webapp/emr/patient_profile.xhtml
+++ b/src/main/webapp/emr/patient_profile.xhtml
@@ -702,8 +702,12 @@
 
                                         </p:tab>
                                         <p:tab id="tabJourney" title="Journey">
-                                            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-                                            <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+                                            <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+                                                integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4"
+                                                crossorigin="anonymous"></script>
+                                            <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
+                                                integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws"
+                                                crossorigin="anonymous"></script>
                                             <h:form id="formJourney">
                                                 <div class="container-fluid p-2">
                                                     <div class="d-flex justify-content-between align-items-center mb-2">
@@ -719,7 +723,7 @@
                                                     </div>
                                                     <h:panelGroup id="journeyChartContainer" layout="block">
                                                         <h:panelGroup layout="block"
-                                                            rendered="#{patientEncounterController.patientRegistrationDate ne null}">
+                                                            rendered="#{patientEncounterController.patientJourneyTimelineReadyForCurrentPatient}">
                                                             <div style="width:100%; height:350px;">
                                                                 <canvas id="journeyCanvas"></canvas>
                                                             </div>
@@ -818,6 +822,8 @@
                                                                             scales: {
                                                                                 x: {
                                                                                     type: 'time',
+                                                                                    min: #{patientEncounterController.patientRegistrationDate.time},
+                                                                                    max: Date.now(),
                                                                                     time: { unit: 'month', displayFormats: { month: 'MMM yyyy' } },
                                                                                     title: { display: true, text: 'Date' }
                                                                                 },
@@ -841,7 +847,7 @@
                                                         </h:panelGroup>
                                                         <h:outputText
                                                             value="Click 'Generate' to view the patient journey timeline."
-                                                            rendered="#{patientEncounterController.patientRegistrationDate eq null}"
+                                                            rendered="#{not patientEncounterController.patientJourneyTimelineReadyForCurrentPatient}"
                                                             styleClass="text-muted d-block text-center mt-3"/>
                                                     </h:panelGroup>
                                                 </div>


### PR DESCRIPTION
## Summary

- Adds a **Journey** tab to `emr/patient_profile.xhtml` with a Chart.js scatter chart that visualises the patient's complete clinical history from registration to today on a time axis
- Colour-coded event categories: Registration (green), OPD Visit (blue), Admission (orange), Discharge (purple), Lab (teal), Surgery (red)
- New `generatePatientJourneyTimeline()` method on `PatientEncounterController` queries all `PatientEncounter` records by `EncounterType` for the current patient; no new entities or schema changes required
- Satisfies Lanka Hospital HIS tender requirement (LH/ICB/26/1133/ID/P90, EHR module, Page 57): *"Ability to visualize the complete patient journey from the date of registration to to-date in a graphical manner"*

## Test plan

- [x] Deployed to local Payara and navigated to `emr/patient_profile.xhtml` for Dr. M H B Ariyaratne
- [x] Clicked **Journey** tab → placeholder text visible, Generate button present
- [x] Clicked **Generate** → AJAX call succeeded, Chart.js scatter chart rendered
- [x] Browser console: **0 errors, 0 warnings**
- [x] OPD visit dot and registration dot plotted at correct dates on the time axis

**Journey tab — initial state:**
![Journey tab](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21652-journey-tab-initial.png)

**After clicking Generate:**
![Patient journey timeline](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21652-journey-timeline-chart.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Journey** tab to the patient profile with an interactive timeline chart showing registration, OPD visits, admissions/discharges, lab tests, and surgeries.
  * Included a **Generate** button to build the journey timeline and refresh the chart via AJAX.
* **Enhancements**
  * The chart renders only when the journey data is ready; otherwise, a prompt is displayed indicating the timeline needs generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->