### PR TITLE
fix: add timeouts to SMS gateway HTTP calls to prevent Lab Report SMS queue freeze

### DIFF
--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -455,6 +455,8 @@ public class SmsManagerEjb {
             URL url = new URL(targetURL);
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(30000);
             connection.setDoOutput(true);
 
             try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream())) {
@@ -493,6 +495,8 @@ public class SmsManagerEjb {
             connection.setRequestProperty("Accept", "*/*");
             connection.setRequestProperty("X-API-VERSION", "v1");
             connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(30000);
             connection.setDoOutput(true);
 
             try (OutputStream os = connection.getOutputStream()) {
@@ -756,6 +760,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
             conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
             conn.setDoOutput(true);
 
             try (OutputStream os = conn.getOutputStream()) {
@@ -823,6 +829,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
 
             JSONObject credentials = new JSONObject();
             credentials.put("username", username);
@@ -850,6 +858,8 @@ public class SmsManagerEjb {
             conn.setRequestProperty("Accept", "*/*");
             conn.setRequestProperty("X-API-VERSION", "v1");
             conn.setRequestProperty("Authorization", "Bearer " + refreshToken);
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(30000);
 
             return extractTokenFromResponse(conn);
         } catch (Exception e) {


### PR DESCRIPTION
Related to #21686 (Southern Lanka prod hotfix: #21685)

closes #21686

## Problem
`SmsManagerEjb` sends to the SMS gateway via `HttpURLConnection` **without connect/read timeouts** (Java default = infinite). When the gateway black-holes a TCP connection, the `@Schedule processPendingLabReportApprovalSmsQueue` timer blocks indefinitely in `SocketInputStream.socketRead0`. Because timer callbacks are **serialized**, the entire pending Lab Report SMS queue stalls until the server is restarted. Verified live on Southern Lanka production via thread dump.

## Fix
Add `setConnectTimeout(10000)` / `setReadTimeout(30000)` to every SMS gateway / OAuth2 token `HttpURLConnection` that lacked them:
- `executePost(String, Map)` — basic-auth path
- `executePost(String, JSONObject, String)`
- `sendSmsByOauth2`
- `getNewAccessToken`, `refreshAccessToken`

This matches `executeJsonPost`, which already sets these. A hung gateway now fails fast (≤30s) and the timer continues instead of freezing.

## Note on scope vs the prod hotfix
The Southern Lanka hotfix (#21685, targeting `southernlanka-prod`) also included:
- **P1** a query guard to skip already-delivered rows, and
- **P2** changing the doctor-reminder timer from `@Schedule(second="*")` to `second="0"`.

`development` **already addresses both** independently — it restructured the queue to mark per-success and filter on a `sendingFailed` flag (P1), and its doctor-reminder timer is already `second="0"` (P2). So only the missing timeouts (P0) apply here.

## Risk
Low — additive only (5 timeout pairs); no behavioural change on the happy path. No DB writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for SMS-related network requests by adding connection and response timeouts.
  * Reduced the chance of requests hanging indefinitely during message sending or authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->