### PR TITLE
fix(pharmacy): BHT issue request navigation hang and PrimeFaces widget init error

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2732,7 +2732,15 @@ public class PharmacySaleBhtController implements Serializable {
             return "";
         }
         setCompleted(false);
-        generateIssueBillComponentsForBhtRequest(bhtRequestBill);
+        // Eager-fetch the bill with items, item details, and stock in one JOIN FETCH
+        // query to avoid lazy-loading on the session-stored (detached) entity.
+        Bill freshBill = getBillItemFacade().loadBillWithItemsFresh(bhtRequestBill.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Request bill not found.");
+            return "";
+        }
+        bhtRequestBill = freshBill;
+        generateIssueBillComponentsForBhtRequest(freshBill);
         return "/ward/ward_pharmacy_bht_issue?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2732,6 +2732,11 @@ public class PharmacySaleBhtController implements Serializable {
             return "";
         }
         setCompleted(false);
+        // The search-list render already initialized patientEncounter (and its
+        // nested patient/person/room associations) on the session-stored entity.
+        // Preserve it here because loadBillWithItemsFresh() does not join-fetch
+        // patientEncounter, so the returned detached bill has an uninitialized proxy.
+        PatientEncounter preservedEncounter = bhtRequestBill.getPatientEncounter();
         // Eager-fetch the bill with items, item details, and stock in one JOIN FETCH
         // query to avoid lazy-loading on the session-stored (detached) entity.
         Bill freshBill = getBillItemFacade().loadBillWithItemsFresh(bhtRequestBill.getId());
@@ -2739,6 +2744,7 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("Request bill not found.");
             return "";
         }
+        freshBill.setPatientEncounter(preservedEncounter);
         bhtRequestBill = freshBill;
         generateIssueBillComponentsForBhtRequest(freshBill);
         return "/ward/ward_pharmacy_bht_issue?faces-redirect=true";

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -104,9 +104,16 @@
 
                                     <div class="d-flex align-items-center my-1">
                                         <i class="fa-solid fa-user me-2 text-primary"></i>
-                                        <h:outputLabel for="acPt2_input" style="font-weight: bold" value="Patient Name or BHT or PHN No"/>
+                                        <h:outputLabel style="font-weight: bold" value="Patient Name or BHT or PHN No"/>
                                     </div>
-                                    
+
+                                    <h:panelGroup rendered="#{pharmacyRequestForBhtController.department eq null}">
+                                        <p:inputText disabled="true"
+                                                     class="col-md-12 my-1"
+                                                     inputStyleClass="form-control"
+                                                     placeholder="Select a pharmacy department first" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{pharmacyRequestForBhtController.department ne null}">
                                     <p:autoComplete
                                         widgetVar="aPt2"
                                         id="acPt2"
@@ -114,7 +121,6 @@
                                         value="#{pharmacyRequestForBhtController.patientEncounter}"
                                         completeMethod="#{admissionController.completePatient}"
                                         var="apt2"
-                                        disabled="#{pharmacyRequestForBhtController.department eq null}"
                                         itemLabel="#{apt2.bhtNo}"
                                         itemValue="#{apt2}"
                                         size="30"
@@ -142,6 +148,7 @@
                                         </p:column>
                                         <p:ajax event="itemSelect" process="acPt2" update="@form" />
                                     </p:autoComplete>
+                                    </h:panelGroup>
                                 </div>
 
 


### PR DESCRIPTION
## Summary

- **Navigation hang** (`ward_pharmacy_bht_issue_request_list_for_issue.xhtml`): `navigateToIssueMedicinesDirectlyForBhtRequest()` was passing the session-stored (potentially detached) `bhtRequestBill` entity directly into `generateIssueBillComponentsForBhtRequest()`. The method called `b.getBillItems()` on this stale entity; EclipseLink lazy-loading outside a JPA transaction threw a `ValidationException`, producing a 500 response that the browser displayed as a chrome-error page. Fix: load the bill via `BillItemFacade.loadBillWithItemsFresh()` (a single JOIN FETCH query) before processing, ensuring all item and stock relationships are eager-loaded in one DB round-trip.

- **PrimeFaces widget init error** (`ward_pharmacy_bht_issue_request_bill.xhtml`): `acPt2` `p:autoComplete` used `disabled="#{...department eq null}"`. PrimeFaces 14.x autocomplete widget init reads `this.panel.hasAttribute(...)`, but the overlay panel element is absent when the component is disabled, causing a `TypeError: Cannot read properties of undefined (reading 'hasAttribute')` on every page load. Fix: replaced `disabled` with `h:panelGroup rendered="..."` blocks (per project JSF convention); a plain disabled `p:inputText` placeholder is shown when no department is selected, and the real autocomplete is rendered only when a department is already set.

## Test plan

- [ ] Log in as Inward → prescribe ward medicines for BHT/55358 → request from Main Pharmacy
- [ ] Switch to Main Pharmacy → open BHT Issue Requests → Search Not Issued → request appears
- [ ] Click **Issue Medicines** → page navigates cleanly to `ward_pharmacy_bht_issue.xhtml` with items pre-populated; no chrome-error page, no server-log exception
- [ ] Open `ward_pharmacy_bht_issue_request_bill.xhtml` directly → browser console shows no `hasAttribute` TypeError; placeholder input visible until department is selected; after selecting a pharmacy, `acPt2` autocomplete appears and works

Tested locally against `coop` database (Payara `rh` domain, PrimeFaces 14.0.6).

Closes #21658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pharmacy BHT medicine request issuance issues caused by missing/expired request bill data and related lazy-loading behavior.
  * Added clear handling when a request bill can’t be found to prevent incorrect processing.

* **User Interface**
  * Updated the pharmacy BHT patient/encounter selection area to conditionally show a disabled prompt or an active autocomplete based on pharmacy department availability.
  * Refined labeling and conditional rendering for the patient selection section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->