### PR TITLE
feat(inward): expose Admission Type on Inward Price Adjustment (margin) UI pages

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -20,6 +20,7 @@ import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.ServiceCategory;
 import com.divudi.core.entity.ServiceSubCategory;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.InwardPriceAdjustment;
 import com.divudi.core.entity.lab.InvestigationCategory;
 import com.divudi.core.entity.pharmacy.ConsumableCategory;
@@ -71,12 +72,14 @@ public class InwardPriceAdjustmntController implements Serializable {
     double margin;
     private Category roomLocation;
     private Institution creditCompany;
+    private AdmissionType admissionType;
 
     private void recreateModel() {
         fromPrice = toPrice + 1;
         toPrice = 0.0;
         margin = 0;
         creditCompany = null;
+        admissionType = null;
         items = null;
     }
 
@@ -85,6 +88,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         toPrice = 0.0;
         margin = 0;
         creditCompany = null;
+        admissionType = null;
         items = null;
     }
 
@@ -152,6 +156,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setPaymentMethod(paymentMethod);
         a.setMargin(margin);
         a.setCreditCompany(creditCompany);
+        a.setAdmissionType(admissionType);
         a.setCreatedAt(new Date());
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
@@ -189,6 +194,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             a.setPaymentMethod(paymentMethod);
             a.setMargin(margin);
             a.setCreditCompany(creditCompany);
+            a.setAdmissionType(admissionType);
             a.setCreatedAt(new Date());
             a.setCreater(getSessionController().getLoggedUser());
             if (a.getId() == null) {
@@ -454,6 +460,14 @@ public class InwardPriceAdjustmntController implements Serializable {
 
     public void setCreditCompany(Institution creditCompany) {
         this.creditCompany = creditCompany;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -437,6 +437,26 @@ public class InwardPriceAdjustmntController implements Serializable {
         //  createItems();
     }
 
+    /**
+     * Load the selected row into {@link #current} for editing in the edit
+     * dialog. The list itself is display-only; all changes are made in the
+     * dialog and committed via {@link #saveEdit()} (or discarded by closing it).
+     */
+    public void prepareEdit(PriceMatrix tmp) {
+        this.current = tmp;
+    }
+
+    /**
+     * Persist the row currently being edited in the edit dialog.
+     */
+    public void saveEdit() {
+        if (current == null) {
+            return;
+        }
+        getFacade().edit(current);
+        current = null;
+    }
+
     public Category getRoomLocation() {
 
         return roomLocation;

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -52,7 +52,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -52,7 +52,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
@@ -87,8 +87,24 @@
                                             id="cmbPs" 
                                             class="w-100"
                                             value="#{inwardPriceAdjustmntController.paymentMethod}"  >
-                                            <f:selectItem itemLabel="Select" />                           
-                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}" />                                    
+                                            <f:selectItem itemLabel="Select" />
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbAdmissionType"
+                                            value="#{inwardPriceAdjustmntController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                            <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                           itemValue="#{at}" itemLabel="#{at.name}" />
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
@@ -301,6 +317,14 @@
                                         </p:column>
                                     </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Admission Type"
+                                    filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/inward/inward_administration.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="mainForm">
                     <p:panel header="Inward Price Adjustment Matrix- Invesitagation" id="reportPrint">
                         <p:panel >
                             <f:facet name="header">
@@ -221,25 +221,7 @@
                                     filterBy="#{a.department.name}" 
                                     filterMatchMode="contains" 
                                     exportable="false">
-                                    
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.department}" 
-                                        completeMethod="#{departmentController.completeDept}" 
-                                        var="dep"
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        itemLabel="#{dep.name}" 
-                                        itemValue="#{dep}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.institution.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.department.name}"/>
-
                                 </p:column>
 
                                 <p:column 
@@ -257,42 +239,25 @@
                                     filterBy="#{a.category.name}" 
                                     filterMatchMode="contains" 
                                     exportable="false">
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.category}"
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        completeMethod="#{categoryController.completeCategoryInvestigation}" 
-                                        var="cat" 
-                                        itemLabel="#{cat.name}" 
-                                        itemValue="#{cat}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                        </p:column> 
-
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.category.name}"/>
                                 </p:column>
 
                                 <p:column headerText="From Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.fromPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.fromPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="To Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.toPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.toPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="Margin" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
