### PR TITLE
Prevent cancelling inpatient bills that are already checked (#21192)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -297,6 +297,14 @@ public class InwardSearch implements Serializable {
     private List<PaymentMethod> inwardDepositCancelationPaymentMethods;
     
     public String navigateToPaymentBillCancellation() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return "";
+        }
         switch (bill.getBillTypeAtomic()) {
             case INWARD_DEPOSIT:
                 inwardDepositCancelationPaymentMethods = new ArrayList<>();
@@ -316,6 +324,30 @@ public class InwardSearch implements Serializable {
             default:
                 return "inward_cancel_bill_payment?faces-redirect=true";
         }
+    }
+
+    public String navigateToCancelInwardServiceBillFromReprint() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return "";
+        }
+        return "/inward/inward_cancel_bill_service?faces-redirect=true";
+    }
+
+    public String navigateToCancelInwardProfessionalBill() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return "";
+        }
+        return "/inward/inward_cancel_bill_professional?faces-redirect=true";
     }
 
     public String navigateToViewInwardDepositCancellationBill(Bill b) {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -362,6 +362,11 @@ public class InwardSearch implements Serializable {
             return "";
         }
 
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return "";
+        }
+
         DepartmentType toBillDepartmentType = DepartmentType.Other;
 
         if (bill.getToDepartment() != null && bill.getToDepartment().getDepartmentType() != null) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -211,6 +211,10 @@ public class PharmacyBillSearch implements Serializable {
             JsfUtil.addErrorMessage("No Bill Selected");
             return null;
         }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return null;
+        }
         return "/inward/pharmacy_cancel_bill_retail_bht?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/bean/store/StoreBillSearch.java
+++ b/src/main/java/com/divudi/bean/store/StoreBillSearch.java
@@ -2012,6 +2012,18 @@ public class StoreBillSearch implements Serializable {
         return bill;
     }
 
