### PR TITLE
feat(inward): drug-allergy alert when adding inpatient medicines

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -69,7 +69,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -2378,31 +2380,70 @@ public class InpatientClinicalDataController implements Serializable {
 
     /**
      * Returns a warning string if the given item matches any recorded patient
-     * allergy by VTM, or null if no match. Allergies are stored at VTM level;
-     * the prescribed item may be an AMP/VMP whose vtm field points to the same
-     * VTM. A direct match (item == allergy item) is also caught.
+     * allergy, or null if no match. Allergies are recorded at VTM level; the
+     * prescribed item may be an AMP/VMP whose VTM is reached through the
+     * AMP -> VMP -> VTM chain (AMP creation only sets {@code vmp}, so an AMP's
+     * own {@code vtm} is often null). A direct match (item == allergy item) is
+     * also caught.
+     * <p>
+     * The {@link #patientAllergies} session list is refreshed for the current
+     * {@link #patient} when it is empty, because some navigation paths (e.g. the
+     * ward-medicine page) set the patient without reloading allergies.
      */
     private String getAllergyWarning(Item prescribedItem) {
-        if (prescribedItem == null || patientAllergies == null || patientAllergies.isEmpty()) {
+        if (prescribedItem == null) {
             return null;
         }
-        for (ClinicalFindingValue allergy : patientAllergies) {
+        List<ClinicalFindingValue> allergies = patientAllergies;
+        if ((allergies == null || allergies.isEmpty()) && patient != null) {
+            allergies = fillPatientAllergies(patient);
+            patientAllergies = allergies;
+        }
+        if (allergies == null || allergies.isEmpty()) {
+            return null;
+        }
+        Set<Long> prescribedVtmIds = collectVtmIds(prescribedItem);
+        for (ClinicalFindingValue allergy : allergies) {
             if (allergy == null || allergy.getItemValue() == null) {
                 continue;
             }
-            Item allergenVtm = allergy.getItemValue();
-            // Direct match
-            if (allergenVtm.getId() != null && allergenVtm.getId().equals(prescribedItem.getId())) {
-                return prescribedItem.getName() + " matches recorded allergy: " + allergenVtm.getName();
+            Item allergen = allergy.getItemValue();
+            if (allergen.getId() == null) {
+                continue;
             }
-            // VTM-level match: prescribed item's vtm equals the recorded allergen
-            if (prescribedItem.getVtm() != null
-                    && allergenVtm.getId() != null
-                    && allergenVtm.getId().equals(prescribedItem.getVtm().getId())) {
-                return prescribedItem.getName() + " matches recorded allergy: " + allergenVtm.getName();
+            // Direct match: the exact item is recorded as an allergy.
+            if (allergen.getId().equals(prescribedItem.getId())) {
+                return prescribedItem.getName() + " matches recorded allergy: " + allergen.getName();
+            }
+            // VTM-level match: any VTM the prescribed item resolves to is the allergen.
+            if (prescribedVtmIds.contains(allergen.getId())) {
+                return prescribedItem.getName() + " matches recorded allergy: " + allergen.getName();
             }
         }
         return null;
+    }
+
+    /**
+     * Collects the VTM ids a prescribed item resolves to: its own
+     * {@code vtm}, and — for an AMP — the VTM of its VMP
+     * ({@code amp.getVmp().getVtm()}), since AMPs link to their VTM through the
+     * VMP rather than directly.
+     */
+    private Set<Long> collectVtmIds(Item prescribedItem) {
+        Set<Long> vtmIds = new HashSet<>();
+        if (prescribedItem == null) {
+            return vtmIds;
+        }
+        if (prescribedItem.getVtm() != null && prescribedItem.getVtm().getId() != null) {
+            vtmIds.add(prescribedItem.getVtm().getId());
+        }
+        if (prescribedItem instanceof Amp) {
+            Vmp vmp = ((Amp) prescribedItem).getVmp();
+            if (vmp != null && vmp.getVtm() != null && vmp.getVtm().getId() != null) {
+                vtmIds.add(vmp.getVtm().getId());
+            }
+        }
+        return vtmIds;
     }
 
     public void addAdmissionWardMedicine() {

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -2376,6 +2376,35 @@ public class InpatientClinicalDataController implements Serializable {
         }
     }
 
+    /**
+     * Returns a warning string if the given item matches any recorded patient
+     * allergy by VTM, or null if no match. Allergies are stored at VTM level;
+     * the prescribed item may be an AMP/VMP whose vtm field points to the same
+     * VTM. A direct match (item == allergy item) is also caught.
+     */
+    private String getAllergyWarning(Item prescribedItem) {
+        if (prescribedItem == null || patientAllergies == null || patientAllergies.isEmpty()) {
+            return null;
+        }
+        for (ClinicalFindingValue allergy : patientAllergies) {
+            if (allergy == null || allergy.getItemValue() == null) {
+                continue;
+            }
+            Item allergenVtm = allergy.getItemValue();
+            // Direct match
+            if (allergenVtm.getId() != null && allergenVtm.getId().equals(prescribedItem.getId())) {
+                return prescribedItem.getName() + " matches recorded allergy: " + allergenVtm.getName();
+            }
+            // VTM-level match: prescribed item's vtm equals the recorded allergen
+            if (prescribedItem.getVtm() != null
+                    && allergenVtm.getId() != null
+                    && allergenVtm.getId().equals(prescribedItem.getVtm().getId())) {
+                return prescribedItem.getName() + " matches recorded allergy: " + allergenVtm.getName();
+            }
+        }
+        return null;
+    }
+
     public void addAdmissionWardMedicine() {
         if (parentAdmission == null || parentAdmission.getId() == null) {
             JsfUtil.addErrorMessage("No admission selected.");
@@ -2384,6 +2413,10 @@ public class InpatientClinicalDataController implements Serializable {
         if (getAdmissionWardMedicine().getPrescription().getItem() == null) {
             JsfUtil.addErrorMessage("Select Medicine");
             return;
+        }
+        String allergyWarning = getAllergyWarning(getAdmissionWardMedicine().getPrescription().getItem());
+        if (allergyWarning != null) {
+            JsfUtil.addWarningMessage("ALLERGY ALERT: " + allergyWarning);
         }
         Prescription rx = getAdmissionWardMedicine().getPrescription();
         rx.setEncounter(parentAdmission);
@@ -3124,6 +3157,10 @@ public class InpatientClinicalDataController implements Serializable {
             JsfUtil.addErrorMessage("Select Medicine");
             return;
         }
+        String allergyWarning = getAllergyWarning(getPatientMedicine().getPrescription().getItem());
+        if (allergyWarning != null) {
+            JsfUtil.addWarningMessage("ALLERGY ALERT: " + allergyWarning);
+        }
         getPatientMedicine().setPatient(patient);
         getPatientMedicine().setClinicalFindingValueType(ClinicalFindingValueType.PatientMedicine);
         prescriptionFacade.create(getPatientMedicine().getPrescription());
@@ -3141,6 +3178,10 @@ public class InpatientClinicalDataController implements Serializable {
         if (getEncounterMedicine().getPrescription().getItem() == null) {
             JsfUtil.addErrorMessage("Select Medicine");
             return;
+        }
+        String allergyWarning = getAllergyWarning(getEncounterMedicine().getPrescription().getItem());
+        if (allergyWarning != null) {
+            JsfUtil.addWarningMessage("ALLERGY ALERT: " + allergyWarning);
         }
         getEncounterMedicine().setEncounter(current);
         getEncounterMedicine().setClinicalFindingValueType(ClinicalFindingValueType.VisitMedicine);


### PR DESCRIPTION
## Summary

Adds a non-blocking **drug-allergy alert** when a clinician adds a medicine to an inpatient (ward medicine, patient medicine, or encounter/visit medicine) on the Inpatient Clinical Data screens. If the prescribed item matches a recorded patient allergy, a `WARNING` message is shown — the medicine is still added (clinical alert, not a hard stop).

Closes #21682

## Matching logic

Allergens are recorded as `ClinicalFindingValue` rows with the allergen in `itemValue`, typically at **VTM** level, while the prescribed item may be an AMP/VMP whose `vtm` points to the same VTM. `getAllergyWarning(Item)` therefore matches on:

- **Direct match** — prescribed item id == recorded allergen id, OR
- **VTM-level match** — prescribed item's `vtm` id == recorded allergen id.

It iterates the already-loaded `patientAllergies` list and returns a message or `null`.

## Changes

`InwardClinicalDataController.java` (`com.divudi.bean.inward.InpatientClinicalDataController`):
- New private helper `getAllergyWarning(Item prescribedItem)`.
- Called after the existing "Select Medicine" null-guard in all three add paths — `addAdmissionWardMedicine()`, the patient-medicine add path, and the encounter/visit-medicine add path — emitting `"ALLERGY ALERT: <item> matches recorded allergy: <allergen>"`.

Purely additive: no existing control flow changes; the warning is non-fatal.

## Provenance

Salvaged from abandoned local WIP that had been sitting on an unrelated branch. The branch's named issue (#20981, LIMS multi-component analyzer overwrite) was already shipped via PR #20982; this allergy-alert code was orphaned, un-shipped work, now given its own tracking issue (#21682) and PR.

## Test plan (QA)

- [ ] Record an allergy for an inpatient (allergen at VTM level).
- [ ] Add a ward medicine that is an AMP/VMP of that VTM → ALLERGY ALERT warning shows; medicine still added.
- [ ] Add the exact allergen item → warning shows.
- [ ] Add an unrelated medicine → no warning.
- [ ] Repeat for patient-medicine and encounter/visit-medicine add paths.
- [ ] Patient with no recorded allergies → no warning, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added allergy checks when adding medicines in admission, patient, and encounter workflows.
  * Displays an **ALLERGY ALERT** warning if the prescribed item matches a recorded allergy directly or at the VTM level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->