+                                    <h:outputText value="#{a.margin}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column
@@ -300,22 +265,6 @@
                                     filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}">
-                                    <p:autoComplete
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        forceSelection="true"
-                                        value="#{a.creditCompany}"
-                                        completeMethod="#{institutionController.completeCreditCompany}"
-                                        var="ins"
-                                        itemLabel="#{ins.name}"
-                                        itemValue="#{ins}"
-                                        placeholder="All companies"
-                                        maxResults="20"
-                                        onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
-                                        <p:column>
-                                            <h:outputText value="#{ins.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
@@ -324,21 +273,19 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
-                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
-                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                                       itemValue="#{at}" itemLabel="#{at.name}" />
-                                    </p:selectOneMenu>
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">
                                     <div class="d-flex">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             id="edit"
-                                            ajax="false"
                                             icon="fa fa-pencil"
-                                            class="ui-button-success mx-1" 
-                                            action="#{inwardPriceAdjustmntController.onEdit(a)}"> 
+                                            class="ui-button-success mx-1"
+                                            process="@this"
+                                            update=":dlgEditForm"
+                                            oncomplete="PF('dlgEdit').show()"
+                                            action="#{inwardPriceAdjustmntController.prepareEdit(a)}">
                                         </p:commandButton>
                                         <p:commandButton 
                                             id="delete"
@@ -358,6 +305,74 @@
                         </p:panel>
                     </p:panel>
                 </h:form>
+
+                <p:dialog header="Edit Price Adjustment" widgetVar="dlgEdit" modal="true"
+                          resizable="false" width="480" id="dlgEdit">
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="2" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Category"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.category.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="From Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Credit Company"/>
+                            <p:autoComplete
+                                inputStyleClass="form-control"
+                                class="w-100"
+                                forceSelection="true"
+                                value="#{inwardPriceAdjustmntController.current.creditCompany}"
+                                completeMethod="#{institutionController.completeCreditCompany}"
+                                var="ins"
+                                itemLabel="#{ins.name}"
+                                itemValue="#{ins}"
+                                placeholder="All companies"
+                                maxResults="20"
+                                onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
+                                <p:column>
+                                    <h:outputText value="#{ins.name}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                               itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton id="dlgSave" value="Save" icon="fa fa-save"
+                                             class="ui-button-success mx-1"
+                                             action="#{inwardPriceAdjustmntController.saveEdit}"
+                                             update=":dlgEditForm :mainForm:inwd"
+                                             oncomplete="PF('dlgEdit').hide()"/>
+                            <p:commandButton id="dlgCancel" value="Cancel" icon="fa fa-times"
+                                             class="ui-button-secondary mx-1"
+                                             type="button"
+                                             onclick="PF('dlgEdit').hide()"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_investigation.xhtml
@@ -324,7 +324,11 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
+                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemValue="#{at}" itemLabel="#{at.name}" />
+                                    </p:selectOneMenu>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/inward/inward_administration.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="mainForm">
                     <p:panel header="Inward Price Adjustment Matrix - Pharmacy" id="reportPrint">
 
                         <p:panel header="Add new adjustment" >
@@ -229,24 +229,7 @@
                                     headerText="Department Name" 
                                     filterBy="#{a.department.name}" 
                                     filterMatchMode="contains" 
-                                    exportable="false">   
-
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.department}" 
-                                        completeMethod="#{departmentController.completeDept}" 
-                                        var="dep" 
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        itemLabel="#{dep.name}" 
-                                        itemValue="#{dep}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.institution.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
+                                    exportable="false">
                                     <p:outputLabel value="#{a.department.name}"/>
                                 </p:column>
 
@@ -263,41 +246,25 @@
                                     filterBy="#{a.category.name}" 
                                     filterMatchMode="contains" 
                                     exportable="false">
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.category}" 
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        completeMethod="#{categoryController.completeCategoryPharmacy}" 
-                                        var="cat" 
-                                        itemLabel="#{cat.name}" 
-                                        itemValue="#{cat}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                        </p:column> 
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.category.name}"/>
                                 </p:column>
 
                                 <p:column headerText="From Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.fromPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.fromPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="To Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.toPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.toPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="Margin" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
+                                    <h:outputText value="#{a.margin}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column
@@ -305,22 +272,6 @@
                                     filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}">
