### PR TITLE
Add privilege control for inward final bill Settle and Save Provisional buttons (#21188)

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -243,6 +243,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillSettleWithoutCheck, "Inward Bill Settle Without Check"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBillUnrestrictedAccess, "Inward Bill Search Without Restriction"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBillUnrestricted, "Inward Final Bill Settle Without Restriction"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBill, "Inward Settle Final Bill"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges
         TreeNode theatreNode = new DefaultTreeNode(new PrivilegeHolder(null, "Theatre"), allNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -97,6 +97,8 @@ public enum Privileges {
     InwardSearchProfessionalBill("Inward Search Professional Bill"),
     InwardSearchFinalBill("Inward Search Final Bill"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
+    InwardSettleFinalBill("Inward Settle Final Bill"),
+    InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
     InwardFinalBillReportEdit("Inward Final Bill Report Edit"),
     InwardAdministration("Inward Administration"),
@@ -1143,6 +1145,8 @@ public enum Privileges {
             case InpatientLetter:
             case InwardFormTemplateAdmin:
             case InwardFormFill:
+            case InwardSettleFinalBill:
+            case InwardSaveProvisionalFinalBill:
             case TheatreSendPatient:
             case TheatreAcceptPatient:
             case TheatreReturnPatient:

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -65,8 +65,8 @@
                                     <p:printer target="printTempBill" />
                                 </p:commandButton>
 
-                                <p:commandButton 
-                                    value="Save Provisional Bill" 
+                                <p:commandButton
+                                    value="Save Provisional Bill"
                                     action="#{bhtSummeryController.saveProvisionalBill()}"
                                     id="saveProvisional"
                                     ajax="false"
@@ -74,10 +74,10 @@
                                     class="ui-button-warning mx-1"
                                     icon="fa fa-save"
                                     style="width: 200px; padding: 1px; margin: auto;"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false)}">
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false) and webUserController.hasPrivilege('InwardSaveProvisionalFinalBill')}">
                                 </p:commandButton>
 
-                                <p:commandButton 
+                                <p:commandButton
                                     value="Settle"
                                     action="#{bhtSummeryController.settle}"
                                     id="settle"
@@ -85,7 +85,8 @@
                                     disabled="#{bhtSummeryController.changed}"
                                     class="ui-button-success mx-1"
                                     icon="fa fa-check"
-                                    style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;">
+                                    style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;"
+                                    rendered="#{webUserController.hasPrivilege('InwardSettleFinalBill')}">
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">


### PR DESCRIPTION
## Issue
Closes #21188 — Final Bill Approval (with Privilege & Application Option)

## Summary
Adds privilege-based access control to the two action buttons on the inward final bill page (`inward/inward_bill_final.xhtml`):

| Button | New Privilege |
|--------|---------------|
| **Settle** | `InwardSettleFinalBill` ("Inward Settle Final Bill") |
| **Save Provisional Bill** | `InwardSaveProvisionalFinalBill` ("Inward Save Provisional Final Bill") |

Only users granted the relevant privilege can see and use each button.

## Changes (committed task by task)
1. **`Privileges.java`** — define the two new enum values and classify them under the `Inward` category in `getCategory()`.
2. **`UserPrivilageController.java`** — register both privileges as tree nodes under **Inward → Additional Privileges** so they are assignable to roles in the privilege administration UI.
3. **`inward_bill_final.xhtml`** — add `webUserController.hasPrivilege(...)` to each button's `rendered` attribute. For *Save Provisional Bill*, the privilege check is ANDed with the existing `Show Save Provisional on Final Bill Edit` application option.

## Notes
- All three steps of the project's privilege-registration requirement are completed (enum value + `getCategory()` case + `UserPrivilageController` tree node).
- The `settle` / `saveProvisional` component IDs are still referenced by existing AJAX `update=` attributes; this follows the page's existing pattern (the Save Provisional button was already conditionally rendered via its application option).
- `persistence.xml` local JNDI config is intentionally excluded from this PR.

## Testing
- Project compiles cleanly (`mvn compile`).
- Recommend verifying the final bill page renders without error for a user lacking each privilege.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new inward privilege options for controlling access to final bill actions.
  * Users with the right access can now see the related **Save Provisional Bill** and **Settle** actions on the inward final bill screen.

* **Bug Fixes**
  * Updated action visibility so these buttons now appear only for authorized users, improving permission handling and reducing unintended access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->