### PR TITLE
feat(icons): coloured SVG icons for Channeling, Lab and Pharmacy modules

### DIFF
--- a/src/main/java/com/divudi/core/data/Icon.java
+++ b/src/main/java/com/divudi/core/data/Icon.java
@@ -191,10 +191,23 @@ public enum Icon {
             IconGroup.PATIENT_MANAGEMENT,
             IconGroup.OPD_BILLING,
             IconGroup.PAYMENTS_AND_REFUNDS,
-            IconGroup.DOCTOR_AND_CHANNEL,
-            IconGroup.LAB_AND_REPORTS,
             IconGroup.OPD_SUMMARIES,
             IconGroup.CASHIER
+    );
+
+    private static final java.util.Set<IconGroup> CHANNELING_GROUPS = java.util.EnumSet.of(
+            IconGroup.DOCTOR_AND_CHANNEL
+    );
+
+    private static final java.util.Set<IconGroup> LAB_GROUPS = java.util.EnumSet.of(
+            IconGroup.LAB_AND_REPORTS
+    );
+
+    private static final java.util.Set<IconGroup> PHARMACY_GROUPS = java.util.EnumSet.of(
+            IconGroup.PHARMACY_SALES,
+            IconGroup.PHARMACY_RETURNS,
+            IconGroup.PHARMACY_STOCK,
+            IconGroup.PHARMACY_REPORTS
     );
 
     private final String label;