-                                    <p:autoComplete
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        forceSelection="true"
-                                        value="#{a.creditCompany}"
-                                        completeMethod="#{institutionController.completeCreditCompany}"
-                                        var="ins"
-                                        itemLabel="#{ins.name}"
-                                        itemValue="#{ins}"
-                                        placeholder="All companies"
-                                        maxResults="20"
-                                        onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
-                                        <p:column>
-                                            <h:outputText value="#{ins.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
@@ -329,21 +280,19 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
-                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
-                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                                       itemValue="#{at}" itemLabel="#{at.name}" />
-                                    </p:selectOneMenu>
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">
                                     <div class="d-flex">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             id="edit"
-                                            ajax="false"
                                             icon="fa fa-pencil"
                                             class="ui-button-success mx-1"
-                                            action="#{inwardPriceAdjustmntController.onEdit(a)}" >
+                                            process="@this"
+                                            update=":dlgEditForm"
+                                            oncomplete="PF('dlgEdit').show()"
+                                            action="#{inwardPriceAdjustmntController.prepareEdit(a)}" >
                                         </p:commandButton>
 
                                         <p:commandButton 
@@ -370,6 +319,74 @@
                     </p:panel>
 
                 </h:form>
+
+                <p:dialog header="Edit Price Adjustment" widgetVar="dlgEdit" modal="true"
+                          resizable="false" width="480" id="dlgEdit">
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="2" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Category"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.category.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="From Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Credit Company"/>
+                            <p:autoComplete
+                                inputStyleClass="form-control"
+                                class="w-100"
+                                forceSelection="true"
+                                value="#{inwardPriceAdjustmntController.current.creditCompany}"
+                                completeMethod="#{institutionController.completeCreditCompany}"
+                                var="ins"
+                                itemLabel="#{ins.name}"
+                                itemValue="#{ins}"
+                                placeholder="All companies"
+                                maxResults="20"
+                                onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
+                                <p:column>
+                                    <h:outputText value="#{ins.name}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                               itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton id="dlgSave" value="Save" icon="fa fa-save"
+                                             class="ui-button-success mx-1"
+                                             action="#{inwardPriceAdjustmntController.saveEdit}"
+                                             update=":dlgEditForm :mainForm:inwd"
+                                             oncomplete="PF('dlgEdit').hide()"/>
+                            <p:commandButton id="dlgCancel" value="Cancel" icon="fa fa-times"
+                                             class="ui-button-secondary mx-1"
+                                             type="button"
+                                             onclick="PF('dlgEdit').hide()"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
 
 

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -97,8 +97,24 @@
                                             class="w-100"
                                             id="cmbPs" 
                                             value="#{inwardPriceAdjustmntController.paymentMethod}"  >
-                                            <f:selectItem itemLabel="Select" />                           
-                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}" />                                    
+                                            <f:selectItem itemLabel="Select" />
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbAdmissionType"
+                                            value="#{inwardPriceAdjustmntController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                            <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                           itemValue="#{at}" itemLabel="#{at.name}" />
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
@@ -306,6 +322,14 @@
                                         </p:column>
                                     </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Admission Type"
+                                    filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -329,7 +329,11 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
+                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemValue="#{at}" itemLabel="#{at.name}" />
+                                    </p:selectOneMenu>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -332,7 +332,11 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
+                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemValue="#{at}" itemLabel="#{at.name}" />
+                                    </p:selectOneMenu>
                                 </p:column>
 
                                 <p:column headerText="Action" width="12%" >

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/inward/inward_administration.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="mainForm">
                     <p:panel header="Inward Price Adjustment Matrix - Service" id="reportPrint" class="row w-100">
                         <p:panel>
                             <f:facet name="header">
@@ -225,22 +225,6 @@
                                     filterMatchMode="contains"
                                     headerText="Department Name"
                                     exportable="false">
-                                    <p:autoComplete
-                                        inputStyleClass="form-control"
-                                        class="w-100 "
-                                        forceSelection="true"
-                                        value="#{a.department}"
-                                        completeMethod="#{departmentController.completeDept}"
-                                        var="dep"
-                                        itemLabel="#{dep.name}"
-                                        itemValue="#{dep}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.institution.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.department.name}"/>
                                 </p:column>
 
@@ -259,48 +243,23 @@
                                     headerText="Category Name"
 
                                     exportable="false">
