### PR TITLE
fix: SMS Lab Report queue freeze + duplicate sends + every-second timer (SLH hotfix)

### DIFF
--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -423,6 +423,8 @@ public class SmsManagerEjb {
             URL url = new URL(targetURL);
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(30000);
             connection.setDoOutput(true);
 
             try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream())) {
@@ -461,6 +463,8 @@ public class SmsManagerEjb {
             connection.setRequestProperty("Accept", "*/*");
             connection.setRequestProperty("X-API-VERSION", "v1");
             connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(30000);
             connection.setDoOutput(true);
 
             try (OutputStream os = connection.getOutputStream()) {
@@ -659,6 +663,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
             conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
             conn.setDoOutput(true);
 
             try (OutputStream os = conn.getOutputStream()) {
@@ -726,6 +732,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
 
             JSONObject credentials = new JSONObject();
             credentials.put("username", username);
@@ -753,6 +761,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
             conn.setRequestProperty("Authorization", "Bearer " + refreshToken);
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
 
             return extractTokenFromResponse(conn);
         } catch (Exception e) {

--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -119,6 +119,7 @@ public class SmsManagerEjb {
         minCreatedAt.add(Calendar.HOUR_OF_DAY, -24);
 
         String jpql = "Select e from Sms e where e.pending=true and e.retired=false "
+                + "and (e.sentSuccessfully is null or e.sentSuccessfully = false) "
                 + "and e.smsType = :smsType and e.createdAt between :from and :to";
         Map<String, Object> params = new HashMap<>();
         params.put("from", minCreatedAt.getTime());
@@ -158,7 +159,7 @@ public class SmsManagerEjb {
 
     // Schedule sendSmsToDoctorsBeforeSession to run every 30 minutes
     @SuppressWarnings("unused")
-    @Schedule(second = "*", minute = "*/1", hour = "*", persistent = false)
+    @Schedule(second = "0", minute = "*/1", hour = "*", persistent = false)
     public void sendSmsToDoctorsBeforeSessionTimer() {
         if (doNotSendAnySms) {
             return;


### PR DESCRIPTION
## Problem
On Southern Lanka production, Lab Report SMS (sent 10 min after report approval) stops going out after 3-4 days of uptime. A server restart temporarily fixes it, then it recurs. Patients also received duplicate report SMS.

## Root cause (verified live on prod)
`SmsManagerEjb` sends to the SMS gateway (`http://www.textit.biz/sendmsg`, Basic Authentication) via `executePost(String, Map)` using `HttpURLConnection` **with no connect/read timeout** (Java default = infinite). A live thread dump caught the `@Schedule processPendingLabReportApprovalSmsQueue` timer blocked in `SocketInputStream.socketRead0` inside `executePost`. Because timer callbacks are **serialized**, one connection black-holed by the gateway blocks the timer thread forever, so the whole pending queue stalls until the JVM restarts.

At investigation time: 2,941 stuck `PENDING=1` Lab Report SMS — 693 already delivered (`SENTSUCCESSFULLY=1`, gateway `OK...Uploaded_Successfully`) but never marked done and therefore re-sent as duplicates; 2,248 never sent.

## Fixes in this PR
**P0 — Gateway HTTP timeouts (stops the freeze).** Add `setConnectTimeout(10000)` / `setReadTimeout(30000)` to every SMS gateway / OAuth2 token `HttpURLConnection` that lacked them: `executePost(String,Map)` (active SLH path), `executePost(String,JSONObject,String)`, `sendSmsByOauth2`, `getNewAccessToken`, `refreshAccessToken`. Matches the existing `executeJsonPost`. A hung gateway now fails fast (≤30s) and the timer keeps running.

**P1 — No duplicate sends.** The queue reprocessed rows where `sentSuccessfully=true` but `pending` was never cleared. Exclude already-sent rows from the queue query (`and (e.sentSuccessfully is null or e.sentSuccessfully = false)`).

**P2 — Every-second timer.** `sendSmsToDoctorsBeforeSessionTimer` was `@Schedule(second="*")`, firing 60x/min and hammering the DB/timer threads. Changed to `second="0"` (once per minute).

## Out of scope
**P3 — backlog data cleanup.** The 2,941 existing stuck rows are left **as-is** by decision (no DB writes); P0 prevents new pile-ups and P1 prevents the 693 from re-sending, so they sit harmlessly. The 24h look-back window is kept (no longer needs widening now that the timer can't hang).

## Risk
Low — only adds timeouts, a query guard, and a cron correction. No happy-path behaviour change. No DB writes.

## Testing
- Verified live on production via thread dump (`jstack`) that the queue timer was blocked in `executePost` socket read with no timeout.
- Confirmed gateway config (`SMS Sent Using Basic Authentication ... = true`, URL `textit.biz`) and 10-minute strategy in `configoption`.
- Diff is additive only (5 timeout pairs + 1 query clause + 1 cron value).