@@ -215,14 +228,17 @@ public enum Icon {
 
     /**
      * Returns the image filename for this icon.
-     * Inpatient-group icons use teal .svg; OPD/Cashier-group icons use indigo/amber .svg;
-     * icons from Patient_Deposit_Management onwards also use .svg; all others use .png (legacy).
+     * Each module family has its own coloured SVG set; all others fall back to legacy PNG.
      */
     public String getImage() {
-        if (iconGroup != null && INPATIENT_GROUPS.contains(iconGroup)) {
-            return this.name() + ".svg";
+        if (iconGroup == null) {
+            return this.name() + ".png";
         }
-        if (iconGroup != null && OPD_GROUPS.contains(iconGroup)) {
+        if (INPATIENT_GROUPS.contains(iconGroup)
+                || OPD_GROUPS.contains(iconGroup)
+                || CHANNELING_GROUPS.contains(iconGroup)
+                || LAB_GROUPS.contains(iconGroup)
+                || PHARMACY_GROUPS.contains(iconGroup)) {
             return this.name() + ".svg";
         }
         if (this.ordinal() >= Patient_Deposit_Management.ordinal()) {

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -143,7 +143,7 @@
                             action="#{pharmacyController.navigateToPharmacyAnalytics()}"
                             ajax="false" 
                             styleClass="svg-link">
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-analytics.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_analytics.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Pharmacy Analytics"/>
                         </p:commandLink>
                     </h:form>
@@ -600,7 +600,7 @@
 
                             actionListener="#{pharmacySaleController.resetAll()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/cart-shopping-solid.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_sale.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Pharmacy - Retail Sale" />
                         </p:commandLink>
                     </h:form>
@@ -617,7 +617,7 @@
                             action="#{pharmacySaleForCashierController.navigateToPharmacyBillForCashier()}" 
 
                             actionListener="#{pharmacySaleController.resetAll()}" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/cashier.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_sale_for_cashier.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Retail Sale for cashier"  />
                         </p:commandLink>
                     </h:form>
@@ -633,7 +633,7 @@
                             action="#{pharmacySaleController.navigateToPharmacySaleWithoutStocks}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/analytics.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_sale_without_stock.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Sale without Stocks" />
                         </p:commandLink>
                     </h:form>
@@ -650,7 +650,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_Search_sale_bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Sale Bill" />
                         </p:commandLink>
                     </h:form>
@@ -666,7 +666,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_sale_pre_bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Sale Pre Bill" />
                         </p:commandLink>
                     </h:form>
@@ -682,7 +682,7 @@
                             actionListener="#{searchController.makeListNull}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_sale_bill_item.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Sale Bill Items" />
                         </p:commandLink>
                     </h:form>
@@ -699,7 +699,7 @@
                             actionListener="#{searchController.makeListNull}"   
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/refund1.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_return_items_only.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Return - Items Only" />
                         </p:commandLink>
                     </h:form>
@@ -716,7 +716,7 @@
                             actionListener="#{searchController.makeListNull}"   
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/refund1.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_return_items_and_payments.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Return - Items and Payments" />
                         </p:commandLink>
                     </h:form>
@@ -733,7 +733,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_return_bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Return Bill (Item)" />
                         </p:commandLink>
                     </h:form>
@@ -751,7 +751,7 @@
 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/analytics.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_add_to_stock.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Add To Stock" />
                         </p:commandLink>
                     </h:form>
@@ -1280,7 +1280,7 @@
                             action="/pharmacy/pharmacy_issue?faces-redirect=true"  
                             actionListener="#{pharmacyIssueController.resetAll()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_issue.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Issue" />
                         </p:commandLink>
                     </h:form>
@@ -1296,7 +1296,7 @@
                             action="/pharmacy/pharmacy_issue?faces-redirect=true"
                             actionListener="#{pharmacyIssueController.resetAll()}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-disposal-issue.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_disposal_issue.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Pharmacy Disposal - Direct Issue" />
                         </p:commandLink>
                     </h:form>
@@ -1312,7 +1312,7 @@
                             actionListener="#{searchController.makeListNull}"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_issue_bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Issue Bill" />
                         </p:commandLink>
                     </h:form>
@@ -1329,7 +1329,7 @@
                             actionListener="#{searchController.makeListNull}"   
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_issue_bill_items.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Issue Bill Items" />
                         </p:commandLink>
                     </h:form>
@@ -1346,7 +1346,7 @@
                             actionListener="#{searchController.makeListNull}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_search_issue_return_bill.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Search Issue Return Bill" />
                         </p:commandLink>
                     </h:form>
@@ -1361,7 +1361,7 @@
                             ajax="false" 
                             action="/store/issue_rate_margin_manager?faces-redirect=true" 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_uint_issue_margin.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Unit Issue Margin" />
                         </p:commandLink>
                     </h:form>
@@ -1378,7 +1378,7 @@
                             actionListener="#{searchController.makeListNull()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_request.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Request" />
                         </p:commandLink>
                     </h:form>
@@ -1395,7 +1395,7 @@
                             actionListener="#{searchController.makeListNull()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_issue_for_request.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Issue for Requests" />
                         </p:commandLink>
                     </h:form>
@@ -1412,7 +1412,7 @@
                             actionListener="#{transferIssueDirectController.makeNull()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_direct_issue.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Direct Issue" />
                         </p:commandLink>
                     </h:form>
@@ -1429,7 +1429,7 @@
                             actionListener="#{searchController.makeListNull()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_receive.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Receive" />
                         </p:commandLink>
                     </h:form>
@@ -1446,7 +1446,7 @@
                             actionListener="#{searchController.makeListNull()}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_disbursement_reports.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Reports" />
                         </p:commandLink>
                     </h:form>
@@ -1712,7 +1712,7 @@
                             actionListener="#{billSearch.recreateModel}" 
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-default.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_item_search.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Item Search" />
                         </p:commandLink>
                     </h:form>
@@ -1728,7 +1728,7 @@
                             action="/pharmacy/pharmacy_search?faces-redirect=true"
                             actionListener="#{billSearch.recreateModel}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-bill-search.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_bill_search.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Pharmacy Bill Search" />
                         </p:commandLink>
                     </h:form>
@@ -1744,7 +1744,7 @@
                             action="#{searchController.navigateToPharmacyBillSearch}"
                             actionListener="#{billSearch.recreateModel}"
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/pharmacy-bill-search-new.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_bill_search_new.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Pharmacy Bill Search (New)" />
                         </p:commandLink>
                     </h:form>
@@ -1760,7 +1760,7 @@
                             action="/pharmacy/pharmacy_reports_index?faces-redirect=true"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/reports.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_generate_report.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Generate Reports" />
                         </p:commandLink>
                     </h:form>
@@ -1819,7 +1819,7 @@
                             action="/pharmacy/pharmacy_summery_index?faces-redirect=true"
 
                             styleClass="svg-link" >
-                            <p:graphicImage class="img-thumbnail" cache="true" library="images" name="home/summary-report.svg" style="cursor: pointer;" width="80" height="80"/>
+                            <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_summary_views.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Summary Views" />
                         </p:commandLink>
                     </h:form>

--- a/src/main/webapp/resources/icons/Channel_Booking.svg
+++ b/src/main/webapp/resources/icons/Channel_Booking.svg
@@ -1,39 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gchb" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shchb" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Calendar rectangle -->
-    <rect x="32" y="50" width="136" height="118" rx="7" fill="url(#grad1a)"/>
-    <!-- Calendar header bar -->
-    <rect x="32" y="50" width="136" height="28" rx="7" fill="#4338CA"/>
-    <rect x="32" y="64" width="136" height="14" fill="#4338CA"/>
-    <!-- Calendar rings -->
-    <rect x="62" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
-    <rect x="128" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
-    <!-- Calendar grid - 4 cols x 3 rows -->
-    <rect x="42" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="72" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="102" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="42" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <!-- Highlighted cell -->
-    <rect x="72" y="114" width="24" height="18" rx="3" fill="#818CF8"/>
-    <rect x="102" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="42" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="72" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="102" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shchb)">
+
+    <rect x="46" y="70" width="108" height="92" rx="8" fill="url(#gchb)"/>
+    <rect x="46" y="70" width="108" height="26" rx="8" fill="#059669"/>
+    <rect x="46" y="86" width="108" height="10" fill="#059669"/>
+    <rect x="68" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <rect x="120" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <polyline points="66,122 86,142 134,96" fill="none" stroke="white" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Channel_Booking_by_Dates.svg
+++ b/src/main/webapp/resources/icons/Channel_Booking_by_Dates.svg
@@ -1,40 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gcbd" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shcbd" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Calendar rectangle -->
-    <rect x="32" y="50" width="136" height="118" rx="7" fill="url(#grad1a)"/>
-    <!-- Header -->
-    <rect x="32" y="50" width="136" height="28" rx="7" fill="#4338CA"/>
-    <rect x="32" y="64" width="136" height="14" fill="#4338CA"/>
-    <!-- Calendar rings -->
-    <rect x="62" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
-    <rect x="128" y="40" width="10" height="24" rx="5" fill="#818CF8"/>
-    <!-- Grid row 1 -->
-    <rect x="42" y="90" width="24" height="18" rx="3" fill="#818CF8"/>
-    <rect x="72" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="102" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="90" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <!-- Row 2 — second highlight in different row/col -->
-    <rect x="42" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="72" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="102" y="114" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="114" width="24" height="18" rx="3" fill="#818CF8"/>
-    <!-- Row 3 -->
-    <rect x="42" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="72" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="102" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
-    <rect x="132" y="138" width="24" height="18" rx="3" fill="#EEF2FF" opacity="0.5"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shcbd)">
+
+    <rect x="46" y="70" width="108" height="92" rx="8" fill="url(#gcbd)"/>
+    <rect x="46" y="70" width="108" height="26" rx="8" fill="#059669"/>
+    <rect x="46" y="86" width="108" height="10" fill="#059669"/>
+    <rect x="68" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <rect x="120" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <rect x="56" y="107" width="28" height="11" rx="4" fill="#6EE7B7"/>
+    <line x1="87" y1="112" x2="113" y2="112" stroke="white" stroke-width="3.5" stroke-linecap="round"/>
+    <polyline points="106,106 114,112 106,118" fill="none" stroke="white" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="116" y="107" width="28" height="11" rx="4" fill="white" opacity="0.85"/>
+    <rect x="56" y="128" width="88" height="8" rx="3" fill="white" opacity="0.5"/>
+    <rect x="56" y="143" width="60" height="8" rx="3" fill="white" opacity="0.4"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Channel_Scheduling.svg
+++ b/src/main/webapp/resources/icons/Channel_Scheduling.svg
@@ -1,35 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gchs" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shchs" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- 3x3 time-slot grid with alternating filled/empty -->
-    <!-- Background panel -->
-    <rect x="38" y="46" width="124" height="110" rx="8" fill="url(#grad1a)"/>
-    <!-- Header bar -->
-    <rect x="38" y="46" width="124" height="20" rx="8" fill="#4338CA"/>
-    <rect x="38" y="56" width="124" height="10" fill="#4338CA"/>
-    <!-- Row 1: filled, empty, filled -->
-    <rect x="48" y="74" width="32" height="24" rx="4" fill="#818CF8"/>
-    <rect x="86" y="74" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
-    <rect x="124" y="74" width="32" height="24" rx="4" fill="#818CF8"/>
-    <!-- Row 2: empty, filled, empty -->
-    <rect x="48" y="104" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
-    <rect x="86" y="104" width="32" height="24" rx="4" fill="#818CF8"/>
-    <rect x="124" y="104" width="32" height="24" rx="4" fill="#EEF2FF" opacity="0.4"/>
-    <!-- Row 3: filled, empty, filled -->
-    <rect x="48" y="134" width="32" height="14" rx="4" fill="#818CF8"/>
-    <rect x="86" y="134" width="32" height="14" rx="4" fill="#EEF2FF" opacity="0.4"/>
-    <rect x="124" y="134" width="32" height="14" rx="4" fill="#818CF8"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shchs)">
+
+    <rect x="40" y="50" width="120" height="112" rx="8" fill="none" stroke="url(#gchs)" stroke-width="5"/>
+    <rect x="40" y="50" width="120" height="23" rx="8" fill="url(#gchs)"/>
+    <rect x="40" y="63" width="120" height="10" fill="#059669"/>
+    <line x1="40" y1="90" x2="160" y2="90" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <line x1="40" y1="115" x2="160" y2="115" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <line x1="40" y1="140" x2="160" y2="140" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <line x1="80" y1="73" x2="80" y2="162" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <line x1="120" y1="73" x2="120" y2="162" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <rect x="43" y="74" width="34" height="13" rx="3" fill="white" opacity="0.65"/>
+    <rect x="83" y="93" width="34" height="21" rx="3" fill="#6EE7B7" opacity="0.7"/>
+    <rect x="123" y="93" width="34" height="21" rx="3" fill="white" opacity="0.5"/>
+    <rect x="83" y="118" width="34" height="21" rx="3" fill="white" opacity="0.4"/>
+    <rect x="123" y="93" width="34" height="46" rx="3" fill="#10B981" opacity="0.55"/>
+    <rect x="43" y="118" width="34" height="21" rx="3" fill="#6EE7B7" opacity="0.5"/>
+    <rect x="43" y="143" width="34" height="16" rx="3" fill="white" opacity="0.35"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Doctor_Mark_in.svg
+++ b/src/main/webapp/resources/icons/Doctor_Mark_in.svg
@@ -1,29 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gdmi" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shdmi" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Stethoscope earpiece circle -->
-    <circle cx="72" cy="52" r="12" fill="url(#grad1a)"/>
-    <circle cx="72" cy="52" r="7" fill="#EEF2FF"/>
-    <!-- Stethoscope tube - curved path from earpiece down to chest piece -->
-    <path d="M72 64 Q72 100 100 100 Q128 100 128 130" fill="none" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round"/>
-    <!-- Chest piece (circle) -->
-    <circle cx="128" cy="148" r="16" fill="url(#grad1a)"/>
-    <circle cx="128" cy="148" r="10" fill="#EEF2FF"/>
-    <circle cx="128" cy="148" r="5" fill="#818CF8"/>
-    <!-- Right-pointing arrow (entering) -->
-    <rect x="35" y="94" width="40" height="12" rx="6" fill="#818CF8"/>
-    <path d="M70 88 L86 100 L70 112" fill="#818CF8"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shdmi)">
+
+    <circle cx="82" cy="68" r="22" fill="url(#gdmi)"/>
+    <path d="M52 148 Q52 114 82 114 Q112 114 112 148 L112 158 Q112 163 107 163 L57 163 Q52 163 52 158 Z" fill="url(#gdmi)"/>
+    <line x1="127" y1="93" x2="160" y2="93" stroke="#6EE7B7" stroke-width="9" stroke-linecap="round"/>
+    <polyline points="143,76 161,93 143,110" fill="none" stroke="#6EE7B7" stroke-width="8" stroke-linejoin="round" stroke-linecap="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Doctor_Mark_out.svg
+++ b/src/main/webapp/resources/icons/Doctor_Mark_out.svg
@@ -1,29 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gdmo" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shdmo" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Stethoscope earpiece circle -->
-    <circle cx="72" cy="52" r="12" fill="url(#grad1a)"/>
-    <circle cx="72" cy="52" r="7" fill="#EEF2FF"/>
-    <!-- Stethoscope tube -->
-    <path d="M72 64 Q72 100 100 100 Q128 100 128 130" fill="none" stroke="url(#grad1a)" stroke-width="8" stroke-linecap="round"/>
-    <!-- Chest piece -->
-    <circle cx="128" cy="148" r="16" fill="url(#grad1a)"/>
-    <circle cx="128" cy="148" r="10" fill="#EEF2FF"/>
-    <circle cx="128" cy="148" r="5" fill="#818CF8"/>
-    <!-- Left-pointing arrow (leaving) -->
-    <rect x="115" y="94" width="40" height="12" rx="6" fill="#818CF8"/>
-    <path d="M120 88 L104 100 L120 112" fill="#818CF8"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shdmo)">
+
+    <circle cx="118" cy="68" r="22" fill="url(#gdmo)"/>
+    <path d="M88 148 Q88 114 118 114 Q148 114 148 148 L148 158 Q148 163 143 163 L93 163 Q88 163 88 158 Z" fill="url(#gdmo)"/>
+    <line x1="73" y1="93" x2="40" y2="93" stroke="#6EE7B7" stroke-width="9" stroke-linecap="round"/>
+    <polyline points="57,76 39,93 57,110" fill="none" stroke="#6EE7B7" stroke-width="8" stroke-linejoin="round" stroke-linecap="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Doctor_Working_Times.svg
+++ b/src/main/webapp/resources/icons/Doctor_Working_Times.svg
@@ -1,38 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gdwt" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shdwt" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Stethoscope earpiece -->
-    <circle cx="62" cy="48" r="11" fill="url(#grad1a)"/>
-    <circle cx="62" cy="48" r="6" fill="#EEF2FF"/>
-    <!-- Stethoscope tube -->
-    <path d="M62 59 Q62 90 88 92 Q108 94 108 118" fill="none" stroke="url(#grad1a)" stroke-width="7" stroke-linecap="round"/>
-    <!-- Chest piece small -->
-    <circle cx="108" cy="132" r="12" fill="url(#grad1a)"/>
-    <circle cx="108" cy="132" r="7" fill="#EEF2FF"/>
-    <circle cx="108" cy="132" r="3" fill="#818CF8"/>
-    <!-- Clock circle overlapping bottom-right -->
-    <circle cx="148" cy="140" r="32" fill="url(#grad1a)"/>
-    <circle cx="148" cy="140" r="24" fill="#EEF2FF"/>
-    <!-- Clock hands -->
-    <line x1="148" y1="140" x2="148" y2="122" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
-    <line x1="148" y1="140" x2="160" y2="148" stroke="#4F46E5" stroke-width="3" stroke-linecap="round"/>
-    <circle cx="148" cy="140" r="3" fill="#4338CA"/>
-    <!-- Clock ticks -->
-    <line x1="148" y1="118" x2="148" y2="122" stroke="#818CF8" stroke-width="2"/>
-    <line x1="148" y1="158" x2="148" y2="162" stroke="#818CF8" stroke-width="2"/>
-    <line x1="126" y1="140" x2="122" y2="140" stroke="#818CF8" stroke-width="2"/>
-    <line x1="170" y1="140" x2="174" y2="140" stroke="#818CF8" stroke-width="2"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shdwt)">
+
+    <circle cx="100" cy="100" r="58" fill="none" stroke="url(#gdwt)" stroke-width="9"/>
+    <line x1="100" y1="100" x2="100" y2="54" stroke="#059669" stroke-width="8" stroke-linecap="round"/>
+    <line x1="100" y1="100" x2="133" y2="110" stroke="#10B981" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="100" cy="100" r="6" fill="#059669"/>
+    <circle cx="100" cy="46" r="5" fill="#059669"/>
+    <circle cx="154" cy="100" r="5" fill="#059669"/>
+    <circle cx="100" cy="154" r="5" fill="#059669"/>
+    <circle cx="46" cy="100" r="5" fill="#059669"/>
+    <line x1="130" y1="54" x2="125" y2="63" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+    <line x1="146" y1="70" x2="137" y2="75" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+    <line x1="70" y1="54" x2="75" y2="63" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+    <line x1="54" y1="70" x2="63" y2="75" stroke="#10B981" stroke-width="3" stroke-linecap="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Investigation_Trace.svg
+++ b/src/main/webapp/resources/icons/Investigation_Trace.svg
@@ -1,32 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="givt" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06B6D4;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0891B2;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shivt" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Microscope base -->
-    <rect x="60" y="155" width="80" height="14" rx="6" fill="url(#grad1a)"/>
-    <!-- Arm vertical post -->
-    <rect x="90" y="80" width="14" height="80" rx="5" fill="url(#grad1a)"/>
-    <!-- Stage (horizontal platform) -->
-    <rect x="68" y="120" width="64" height="10" rx="4" fill="#4338CA"/>
-    <!-- Eyepiece tube angled -->
-    <rect x="75" y="44" width="12" height="48" rx="6" fill="url(#grad1a)" transform="rotate(-15, 81, 68)"/>
-    <!-- Eyepiece top cap -->
-    <ellipse cx="72" cy="42" rx="10" ry="6" fill="#4338CA"/>
-    <!-- Objective lens -->
-    <rect x="92" y="128" width="10" height="20" rx="5" fill="#818CF8"/>
-    <!-- Sample on stage -->
-    <circle cx="97" cy="115" r="8" fill="#EEF2FF" stroke="#818CF8" stroke-width="2"/>
-    <circle cx="97" cy="115" r="3" fill="#818CF8"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFEFF"/>
+  <g filter="url(#shivt)">
+
+    <circle cx="80" cy="68" r="22" fill="url(#givt)"/>
+    <path d="M50 148 Q50 113 80 113 Q110 113 110 148 L110 158 Q110 163 105 163 L55 163 Q50 163 50 158 Z" fill="url(#givt)"/>
+    <circle cx="142" cy="130" r="24" fill="none" stroke="#67E8F9" stroke-width="9"/>
+    <line x1="158" y1="146" x2="172" y2="160" stroke="#67E8F9" stroke-width="9" stroke-linecap="round"/>
+    <circle cx="136" cy="124" r="10" fill="none" stroke="#67E8F9" stroke-width="3" opacity="0.5"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Lab_Report_Print.svg
+++ b/src/main/webapp/resources/icons/Lab_Report_Print.svg
@@ -1,35 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="glrp" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06B6D4;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0891B2;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shlrp" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Conical flask/beaker body -->
-    <path d="M84 38 L84 72 L52 118 Q48 128 58 132 L142 132 Q152 128 148 118 L116 72 L116 38 Z" fill="url(#grad1a)"/>
-    <!-- Flask neck top -->
-    <rect x="80" y="34" width="40" height="10" rx="5" fill="#4338CA"/>
-    <!-- Liquid in flask -->
-    <path d="M62 122 L138 122 Q144 124 140 128 L60 128 Q56 124 62 122 Z" fill="#818CF8" opacity="0.8"/>
-    <!-- Bubbles in liquid -->
-    <circle cx="82" cy="120" r="4" fill="#EEF2FF" opacity="0.6"/>
-    <circle cx="100" cy="118" r="3" fill="#EEF2FF" opacity="0.6"/>
-    <circle cx="118" cy="121" r="4" fill="#EEF2FF" opacity="0.6"/>
-    <!-- Printer rectangle below -->
-    <rect x="42" y="140" width="116" height="34" rx="6" fill="url(#grad1a)"/>
-    <!-- Printer slot -->
-    <rect x="56" y="148" width="88" height="6" rx="2" fill="#EEF2FF" opacity="0.5"/>
-    <!-- Paper coming out -->
-    <rect x="64" y="168" width="72" height="18" rx="3" fill="#EEF2FF"/>
-    <rect x="70" y="172" width="60" height="4" rx="1" fill="#818CF8" opacity="0.6"/>
-    <rect x="70" y="178" width="44" height="4" rx="1" fill="#818CF8" opacity="0.4"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFEFF"/>
+  <g filter="url(#shlrp)">
+
+    <rect x="40" y="95" width="120" height="68" rx="8" fill="url(#glrp)"/>
+    <rect x="62" y="60" width="76" height="44" rx="4" fill="white"/>
+    <rect x="72" y="69" width="56" height="6" rx="2" fill="#06B6D4" opacity="0.35"/>
+    <rect x="72" y="80" width="42" height="6" rx="2" fill="#06B6D4" opacity="0.35"/>
+    <rect x="62" y="98" width="76" height="10" fill="#0891B2"/>
+    <rect x="68" y="147" width="64" height="28" rx="4" fill="white"/>
+    <rect x="76" y="156" width="48" height="5" rx="2" fill="#0891B2" opacity="0.4"/>
+    <rect x="76" y="165" width="32" height="5" rx="2" fill="#0891B2" opacity="0.4"/>
+    <circle cx="136" cy="122" r="7" fill="#67E8F9"/>
+    <circle cx="118" cy="122" r="4" fill="#67E8F9" opacity="0.6"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Manage_Appointment.svg
+++ b/src/main/webapp/resources/icons/Manage_Appointment.svg
@@ -1,39 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad8a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0E7490;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#155E75;stop-opacity:1"/>
+    <linearGradient id="gmap" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad8" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shmap" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#F0FDFA"/>
-  <g filter="url(#shad8)">
-    <!-- Calendar body -->
-    <rect x="35" y="48" width="130" height="110" rx="8" fill="url(#grad8a)"/>
-    <rect x="35" y="48" width="130" height="30" rx="8" fill="#155E75"/>
-    <rect x="35" y="65" width="130" height="13" fill="#155E75"/>
-    <!-- Binding tabs -->
-    <rect x="60" y="38" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
-    <rect x="130" y="38" width="10" height="20" rx="5" fill="white" opacity="0.9"/>
-    <!-- Calendar rows -->
-    <line x1="35" y1="98" x2="165" y2="98" stroke="white" stroke-width="0.8" opacity="0.25"/>
-    <line x1="35" y1="118" x2="165" y2="118" stroke="white" stroke-width="0.8" opacity="0.25"/>
-    <line x1="35" y1="138" x2="165" y2="138" stroke="white" stroke-width="0.8" opacity="0.25"/>
-    <!-- Day cells with checkmarks -->
-    <rect x="50" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
-    <rect x="78" y="104" width="18" height="14" rx="3" fill="#22D3EE"/>
-    <rect x="106" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
-    <rect x="134" y="104" width="18" height="14" rx="3" fill="white" opacity="0.5"/>
-    <!-- Checkmark on highlighted cell -->
-    <path d="M81 111 L85 115 L91 108" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <!-- Large checkmark overlay -->
-    <circle cx="148" cy="148" r="22" fill="white"/>
-    <circle cx="148" cy="148" r="18" fill="#22D3EE"/>
-    <path d="M137 148 L145 156 L160 140" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shmap)">
+
+    <rect x="46" y="70" width="108" height="92" rx="8" fill="url(#gmap)"/>
+    <rect x="46" y="70" width="108" height="26" rx="8" fill="#059669"/>
+    <rect x="46" y="86" width="108" height="10" fill="#059669"/>
+    <rect x="68" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <rect x="120" y="61" width="12" height="22" rx="5" fill="#6EE7B7"/>
+    <circle cx="100" cy="114" r="15" fill="white"/>
+    <path d="M74 158 Q74 140 100 140 Q126 140 126 158 L126 162 L74 162 Z" fill="white"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Manage_Token.svg
+++ b/src/main/webapp/resources/icons/Manage_Token.svg
@@ -1,30 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="gmto" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shmto" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Ticket/token main body -->
-    <rect x="45" y="55" width="120" height="90" rx="10" fill="url(#grad1a)"/>
-    <!-- Tear-off perforation on left -->
-    <line x1="72" y1="55" x2="72" y2="145" stroke="#EEF2FF" stroke-width="2" stroke-dasharray="5,4"/>
-    <!-- Notch circles on edges for tear-off -->
-    <circle cx="72" cy="55" r="7" fill="#EEF2FF"/>
-    <circle cx="72" cy="145" r="7" fill="#EEF2FF"/>
-    <!-- Left stub area -->
-    <rect x="45" y="55" width="27" height="90" rx="10" fill="#4338CA"/>
-    <!-- Large number "1" on main body -->
-    <text x="128" y="118" text-anchor="middle" font-size="58" font-weight="bold" fill="#EEF2FF" font-family="sans-serif" opacity="0.95">1</text>
-    <!-- Token label on left stub -->
-    <text x="58" y="105" text-anchor="middle" font-size="11" font-weight="bold" fill="#818CF8" font-family="sans-serif" transform="rotate(-90, 58, 100)">TOKEN</text>
+  <circle cx="100" cy="100" r="95" fill="#ECFDF5"/>
+  <g filter="url(#shmto)">
+
+    <rect x="36" y="74" width="128" height="55" rx="10" fill="url(#gmto)"/>
+    <circle cx="36" cy="101" r="14" fill="#ECFDF5"/>
+    <circle cx="164" cy="101" r="14" fill="#ECFDF5"/>
+    <line x1="50" y1="101" x2="150" y2="101" stroke="#6EE7B7" stroke-width="2.5" stroke-dasharray="7,5"/>
+    <rect x="52" y="81" width="36" height="12" rx="5" fill="white" opacity="0.8"/>
+    <rect x="52" y="100" width="36" height="12" rx="5" fill="#6EE7B7" opacity="0.65"/>
+    <circle cx="133" cy="89" r="17" fill="none" stroke="#6EE7B7" stroke-width="4" opacity="0.7"/>
+    <line x1="133" y1="89" x2="133" y2="80" stroke="#6EE7B7" stroke-width="3.5" stroke-linecap="round"/>
+    <line x1="133" y1="89" x2="139" y2="94" stroke="#6EE7B7" stroke-width="3.5" stroke-linecap="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/Report_Execution_Logs.svg
+++ b/src/main/webapp/resources/icons/Report_Execution_Logs.svg
@@ -1,33 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
   <defs>