-                                    <p:autoComplete
-                                        inputStyleClass="form-control"
-                                        class="w-100 "
-                                        forceSelection="true"
-                                        value="#{a.category}"
-                                        completeMethod="#{categoryController.completeCategoryService}"
-                                        var="cat"
-                                        itemLabel="#{cat.name} #{cat.parentCategory}"
-                                        itemValue="#{cat}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                        </p:column>
-                                        <p:column headerText="TYPE">
-                                            <h:outputLabel value="Parent Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.ServiceCategory'}"/>
-                                            <h:outputLabel value="Child Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.ServiceSubCategory'}"/>
-                                            <h:outputLabel value="Investigation Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.InventoryCategory'}"/>
-                                        </p:column>
-
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.category.name}"/>
                                 </p:column>
 
                                 <p:column headerText="From Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.fromPrice}" style="width: 5em;" >
+                                    <h:outputText value="#{a.fromPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
                                 <p:column  headerText="To Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.toPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.toPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
                                 <p:column  headerText="Margin" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
+                                    <h:outputText value="#{a.margin}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column
@@ -308,22 +267,6 @@
                                     filterBy="#{empty a.creditCompany ? '' : a.creditCompany.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}">
-                                    <p:autoComplete
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        forceSelection="true"
-                                        value="#{a.creditCompany}"
-                                        completeMethod="#{institutionController.completeCreditCompany}"
-                                        var="ins"
-                                        itemLabel="#{ins.name}"
-                                        itemValue="#{ins}"
-                                        placeholder="All companies"
-                                        maxResults="20"
-                                        onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
-                                        <p:column>
-                                            <h:outputText value="#{ins.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
                                 </p:column>
 
@@ -332,21 +275,19 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
-                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
-                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                                       itemValue="#{at}" itemLabel="#{at.name}" />
-                                    </p:selectOneMenu>
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="12%" >
                                     <div class="d-flex">
                                         <p:commandButton
                                             id="edit"
-                                            ajax="false"
                                             icon="fa fa-pencil"
                                             class="ui-button-success mx-1"
-                                            action="#{inwardPriceAdjustmntController.onEdit(a)}" >
+                                            process="@this"
+                                            update=":dlgEditForm"
+                                            oncomplete="PF('dlgEdit').show()"
+                                            action="#{inwardPriceAdjustmntController.prepareEdit(a)}" >
                                         </p:commandButton>
                                         <p:commandButton
                                             id="delete"
@@ -366,6 +307,74 @@
                         </p:panel>
                     </p:panel>
                 </h:form>
+
+                <p:dialog header="Edit Price Adjustment" widgetVar="dlgEdit" modal="true"
+                          resizable="false" width="480" id="dlgEdit">
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="2" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Category"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.category.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="From Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Credit Company"/>
+                            <p:autoComplete
+                                inputStyleClass="form-control"
+                                class="w-100"
+                                forceSelection="true"
+                                value="#{inwardPriceAdjustmntController.current.creditCompany}"
+                                completeMethod="#{institutionController.completeCreditCompany}"
+                                var="ins"
+                                itemLabel="#{ins.name}"
+                                itemValue="#{ins}"
+                                placeholder="All companies"
+                                maxResults="20"
+                                onkeydown="if (event.key === 'Enter') { event.preventDefault(); return false; }">
+                                <p:column>
+                                    <h:outputText value="#{ins.name}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                               itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton id="dlgSave" value="Save" icon="fa fa-save"
+                                             class="ui-button-success mx-1"
+                                             action="#{inwardPriceAdjustmntController.saveEdit}"
+                                             update=":dlgEditForm :mainForm:inwd"
+                                             oncomplete="PF('dlgEdit').hide()"/>
+                            <p:commandButton id="dlgCancel" value="Cancel" icon="fa fa-times"
+                                             class="ui-button-secondary mx-1"
+                                             type="button"
+                                             onclick="PF('dlgEdit').hide()"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -96,6 +96,22 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbAdmissionType"
+                                            value="#{inwardPriceAdjustmntController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                            <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                           itemValue="#{at}" itemLabel="#{at.name}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="From" class="mt-2"></h:outputLabel>
                                     </div>
                                     <div class="col-4">
@@ -309,6 +325,14 @@
                                         </p:column>
                                     </p:autoComplete>
                                     <h:outputText value="#{empty a.creditCompany ? 'All Companies' : a.creditCompany.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Admission Type"
