### PR TITLE
feat(api): add manage_config_option AI agent tool for config read/write (#21544)

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1,6 +1,8 @@
 package com.divudi.service;
 
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.OptionScope;
+import com.divudi.core.data.OptionValueType;
 import com.divudi.core.entity.AiMessage;
 import com.divudi.core.entity.ConfigOption;
 import com.divudi.core.facade.ConfigOptionFacade;
@@ -21,6 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
@@ -40,6 +43,9 @@ public class AnthropicApiService implements Serializable {
 
     @EJB
     private ConfigOptionFacade configOptionFacade;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
 
     // -------------------------------------------------------------------------
     // Public API
@@ -306,6 +312,29 @@ public class AnthropicApiService implements Serializable {
                                         .add("type", "string")
                                         .add("description", "Keyword to search in config option keys (case-insensitive)")))
                         .add("required", Json.createArrayBuilder().add("keyword")))
+                .build();
+
+        JsonObject manageConfigOptionTool = Json.createObjectBuilder()
+                .add("name", "manage_config_option")
+                .add("description",
+                        "Read or update a single HMIS application configuration option by its exact key. "
+                        + "Use GET to read the current value; use PUT to update it (flushes in-memory cache immediately). "
+                        + "The option must already exist — this tool does not create new keys. "
+                        + "Sensitive values (API keys, passwords, tokens) are masked on reads. "
+                        + "Use search_config_options first if you need to discover the exact key name.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "HTTP method: GET to read, PUT to update"))
+                                .add("key", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Exact config option key (case-sensitive)"))
+                                .add("value", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "New value (required for PUT)")))
+                        .add("required", Json.createArrayBuilder().add("method").add("key")))
                 .build();
 
         JsonObject clinicalMetadataTool = Json.createObjectBuilder()
@@ -1344,6 +1373,7 @@ public class AnthropicApiService implements Serializable {
                 .add(searchCodeTool)
                 .add(fetchFileTool)
                 .add(searchConfigTool)
+                .add(manageConfigOptionTool)
                 .add(clinicalMetadataTool)
                 .add(collectingCentreFeesTool)
                 .add(inwardDiscountMatrixTool)
@@ -1392,6 +1422,12 @@ public class AnthropicApiService implements Serializable {
                 case "search_config_options": {
                     String keyword = toolInput.getString("keyword", "");
                     return searchConfigOptions(keyword);
+                }
+                case "manage_config_option": {
+                    String method = toolInput.getString("method", "GET");
+                    String key    = toolInput.containsKey("key")   ? toolInput.getString("key", "")   : "";
+                    String value  = toolInput.containsKey("value") ? toolInput.getString("value", "") : null;
+                    return manageConfigOption(method, key, value);
                 }
                 case "manage_clinical_metadata": {
                     String method = toolInput.getString("method", "GET");
@@ -1848,6 +1884,58 @@ public class AnthropicApiService implements Serializable {
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Config option search failed", e);
             return "Config search error: " + e.getMessage();
+        }
+    }
+
+    private String manageConfigOption(String method, String key, String newValue) {
+        if (key == null || key.trim().isEmpty()) {
+            return "Error: key is required.";
+        }
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("scope", OptionScope.APPLICATION);
+            params.put("k", key);
+            ConfigOption option = configOptionFacade.findFirstByJpql(
+                    "SELECT o FROM ConfigOption o WHERE o.retired = false AND o.scope = :scope AND o.optionKey = :k",
+                    params);
+
+            if ("PUT".equalsIgnoreCase(method)) {
+                if (newValue == null) {
+                    return "Error: value is required for PUT.";
+                }
+                if (option == null) {
+                    return "Error: config option not found: " + key;
+                }
+                String oldValue = option.getOptionValue();
+                if (option.getValueType() == OptionValueType.LONG_TEXT) {
+                    configOptionApplicationController.setLongTextValueByKey(key, newValue);
+                } else {
+                    option.setOptionValue(newValue);
+                    configOptionFacade.edit(option);
+                    configOptionApplicationController.loadApplicationOptions();
+                }
+                LOG.log(Level.INFO, "CONFIG_UPDATED via AI tool key=[{0}] old=[{1}] new=[{2}]",
+                        new Object[]{key,
+                            maskSensitiveValue(key, oldValue),
+                            maskSensitiveValue(key, newValue)});
+                return "Config option updated.\nKey: " + key + "\nOld value: "
+                        + maskSensitiveValue(key, oldValue) + "\nNew value: "
+                        + maskSensitiveValue(key, newValue);
+            }
+
+            // GET
+            if (option == null) {
+                return "Config option not found: " + key;
+            }
+            String value = maskSensitiveValue(option.getOptionKey(), option.getOptionValue());
+            if (value != null && value.length() > 500) {
+                value = value.substring(0, 500) + "... (truncated)";
+            }
+            return "Key: " + option.getOptionKey() + "\nType: " + option.getValueType()
+                    + "\nScope: " + option.getScope() + "\nValue: " + value;
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "manage_config_option failed", e);
+            return "Error: " + e.getMessage();
         }
     }
 

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -4,7 +4,9 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.OptionValueType;
 import com.divudi.core.entity.AiMessage;