-    <linearGradient id="grad1a" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#4338CA;stop-opacity:1"/>
+    <linearGradient id="grel" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06B6D4;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0891B2;stop-opacity:1"/>
     </linearGradient>
-    <filter id="shad1" x="-20%" y="-20%" width="140%" height="140%">
+    <filter id="shrel" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
       <feOffset dx="1" dy="1" result="offsetblur"/>
       <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
       <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
-  <circle cx="100" cy="100" r="95" fill="#EEF2FF"/>
-  <g filter="url(#shad1)">
-    <!-- Document page -->
-    <rect x="38" y="38" width="118" height="140" rx="7" fill="url(#grad1a)"/>
-    <!-- Page fold top-right -->
-    <path d="M128 38 L156 38 L156 66 Z" fill="#4338CA"/>
-    <path d="M128 38 L128 66 L156 66" fill="#EEF2FF" opacity="0.2"/>
-    <!-- Text lines -->
-    <rect x="52" y="70" width="88" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
-    <rect x="52" y="86" width="72" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
-    <rect x="52" y="102" width="82" height="8" rx="3" fill="#EEF2FF" opacity="0.9"/>
-    <rect x="52" y="118" width="60" height="8" rx="3" fill="#EEF2FF" opacity="0.7"/>
-    <!-- Clock icon at top-right corner -->
-    <circle cx="148" cy="55" r="18" fill="#818CF8"/>
-    <circle cx="148" cy="55" r="12" fill="#EEF2FF"/>
-    <line x1="148" y1="55" x2="148" y2="46" stroke="#4F46E5" stroke-width="2" stroke-linecap="round"/>
-    <line x1="148" y1="55" x2="154" y2="59" stroke="#4F46E5" stroke-width="2" stroke-linecap="round"/>
-    <circle cx="148" cy="55" r="2" fill="#4338CA"/>
+  <circle cx="100" cy="100" r="95" fill="#ECFEFF"/>
+  <g filter="url(#shrel)">
+
+    <rect x="50" y="46" width="90" height="114" rx="8" fill="url(#grel)"/>
+    <polygon points="118,46 140,68 118,68" fill="#0891B2"/>
+    <rect x="50" y="46" width="68" height="114" rx="8" fill="url(#grel)"/>
+    <rect x="50" y="46" width="90" height="114" rx="8" fill="url(#grel)" opacity="0.88"/>
+    <rect x="65" y="65" width="70" height="6" rx="2" fill="white"/>
+    <rect x="65" y="77" width="54" height="6" rx="2" fill="white" opacity="0.8"/>
+    <rect x="65" y="89" width="62" height="6" rx="2" fill="white" opacity="0.7"/>
+    <rect x="65" y="101" width="44" height="6" rx="2" fill="white" opacity="0.6"/>
+    <circle cx="130" cy="145" r="22" fill="#ECFEFF"/>
+    <circle cx="130" cy="145" r="15" fill="none" stroke="#06B6D4" stroke-width="4"/>
+    <line x1="130" y1="145" x2="130" y2="134" stroke="#06B6D4" stroke-width="3" stroke-linecap="round"/>
+    <line x1="130" y1="145" x2="138" y2="150" stroke="#06B6D4" stroke-width="3" stroke-linecap="round"/>
+
   </g>
 </svg>