+                                    filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="12%" >

--- a/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
@@ -59,6 +59,12 @@
                                 <p:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.toPrice}" />
                                 <h:outputLabel value="Margin" ></h:outputLabel>
                                 <p:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.margin}" />
+                                <h:outputLabel value="Admission Type" ></h:outputLabel>
+                                <p:selectOneMenu id="cmbAdmissionType" value="#{inwardPriceAdjustmntController.admissionType}">
+                                    <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                    <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                   itemValue="#{at}" itemLabel="#{at.name}" />
+                                </p:selectOneMenu>
                                 <h:outputLabel value="" ></h:outputLabel>
                                 <p:commandButton id="btnAdd" value="Add" ajax="false"
                                                 action="#{inwardPriceAdjustmntController.saveSelected}"  >
@@ -135,6 +141,9 @@
                                     <h:inputText autocomplete="off" id="mg" value="#{a.margin}" >
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:inputText>
+                                </p:column>
+                                <p:column headerText="Admission Type">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
                                 <p:column>
                                     <p:commandButton ajax="false" value="Update" action="#{inwardPriceAdjustmntController.onEdit(a)}"  />

--- a/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
@@ -143,7 +143,11 @@
                                     </h:inputText>
                                 </p:column>
                                 <p:column headerText="Admission Type">
-                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
+                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemValue="#{at}" itemLabel="#{at.name}" />
+                                    </p:selectOneMenu>
                                 </p:column>
                                 <p:column>
                                     <p:commandButton ajax="false" value="Update" action="#{inwardPriceAdjustmntController.onEdit(a)}"  />

--- a/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service_all.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/resources/template/template.xhtml">
 
             <ui:define name="content">
-                <h:form>
+                <h:form id="mainForm">
                     <p:panel header="Inward Price Adjustment Matrix " id="reportPrint">
 
                         <p:panel header="Add new adjustment" >
@@ -89,68 +89,38 @@
                                          var="a" editable="true" scrollable="true" scrollHeight="500">
 
                                 <p:column filterBy="#{a.department.name}" filterMatchMode="contains" headerText="Department Name">
-<!--                                    <h:inputText autocomplete="off" value="#{a.department.name}" />-->
-
-                                    <p:autoComplete id="dep" forceSelection="true" value="#{a.department}"
-                                                    completeMethod="#{departmentController.completeDept}"
-                                                    var="dep" itemLabel="#{dep.name}" itemValue="#{dep}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.institution.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
-
+                                    <h:outputText value="#{a.department.name}"/>
                                 </p:column>
 
 
                                 <p:column filterBy="#{a.category.name}"
                                           filterMatchMode="contains" headerText="Category Name">
-                                    <p:autoComplete id="cat" forceSelection="true" value="#{a.category}"
-                                                    completeMethod="#{categoryController.completeCategoryServicePharmacy}"
-                                                    var="cat" itemLabel="#{cat.name} #{cat.parentCategory.name}" itemValue="#{cat}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                        </p:column>
-                                        <p:column headerText="TYPE">
-                                            <h:outputLabel value="Parent Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.ServiceCategory'}"/>
-                                            <h:outputLabel value="Child Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.ServiceSubCategory'}"/>
-                                            <h:outputLabel value="Investigation Category"
-                                                           rendered="#{cat.categoryClass eq 'class com.divudi.core.entity.InventoryCategory'}"/>
-                                        </p:column>
-
-                                    </p:autoComplete>
+                                    <h:outputText value="#{a.category.name}"/>
                                 </p:column>
                                 <p:column headerText="From Price">
-                                    <h:inputText autocomplete="off" id="frm" value="#{a.fromPrice}" >
+                                    <h:outputText value="#{a.fromPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
                                 <p:column  headerText="To Price">
-                                    <h:inputText autocomplete="off" id="to" value="#{a.toPrice}" >
+                                    <h:outputText value="#{a.toPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
                                 <p:column  headerText="Margin">
-                                    <h:inputText autocomplete="off" id="mg" value="#{a.margin}" >
+                                    <h:outputText value="#{a.margin}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
                                 <p:column headerText="Admission Type">
-                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
-                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
-                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                                       itemValue="#{at}" itemLabel="#{at.name}" />
-                                    </p:selectOneMenu>
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
                                 <p:column>