+    public String navigateToCancelStoreDirectIssueToInpatients() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return null;
+        }
+        return "/store/store_cancel_bill_retail_bht?faces-redirect=true";
+    }
+
     public void setBill(Bill bill) {
         recreateModel();
         this.bill = bill;

--- a/src/main/java/com/divudi/bean/store/StoreBillSearch.java
+++ b/src/main/java/com/divudi/bean/store/StoreBillSearch.java
@@ -2024,6 +2024,18 @@ public class StoreBillSearch implements Serializable {
         return "/store/store_cancel_bill_retail_bht?faces-redirect=true";
     }
 
+    public String navigateToCancelStoreReturnDirectIssueToInpatients() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return null;
+        }
+        return "/store/store_cancel_bill_return_bht?faces-redirect=true";
+    }
+
     public void setBill(Bill bill) {
         recreateModel();
         this.bill = bill;

--- a/src/main/webapp/inward/inward_reprint_bill.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill.xhtml
@@ -19,7 +19,7 @@
                         <div class=" d-flex justify-content-between m-1">
                             <div>
                                 <p:commandButton ajax="false" value="Cancel"
-                                                 action="inward_cancel_bill_service" 
+                                                 action="#{inwardSearch.navigateToCancelInwardServiceBillFromReprint()}"
                                                  disabled="#{inwardSearch.bill.cancelled}"
                                                  class="m-2 ui-button-danger"
                                                  icon="fa fa-ban">                           

--- a/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
@@ -26,7 +26,7 @@
                                         icon="fa fa-cancel"
                                         class="ui-button-danger mx-1"
                                         rendered="#{inwardSearch.bill.billClass ne 'class com.divudi.core.entity.CancelledBill'}"
-                                        action="inward_cancel_bill_professional"  
+                                        action="#{inwardSearch.navigateToCancelInwardProfessionalBill()}"
                                         disabled="#{inwardSearch.bill.cancelled}"  >                           
                                     </p:commandButton>
                                     <p:commandButton 

--- a/src/main/webapp/inward/store_reprint_bill_sale_bht.xhtml
+++ b/src/main/webapp/inward/store_reprint_bill_sale_bht.xhtml
@@ -25,8 +25,8 @@
                             <p:commandButton ajax="false" value="Cancel" 
                                              icon="fa fa-ban"
                                              class="m-2 ui-button-danger"
-                                             action="/store/store_cancel_bill_retail_bht"
-                                             disabled="#{storeBillSearch.bill.cancelled}"  >                           
+                                             action="#{storeBillSearch.navigateToCancelStoreDirectIssueToInpatients()}"
+                                             disabled="#{storeBillSearch.bill.cancelled}"  >                         
                             </p:commandButton>
                             <p:commandButton ajax="false" value="Return Item" 
                                              action="/store/store_bill_return_bht_issue"   

--- a/src/main/webapp/store/store_reprint_bill_return_bht.xhtml
+++ b/src/main/webapp/store/store_reprint_bill_return_bht.xhtml
@@ -20,9 +20,9 @@
                             <p:commandButton value="Reprint" ajax="false">
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
-                            <p:commandButton ajax="false" value="Cancel" 
-                                            action="store_cancel_bill_return_bht" 
-                                             disabled="#{storeBillSearch.bill.cancelled}"  >                           
+                            <p:commandButton ajax="false" value="Cancel"
+                                            action="#{storeBillSearch.navigateToCancelStoreReturnDirectIssueToInpatients()}"
+                                             disabled="#{storeBillSearch.bill.cancelled}"  >                         
                             </p:commandButton>
                             
                         </f:facet>

--- a/src/main/webapp/store/store_reprint_bill_sale_bht.xhtml
+++ b/src/main/webapp/store/store_reprint_bill_sale_bht.xhtml
@@ -20,7 +20,7 @@
                             <p:commandButton value="Reprint" ajax="false" >
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
-                            <p:commandButton ajax="false" value="Cancel" action="store_cancel_bill_retail_bht"
+                            <p:commandButton ajax="false" value="Cancel" action="#{storeBillSearch.navigateToCancelStoreDirectIssueToInpatients()}"
                                              disabled="#{storeBillSearch.bill.cancelled}">                           
                             </p:commandButton>
                            


### PR DESCRIPTION
## Summary

Once an inpatient service bill has been **marked as checked / processed** at a service station (X-Ray, CT, MRI, Ultrasound, Echo, etc.), it must no longer be cancellable. Previously the reprint pages allowed navigating straight to the cancel page even for a checked bill.

This PR adds a guard across all the inpatient reprint pages: if the selected bill is already checked (`Bill.getCheckeAt() != null`), navigation to the cancel page is blocked and an error message is shown:

> This bill is already checked. A checked bill cannot be cancelled.

Closes #21192

## Changes

**`InwardSearch.java`**
- `navigateToCancelInpatientBill()` — added checked-bill guard (used by `inward_reprint_bill_service`)
- `navigateToPaymentBillCancellation()` — added null + checked-bill guard (used by `inward_reprint_bill_payment`)
- New `navigateToCancelInwardServiceBillFromReprint()` — guarded navigation to `inward_cancel_bill_service` (used by `inward_reprint_bill`)
- New `navigateToCancelInwardProfessionalBill()` — guarded navigation to `inward_cancel_bill_professional` (used by `inward_reprint_bill_professional`)

**`PharmacyBillSearch.java`**
- `navigateToCancelPharmacyDirectIssueToInpatients()` — added checked-bill guard (used by `pharmacy_reprint_bill_sale_bht`)

**`StoreBillSearch.java`**
- New `navigateToCancelStoreDirectIssueToInpatients()` — guarded navigation to `store_cancel_bill_retail_bht` (used by `store_reprint_bill_sale_bht`)
- New `navigateToCancelStoreReturnDirectIssueToInpatients()` — guarded navigation to `store_cancel_bill_return_bht` (used by `store_reprint_bill_return_bht`)

**XHTML** — Cancel buttons rewired from raw page outcomes to the guarded controller methods:
- `inward/inward_reprint_bill.xhtml`
- `inward/inward_reprint_bill_professional.xhtml`
- `inward/store_reprint_bill_sale_bht.xhtml`
- `store/store_reprint_bill_sale_bht.xhtml`
- `store/store_reprint_bill_return_bht.xhtml`

## Testing

- A checked bill: pressing **Cancel / To Cancel** keeps the user on the reprint page and shows the error message.
- An unchecked bill: cancellation proceeds to the cancel page as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents cancellation of bills that have already been verified or checked, protecting finalized transactions across inward, pharmacy, and store operations. Enhanced validation is now enforced before allowing any bill cancellation requests to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->