--- a/src/main/webapp/resources/icons/pharmacy_Search_sale_bill.svg
+++ b/src/main/webapp/resources/icons/pharmacy_Search_sale_bill.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpssb" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpssb" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpssb)">
+
+    <rect x="40" y="56" width="86" height="104" rx="7" fill="url(#gpssb)"/>
+    <rect x="52" y="72" width="62" height="6" rx="2" fill="white"/>
+    <rect x="52" y="84" width="48" height="6" rx="2" fill="white" opacity="0.8"/>
+    <rect x="52" y="96" width="56" height="6" rx="2" fill="white" opacity="0.7"/>
+    <rect x="52" y="108" width="38" height="6" rx="2" fill="white" opacity="0.6"/>
+    <rect x="52" y="120" width="50" height="6" rx="2" fill="white" opacity="0.5"/>
+    <circle cx="145" cy="140" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="164" y1="159" x2="177" y2="172" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_add_to_stock.svg
+++ b/src/main/webapp/resources/icons/pharmacy_add_to_stock.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpats" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpats" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpats)">
+
+    <rect x="40" y="143" width="108" height="13" rx="5" fill="url(#gpats)"/>
+    <rect x="40" y="118" width="108" height="13" rx="5" fill="url(#gpats)"/>
+    <rect x="40" y="93" width="108" height="13" rx="5" fill="url(#gpats)"/>
+    <rect x="50" y="106" width="15" height="12" rx="2" fill="#7E22CE"/>
+    <rect x="72" y="106" width="15" height="12" rx="2" fill="#9333EA"/>
+    <rect x="94" y="106" width="15" height="12" rx="2" fill="#7E22CE"/>
+    <rect x="50" y="131" width="15" height="12" rx="2" fill="#9333EA"/>
+    <rect x="72" y="131" width="28" height="12" rx="2" fill="#7E22CE"/>
+    <circle cx="150" cy="60" r="30" fill="url(#gpats)"/>
+    <line x1="150" y1="43" x2="150" y2="77" stroke="white" stroke-width="9" stroke-linecap="round"/>
+    <line x1="133" y1="60" x2="167" y2="60" stroke="white" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_analytics.svg
+++ b/src/main/webapp/resources/icons/pharmacy_analytics.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpan" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpan" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpan)">
+
+    <line x1="40" y1="158" x2="40" y2="50" stroke="url(#gpan)" stroke-width="5" stroke-linecap="round"/>
+    <line x1="40" y1="158" x2="168" y2="158" stroke="url(#gpan)" stroke-width="5" stroke-linecap="round"/>
+    <polyline points="53,138 82,112 111,90 138,66 158,50" fill="none" stroke="#C084FC" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="53" cy="138" r="7" fill="url(#gpan)"/>
+    <circle cx="82" cy="112" r="7" fill="url(#gpan)"/>
+    <circle cx="111" cy="90" r="7" fill="url(#gpan)"/>
+    <circle cx="138" cy="66" r="7" fill="url(#gpan)"/>
+    <circle cx="158" cy="50" r="7" fill="url(#gpan)"/>
+    <circle cx="82" cy="112" r="16" fill="none" stroke="#C084FC" stroke-width="3" opacity="0.45"/>
+    <circle cx="138" cy="66" r="16" fill="none" stroke="#C084FC" stroke-width="3" opacity="0.45"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_bill_search.svg
+++ b/src/main/webapp/resources/icons/pharmacy_bill_search.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpbs" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpbs" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpbs)">
+
+    <rect x="43" y="48" width="92" height="118" rx="7" fill="url(#gpbs)"/>
+    <rect x="55" y="63" width="68" height="7" rx="2" fill="white"/>
+    <rect x="55" y="76" width="52" height="7" rx="2" fill="white" opacity="0.8"/>
+    <rect x="55" y="89" width="60" height="7" rx="2" fill="white" opacity="0.7"/>
+    <rect x="55" y="102" width="42" height="7" rx="2" fill="white" opacity="0.6"/>
+    <rect x="55" y="115" width="54" height="7" rx="2" fill="white" opacity="0.5"/>
+    <rect x="55" y="128" width="36" height="7" rx="2" fill="white" opacity="0.4"/>
+    <circle cx="152" cy="155" r="22" fill="none" stroke="#C084FC" stroke-width="8"/>
+    <line x1="167" y1="170" x2="177" y2="180" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_bill_search_new.svg
+++ b/src/main/webapp/resources/icons/pharmacy_bill_search_new.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpbsn" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpbsn" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpbsn)">
+
+    <rect x="43" y="54" width="90" height="112" rx="7" fill="url(#gpbsn)"/>
+    <rect x="55" y="68" width="66" height="7" rx="2" fill="white"/>
+    <rect x="55" y="81" width="50" height="7" rx="2" fill="white" opacity="0.8"/>
+    <rect x="55" y="94" width="58" height="7" rx="2" fill="white" opacity="0.7"/>
+    <rect x="55" y="107" width="40" height="7" rx="2" fill="white" opacity="0.6"/>
+    <circle cx="150" cy="148" r="22" fill="none" stroke="#C084FC" stroke-width="8"/>
+    <line x1="165" y1="163" x2="175" y2="173" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+    <polygon points="148,50 152,62 165,62 155,70 158,82 148,75 138,82 141,70 131,62 144,62" fill="#C084FC"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_direct_issue.svg
+++ b/src/main/webapp/resources/icons/pharmacy_direct_issue.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpdit" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpdit" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpdit)">
+
+    <polygon points="116,40 74,108 100,108 82,160 138,88 110,88" fill="url(#gpdit)"/>
+    <polygon points="116,40 74,108 100,108 82,160 138,88 110,88" fill="none" stroke="#FAF5FF" stroke-width="3" stroke-linejoin="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_disbursement_reports.svg
+++ b/src/main/webapp/resources/icons/pharmacy_disbursement_reports.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpdr" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpdr" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpdr)">
+
+    <rect x="46" y="50" width="84" height="108" rx="7" fill="url(#gpdr)"/>
+    <rect x="58" y="65" width="60" height="7" rx="2" fill="white"/>
+    <rect x="58" y="78" width="46" height="7" rx="2" fill="white" opacity="0.8"/>
+    <rect x="58" y="91" width="54" height="7" rx="2" fill="white" opacity="0.7"/>
+    <rect x="58" y="104" width="38" height="7" rx="2" fill="white" opacity="0.6"/>
+    <rect x="58" y="117" width="50" height="7" rx="2" fill="white" opacity="0.5"/>
+    <line x1="143" y1="88" x2="175" y2="68" stroke="#C084FC" stroke-width="7" stroke-linecap="round"/>
+    <polyline points="162,60 176,67 170,82" fill="none" stroke="#C084FC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="143" y1="110" x2="175" y2="110" stroke="#C084FC" stroke-width="7" stroke-linecap="round"/>
+    <polyline points="161,97 175,110 161,123" fill="none" stroke="#C084FC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="143" y1="132" x2="175" y2="152" stroke="#C084FC" stroke-width="7" stroke-linecap="round"/>
+    <polyline points="162,145 176,152 170,167" fill="none" stroke="#C084FC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_disposal_issue.svg
+++ b/src/main/webapp/resources/icons/pharmacy_disposal_issue.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpdsp" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpdsp" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpdsp)">
+
+    <rect x="58" y="92" width="84" height="76" rx="6" fill="url(#gpdsp)"/>
+    <rect x="50" y="80" width="100" height="16" rx="4" fill="#7E22CE"/>
+    <rect x="78" y="62" width="44" height="22" rx="4" fill="url(#gpdsp)"/>
+    <line x1="80" y1="108" x2="80" y2="158" stroke="white" stroke-width="5" stroke-linecap="round"/>
+    <line x1="100" y1="108" x2="100" y2="158" stroke="white" stroke-width="5" stroke-linecap="round"/>
+    <line x1="120" y1="108" x2="120" y2="158" stroke="white" stroke-width="5" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_generate_report.svg
+++ b/src/main/webapp/resources/icons/pharmacy_generate_report.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpgr" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpgr" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpgr)">
+
+    <rect x="50" y="74" width="78" height="94" rx="7" fill="url(#gpgr)"/>
+    <rect x="62" y="89" width="54" height="6" rx="2" fill="white"/>
+    <rect x="62" y="101" width="40" height="6" rx="2" fill="white" opacity="0.8"/>
+    <rect x="62" y="113" width="48" height="6" rx="2" fill="white" opacity="0.7"/>
+    <rect x="62" y="125" width="34" height="6" rx="2" fill="white" opacity="0.6"/>
+    <circle cx="148" cy="66" r="30" fill="url(#gpgr)"/>
+    <circle cx="148" cy="66" r="15" fill="#FAF5FF"/>
+    <circle cx="148" cy="66" r="8" fill="url(#gpgr)"/>
+    <rect x="144" y="33" width="8" height="13" rx="3" fill="url(#gpgr)"/>
+    <rect x="144" y="86" width="8" height="13" rx="3" fill="url(#gpgr)"/>
+    <rect x="111" y="62" width="13" height="8" rx="3" fill="url(#gpgr)"/>
+    <rect x="172" y="62" width="13" height="8" rx="3" fill="url(#gpgr)"/>
+    <rect x="120" y="43" width="13" height="8" rx="3" fill="url(#gpgr)" transform="rotate(45 126 47)"/>
+    <rect x="161" y="80" width="13" height="8" rx="3" fill="url(#gpgr)" transform="rotate(45 167 84)"/>
+    <rect x="120" y="79" width="13" height="8" rx="3" fill="url(#gpgr)" transform="rotate(-45 126 83)"/>
+    <rect x="161" y="43" width="13" height="8" rx="3" fill="url(#gpgr)" transform="rotate(-45 167 47)"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_issue.svg
+++ b/src/main/webapp/resources/icons/pharmacy_issue.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpisu" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpisu" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpisu)">
+
+    <rect x="48" y="84" width="92" height="78" rx="6" fill="url(#gpisu)"/>
+    <rect x="48" y="84" width="92" height="22" rx="6" fill="#7E22CE"/>
+    <rect x="48" y="95" width="92" height="11" fill="#7E22CE"/>
+    <line x1="78" y1="84" x2="78" y2="56" stroke="#9333EA" stroke-width="4" stroke-dasharray="5,3"/>
+    <line x1="112" y1="84" x2="112" y2="56" stroke="#9333EA" stroke-width="4" stroke-dasharray="5,3"/>
+    <line x1="138" y1="45" x2="172" y2="45" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+    <polyline points="156,30 173,45 156,60" fill="none" stroke="#C084FC" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_issue_for_request.svg
+++ b/src/main/webapp/resources/icons/pharmacy_issue_for_request.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpifr" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpifr" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpifr)">
+
+    <rect x="40" y="62" width="90" height="104" rx="8" fill="url(#gpifr)"/>
+    <rect x="66" y="54" width="38" height="18" rx="5" fill="#7E22CE"/>
+    <rect x="52" y="82" width="66" height="7" rx="3" fill="white"/>
+    <rect x="52" y="95" width="52" height="7" rx="3" fill="white" opacity="0.8"/>
+    <rect x="52" y="108" width="60" height="7" rx="3" fill="white" opacity="0.7"/>
+    <rect x="52" y="121" width="44" height="7" rx="3" fill="white" opacity="0.6"/>
+    <line x1="148" y1="100" x2="178" y2="100" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+    <polyline points="163,84 179,100 163,116" fill="none" stroke="#C084FC" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_item_search.svg
+++ b/src/main/webapp/resources/icons/pharmacy_item_search.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpitm" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpitm" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpitm)">
+
+    <rect x="48" y="84" width="76" height="28" rx="14" fill="url(#gpitm)"/>
+    <line x1="86" y1="84" x2="86" y2="112" stroke="white" stroke-width="5"/>
+    <rect x="48" y="122" width="76" height="28" rx="14" fill="url(#gpitm)" opacity="0.65"/>
+    <line x1="86" y1="122" x2="86" y2="150" stroke="white" stroke-width="5"/>
+    <circle cx="152" cy="86" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="171" y1="105" x2="184" y2="118" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_receive.svg
+++ b/src/main/webapp/resources/icons/pharmacy_receive.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gprec" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shprec" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shprec)">
+
+    <rect x="48" y="90" width="92" height="78" rx="6" fill="url(#gprec)"/>
+    <rect x="48" y="90" width="92" height="22" rx="6" fill="#7E22CE"/>
+    <rect x="48" y="100" width="92" height="12" fill="#7E22CE"/>
+    <line x1="78" y1="90" x2="78" y2="62" stroke="#9333EA" stroke-width="4" stroke-dasharray="5,3"/>
+    <line x1="112" y1="90" x2="112" y2="62" stroke="#9333EA" stroke-width="4" stroke-dasharray="5,3"/>
+    <line x1="26" y1="46" x2="57" y2="46" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+    <polyline points="38,30 24,46 38,62" fill="none" stroke="#C084FC" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_request.svg
+++ b/src/main/webapp/resources/icons/pharmacy_request.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpreq" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpreq" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpreq)">
+
+    <rect x="50" y="62" width="100" height="112" rx="8" fill="url(#gpreq)"/>
+    <rect x="76" y="54" width="48" height="20" rx="6" fill="#7E22CE"/>
+    <rect x="83" y="54" width="34" height="12" rx="3" fill="#9333EA"/>
+    <rect x="63" y="84" width="74" height="8" rx="3" fill="white"/>
+    <rect x="63" y="99" width="58" height="8" rx="3" fill="white" opacity="0.8"/>
+    <rect x="63" y="114" width="65" height="8" rx="3" fill="white" opacity="0.7"/>
+    <rect x="63" y="129" width="48" height="8" rx="3" fill="white" opacity="0.6"/>
+    <rect x="63" y="144" width="56" height="8" rx="3" fill="white" opacity="0.5"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_return_items_and_payments.svg
+++ b/src/main/webapp/resources/icons/pharmacy_return_items_and_payments.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gprip" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shprip" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shprip)">
+
+    <rect x="60" y="70" width="80" height="26" rx="13" fill="url(#gprip)"/>
+    <line x1="100" y1="70" x2="100" y2="96" stroke="white" stroke-width="5"/>
+    <path d="M64 60 Q40 60 40 80 Q40 100 64 100" fill="none" stroke="#C084FC" stroke-width="7" stroke-linecap="round"/>
+    <polyline points="52,48 64,60 51,70" fill="none" stroke="#C084FC" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <ellipse cx="100" cy="142" rx="32" ry="10" fill="url(#gprip)"/>
+    <rect x="68" y="132" width="64" height="10" fill="url(#gprip)"/>
+    <ellipse cx="100" cy="132" rx="32" ry="10" fill="url(#gprip)" opacity="0.85"/>
+    <ellipse cx="140" cy="150" rx="24" ry="8" fill="url(#gprip)" opacity="0.7"/>
+    <rect x="116" y="142" width="48" height="8" fill="url(#gprip)" opacity="0.7"/>
+    <ellipse cx="140" cy="142" rx="24" ry="8" fill="url(#gprip)" opacity="0.6"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_return_items_only.svg
+++ b/src/main/webapp/resources/icons/pharmacy_return_items_only.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gprio" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shprio" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shprio)">
+
+    <rect x="60" y="88" width="80" height="28" rx="14" fill="url(#gprio)"/>
+    <line x1="100" y1="88" x2="100" y2="116" stroke="white" stroke-width="5"/>
+    <path d="M68 75 Q44 75 44 96 Q44 117 68 117" fill="none" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+    <polyline points="56,63 68,75 55,85" fill="none" stroke="#C084FC" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="54" y="132" width="92" height="9" rx="4" fill="url(#gprio)" opacity="0.5"/>
+    <rect x="62" y="148" width="76" height="9" rx="4" fill="url(#gprio)" opacity="0.38"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_sale.svg
+++ b/src/main/webapp/resources/icons/pharmacy_sale.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gps0" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shps0" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shps0)">
+
+    <path d="M38 60 L55 60 L72 118 L152 118 L163 76 L60 76" fill="none" stroke="url(#gps0)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="86" cy="134" r="13" fill="url(#gps0)"/>
+    <circle cx="136" cy="134" r="13" fill="url(#gps0)"/>
+    <rect x="82" y="84" width="50" height="24" rx="12" fill="#7E22CE" opacity="0.85"/>
+    <line x1="107" y1="84" x2="107" y2="108" stroke="#C084FC" stroke-width="4"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_sale_for_cashier.svg
+++ b/src/main/webapp/resources/icons/pharmacy_sale_for_cashier.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsfc" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsfc" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsfc)">
+
+    <rect x="44" y="90" width="112" height="66" rx="8" fill="url(#gpsfc)"/>
+    <rect x="50" y="65" width="100" height="34" rx="8" fill="#7E22CE"/>
+    <rect x="60" y="73" width="80" height="18" rx="3" fill="#C084FC" opacity="0.4"/>
+    <circle cx="70" cy="117" r="7" fill="white"/>
+    <circle cx="93" cy="117" r="7" fill="white"/>
+    <circle cx="116" cy="117" r="7" fill="white"/>
+    <circle cx="70" cy="138" r="7" fill="white"/>
+    <circle cx="93" cy="138" r="7" fill="white"/>
+    <rect x="108" y="130" width="38" height="16" rx="4" fill="#C084FC"/>
+    <rect x="76" y="156" width="48" height="12" rx="2" fill="white"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_sale_without_stock.svg
+++ b/src/main/webapp/resources/icons/pharmacy_sale_without_stock.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsws" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsws" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsws)">
+
+    <rect x="56" y="88" width="88" height="30" rx="15" fill="url(#gpsws)"/>
+    <line x1="100" y1="88" x2="100" y2="118" stroke="white" stroke-width="5"/>
+    <circle cx="148" cy="60" r="24" fill="white" stroke="url(#gpsws)" stroke-width="4"/>
+    <line x1="135" y1="47" x2="161" y2="73" stroke="#9333EA" stroke-width="7" stroke-linecap="round"/>
+    <line x1="161" y1="47" x2="135" y2="73" stroke="#9333EA" stroke-width="7" stroke-linecap="round"/>
+    <rect x="52" y="130" width="96" height="9" rx="4" fill="url(#gpsws)" opacity="0.5"/>
+    <rect x="62" y="147" width="76" height="9" rx="4" fill="url(#gpsws)" opacity="0.35"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_issue_bill.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_issue_bill.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsib" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsib" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsib)">
+
+    <rect x="40" y="52" width="90" height="112" rx="7" fill="url(#gpsib)"/>
+    <rect x="52" y="67" width="66" height="7" rx="2" fill="white"/>
+    <rect x="52" y="80" width="50" height="7" rx="2" fill="white" opacity="0.8"/>
+    <rect x="52" y="93" width="58" height="7" rx="2" fill="white" opacity="0.7"/>
+    <rect x="52" y="106" width="40" height="7" rx="2" fill="white" opacity="0.6"/>
+    <rect x="52" y="119" width="52" height="7" rx="2" fill="white" opacity="0.5"/>
+    <circle cx="148" cy="145" r="26" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="165" y1="162" x2="176" y2="173" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_issue_bill_items.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_issue_bill_items.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsibi" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsibi" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsibi)">
+
+    <rect x="46" y="72" width="62" height="24" rx="12" fill="url(#gpsibi)"/>
+    <line x1="77" y1="72" x2="77" y2="96" stroke="white" stroke-width="4"/>
+    <rect x="46" y="103" width="62" height="24" rx="12" fill="url(#gpsibi)" opacity="0.7"/>
+    <line x1="77" y1="103" x2="77" y2="127" stroke="white" stroke-width="4"/>
+    <rect x="46" y="134" width="62" height="24" rx="12" fill="url(#gpsibi)" opacity="0.45"/>
+    <line x1="77" y1="134" x2="77" y2="158" stroke="white" stroke-width="4"/>
+    <circle cx="152" cy="92" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="171" y1="111" x2="184" y2="124" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_issue_return_bill.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_issue_return_bill.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsirb" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsirb" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsirb)">
+
+    <rect x="38" y="52" width="90" height="112" rx="7" fill="url(#gpsirb)"/>
+    <rect x="50" y="67" width="66" height="7" rx="2" fill="white"/>
+    <rect x="50" y="80" width="50" height="7" rx="2" fill="white" opacity="0.8"/>
+    <rect x="50" y="93" width="58" height="7" rx="2" fill="white" opacity="0.7"/>
+    <path d="M50 116 Q35 116 35 130 Q35 144 50 144" fill="none" stroke="#C084FC" stroke-width="6" stroke-linecap="round"/>
+    <polyline points="41,107 50,117 40,126" fill="none" stroke="#C084FC" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="150" cy="142" r="26" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="167" y1="159" x2="178" y2="170" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_return_bill.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_return_bill.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsrb" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsrb" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsrb)">
+
+    <rect x="40" y="56" width="86" height="104" rx="7" fill="url(#gpsrb)"/>
+    <rect x="52" y="72" width="62" height="6" rx="2" fill="white"/>
+    <rect x="52" y="84" width="48" height="6" rx="2" fill="white" opacity="0.8"/>
+    <rect x="52" y="96" width="56" height="6" rx="2" fill="white" opacity="0.7"/>
+    <line x1="52" y1="114" x2="78" y2="114" stroke="#C084FC" stroke-width="6" stroke-linecap="round"/>
+    <polyline points="61,105 51,114 61,123" fill="none" stroke="#C084FC" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="145" cy="140" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="164" y1="159" x2="177" y2="172" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_sale_bill_item.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_sale_bill_item.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsbi" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsbi" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsbi)">
+
+    <rect x="54" y="84" width="64" height="26" rx="13" fill="url(#gpsbi)"/>
+    <line x1="86" y1="84" x2="86" y2="110" stroke="white" stroke-width="4"/>
+    <rect x="50" y="120" width="72" height="26" rx="13" fill="url(#gpsbi)" opacity="0.65"/>
+    <line x1="86" y1="120" x2="86" y2="146" stroke="white" stroke-width="4"/>
+    <circle cx="152" cy="72" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="171" y1="91" x2="184" y2="104" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_search_sale_pre_bill.svg
+++ b/src/main/webapp/resources/icons/pharmacy_search_sale_pre_bill.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpspb" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpspb" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpspb)">
+
+    <rect x="40" y="56" width="86" height="104" rx="7" fill="none" stroke="url(#gpspb)" stroke-width="5" stroke-dasharray="9,5"/>
+    <rect x="52" y="72" width="62" height="6" rx="2" fill="url(#gpspb)"/>
+    <rect x="52" y="84" width="48" height="6" rx="2" fill="url(#gpspb)" opacity="0.8"/>
+    <rect x="52" y="96" width="56" height="6" rx="2" fill="url(#gpspb)" opacity="0.65"/>
+    <rect x="52" y="108" width="38" height="6" rx="2" fill="url(#gpspb)" opacity="0.5"/>
+    <circle cx="145" cy="140" r="28" fill="none" stroke="#C084FC" stroke-width="9"/>
+    <line x1="164" y1="159" x2="177" y2="172" stroke="#C084FC" stroke-width="9" stroke-linecap="round"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_summary_views.svg
+++ b/src/main/webapp/resources/icons/pharmacy_summary_views.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpsv" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpsv" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpsv)">
+
+    <rect x="43" y="157" width="114" height="8" rx="3" fill="url(#gpsv)"/>
+    <line x1="40" y1="157" x2="40" y2="52" stroke="url(#gpsv)" stroke-width="5" stroke-linecap="round"/>
+    <rect x="52" y="118" width="24" height="39" rx="4" fill="url(#gpsv)"/>
+    <rect x="84" y="92" width="24" height="65" rx="4" fill="url(#gpsv)"/>
+    <rect x="116" y="66" width="24" height="91" rx="4" fill="url(#gpsv)"/>
+    <rect x="52" y="118" width="24" height="39" rx="4" fill="#C084FC" opacity="0.3"/>
+    <rect x="84" y="92" width="24" height="65" rx="4" fill="#C084FC" opacity="0.2"/>
+    <rect x="116" y="66" width="24" height="91" rx="4" fill="#C084FC" opacity="0.1"/>
+
+  </g>
+</svg>

