### PR TITLE
Capture foreigner flag at inward admission (#21175)

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -927,6 +927,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
         quickSearchPhoneNumber = null;
         admissionController.setPatientAllergies(null);
         admissionController.setCurrentReservation(null);
+        
+        admissionController.setPatientForiegner(false);
         return "/inward/inward_admission?faces-redirect=true";
 
     }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -211,6 +211,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private Reservation latestfoundReservation;
 
     private Reservation currentReservation;
+    
+    private boolean patientForiegner;
 
     @PostConstruct
     public void init() {
@@ -1662,6 +1664,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         Person person = getPatient().getPerson();
         // DON'T set to null - keep reference throughout
+        
+        if(patientForiegner){
+            getPatient().getPerson().setForeigner(true);
+        }
 
         // Save Person first (no flush yet)
         if (person != null) {
@@ -2322,6 +2328,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             getCurrent().setBhtLong(getInwardBean().getLastGeneratedBhtLong());
         }
         getCurrent().setPaymentScheme(paymentScheme);
+        getCurrent().setForiegner(patientForiegner);
 
         if (getCurrent().getId() != null && getCurrent().getId() > 0) {
             getFacade().edit(getCurrent());
@@ -2435,6 +2442,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         // Need to create EncounterCredit
         admittingProcessStarted = false;
         currentReservation = null;
+        patientForiegner = false;
         printPreview = true;
     }
 
@@ -3188,6 +3196,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     public void setCurrentReservation(Reservation currentReservation) {
         this.currentReservation = currentReservation;
+    }
+
+    public boolean isPatientForiegner() {
+        return patientForiegner;
+    }
+
+    public void setPatientForiegner(boolean patientForiegner) {
+        this.patientForiegner = patientForiegner;
     }
 
     /**

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -85,7 +85,7 @@
                                 <p:commandButton
                                     id="admt"
                                     action="#{admissionController.checkBeforeAdmit}"
-                                    update="@form"
+                                    ajax="false"
                                     styleClass="ui-button-success"
                                     icon="pi pi-check-circle"
                                     style="min-width:120px"
@@ -433,7 +433,7 @@
                                     <h:panelGroup id="pg1">
                                         <div class="mb-2">
                                             <p:selectBooleanCheckbox
-                                                value="#{admissionController.current.foriegner}"
+                                                value="#{admissionController.patientForiegner}"
                                                 itemLabel="Mark as Foreigner"/>
                                         </div>
                                         <div class="mb-2">


### PR DESCRIPTION
## Summary

Implements **"Mark as Foreigner" at admission time** so that foreigner tariffs apply accordingly for inpatient admissions (issue #21175).

Previously the "Mark as Foreigner" checkbox on the inward admission page wrote directly to `current.foriegner` on the in-progress `PatientEncounter`. This change routes the selection through a dedicated transient flag on `AdmissionController` and applies it to **both** the patient's `Person` and the `Admission`, with proper reset between admissions.

## Changes

- **`AdmissionController`**
  - Added a transient `boolean patientForiegner` field with getter/setter.
  - On save, when `patientForiegner` is set, mark the patient's `Person.foreigner = true` so the foreigner tariff applies.
  - Set `current.foriegner = patientForiegner` on the admission record.
  - Reset `patientForiegner = false` after a successful admission.
- **`PatientController`**
  - Reset `patientForiegner = false` when navigating to start a new admission, so the flag does not leak from a previous patient.
- **`inward_admission.xhtml`**
  - Bind the "Mark as Foreigner" checkbox to `admissionController.patientForiegner` instead of `current.foriegner`.
  - Make the **Admit** button a full (non-AJAX) submit (`ajax="false"`) so the checkbox value is committed reliably on admission.

## Testing

- Verified locally that marking a patient as foreigner at admission flags both the person and the admission, and that the flag clears when starting a new admission.

Closes #21175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Mark as Foreigner" checkbox in the patient admission interface now correctly maintains patient foreigner status throughout the admission workflow, ensuring consistent tracking from initial setup through completion.
  * The "Admit" button submission method has been updated to provide improved form processing and better compatibility with the admission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->