### PR TITLE
feat(ui): coloured SVG icon set for OPD and Cashier home dashboard tiles

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -187,6 +187,16 @@ public enum Icon {
             IconGroup.INPATIENT_DIRECT_ISSUES
     );
 
+    private static final java.util.Set<IconGroup> OPD_GROUPS = java.util.EnumSet.of(
+            IconGroup.PATIENT_MANAGEMENT,
+            IconGroup.OPD_BILLING,
+            IconGroup.PAYMENTS_AND_REFUNDS,
+            IconGroup.DOCTOR_AND_CHANNEL,
+            IconGroup.LAB_AND_REPORTS,
+            IconGroup.OPD_SUMMARIES,
+            IconGroup.CASHIER
+    );
+
     private final String label;
     private final IconGroup iconGroup;
 
@@ -205,11 +215,14 @@ public enum Icon {
 
     /**
      * Returns the image filename for this icon.
-     * All inpatient-group icons use .svg; icons from Patient_Deposit_Management
-     * onwards also use .svg; all others use .png (legacy format).
+     * Inpatient-group icons use teal .svg; OPD/Cashier-group icons use indigo/amber .svg;
+     * icons from Patient_Deposit_Management onwards also use .svg; all others use .png (legacy).
      */
     public String getImage() {
         if (iconGroup != null && INPATIENT_GROUPS.contains(iconGroup)) {
+            return this.name() + ".svg";
+        }
+        if (iconGroup != null && OPD_GROUPS.contains(iconGroup)) {
             return this.name() + ".svg";
         }
         if (this.ordinal() >= Patient_Deposit_Management.ordinal()) {

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -49,13 +49,73 @@
                 <h:panelGroup rendered="#{ui.icon eq 'Cashier_Drawer'}" layout="block" class="col-1 p-1" >
                     <h:form>
                         <p:tooltip for="Cashier_Drawer" value="Cashier Drawer"  showDelay="0" hideDelay="0"></p:tooltip>
-                        <p:commandLink 
+                        <p:commandLink
                             id="Cashier_Drawer"
                             ajax="false"
                             action="#{financialTransactionController.navigateToMyDrawer()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/cashier-drawer.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Cashier_Drawer.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Cashier Drawer"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Cashier Summaries -->
+                <h:panelGroup rendered="#{ui.icon eq 'Cashier_Summaries'}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Cashier_Summaries" value="Cashier Summaries" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Cashier_Summaries"
+                            ajax="false"
+                            action="#{financialTransactionController.navigateToCashierSummary()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Cashier_Summaries.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Cashier Summaries"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Shift End Summary -->
+                <h:panelGroup rendered="#{ui.icon eq 'Shift_End_Summary'}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Shift_End_Summary" value="Shift End Summary" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Shift_End_Summary"
+                            ajax="false"
+                            action="#{cashierReportController.navigateToShiftEndSummary()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Shift_End_Summary.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Shift End Summary"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Day End Summary -->
+                <h:panelGroup rendered="#{ui.icon eq 'Day_End_Summary'}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Day_End_Summary" value="Day End Summary" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Day_End_Summary"
+                            ajax="false"
+                            action="#{cashierReportController.navigateToDayEndSummary()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Day_End_Summary.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Day End Summary"/>
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Manage Shift Fund Bills -->
+                <h:panelGroup rendered="#{ui.icon eq 'Manage_Shift_Fund_Bills'}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Manage_Shift_Fund_Bills" value="Manage Shift Fund Bills" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Manage_Shift_Fund_Bills"
+                            ajax="false"
+                            action="#{financialTransactionController.navigateToListShiftEndSummaries()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Manage_Shift_Fund_Bills.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Manage Shift Fund Bills"/>
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>
@@ -69,7 +129,7 @@
                             action="opd/patient_search.xhtml" 
                             ajax="false" 
                             styleClass="svg-link">
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/health-worker-form.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Patient_Lookup.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Patient Lookup"/>
                         </p:commandLink>
                     </h:form>
@@ -112,7 +172,7 @@
                             action="opd/patient_edit.xhtml" 
                             ajax="false" 
                             styleClass="svg-link">
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/add-patient.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Patient_Add_New.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Add New Patient" />
                         </p:commandLink>
                     </h:form>
@@ -129,7 +189,7 @@
                             ajax="false" 
                             styleClass="svg-link" 
                             >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/invoice.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Opd_Billing.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="OPD Billing" rendered="#{webUserController.hasPrivilege('OpdPreBilling')}"/>
                         </p:commandLink>
                     </h:form>
@@ -146,7 +206,7 @@
                             actionListener="#{opdPreBillController.prepareNewBill}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/cashier.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Billing_For_Cashier.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Billing For Cashier" rendered="#{webUserController.hasPrivilege('OpdPreBilling')}"/>
                         </p:commandLink>
                     </h:form>
@@ -162,7 +222,7 @@
                             action="#{collectingCentreBillController.navigateToCollectingCenterBillingromMenu()}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/hospital.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Collecting_Centre_Billing.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Collecting Centre Billing"/>
                         </p:commandLink>
                     </h:form>
@@ -177,7 +237,7 @@
                             action="opd_bill_package?faces-redirect=true"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/opd-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Medical_Package_Billing.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Package Billing" rendered="#{webUserController.hasPrivilege('OpdPreBilling')}"/>
                         </p:commandLink>
                     </h:form>
@@ -191,7 +251,7 @@
                             ajax="false"
                             action="#{opdPreSettleController.navigateToScanBills()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/scan.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Scan_to_Pay.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Scan Bills"/>
                         </p:commandLink>
                     </h:form>
@@ -206,7 +266,7 @@
                             action="/opd/opd_search_pre_bill?faces-redirect=true"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/bill-bprove.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Accept_Payments_For_OPD_Bills.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Package Billing" rendered="#{webUserController.hasPrivilege('OpdPreBilling')}"/>
                         </p:commandLink>
                     </h:form>               
@@ -221,7 +281,7 @@
                             action="opd_search_pre_batch_bill?faces-redirect=true" 
                             actionListener="#{searchController.makeListNull}" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/bill-bprove.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Accept_Payments_For_OPD_Batch_Bills.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Accept Payment for OPD Batch Bills"/>
                         </p:commandLink>
                     </h:form >
@@ -235,7 +295,7 @@
                             ajax="false"
                             action="/pharmacy/pharmacy_search_pre_bill?faces-redirect=true" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/bill-bprove.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Accept_Payments_For_Pharmacy_Bills.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Accept Payments for Pharmacy Bills" />
                         </p:commandLink>
                     </h:form>
@@ -250,7 +310,7 @@
                             ajax="false"
                             action="/patient_deposit/index?faces-redirect=true"
                             styleClass="svg-link">
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/patient-deposit-management.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Patient_Deposit_Management.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Patient Deposit Management" />
                         </p:commandLink>
                     </h:form>
@@ -265,7 +325,7 @@
                             action="/pharmacy/pharmacy_search_pre_refund_bill_for_return_cash?faces-redirect=true" 
                             actionListener="#{searchController.makeListNull}" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/refund1.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Refunds.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Refunds" />
                         </p:commandLink>
                     </h:form>
@@ -280,7 +340,7 @@
                             action="/opd/opd_search_pre_refund_bill_for_return_cash?faces-redirect=true" 
                             actionListener="#{searchController.makeListNull}" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/refund1.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="RefundsforOPDBills.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Refunds for OPD Bills" />
                         </p:commandLink>
                     </h:form>
@@ -295,7 +355,7 @@
                             action="/pharmacy/pharmacy_search_pre_refund_bill_for_return_cash?faces-redirect=true" 
                             actionListener="#{searchController.makeListNull}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/refund1.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="RefundsforPharmacyBills.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Refunds for Pharmacy Bills" />
                         </p:commandLink>
                     </h:form>
@@ -311,7 +371,7 @@
                             action="opd/opd_bill_search?faces-redirect=true"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Opd_Bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="OPD Bill Search" />
                         </p:commandLink>
                     </h:form>               
@@ -328,7 +388,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Opd_Bill_Item.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="OPD Bill Item Search" />
                         </p:commandLink>
                     </h:form>               
@@ -343,7 +403,7 @@
                             ajax="false"
                             action="/opd_search_bill_fee_payment?faces-redirect=true"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Opd_Payment.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="OPD Payment Search" />
                         </p:commandLink>
                     </h:form>               
@@ -360,7 +420,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Collecting_Centre_Bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Collecting Centre Bill Search" />
                         </p:commandLink>
                     </h:form>               
@@ -376,7 +436,7 @@
                             actionListener="#{billController.clear()}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Bill_to_Pay.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Bills To Pay Search" />
                         </p:commandLink>
                     </h:form>               
@@ -393,7 +453,7 @@
                             actionListener="#{billController.clear()}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Credit_Paid_Bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Credit paid Bill Search" />
                         </p:commandLink>
                     </h:form>               
@@ -410,7 +470,7 @@
                             actionListener="#{billController.clear()}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Search_Credit_Paid_Bill_with_OPD_Bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Credit paid Bills with OPD Bill Search" />
                         </p:commandLink>
                     </h:form>               
@@ -427,7 +487,7 @@
                             action="#{workingTimeController.navigateToMarkIn()}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/in.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Doctor_Mark_in.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Mark In" />
                         </p:commandLink>
                     </h:form>               
@@ -442,7 +502,7 @@
                             ajax="false"
                             action="#{workingTimeController.navigateToListCurrentWorkTimes()}" 
                             >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/out.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Doctor_Mark_out.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Mark Out" />
                         </p:commandLink>
                     </h:form>               
@@ -458,7 +518,7 @@
                             action="#{workingTimeController.navigateToListWorkTimes()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/times.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Doctor_Working_Times.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Working Times" />
                         </p:commandLink>
                     </h:form>               
@@ -474,7 +534,7 @@
                             ajax="false"
                             action="#{tokenController.navigateToTokenIndex()}" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/token.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Manage_Token.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Manage Token" />
                         </p:commandLink>
                     </h:form>
@@ -490,7 +550,7 @@
                             ajax="false"
                             action="/lab/report_for_opd_print?faces-redirect=true" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/lab-report.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Lab_Report_Print.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Lab Report print" />
                         </p:commandLink>
                     </h:form>
@@ -504,9 +564,9 @@
                         <p:commandLink 
                             id="OPD_Summaries"
                             ajax="false"
-                            action="#{cashierReportController.navigateToOpdAnalytics()}" 
+                            action="#{cashierReportController.navigateToOpdAnalytics()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/summary-report.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="OPD_Summaries.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Summaries" />
                         </p:commandLink>
                     </h:form>
@@ -521,7 +581,7 @@
                             ajax="false"
                             action="#{opdBillController.navigateToOpdAnalyticsIndex()}" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/analytics.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="OPD_Analytics.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Analytics" />
                         </p:commandLink>
                     </h:form>
@@ -1774,7 +1834,7 @@
                             ajax="false"
                             action="#{financialTransactionController.navigateToFinancialTransactionIndex()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/financial-transaction-manager.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Financial_Transaction_Manager.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Financial Transaction Manager" />
                         </p:commandLink>
                     </h:form>
@@ -1789,7 +1849,7 @@
                             ajax="false"
                             action="/dataAdmin/report_execution_logs?faces-redirect=true"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/report-execution-logs.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Report_Execution_Logs.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Report Execution Logs" />
                         </p:commandLink>
                     </h:form>
@@ -1804,8 +1864,23 @@
                             ajax="false"
                             action="#{bookingControllerViewScope.navigateToChannelBookingFromMenuByDate()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/channel-booking-by-dates.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Channel_Booking_by_Dates.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Channel Booking by Dates" />
+                        </p:commandLink>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Channel Booking -->
+                <h:panelGroup rendered="#{ui.icon eq 'Channel_Booking' and webUserController.hasPrivilege('ChannellingChannelBooking')}" layout="block" class="col-1 p-1">
+                    <h:form>
+                        <p:tooltip for="Channel_Booking" value="Channel Booking" showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:commandLink
+                            id="Channel_Booking"
+                            ajax="false"
+                            action="#{bookingController.navigateToChannelBookingFromMenu()}"
+                            styleClass="svg-link" >
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Channel_Booking.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <h:outputText style="display: none;" value="Channel Booking"/>
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>
@@ -1819,7 +1894,7 @@
                             ajax="false"
                             action="/channel/channel_scheduling/index?faces-redirect=true"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/channel-scheduling.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Channel_Scheduling.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Channel Scheduling" />
                         </p:commandLink>
                     </h:form>

--- a/src/main/webapp/resources/icons/Accept_Payments.svg
+++ b/src/main/webapp/resources/icons/Accept_Payments.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Coin from above -->
+    <circle cx="100" cy="48" r="22" fill="#818CF8"/>
+    <circle cx="100" cy="48" r="16" fill="#4F46E5"/>
+    <text x="100" y="54" text-anchor="middle" font-size="16" font-weight="bold" fill="#EEF2FF" font-family="sans-serif">$</text>
+    <!-- Downward arrow to hand -->
+    <line x1="100" y1="70" x2="100" y2="100" stroke="#818CF8" stroke-width="5" stroke-linecap="round"/>
+    <path d="M88 92 L100 105 L112 92" fill="none" stroke="#818CF8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Open hand shape -->
+    <!-- Palm -->
+    <rect x="68" y="118" width="64" height="38" rx="8" fill="url(#grad1a)"/>
+    <!-- Fingers -->
+    <rect x="68" y="100" width="12" height="28" rx="6" fill="url(#grad1a)"/>
+    <rect x="84" y="94" width="12" height="34" rx="6" fill="url(#grad1a)"/>
+    <rect x="100" y="92" width="12" height="36" rx="6" fill="url(#grad1a)"/>
+    <rect x="116" y="96" width="12" height="32" rx="6" fill="url(#grad1a)"/>
+    <!-- Thumb -->
+    <rect x="56" y="120" width="18" height="10" rx="5" fill="url(#grad1a)"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Accept_Payments_For_OPD_Batch_Bills.svg
+++ b/src/main/webapp/resources/icons/Accept_Payments_For_OPD_Batch_Bills.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Back bill (offset) -->
+    <rect x="55" y="38" width="100" height="118" rx="6" fill="#818CF8" opacity="0.7"/>
+    <!-- Front bill -->
+    <rect x="45" y="48" width="100" height="118" rx="6" fill="url(#grad1a)"/>
+    <rect x="55" y="62" width="80" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="55" y="77" width="62" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="55" y="92" width="72" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="55" y="107" width="50" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Downward arrow -->
+    <circle cx="130" cy="148" r="16" fill="#818CF8"/>
+    <path d="M130 138 L130 154" stroke="#EEF2FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M122 148 L130 156 L138 148" fill="none" stroke="#EEF2FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Accept_Payments_For_OPD_Bills.svg
+++ b/src/main/webapp/resources/icons/Accept_Payments_For_OPD_Bills.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Bill document -->
+    <rect x="42" y="42" width="116" height="130" rx="6" fill="url(#grad1a)"/>
+    <rect x="52" y="55" width="96" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="70" width="76" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="85" width="86" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="100" width="60" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Downward arrow into bill -->
+    <circle cx="100" cy="148" r="16" fill="#818CF8"/>
+    <path d="M100 138 L100 154" stroke="#EEF2FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M92 148 L100 156 L108 148" fill="none" stroke="#EEF2FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Accept_Payments_For_Pharmacy_Bills.svg
+++ b/src/main/webapp/resources/icons/Accept_Payments_For_Pharmacy_Bills.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Pill/capsule shape (horizontal oval split diagonally) -->
+    <ellipse cx="90" cy="88" rx="46" ry="28" fill="url(#grad1a)"/>
+    <!-- Left half of pill -->
+    <path d="M90 60 A46 28 0 0 0 90 116 Z" fill="#4338CA"/>
+    <!-- Split line -->
+    <line x1="90" y1="60" x2="90" y2="116" stroke="#EEF2FF" stroke-width="4"/>
+    <!-- Accent highlight on right half -->
+    <ellipse cx="113" cy="80" rx="10" ry="6" fill="#818CF8" opacity="0.5"/>
+    <!-- Downward payment arrow -->
+    <circle cx="148" cy="130" r="20" fill="#818CF8"/>
+    <path d="M148 118 L148 136" stroke="#EEF2FF" stroke-width="5" stroke-linecap="round"/>
+    <path d="M138 130 L148 142 L158 130" fill="none" stroke="#EEF2FF" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Billing_For_Cashier.svg
+++ b/src/main/webapp/resources/icons/Billing_For_Cashier.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Bill document -->
+    <rect x="50" y="38" width="100" height="105" rx="6" fill="url(#grad1a)"/>
+    <!-- Bill lines -->
+    <rect x="63" y="58" width="74" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="63" y="74" width="58" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="63" y="90" width="68" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="63" y="106" width="44" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Tray / drawer rectangle at base -->
+    <rect x="38" y="148" width="124" height="22" rx="5" fill="#818CF8"/>
+    <rect x="44" y="154" width="112" height="10" rx="3" fill="#4338CA" opacity="0.5"/>
+    <!-- Handle bump -->
+    <rect x="88" y="165" width="24" height="6" rx="3" fill="#EEF2FF" opacity="0.8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Cashier_Drawer.svg
+++ b/src/main/webapp/resources/icons/Cashier_Drawer.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Drawer body (register base unit) -->
+    <rect x="22" y="80" width="156" height="80" rx="8" fill="url(#grad1a)"/>
+    <!-- Open tray (front face sliding out) -->
+    <rect x="28" y="110" width="144" height="55" rx="5" fill="#B45309"/>
+    <!-- Tray interior -->
+    <rect x="34" y="116" width="132" height="44" rx="4" fill="#FFFBEB" opacity="0.15"/>
+    <!-- Internal dividers (horizontal) -->
+    <line x1="34" y1="135" x2="166" y2="135" stroke="#D97706" stroke-width="2" opacity="0.6"/>
+    <!-- Internal dividers (vertical) -->
+    <line x1="82" y1="116" x2="82" y2="160" stroke="#D97706" stroke-width="2" opacity="0.6"/>
+    <line x1="118" y1="116" x2="118" y2="160" stroke="#D97706" stroke-width="2" opacity="0.6"/>
+    <!-- Coin circles in bottom row slots -->
+    <circle cx="58" cy="148" r="8" fill="#FBBF24"/>
+    <circle cx="100" cy="148" r="8" fill="#FBBF24"/>
+    <circle cx="142" cy="148" r="8" fill="#FBBF24"/>
+    <!-- Bill papers in top row -->
+    <rect x="38" y="118" width="40" height="14" rx="2" fill="#FBBF24" opacity="0.7"/>
+    <rect x="86" y="118" width="28" height="14" rx="2" fill="#FBBF24" opacity="0.7"/>
+    <rect x="122" y="118" width="40" height="14" rx="2" fill="#FBBF24" opacity="0.7"/>
+    <!-- Handle -->
+    <rect x="80" y="155" width="40" height="8" rx="4" fill="#FBBF24"/>
+    <!-- Front panel top -->
+    <rect x="22" y="80" width="156" height="34" rx="8" fill="#B45309" opacity="0.6"/>
+    <rect x="22" y="100" width="156" height="14" fill="#B45309" opacity="0.6"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Cashier_Summaries.svg
+++ b/src/main/webapp/resources/icons/Cashier_Summaries.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Cash register body -->
+    <rect x="30" y="80" width="130" height="80" rx="8" fill="url(#grad1a)"/>
+    <!-- Display screen -->
+    <rect x="44" y="88" width="102" height="28" rx="4" fill="#B45309"/>
+    <rect x="48" y="92" width="94" height="20" rx="3" fill="#FFFBEB" opacity="0.85"/>
+    <!-- Keys row -->
+    <rect x="44" y="122" width="16" height="12" rx="3" fill="#FBBF24"/>
+    <rect x="66" y="122" width="16" height="12" rx="3" fill="#FBBF24"/>
+    <rect x="88" y="122" width="16" height="12" rx="3" fill="#FBBF24"/>
+    <rect x="110" y="122" width="16" height="12" rx="3" fill="#FBBF24"/>
+    <rect x="132" y="122" width="18" height="12" rx="3" fill="#B45309"/>
+    <!-- Base / drawer -->
+    <rect x="24" y="152" width="142" height="16" rx="6" fill="#B45309"/>
+    <!-- Report page (small, top right) -->
+    <rect x="138" y="52" width="36" height="44" rx="4" fill="url(#grad1a)" opacity="0.9"/>
+    <rect x="143" y="60" width="26" height="4" rx="2" fill="#FFFBEB" opacity="0.9"/>
+    <rect x="143" y="68" width="20" height="4" rx="2" fill="#FFFBEB" opacity="0.9"/>
+    <rect x="143" y="76" width="24" height="4" rx="2" fill="#FFFBEB" opacity="0.7"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Channel_Booking.svg
+++ b/src/main/webapp/resources/icons/Channel_Booking.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Calendar rectangle -->
+    <rect x="32" y="50" width="136" height="118" rx="7" fill="url(#grad1a)"/>
+    <!-- Calendar header bar -->
+    <rect x="32" y="50" width="136" height="28" rx="7" fill="#4338CA"/>
+    <rect x="32" y="64" width="136" height="14" fill="#4338CA"/>
+    <!-- Calendar rings -->
+    <rect x="62" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
+    <rect x="128" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
+    <!-- Calendar grid - 4 cols x 3 rows -->
+    <rect x="42" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="72" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="102" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="42" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <!-- Highlighted cell -->
+    <rect x="72" y="114" width="24" height="18" rx="3" fill="#818CF8"/>
+    <rect x="102" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="42" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="72" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="102" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Channel_Booking_by_Dates.svg
+++ b/src/main/webapp/resources/icons/Channel_Booking_by_Dates.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Calendar rectangle -->
+    <rect x="32" y="50" width="136" height="118" rx="7" fill="url(#grad1a)"/>
+    <!-- Header -->
+    <rect x="32" y="50" width="136" height="28" rx="7" fill="#4338CA"/>
+    <rect x="32" y="64" width="136" height="14" fill="#4338CA"/>
+    <!-- Calendar rings -->
+    <rect x="62" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
+    <rect x="128" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
+    <!-- Grid row 1 -->
+    <rect x="42" y="90" width="24" height="18" rx="3" fill="#818CF8"/>
+    <rect x="72" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="102" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <!-- Row 2 — second highlight in different row/col -->
+    <rect x="42" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="72" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="102" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="114" width="24" height="18" rx="3" fill="#818CF8"/>
+    <!-- Row 3 -->
+    <rect x="42" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="72" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="102" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+    <rect x="132" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Channel_Scheduling.svg
+++ b/src/main/webapp/resources/icons/Channel_Scheduling.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- 3x3 time-slot grid with alternating filled/empty -->
+    <!-- Background panel -->
+    <rect x="38" y="46" width="124" height="110" rx="8" fill="url(#grad1a)"/>
+    <!-- Header bar -->
+    <rect x="38" y="46" width="124" height="20" rx="8" fill="#4338CA"/>
+    <rect x="38" y="56" width="124" height="10" fill="#4338CA"/>
+    <!-- Row 1: filled, empty, filled -->
+    <rect x="48" y="74" width="32" height="24" rx="4" fill="#818CF8"/>
+    <rect x="86" y="74" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
+    <rect x="124" y="74" width="32" height="24" rx="4" fill="#818CF8"/>
+    <!-- Row 2: empty, filled, empty -->
+    <rect x="48" y="104" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
+    <rect x="86" y="104" width="32" height="24" rx="4" fill="#818CF8"/>
+    <rect x="124" y="104" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
+    <!-- Row 3: filled, empty, filled -->
+    <rect x="48" y="134" width="32" height="14" rx="4" fill="#818CF8"/>
+    <rect x="86" y="134" width="32" height="14" rx="4" fill="#EEF2FF" opacity="0.4"/>
+    <rect x="124" y="134" width="32" height="14" rx="4" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Collecting_Centre_Billing.svg
+++ b/src/main/webapp/resources/icons/Collecting_Centre_Billing.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Tilted test tube -->
+    <g transform="rotate(-25, 82, 105)">
+      <rect x="68" y="48" width="28" height="90" rx="14" fill="url(#grad1a)"/>
+      <!-- Liquid inside -->
+      <rect x="68" y="108" width="28" height="30" rx="0" fill="#818CF8" opacity="0.7"/>
+      <rect x="68" y="130" width="28" height="8" rx="14" fill="#818CF8" opacity="0.7"/>
+      <!-- Tube top cap -->
+      <rect x="65" y="44" width="34" height="10" rx="4" fill="#4338CA"/>
+    </g>
+    <!-- Small document to right -->
+    <rect x="122" y="65" width="50" height="65" rx="5" fill="url(#grad1a)" opacity="0.9"/>
+    <rect x="129" y="78" width="36" height="5" rx="2" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="129" y="91" width="28" height="5" rx="2" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="129" y="104" width="32" height="5" rx="2" fill="#EEF2FF" opacity="0.9"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Day_End_Summary.svg
+++ b/src/main/webapp/resources/icons/Day_End_Summary.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Half-sun arc at top -->
+    <path d="M42 78 A58 58 0 0 1 158 78" fill="url(#grad1a)"/>
+    <!-- Sun rays -->
+    <line x1="100" y1="18" x2="100" y2="28" stroke="#FBBF24" stroke-width="5" stroke-linecap="round"/>
+    <line x1="138" y1="30" x2="132" y2="38" stroke="#FBBF24" stroke-width="5" stroke-linecap="round"/>
+    <line x1="162" y1="64" x2="153" y2="68" stroke="#FBBF24" stroke-width="5" stroke-linecap="round"/>
+    <line x1="62" y1="30" x2="68" y2="38" stroke="#FBBF24" stroke-width="5" stroke-linecap="round"/>
+    <line x1="38" y1="64" x2="47" y2="68" stroke="#FBBF24" stroke-width="5" stroke-linecap="round"/>
+    <!-- Horizon line -->
+    <line x1="32" y1="78" x2="168" y2="78" stroke="url(#grad1a)" stroke-width="4"/>
+    <!-- Document with bar chart below -->
+    <rect x="44" y="88" width="112" height="80" rx="6" fill="url(#grad1a)"/>
+    <!-- Bar chart inside doc -->
+    <rect x="58" y="140" width="16" height="20" rx="2" fill="#FBBF24" opacity="0.9"/>
+    <rect x="80" y="126" width="16" height="34" rx="2" fill="#FBBF24"/>
+    <rect x="102" y="114" width="16" height="46" rx="2" fill="#FFFBEB" opacity="0.9"/>
+    <rect x="124" y="104" width="16" height="56" rx="2" fill="#FFFBEB"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Doctor_Mark_in.svg
+++ b/src/main/webapp/resources/icons/Doctor_Mark_in.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Stethoscope earpiece circle -->
+    <circle cx="72" cy="52" r="12" fill="url(#grad1a)"/>
+    <circle cx="72" cy="52" r="7" fill="#EEF2FF"/>
+    <!-- Stethoscope tube - curved path from earpiece down to chest piece -->
+    <path d="M72 64 Q72 100 100 100 Q128 100 128 130" fill="none" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round"/>
+    <!-- Chest piece (circle) -->
+    <circle cx="128" cy="148" r="16" fill="url(#grad1a)"/>
+    <circle cx="128" cy="148" r="10" fill="#EEF2FF"/>
+    <circle cx="128" cy="148" r="5" fill="#818CF8"/>
+    <!-- Right-pointing arrow (entering) -->
+    <rect x="35" y="94" width="40" height="12" rx="6" fill="#818CF8"/>
+    <path d="M70 88 L86 100 L70 112" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Doctor_Mark_out.svg
+++ b/src/main/webapp/resources/icons/Doctor_Mark_out.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Stethoscope earpiece circle -->
+    <circle cx="72" cy="52" r="12" fill="url(#grad1a)"/>
+    <circle cx="72" cy="52" r="7" fill="#EEF2FF"/>
+    <!-- Stethoscope tube -->
+    <path d="M72 64 Q72 100 100 100 Q128 100 128 130" fill="none" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round"/>
+    <!-- Chest piece -->
+    <circle cx="128" cy="148" r="16" fill="url(#grad1a)"/>
+    <circle cx="128" cy="148" r="10" fill="#EEF2FF"/>
+    <circle cx="128" cy="148" r="5" fill="#818CF8"/>
+    <!-- Left-pointing arrow (leaving) -->
+    <rect x="115" y="94" width="40" height="12" rx="6" fill="#818CF8"/>
+    <path d="M120 88 L104 100 L120 112" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Doctor_Working_Times.svg
+++ b/src/main/webapp/resources/icons/Doctor_Working_Times.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Stethoscope earpiece -->
+    <circle cx="62" cy="48" r="11" fill="url(#grad1a)"/>
+    <circle cx="62" cy="48" r="6" fill="#EEF2FF"/>
+    <!-- Stethoscope tube -->
+    <path d="M62 59 Q62 90 88 92 Q108 94 108 118" fill="none" stroke="url(#grad1a)" stroke-width="7" stroke-linecap="round"/>
+    <!-- Chest piece small -->
+    <circle cx="108" cy="132" r="12" fill="url(#grad1a)"/>
+    <circle cx="108" cy="132" r="7" fill="#EEF2FF"/>
+    <circle cx="108" cy="132" r="3" fill="#818CF8"/>
+    <!-- Clock circle overlapping bottom-right -->
+    <circle cx="148" cy="140" r="32" fill="url(#grad1a)"/>
+    <circle cx="148" cy="140" r="24" fill="#EEF2FF"/>
+    <!-- Clock hands -->
+    <line x1="148" y1="140" x2="148" y2="122" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
+    <line x1="148" y1="140" x2="160" y2="148" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="148" cy="140" r="3" fill="#4338CA"/>
+    <!-- Clock ticks -->
+    <line x1="148" y1="118" x2="148" y2="122" stroke="#818CF8" stroke-width="2"/>
+    <line x1="148" y1="158" x2="148" y2="162" stroke="#818CF8" stroke-width="2"/>
+    <line x1="126" y1="140" x2="122" y2="140" stroke="#818CF8" stroke-width="2"/>
+    <line x1="170" y1="140" x2="174" y2="140" stroke="#818CF8" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Financial_Transaction_Manager.svg
+++ b/src/main/webapp/resources/icons/Financial_Transaction_Manager.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Left coin -->
+    <circle cx="58" cy="100" r="36" fill="url(#grad1a)"/>
+    <circle cx="58" cy="100" r="26" fill="#B45309"/>
+    <text x="58" y="107" text-anchor="middle" font-size="22" font-weight="bold" fill="#FFFBEB" font-family="sans-serif">$</text>
+    <!-- Right coin -->
+    <circle cx="142" cy="100" r="36" fill="url(#grad1a)"/>
+    <circle cx="142" cy="100" r="26" fill="#B45309"/>
+    <text x="142" y="107" text-anchor="middle" font-size="22" font-weight="bold" fill="#FFFBEB" font-family="sans-serif">$</text>
+    <!-- Upward arrow (left side) -->
+    <line x1="96" y1="74" x2="96" y2="58" stroke="#FBBF24" stroke-width="6" stroke-linecap="round"/>
+    <path d="M88 66 L96 54 L104 66" fill="none" stroke="#FBBF24" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Downward arrow (right side) -->
+    <line x1="104" y1="126" x2="104" y2="142" stroke="#FBBF24" stroke-width="6" stroke-linecap="round"/>
+    <path d="M96 134 L104 146 L112 134" fill="none" stroke="#FBBF24" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Investigation_Trace.svg
+++ b/src/main/webapp/resources/icons/Investigation_Trace.svg
@@ -1,43 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad43a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad43" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
-  <g filter="url(#shad43)">
-    <!-- Test tube (left, angled) -->
-    <g transform="rotate(20 65 110)">
-      <rect x="54" y="50" width="22" height="80" rx="4" fill="url(#grad43a)"/>
-      <rect x="50" y="44" width="30" height="14" rx="4" fill="#155E75"/>
-      <!-- Liquid in tube -->
-      <rect x="54" y="108" width="22" height="22" rx="0" fill="#22D3EE" opacity="0.85"/>
-      <ellipse cx="65" cy="130" rx="11" ry="4" fill="#22D3EE"/>
-      <!-- Bubble -->
-      <circle cx="60" cy="118" r="3" fill="white" opacity="0.5"/>
-    </g>
-    <!-- Microscope (center-right) -->
-    <!-- Base -->
-    <rect x="100" y="152" width="68" height="12" rx="5" fill="url(#grad43a)"/>
-    <!-- Column -->
-    <rect x="128" y="90" width="12" height="65" rx="4" fill="url(#grad43a)"/>
-    <!-- Stage arm -->
-    <rect x="100" y="110" width="40" height="10" rx="4" fill="url(#grad43a)"/>
-    <!-- Objective -->
-    <rect x="125" y="65" width="18" height="32" rx="5" fill="#155E75"/>
-    <circle cx="134" cy="98" r="8" fill="url(#grad43a)"/>
-    <!-- Eyepiece -->
-    <rect x="130" y="48" width="8" height="20" rx="4" fill="url(#grad43a)"/>
-    <!-- Magnifying glass overlay -->
-    <circle cx="110" cy="78" r="22" fill="none" stroke="#22D3EE" stroke-width="5"/>
-    <circle cx="110" cy="78" r="14" fill="#F0FDFA" opacity="0.6"/>
-    <line x1="126" y1="94" x2="134" y2="102" stroke="#22D3EE" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Microscope base -->
+    <rect x="60" y="155" width="80" height="14" rx="6" fill="url(#grad1a)"/>
+    <!-- Arm vertical post -->
+    <rect x="90" y="80" width="14" height="80" rx="5" fill="url(#grad1a)"/>
+    <!-- Stage (horizontal platform) -->
+    <rect x="68" y="120" width="64" height="10" rx="4" fill="#4338CA"/>
+    <!-- Eyepiece tube angled -->
+    <rect x="75" y="44" width="12" height="48" rx="6" fill="url(#grad1a)" transform="rotate(-15, 81, 68)"/>
+    <!-- Eyepiece top cap -->
+    <ellipse cx="72" cy="42" rx="10" ry="6" fill="#4338CA"/>
+    <!-- Objective lens -->
+    <rect x="92" y="128" width="10" height="20" rx="5" fill="#818CF8"/>
+    <!-- Sample on stage -->
+    <circle cx="97" cy="115" r="8" fill="#EEF2FF" stroke="#818CF8" stroke-width="2"/>
+    <circle cx="97" cy="115" r="3" fill="#818CF8"/>
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Lab_Report_Print.svg
+++ b/src/main/webapp/resources/icons/Lab_Report_Print.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Conical flask/beaker body -->
+    <path d="M84 38 L84 72 L52 118 Q48 128 58 132 L142 132 Q152 128 148 118 L116 72 L116 38 Z" fill="url(#grad1a)"/>
+    <!-- Flask neck top -->
+    <rect x="80" y="34" width="40" height="10" rx="5" fill="#4338CA"/>
+    <!-- Liquid in flask -->
+    <path d="M62 122 L138 122 Q144 124 140 128 L60 128 Q56 124 62 122 Z" fill="#818CF8" opacity="0.8"/>
+    <!-- Bubbles in liquid -->
+    <circle cx="82" cy="120" r="4" fill="#EEF2FF" opacity="0.6"/>
+    <circle cx="100" cy="118" r="3" fill="#EEF2FF" opacity="0.6"/>
+    <circle cx="118" cy="121" r="4" fill="#EEF2FF" opacity="0.6"/>
+    <!-- Printer rectangle below -->
+    <rect x="42" y="140" width="116" height="34" rx="6" fill="url(#grad1a)"/>
+    <!-- Printer slot -->
+    <rect x="56" y="148" width="88" height="6" rx="2" fill="#EEF2FF" opacity="0.5"/>
+    <!-- Paper coming out -->
+    <rect x="64" y="168" width="72" height="18" rx="3" fill="#EEF2FF"/>
+    <rect x="70" y="172" width="60" height="4" rx="1" fill="#818CF8" opacity="0.6"/>
+    <rect x="70" y="178" width="44" height="4" rx="1" fill="#818CF8" opacity="0.4"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Manage_Shift_Fund_Bills.svg
+++ b/src/main/webapp/resources/icons/Manage_Shift_Fund_Bills.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Stack of banknotes (offset rectangles) -->
+    <!-- Back note -->
+    <rect x="28" y="60" width="110" height="54" rx="5" fill="#B45309" opacity="0.6"/>
+    <!-- Middle note -->
+    <rect x="22" y="72" width="110" height="54" rx="5" fill="#D97706" opacity="0.8"/>
+    <!-- Front note -->
+    <rect x="16" y="84" width="110" height="54" rx="5" fill="url(#grad1a)"/>
+    <!-- Note lines -->
+    <rect x="28" y="98" width="60" height="5" rx="2" fill="#FFFBEB" opacity="0.8"/>
+    <rect x="28" y="110" width="44" height="5" rx="2" fill="#FFFBEB" opacity="0.8"/>
+    <rect x="28" y="122" width="52" height="5" rx="2" fill="#FFFBEB" opacity="0.6"/>
+    <!-- Value circle on note -->
+    <circle cx="104" cy="111" r="16" fill="#B45309"/>
+    <text x="104" y="116" text-anchor="middle" font-size="13" font-weight="bold" fill="#FFFBEB" font-family="sans-serif">$</text>
+    <!-- Coin circle (right side) -->
+    <circle cx="152" cy="130" r="28" fill="#FBBF24"/>
+    <circle cx="152" cy="130" r="20" fill="url(#grad1a)"/>
+    <text x="152" y="137" text-anchor="middle" font-size="20" font-weight="bold" fill="#FFFBEB" font-family="sans-serif">¢</text>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Manage_Token.svg
+++ b/src/main/webapp/resources/icons/Manage_Token.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Ticket/token main body -->
+    <rect x="45" y="55" width="120" height="90" rx="10" fill="url(#grad1a)"/>
+    <!-- Tear-off perforation on left -->
+    <line x1="72" y1="55" x2="72" y2="145" stroke="#EEF2FF" stroke-width="2" stroke-dasharray="5,4"/>
+    <!-- Notch circles on edges for tear-off -->
+    <circle cx="72" cy="55" r="7" fill="#EEF2FF"/>
+    <circle cx="72" cy="145" r="7" fill="#EEF2FF"/>
+    <!-- Left stub area -->
+    <rect x="45" y="55" width="27" height="90" rx="10" fill="#4338CA"/>
+    <!-- Large number "1" on main body -->
+    <text x="128" y="118" text-anchor="middle" font-size="58" font-weight="bold" fill="#EEF2FF" font-family="sans-serif" opacity="0.95">1</text>
+    <!-- Token label on left stub -->
+    <text x="58" y="105" text-anchor="middle" font-size="11" font-weight="bold" fill="#818CF8" font-family="sans-serif" transform="rotate(-90, 58, 100)">TOKEN</text>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Medical_Package_Billing.svg
+++ b/src/main/webapp/resources/icons/Medical_Package_Billing.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Box/package outline -->
+    <rect x="38" y="70" width="124" height="95" rx="6" fill="url(#grad1a)"/>
+    <!-- Box lid top -->
+    <rect x="35" y="55" width="130" height="22" rx="5" fill="#4338CA"/>
+    <!-- Box ribbon vertical -->
+    <rect x="90" y="55" width="20" height="110" rx="0" fill="#818CF8" opacity="0.5"/>
+    <!-- Box ribbon horizontal -->
+    <rect x="35" y="105" width="130" height="16" rx="0" fill="#818CF8" opacity="0.5"/>
+    <!-- Medical cross inside -->
+    <rect x="82" y="85" width="36" height="10" rx="5" fill="#EEF2FF"/>
+    <rect x="95" y="72" width="10" height="36" rx="5" fill="#EEF2FF"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/OPD_Analytics.svg
+++ b/src/main/webapp/resources/icons/OPD_Analytics.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Axes -->
+    <line x1="40" y1="160" x2="40" y2="42" stroke="url(#grad1a)" stroke-width="5" stroke-linecap="round"/>
+    <line x1="40" y1="160" x2="168" y2="160" stroke="url(#grad1a)" stroke-width="5" stroke-linecap="round"/>
+    <!-- Y-axis arrow -->
+    <path d="M34 50 L40 38 L46 50" fill="url(#grad1a)"/>
+    <!-- X-axis arrow -->
+    <path d="M160 154 L172 160 L160 166" fill="url(#grad1a)"/>
+    <!-- Line chart going up-right -->
+    <polyline points="52,148 78,128 104,108 128,80 152,55" fill="none" stroke="#818CF8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Data point dots -->
+    <circle cx="52" cy="148" r="7" fill="url(#grad1a)"/>
+    <circle cx="78" cy="128" r="7" fill="url(#grad1a)"/>
+    <circle cx="104" cy="108" r="7" fill="url(#grad1a)"/>
+    <circle cx="128" cy="80" r="7" fill="url(#grad1a)"/>
+    <circle cx="152" cy="55" r="7" fill="url(#grad1a)"/>
+    <!-- Inner dot highlight -->
+    <circle cx="52" cy="148" r="3" fill="#EEF2FF"/>
+    <circle cx="78" cy="128" r="3" fill="#EEF2FF"/>
+    <circle cx="104" cy="108" r="3" fill="#EEF2FF"/>
+    <circle cx="128" cy="80" r="3" fill="#EEF2FF"/>
+    <circle cx="152" cy="55" r="3" fill="#EEF2FF"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/OPD_Summaries.svg
+++ b/src/main/webapp/resources/icons/OPD_Summaries.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Baseline -->
+    <rect x="38" y="155" width="124" height="6" rx="3" fill="url(#grad1a)"/>
+    <!-- Bar 1 (short) -->
+    <rect x="50" y="120" width="28" height="40" rx="4" fill="url(#grad1a)" opacity="0.7"/>
+    <!-- Bar 2 (medium) -->
+    <rect x="88" y="94" width="28" height="66" rx="4" fill="url(#grad1a)"/>
+    <!-- Bar 3 (tall) -->
+    <rect x="126" y="62" width="28" height="98" rx="4" fill="#818CF8"/>
+    <!-- Value dots on top -->
+    <circle cx="64" cy="118" r="5" fill="#EEF2FF"/>
+    <circle cx="102" cy="92" r="5" fill="#EEF2FF"/>
+    <circle cx="140" cy="60" r="5" fill="#EEF2FF"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Opd_Billing.svg
+++ b/src/main/webapp/resources/icons/Opd_Billing.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Document rectangle -->
+    <rect x="45" y="45" width="100" height="125" rx="6" fill="url(#grad1a)"/>
+    <rect x="52" y="52" width="86" height="111" rx="4" fill="#EEF2FF" opacity="0.15"/>
+    <!-- Bill lines -->
+    <rect x="60" y="75" width="70" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="60" y="92" width="55" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="60" y="109" width="65" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="60" y="126" width="45" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Medical cross top-right -->
+    <rect x="118" y="42" width="28" height="8" rx="4" fill="#818CF8"/>
+    <rect x="128" y="32" width="8" height="28" rx="4" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Patient_Add_New.svg
+++ b/src/main/webapp/resources/icons/Patient_Add_New.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Person head -->
+    <circle cx="85" cy="72" r="22" fill="url(#grad1a)"/>
+    <!-- Person body -->
+    <path d="M52 138 Q52 112 85 112 Q118 112 118 138 L118 152 Q118 157 113 157 L57 157 Q52 157 52 152 Z" fill="url(#grad1a)"/>
+    <!-- Plus sign top-right -->
+    <rect x="120" y="48" width="32" height="8" rx="4" fill="#818CF8"/>
+    <rect x="132" y="36" width="8" height="32" rx="4" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Patient_Deposit_Management.svg
+++ b/src/main/webapp/resources/icons/Patient_Deposit_Management.svg
@@ -1,76 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <!-- Gradient for person -->
-    <linearGradient id="personGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4A90E2;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#357ABD;stop-opacity:1" />
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
     </linearGradient>
-
-    <!-- Gradient for dollar bill -->
-    <linearGradient id="moneyGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#5CB85C;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#449D44;stop-opacity:1" />
-    </linearGradient>
-
-    <!-- Gradient for dollar symbol -->
-    <linearGradient id="dollarGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#FFF;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#E8F5E8;stop-opacity:1" />
-    </linearGradient>
-
-    <!-- Shadow filter -->
-    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
-      <feOffset dx="2" dy="2" result="offsetblur"/>
-      <feComponentTransfer>
-        <feFuncA type="linear" slope="0.3"/>
-      </feComponentTransfer>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-
-  <!-- Background circle (optional, can be removed for transparent background) -->
-  <circle cx="100" cy="100" r="95" fill="#F8F9FA" opacity="0.5"/>
-
-  <!-- Person silhouette -->
-  <g filter="url(#shadow)">
-    <!-- Head -->
-    <circle cx="75" cy="60" r="22" fill="url(#personGradient)"/>
-
-    <!-- Body -->
-    <path d="M 75 82 Q 55 85 50 110 L 50 140 Q 50 145 55 145 L 65 145 L 65 120 Q 65 115 70 115 L 80 115 Q 85 115 85 120 L 85 145 L 95 145 Q 100 145 100 140 L 100 110 Q 95 85 75 82 Z"
-          fill="url(#personGradient)" stroke="#2E6DA4" stroke-width="1"/>
-  </g>
-
-  <!-- Dollar bill -->
-  <g filter="url(#shadow)">
-    <!-- Bill rectangle with rounded corners -->
-    <rect x="95" y="95" width="80" height="50" rx="5" ry="5"
-          fill="url(#moneyGradient)" stroke="#3D8B3D" stroke-width="2"/>
-
-    <!-- Decorative corner circles -->
-    <circle cx="105" cy="105" r="4" fill="#449D44" opacity="0.5"/>
-    <circle cx="165" cy="105" r="4" fill="#449D44" opacity="0.5"/>
-    <circle cx="105" cy="135" r="4" fill="#449D44" opacity="0.5"/>
-    <circle cx="165" cy="135" r="4" fill="#449D44" opacity="0.5"/>
-
-    <!-- Dollar sign -->
-    <text x="135" y="132" font-family="Arial, sans-serif" font-size="32" font-weight="bold"
-          fill="url(#dollarGradient)" text-anchor="middle">$</text>
-
-    <!-- Decorative lines on bill -->
-    <line x1="100" y1="110" x2="115" y2="110" stroke="#449D44" stroke-width="1.5" opacity="0.6"/>
-    <line x1="100" y1="130" x2="115" y2="130" stroke="#449D44" stroke-width="1.5" opacity="0.6"/>
-    <line x1="155" y1="110" x2="170" y2="110" stroke="#449D44" stroke-width="1.5" opacity="0.6"/>
-    <line x1="155" y1="130" x2="170" y2="130" stroke="#449D44" stroke-width="1.5" opacity="0.6"/>
-  </g>
-
-  <!-- Deposit arrow (optional enhancement) -->
-  <g filter="url(#shadow)" opacity="0.9">
-    <path d="M 135 75 L 135 90" stroke="#F39C12" stroke-width="4" stroke-linecap="round"/>
-    <path d="M 128 83 L 135 90 L 142 83" fill="none" stroke="#F39C12" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Wallet body -->
+    <rect x="32" y="68" width="136" height="96" rx="10" fill="url(#grad1a)"/>
+    <!-- Wallet flap top -->
+    <rect x="32" y="68" width="136" height="30" rx="10" fill="#4338CA"/>
+    <rect x="32" y="84" width="136" height="14" fill="#4338CA"/>
+    <!-- Card slot lines -->
+    <rect x="44" y="110" width="80" height="6" rx="3" fill="#EEF2FF" opacity="0.4"/>
+    <rect x="44" y="122" width="80" height="6" rx="3" fill="#EEF2FF" opacity="0.4"/>
+    <!-- Coin pocket right side -->
+    <rect x="140" y="108" width="22" height="44" rx="8" fill="#4338CA"/>
+    <!-- Coin inside pocket -->
+    <circle cx="151" cy="130" r="12" fill="#818CF8"/>
+    <circle cx="151" cy="130" r="8" fill="url(#grad1a)"/>
+    <text x="151" y="134" text-anchor="middle" font-size="10" font-weight="bold" fill="#EEF2FF" font-family="sans-serif">$</text>
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Patient_Lookup.svg
+++ b/src/main/webapp/resources/icons/Patient_Lookup.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Person head -->
+    <circle cx="85" cy="68" r="20" fill="url(#grad1a)"/>
+    <!-- Person body arc -->
+    <path d="M55 130 Q55 105 85 105 Q115 105 115 130 L115 145 Q115 150 110 150 L60 150 Q55 150 55 145 Z" fill="url(#grad1a)"/>
+    <!-- Magnifying glass circle -->
+    <circle cx="138" cy="138" r="22" fill="none" stroke="#818CF8" stroke-width="8"/>
+    <!-- Magnifying glass handle -->
+    <line x1="154" y1="154" x2="168" y2="168" stroke="#818CF8" stroke-width="8" stroke-linecap="round"/>
+    <!-- Inner glass highlight -->
+    <circle cx="133" cy="133" r="10" fill="none" stroke="#818CF8" stroke-width="3" opacity="0.5"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Refunds.svg
+++ b/src/main/webapp/resources/icons/Refunds.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Coin circle -->
+    <circle cx="100" cy="88" r="38" fill="url(#grad1a)"/>
+    <circle cx="100" cy="88" r="28" fill="#4338CA"/>
+    <text x="100" y="95" text-anchor="middle" font-size="22" font-weight="bold" fill="#EEF2FF" font-family="sans-serif">$</text>
+    <!-- Curved return arrow (arc going left) -->
+    <path d="M138 120 Q160 148 120 158 Q82 168 62 142" fill="none" stroke="#818CF8" stroke-width="7" stroke-linecap="round"/>
+    <!-- Arrowhead pointing left -->
+    <path d="M55 150 L62 140 L72 150" fill="none" stroke="#818CF8" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/RefundsforOPDBills.svg
+++ b/src/main/webapp/resources/icons/RefundsforOPDBills.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Bill rectangle -->
+    <rect x="52" y="38" width="106" height="130" rx="6" fill="url(#grad1a)"/>
+    <rect x="62" y="55" width="86" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="62" y="70" width="68" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="62" y="85" width="78" height="7" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="62" y="100" width="54" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <rect x="62" y="115" width="64" height="7" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Left-pointing arrow overlaid -->
+    <rect x="55" y="143" width="90" height="12" rx="6" fill="#818CF8"/>
+    <path d="M62 137 L42 149 L62 161" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/RefundsforPharmacyBills.svg
+++ b/src/main/webapp/resources/icons/RefundsforPharmacyBills.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Pill capsule (horizontal) -->
+    <ellipse cx="100" cy="85" rx="52" ry="30" fill="url(#grad1a)"/>
+    <!-- Left half darker -->
+    <path d="M100 55 A52 30 0 0 0 100 115 Z" fill="#4338CA"/>
+    <!-- Dividing line -->
+    <line x1="100" y1="55" x2="100" y2="115" stroke="#EEF2FF" stroke-width="4"/>
+    <!-- Highlight -->
+    <ellipse cx="122" cy="74" rx="12" ry="7" fill="#818CF8" opacity="0.5"/>
+    <!-- Left-pointing return arrow -->
+    <rect x="52" y="135" width="96" height="12" rx="6" fill="#818CF8"/>
+    <path d="M60 129 L40 141 L60 153" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Report_Execution_Logs.svg
+++ b/src/main/webapp/resources/icons/Report_Execution_Logs.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Document page -->
+    <rect x="38" y="38" width="118" height="140" rx="7" fill="url(#grad1a)"/>
+    <!-- Page fold top-right -->
+    <path d="M128 38 L156 38 L156 66 Z" fill="#4338CA"/>
+    <path d="M128 38 L128 66 L156 66" fill="#EEF2FF" opacity="0.2"/>
+    <!-- Text lines -->
+    <rect x="52" y="70" width="88" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="86" width="72" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="102" width="82" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="52" y="118" width="60" height="8" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Clock icon at top-right corner -->
+    <circle cx="148" cy="55" r="18" fill="#818CF8"/>
+    <circle cx="148" cy="55" r="12" fill="#EEF2FF"/>
+    <line x1="148" y1="55" x2="148" y2="46" stroke="#4F46E5" stroke-width="2" stroke-linecap="round"/>
+    <line x1="148" y1="55" x2="154" y2="59" stroke="#4F46E5" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="148" cy="55" r="2" fill="#4338CA"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Scan_to_Pay.svg
+++ b/src/main/webapp/resources/icons/Scan_to_Pay.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- QR code outer frame -->
+    <rect x="42" y="62" width="116" height="116" rx="6" fill="url(#grad1a)"/>
+    <rect x="48" y="68" width="104" height="104" rx="4" fill="#EEF2FF"/>
+    <!-- Top-left QR block -->
+    <rect x="54" y="74" width="38" height="38" rx="3" fill="url(#grad1a)"/>
+    <rect x="60" y="80" width="26" height="26" rx="2" fill="#EEF2FF"/>
+    <rect x="65" y="85" width="16" height="16" rx="1" fill="url(#grad1a)"/>
+    <!-- Top-right QR block -->
+    <rect x="108" y="74" width="38" height="38" rx="3" fill="url(#grad1a)"/>
+    <rect x="114" y="80" width="26" height="26" rx="2" fill="#EEF2FF"/>
+    <rect x="119" y="85" width="16" height="16" rx="1" fill="url(#grad1a)"/>
+    <!-- Bottom-left QR block -->
+    <rect x="54" y="128" width="38" height="38" rx="3" fill="url(#grad1a)"/>
+    <rect x="60" y="134" width="26" height="26" rx="2" fill="#EEF2FF"/>
+    <rect x="65" y="139" width="16" height="16" rx="1" fill="url(#grad1a)"/>
+    <!-- Center data dots -->
+    <rect x="108" y="128" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="122" y="128" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="136" y="128" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="108" y="142" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="136" y="142" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="108" y="156" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <rect x="122" y="156" width="10" height="10" rx="1" fill="url(#grad1a)"/>
+    <!-- Wifi arc at top -->
+    <path d="M78 52 Q100 36 122 52" fill="none" stroke="#818CF8" stroke-width="5" stroke-linecap="round"/>
+    <path d="M86 44 Q100 33 114 44" fill="none" stroke="#818CF8" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="100" cy="40" r="4" fill="#818CF8"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Bill_to_Pay.svg
+++ b/src/main/webapp/resources/icons/Search_Bill_to_Pay.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Bill document -->
+    <rect x="35" y="42" width="100" height="120" rx="6" fill="url(#grad1a)"/>
+    <rect x="45" y="56" width="80" height="6" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="45" y="70" width="64" height="6" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="45" y="84" width="72" height="6" rx="3" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="45" y="98" width="50" height="6" rx="3" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Clock face bottom-right overlapping -->
+    <circle cx="145" cy="138" r="30" fill="url(#grad1a)"/>
+    <circle cx="145" cy="138" r="24" fill="#EEF2FF"/>
+    <!-- Clock hands -->
+    <line x1="145" y1="138" x2="145" y2="122" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
+    <line x1="145" y1="138" x2="155" y2="144" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="145" cy="138" r="3" fill="#4338CA"/>
+    <!-- Clock rim ticks -->
+    <line x1="145" y1="116" x2="145" y2="120" stroke="#818CF8" stroke-width="2"/>
+    <line x1="145" y1="156" x2="145" y2="160" stroke="#818CF8" stroke-width="2"/>
+    <line x1="123" y1="138" x2="119" y2="138" stroke="#818CF8" stroke-width="2"/>
+    <line x1="167" y1="138" x2="171" y2="138" stroke="#818CF8" stroke-width="2"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Collecting_Centre_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Collecting_Centre_Bill.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Magnifying glass circle -->
+    <circle cx="88" cy="88" r="48" fill="url(#grad1a)"/>
+    <circle cx="88" cy="88" r="38" fill="#EEF2FF"/>
+    <!-- Test tube inside glass -->
+    <rect x="81" y="62" width="14" height="46" rx="7" fill="url(#grad1a)"/>
+    <!-- Liquid in tube -->
+    <rect x="81" y="90" width="14" height="18" rx="0" fill="#818CF8" opacity="0.8"/>
+    <rect x="81" y="100" width="14" height="8" rx="7" fill="#818CF8" opacity="0.8"/>
+    <!-- Tube cap -->
+    <rect x="78" y="58" width="20" height="7" rx="3" fill="#4338CA"/>
+    <!-- Handle -->
+    <line x1="126" y1="126" x2="160" y2="160" stroke="url(#grad1a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Credit_Paid_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Credit_Paid_Bill.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Credit card shape (rounded rect) -->
+    <rect x="32" y="68" width="120" height="76" rx="8" fill="url(#grad1a)"/>
+    <!-- Card magnetic stripe -->
+    <rect x="32" y="88" width="120" height="16" fill="#4338CA"/>
+    <!-- Card signature strip -->
+    <rect x="44" y="112" width="72" height="12" rx="2" fill="#EEF2FF" opacity="0.8"/>
+    <!-- Chip area -->
+    <rect x="44" y="74" width="24" height="18" rx="3" fill="#818CF8"/>
+    <!-- Magnifying glass overlay -->
+    <circle cx="148" cy="140" r="26" fill="url(#grad1a)"/>
+    <circle cx="148" cy="140" r="18" fill="#EEF2FF"/>
+    <!-- Handle -->
+    <line x1="164" y1="156" x2="178" y2="170" stroke="url(#grad1a)" stroke-width="10" stroke-linecap="round"/>
+    <!-- Inner glass X lines representing search -->
+    <line x1="139" y1="131" x2="157" y2="149" stroke="#818CF8" stroke-width="3" stroke-linecap="round"/>
+    <line x1="157" y1="131" x2="139" y2="149" stroke="#818CF8" stroke-width="3" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Credit_Paid_Bill_with_OPD_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Credit_Paid_Bill_with_OPD_Bill.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Small bill on left -->
+    <rect x="28" y="88" width="60" height="74" rx="5" fill="url(#grad1a)" opacity="0.9"/>
+    <rect x="35" y="98" width="46" height="5" rx="2" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="35" y="109" width="36" height="5" rx="2" fill="#EEF2FF" opacity="0.9"/>
+    <rect x="35" y="120" width="40" height="5" rx="2" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Small credit card on right -->
+    <rect x="100" y="94" width="66" height="42" rx="5" fill="#818CF8"/>
+    <rect x="100" y="105" width="66" height="9" fill="#4338CA"/>
+    <rect x="108" y="97" width="14" height="10" rx="2" fill="#EEF2FF" opacity="0.7"/>
+    <!-- Magnifying glass above both -->
+    <circle cx="100" cy="60" r="28" fill="url(#grad1a)"/>
+    <circle cx="100" cy="60" r="20" fill="#EEF2FF"/>
+    <line x1="115" y1="76" x2="128" y2="88" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round"/>
+    <!-- Search lines in glass -->
+    <rect x="88" y="53" width="24" height="4" rx="2" fill="url(#grad1a)"/>
+    <rect x="88" y="62" width="18" height="4" rx="2" fill="url(#grad1a)"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Opd_Bill.svg
+++ b/src/main/webapp/resources/icons/Search_Opd_Bill.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Magnifying glass outer circle -->
+    <circle cx="88" cy="88" r="48" fill="url(#grad1a)"/>
+    <!-- Inner glass area (shows bill lines) -->
+    <circle cx="88" cy="88" r="38" fill="#EEF2FF"/>
+    <!-- Bill lines inside glass -->
+    <rect x="68" y="74" width="40" height="6" rx="2" fill="url(#grad1a)"/>
+    <rect x="68" y="86" width="32" height="6" rx="2" fill="url(#grad1a)"/>
+    <rect x="68" y="98" width="36" height="6" rx="2" fill="url(#grad1a)"/>
+    <!-- Magnifying glass handle -->
+    <line x1="126" y1="126" x2="160" y2="160" stroke="url(#grad1a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Opd_Bill_Item.svg
+++ b/src/main/webapp/resources/icons/Search_Opd_Bill_Item.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Magnifying glass circle -->
+    <circle cx="88" cy="88" r="48" fill="url(#grad1a)"/>
+    <circle cx="88" cy="88" r="38" fill="#EEF2FF"/>
+    <!-- Horizontal list lines visible through glass -->
+    <rect x="65" y="70" width="46" height="5" rx="2" fill="url(#grad1a)"/>
+    <rect x="65" y="81" width="36" height="5" rx="2" fill="url(#grad1a)"/>
+    <rect x="65" y="92" width="42" height="5" rx="2" fill="url(#grad1a)"/>
+    <rect x="65" y="103" width="30" height="5" rx="2" fill="url(#grad1a)"/>
+    <!-- Small bullet dots -->
+    <circle cx="62" cy="72" r="3" fill="#818CF8"/>
+    <circle cx="62" cy="83" r="3" fill="#818CF8"/>
+    <circle cx="62" cy="94" r="3" fill="#818CF8"/>
+    <circle cx="62" cy="105" r="3" fill="#818CF8"/>
+    <!-- Handle -->
+    <line x1="126" y1="126" x2="160" y2="160" stroke="url(#grad1a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Search_Opd_Payment.svg
+++ b/src/main/webapp/resources/icons/Search_Opd_Payment.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
+  <g filter="url(#shad1)">
+    <!-- Magnifying glass circle -->
+    <circle cx="88" cy="88" r="48" fill="url(#grad1a)"/>
+    <circle cx="88" cy="88" r="38" fill="#EEF2FF"/>
+    <!-- Coin inside glass -->
+    <circle cx="88" cy="88" r="22" fill="#818CF8"/>
+    <circle cx="88" cy="88" r="16" fill="url(#grad1a)"/>
+    <text x="88" y="94" text-anchor="middle" font-size="16" font-weight="bold" fill="#EEF2FF" font-family="sans-serif">$</text>
+    <!-- Handle -->
+    <line x1="126" y1="126" x2="160" y2="160" stroke="url(#grad1a)" stroke-width="12" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/Shift_End_Summary.svg
+++ b/src/main/webapp/resources/icons/Shift_End_Summary.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FFFBEB"/>
+  <g filter="url(#shad1)">
+    <!-- Clock face outer ring -->
+    <circle cx="100" cy="88" r="50" fill="url(#grad1a)"/>
+    <circle cx="100" cy="88" r="42" fill="#FFFBEB"/>
+    <!-- Clock ticks -->
+    <line x1="100" y1="48" x2="100" y2="54" stroke="#D97706" stroke-width="3"/>
+    <line x1="100" y1="122" x2="100" y2="128" stroke="#D97706" stroke-width="3"/>
+    <line x1="60" y1="88" x2="54" y2="88" stroke="#D97706" stroke-width="3"/>
+    <line x1="140" y1="88" x2="146" y2="88" stroke="#D97706" stroke-width="3"/>
+    <!-- Hour hand pointing to end-of-shift (5 o'clock position) -->
+    <line x1="100" y1="88" x2="118" y2="106" stroke="#B45309" stroke-width="5" stroke-linecap="round"/>
+    <!-- Minute hand pointing up (12) -->
+    <line x1="100" y1="88" x2="100" y2="58" stroke="#D97706" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="100" cy="88" r="5" fill="#B45309"/>
+    <!-- Checkmark below clock -->
+    <path d="M72 152 L88 168 L128 138" fill="none" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Added **40 new SVG icon files** to `resources/icons/` covering all OPD and Cashier dashboard tiles:
  - **34 OPD icons** — indigo palette (`#EEF2FF` bg, `#4F46E5→#4338CA` gradient, `#818CF8` accent) across PATIENT_MANAGEMENT, OPD_BILLING, PAYMENTS_AND_REFUNDS, DOCTOR_AND_CHANNEL, LAB_AND_REPORTS, OPD_SUMMARIES
  - **6 Cashier icons** — amber palette (`#FFFBEB` bg, `#D97706→#B45309` gradient, `#FBBF24` accent) for CASHIER group
- Updated `Icon.getImage()` to return `.svg` for all OPD and Cashier `IconGroup` values (same pattern as the teal inpatient set from PR #21609)
- Updated `home.xhtml`: all 33 existing OPD/Cashier tiles switched from `library="images"` to `library="icons"` with correct SVG names; **5 previously missing tiles added**: `Cashier_Summaries`, `Shift_End_Summary`, `Day_End_Summary`, `Manage_Shift_Fund_Bills`, `Channel_Booking`
- Updated `Investigation_Trace.svg` and `Patient_Deposit_Management.svg` to indigo palette (both belong to OPD groups, not inpatient)

Fixes the root cause: all old `home/*.svg` files use `fill="currentColor"` which defaults to black when loaded as an external `<img>` via `p:graphicImage`. The new hardcoded-fill SVGs render with full colour.

## Test plan

- [ ] Login to local app as `buddhika` → select **OPD** department → verify dashboard shows 34 indigo coloured tiles (all distinct icons, no black icons)
- [ ] Login as `buddhika` → select **Inward** department → verify existing teal inpatient tiles still render correctly (no regression)
- [ ] Verify 5 newly added tiles render and navigate correctly: Cashier Summaries, Shift End Summary, Day End Summary, Manage Shift Fund Bills, Channel Booking
- [ ] Verify Cashier group tiles (amber) are visually distinct from OPD (indigo) and Inpatient (teal)

Closes #21692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new home-menu tiles for Cashier-related actions.
  * Updated many home screen icons to use the newer icon set, improving visual consistency across OPD, payment, search, doctor, pharmacy, admin, inpatient, and channel sections.

* **Bug Fixes**
  * Improved icon selection so more menu items now display in the correct image format, helping prevent missing or inconsistent icons on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->