-                                    <p:commandButton ajax="false" value="Update" action="#{inwardPriceAdjustmntController.onEdit(a)}"  />
+                                    <p:commandButton value="Edit" icon="fa fa-pencil"
+                                                     process="@this"
+                                                     update=":dlgEditForm"
+                                                     oncomplete="PF('dlgEdit').show()"
+                                                     action="#{inwardPriceAdjustmntController.prepareEdit(a)}"/>
                                 </p:column>
                                 <p:column>
                                     <p:commandButton value="Delete" action="#{inwardPriceAdjustmntController.delete}">
@@ -166,6 +136,56 @@
                     </p:panel>
 
                 </h:form>
+
+                <p:dialog header="Edit Price Adjustment" widgetVar="dlgEdit" modal="true"
+                          resizable="false" width="480" id="dlgEdit">
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="2" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Category"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.category.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="From Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                               itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton id="dlgSave" value="Save" icon="fa fa-save"
+                                             class="ui-button-success mx-1"
+                                             action="#{inwardPriceAdjustmntController.saveEdit}"
+                                             update=":dlgEditForm :mainForm:inwd"
+                                             oncomplete="PF('dlgEdit').hide()"/>
+                            <p:commandButton id="dlgCancel" value="Cancel" icon="fa fa-times"
+                                             class="ui-button-secondary mx-1"
+                                             type="button"
+                                             onclick="PF('dlgEdit').hide()"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
 
 

--- a/src/main/webapp/inward/inward_price_adjustment_store.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_store.xhtml
@@ -278,7 +278,11 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
+                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemValue="#{at}" itemLabel="#{at.name}" />
+                                    </p:selectOneMenu>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_store.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_store.xhtml
@@ -87,8 +87,24 @@
                                             class="w-100"
                                             id="cmbPs" 
                                             value="#{inwardPriceAdjustmntController.paymentMethod}"  >
-                                            <f:selectItem itemLabel="Select" />                           
+                                            <f:selectItem itemLabel="Select" />
                                             <f:selectItems value="#{enumController.paymentMethodForAdmission}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbAdmissionType"
+                                            value="#{inwardPriceAdjustmntController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                            <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                           itemValue="#{at}" itemLabel="#{at.name}" />
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
@@ -255,6 +271,14 @@
                                     <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:inputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Admission Type"
+                                    filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">

--- a/src/main/webapp/inward/inward_price_adjustment_store.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_store.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/inward/inward_administration.xhtml">
 
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="mainForm">
                     <p:panel header="Inward Price Adjustment Matrix- Store" id="reportPrint">
                         <p:panel >
                             <f:facet name="header">
@@ -199,23 +199,6 @@
                                     width="25%"
                                     filterMatchMode="contains" 
                                     exportable="false">
-
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.department}"
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        completeMethod="#{departmentController.completeDept}" 
-                                        var="dep" 
-                                        itemLabel="#{dep.name}" 
-                                        itemValue="#{dep}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{dep.institution.name}"/>
-                                        </p:column>
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.department.name}"/>
                                 </p:column>
 
@@ -235,42 +218,25 @@
                                     filterBy="#{a.category.name}" 
                                     filterMatchMode="contains" 
                                     exportable="false">
-                                    <p:autoComplete 
-                                        forceSelection="true" 
-                                        value="#{a.category}"
-                                        inputStyleClass="form-control"
-                                        class="w-100"
-                                        completeMethod="#{categoryController.completeCategoryStore}" 
-                                        var="cat" 
-                                        itemLabel="#{cat.name}" 
-                                        itemValue="#{cat}" >
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.name}"/>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputLabel value="#{cat.parentCategory.name}"/>
-                                        </p:column> 
-
-                                    </p:autoComplete>
                                     <p:outputLabel value="#{a.category.name}"/>
                                 </p:column>
 
                                 <p:column headerText="From Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.fromPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.fromPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="To Price" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.toPrice}" style="width: 5em;">
+                                    <h:outputText value="#{a.toPrice}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column  headerText="Margin" width="8%">
-                                    <h:inputText autocomplete="off" value="#{a.margin}" style="width: 5em;">
+                                    <h:outputText value="#{a.margin}">
                                         <f:convertNumber pattern="#,##0.00"/>
-                                    </h:inputText>
+                                    </h:outputText>
                                 </p:column>
 
                                 <p:column