--- a/src/main/webapp/resources/icons/pharmacy_uint_issue_margin.svg
+++ b/src/main/webapp/resources/icons/pharmacy_uint_issue_margin.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="gpuim" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333EA;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#7E22CE;stop-opacity:1"/>
+    </linearGradient>
+    <filter id="shpuim" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="1" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="#FAF5FF"/>
+  <g filter="url(#shpuim)">
+
+    <circle cx="72" cy="70" r="24" fill="url(#gpuim)"/>
+    <circle cx="72" cy="70" r="12" fill="none" stroke="white" stroke-width="5"/>
+    <circle cx="128" cy="130" r="24" fill="url(#gpuim)"/>
+    <circle cx="128" cy="130" r="12" fill="none" stroke="white" stroke-width="5"/>
+    <line x1="62" y1="148" x2="138" y2="52" stroke="#C084FC" stroke-width="8" stroke-linecap="round"/>
+
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- **Channeling** (8 icons, emerald/green `#10B981 → #059669`): `Doctor_Mark_in`, `Doctor_Mark_out`, `Doctor_Working_Times`, `Manage_Token`, `Channel_Booking`, `Channel_Booking_by_Dates`, `Channel_Scheduling`, plus new `Manage_Appointment` (was missing entirely)
- **Lab** (3 icons, sky/cyan `#06B6D4 → #0891B2`): `Lab_Report_Print`, `Investigation_Trace`, `Report_Execution_Logs`
- **Pharmacy** (27 icons, purple/violet `#9333EA → #7E22CE`): all pharmacy sale, return, stock, report, and search tiles
- `Icon.java`: moved `DOCTOR_AND_CHANNEL` and `LAB_AND_REPORTS` into dedicated `CHANNELING_GROUPS` / `LAB_GROUPS` EnumSets; added `PHARMACY_GROUPS` so `getImage()` returns `.svg` for pharmacy icons
- `home.xhtml`: 27 pharmacy tiles switched from `library="images"` (legacy PNG) to `library="icons"` (`.svg`)

## Test plan

- [ ] Log in as a user with a **Channeling** department assignment — dashboard tiles should show emerald/green icons
- [ ] Log in as a user with a **Lab** department assignment — dashboard tiles should show sky/cyan icons
- [ ] Log in as a user with a **Pharmacy** department assignment — dashboard tiles should show purple/violet icons
- [ ] Confirm old inpatient (teal), OPD (indigo), and Cashier (amber) icons are unaffected
- [ ] Verify `Manage_Appointment` tile is now visible for departments that have it assigned

Closes #21694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated several pharmacy menu tiles to use clearer, tile-specific SVG icons for a more consistent home screen.

* **Bug Fixes**
  * Improved icon selection so the correct image format is chosen more reliably across different module areas.
  * Prevented missing or incorrect icon rendering when an icon group is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->