+import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.ConfigOption;
+import com.divudi.core.facade.ApiKeyFacade;
 import com.divudi.core.facade.ConfigOptionFacade;
 import java.io.Serializable;
 import java.io.StringReader;
@@ -43,6 +45,9 @@ public class AnthropicApiService implements Serializable {
 
     @EJB
     private ConfigOptionFacade configOptionFacade;
+
+    @EJB
+    private ApiKeyFacade apiKeyFacade;
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
@@ -327,6 +332,7 @@ public class AnthropicApiService implements Serializable {
                         .add("properties", Json.createObjectBuilder()
                                 .add("method", Json.createObjectBuilder()
                                         .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("GET").add("PUT"))
                                         .add("description", "HTTP method: GET to read, PUT to update"))
                                 .add("key", Json.createObjectBuilder()
                                         .add("type", "string")
@@ -1427,7 +1433,7 @@ public class AnthropicApiService implements Serializable {
                     String method = toolInput.getString("method", "GET");
                     String key    = toolInput.containsKey("key")   ? toolInput.getString("key", "")   : "";
                     String value  = toolInput.containsKey("value") ? toolInput.getString("value", "") : null;
-                    return manageConfigOption(method, key, value);
+                    return manageConfigOption(method, key, value, hmisApiKey);
                 }
                 case "manage_clinical_metadata": {
                     String method = toolInput.getString("method", "GET");
@@ -1887,9 +1893,13 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
-    private String manageConfigOption(String method, String key, String newValue) {
+    private String manageConfigOption(String method, String key, String newValue, String hmisApiKey) {
         if (key == null || key.trim().isEmpty()) {
             return "Error: key is required.";
+        }
+        String normalizedMethod = method == null ? "GET" : method.trim().toUpperCase();
+        if (!"GET".equals(normalizedMethod) && !"PUT".equals(normalizedMethod)) {
+            return "Error: Unknown method '" + method + "'. Supported: GET, PUT";
         }
         try {
             Map<String, Object> params = new HashMap<>();
@@ -1899,7 +1909,7 @@ public class AnthropicApiService implements Serializable {
                     "SELECT o FROM ConfigOption o WHERE o.retired = false AND o.scope = :scope AND o.optionKey = :k",
                     params);
 
-            if ("PUT".equalsIgnoreCase(method)) {
+            if ("PUT".equals(normalizedMethod)) {
                 if (newValue == null) {
                     return "Error: value is required for PUT.";
                 }
@@ -1907,20 +1917,25 @@ public class AnthropicApiService implements Serializable {
                     return "Error: config option not found: " + key;
                 }
                 String oldValue = option.getOptionValue();
-                if (option.getValueType() == OptionValueType.LONG_TEXT) {
-                    configOptionApplicationController.setLongTextValueByKey(key, newValue);
-                } else {
-                    option.setOptionValue(newValue);
-                    configOptionFacade.edit(option);
-                    configOptionApplicationController.loadApplicationOptions();
+                OptionValueType vt = option.getValueType();
+                String validationError = validateTypedValue(vt, newValue);
+                if (validationError != null) {
+                    return validationError;
                 }
-                LOG.log(Level.INFO, "CONFIG_UPDATED via AI tool key=[{0}] old=[{1}] new=[{2}]",
+                applyTypedUpdate(key, newValue, option, vt);
+
+                String callerName = resolveCallerName(hmisApiKey);
+                LOG.log(Level.INFO,
+                        "CONFIG_UPDATED via AI Chat tool key=[{0}] old=[{1}] new=[{2}] by=[{3}] at=[{4}]",
                         new Object[]{key,
                             maskSensitiveValue(key, oldValue),
-                            maskSensitiveValue(key, newValue)});
-                return "Config option updated.\nKey: " + key + "\nOld value: "
-                        + maskSensitiveValue(key, oldValue) + "\nNew value: "
-                        + maskSensitiveValue(key, newValue);
+                            maskSensitiveValue(key, newValue),
+                            callerName,
+                            new java.util.Date()});
+                return "Config option updated.\nKey: " + key
+                        + "\nOld value: " + maskSensitiveValue(key, oldValue)
+                        + "\nNew value: " + maskSensitiveValue(key, newValue)
+                        + "\nUpdated by: " + callerName;
             }
 
             // GET
@@ -1937,6 +1952,75 @@ public class AnthropicApiService implements Serializable {
             LOG.log(Level.WARNING, "manage_config_option failed", e);
             return "Error: " + e.getMessage();
         }
+    }
+
+    private String validateTypedValue(OptionValueType vt, String newValue) {
+        if (vt == null) {
+            return null;
+        }
+        switch (vt) {
+            case BOOLEAN:
+                if (!"true".equalsIgnoreCase(newValue.trim()) && !"false".equalsIgnoreCase(newValue.trim())) {
+                    return "Error: Value '" + newValue + "' is not a valid boolean (must be true or false).";
+                }
+                break;
+            case INTEGER:
+                try {
+                    Integer.parseInt(newValue.trim());
+                } catch (NumberFormatException e) {
+                    return "Error: Value '" + newValue + "' is not a valid integer.";
+                }
+                break;
+            case LONG:
+                try {
+                    Long.parseLong(newValue.trim());
+                } catch (NumberFormatException e) {
+                    return "Error: Value '" + newValue + "' is not a valid long integer.";
+                }
+                break;
+            case DOUBLE:
+                try {
+                    Double.parseDouble(newValue.trim());
+                } catch (NumberFormatException e) {
+                    return "Error: Value '" + newValue + "' is not a valid number.";
+                }
+                break;
+            default:
+                break;
+        }
+        return null;
+    }
+
+    private void applyTypedUpdate(String key, String newValue, ConfigOption option, OptionValueType vt) {
+        if (vt == OptionValueType.LONG_TEXT) {
+            configOptionApplicationController.setLongTextValueByKey(key, newValue);
+        } else if (vt == OptionValueType.BOOLEAN) {
+            configOptionApplicationController.setBooleanValueByKey(key, Boolean.parseBoolean(newValue.trim()));
+        } else if (vt == OptionValueType.INTEGER) {
+            configOptionApplicationController.setIntegerValueByKey(key, Integer.parseInt(newValue.trim()));
+        } else {
+            option.setOptionValue(newValue);
+            configOptionFacade.edit(option);
+            configOptionApplicationController.loadApplicationOptions();
+        }
+    }
+
+    private String resolveCallerName(String hmisApiKey) {
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "AI Chat (user unknown)";
+        }
+        try {
+            Map<String, Object> p = new HashMap<>();
+            p.put("k", hmisApiKey);
+            ApiKey ak = apiKeyFacade.findFirstByJpql(
+                    "SELECT a FROM ApiKey a WHERE a.keyValue = :k AND a.retired = false", p);
+            if (ak != null && ak.getWebUser() != null) {
+                return ak.getWebUser().getName() + " (AI Chat)";
+            }
+        } catch (Exception e) {
+            LOG.log(Level.FINE, "Could not resolve caller name from hmisApiKey", e);
+        }
+        return "AI Chat (user unknown)";
     }
 
     private String maskSensitiveValue(String key, String value) {


### PR DESCRIPTION
## Summary

- Adds a `manage_config_option` tool to the AI chat agent (AnthropicApiService) so Claude can read or update any application config option by exact key — no direct DB access required
- **GET**: returns key, type, scope, and current value (sensitive keys masked)
- **PUT**: writes the new value, handles LONG_TEXT via `setLongTextValueByKey()` for JSoup sanitisation, then calls `loadApplicationOptions()` to flush the `@ApplicationScoped` cache immediately
- Also adds `@Inject ConfigOptionApplicationController` and `OptionValueType` import to support type-aware update logic

The REST endpoints (`GET /api/config/{key}`, `PUT /api/config/{key}`, `GET /api/config?scope=`, `GET /api/config/search`) and their system-prompt documentation were already implemented; this PR closes the gap by wiring them up as AI agent tools.

## Test plan

- [ ] Start AI chat; ask "What is the value of config key 'Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation'?" — agent should call `manage_config_option` GET and return the current value
- [ ] Ask "Set config option 'Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation' to true" — agent should call `manage_config_option` PUT and confirm the update
- [ ] Verify the change is visible immediately in the HMIS UI (no restart needed)
- [ ] Confirm sensitive keys (containing "api key", "password", "token") are returned as `***masked***`

Closes #21544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI agent now supports a configuration management tool that can retrieve and update a single live application setting by exact key.
  * Supports **GET** (returns the option’s type and masked value) and **PUT** (validates the update and applies it only when the option exists and matches the expected value type).
  * Improved input validation and clearer failure behavior when keys are missing or values don’t conform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->