@@ -278,21 +244,19 @@
                                     filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
                                     filterMatchMode="contains"
                                     exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
-                                    <p:selectOneMenu value="#{a.admissionType}" class="w-100">
-                                        <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
-                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                                       itemValue="#{at}" itemLabel="#{at.name}" />
-                                    </p:selectOneMenu>
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
                                 <p:column headerText="Action" width="11%">
                                     <div class="d-flex">
-                                        <p:commandButton 
-                                            ajax="false"  
+                                        <p:commandButton
                                             id="edit"
                                             icon="fa fa-pencil"
                                             class="ui-button-success mx-1"
-                                            action="#{inwardPriceAdjustmntController.onEdit(a)}" > 
+                                            process="@this"
+                                            update=":dlgEditForm"
+                                            oncomplete="PF('dlgEdit').show()"
+                                            action="#{inwardPriceAdjustmntController.prepareEdit(a)}" >
                                         </p:commandButton>
                                         <p:commandButton
                                             id="delete"
@@ -312,6 +276,56 @@
                         </p:panel>
                     </p:panel>
                 </h:form>
+
+                <p:dialog header="Edit Price Adjustment" widgetVar="dlgEdit" modal="true"
+                          resizable="false" width="480" id="dlgEdit">
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="2" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Category"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.category.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="From Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <h:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:inputText>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                               itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton id="dlgSave" value="Save" icon="fa fa-save"
+                                             class="ui-button-success mx-1"
+                                             action="#{inwardPriceAdjustmntController.saveEdit}"
+                                             update=":dlgEditForm :mainForm:inwd"
+                                             oncomplete="PF('dlgEdit').hide()"/>
+                            <p:commandButton id="dlgCancel" value="Cancel" icon="fa fa-times"
+                                             class="ui-button-secondary mx-1"
+                                             type="button"
+                                             onclick="PF('dlgEdit').hide()"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
## Summary

Exposes the **Admission Type** dimension on the Inward Price Adjustment (margin matrix) admin UI. The data and billing layers already supported admission-type-scoped margins (#21542 / PR #21547 for the API; #21551 / PR #21614 for the billing lookup), but staff could only create such rows via the API. This PR adds the UI so they can be created/edited from the application.

Closes #21616

## Changes

**Controller** — `InwardPriceAdjustmntController.java`
- Adds `AdmissionType admissionType` property with getter/setter.
- Sets it on the `InwardPriceAdjustment` entity in both save paths.
- Resets it in `recreateModel()` and the second reset path so a new row starts blank.

**Pages** — admission-type selector + list column added to all five price-adjustment pages:
- `inward_price_adjustment_service.xhtml`
- `inward_price_adjustment_investigation.xhtml`
- `inward_price_adjustment_pharmacy.xhtml`
- `inward_price_adjustment_service_all.xhtml`
- `inward_price_adjustment_store.xhtml`

Each selector is a `p:selectOneMenu` over `admissionTypeController.items` with a leading **"All Admission Types" → `#{null}`** option, so leaving it blank creates a wildcard (NULL) row — preserving today's behaviour. The list/table shows the admission type name, or "All Admission Types" for wildcard rows.

## Acceptance criteria

- [x] User can create/edit an inward price-adjustment row and optionally pick an admission type.
- [x] Leaving admission type blank creates a NULL (wildcard) row, exactly as today.
- [x] The list view shows the admission type (or "All Admission Types" for wildcard rows).
- [x] Saved rows are picked up by billing per the #21551 specific-wins semantics (data layer unchanged).

## Notes
- The backing field `admissionType` lives on `PriceMatrix` (parent of `InwardPriceAdjustment`) and already exists from #21542.
- No schema change in this PR.

## Test plan (QA)
See branch-specific QA plan. In short: open each of the five pages, create a row with an admission type and one without, confirm the list shows them correctly, and confirm billing applies the admission-specific margin with specific-wins/null-wildcard semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Admission Type” filter and editable “Admission Type” column to inward price adjustment screens (investigation, pharmacy, service, store, and service-all).
  * Included “All Admission Types” as the default option in the new and existing dropdowns.
* **Bug Fixes**
  * Ensured the “All Admission Types” state is handled consistently for filtering, display, and exports when no admission type is selected.
  * Saved the selected Admission Type when creating or updating adjustments so it remains in sync across the views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->