### PR TITLE
Restore on-demand 'Alternatives' (substitute medicines) panel on Retail Sale, Fast Sale & Sale for Cashier (native SQL)

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -32,6 +32,12 @@ This document lists the configuration options used in the application and their 
 | `Pharmacy Transfer Issue Bill Footer CSS`                        | String    | `''`    | CSS for the footer of the transfer issue bill.                                                            |
 | `Pharmacy Transfer Issue Bill Footer Text`                       | String    | `''`    | Text for the footer of the transfer issue bill.                                                             |
 
+## Pharmacy Retail Sale
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Show alternative medicines available during retail sale`        | Boolean   | `true`  | Gates the on-demand "Alternatives" (substitute medicines) UI on the Retail Sale, Fast Sale and Sale for Cashier pages. When `true`, each bill-item row shows a Substitute button that opens a dialog listing in-stock, non-expired substitute stocks in the current department (FEFO order) and lets the cashier swap one in. When `false`, no Substitute control appears and no alternatives query runs. See issue #21697. |
+
 ## OPD Billing
 
 | Key                                                              | Type      | Default | Description                                                                                             |

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -961,8 +961,8 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
     // On-demand substitute (alternative) medicines (issue #21697)
     // ===================================================================
     private BillItem itemForSubstitution;
-    private Stock selectedSubstituteStock;
-    private List<Stock> substituteStocks;
+    private com.divudi.core.data.dto.StockDTO selectedSubstituteStock;
+    private List<com.divudi.core.data.dto.StockDTO> substituteStocks;
 
     public void prepareSubstitute(BillItem bi) {
         itemForSubstitution = bi;
@@ -993,19 +993,19 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
         this.itemForSubstitution = itemForSubstitution;
     }
 
-    public Stock getSelectedSubstituteStock() {
+    public com.divudi.core.data.dto.StockDTO getSelectedSubstituteStock() {
         return selectedSubstituteStock;
     }
 
-    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+    public void setSelectedSubstituteStock(com.divudi.core.data.dto.StockDTO selectedSubstituteStock) {
         this.selectedSubstituteStock = selectedSubstituteStock;
     }
 
-    public List<Stock> getSubstituteStocks() {
+    public List<com.divudi.core.data.dto.StockDTO> getSubstituteStocks() {
         return substituteStocks;
     }
 
-    public void setSubstituteStocks(List<Stock> substituteStocks) {
+    public void setSubstituteStocks(List<com.divudi.core.data.dto.StockDTO> substituteStocks) {
         this.substituteStocks = substituteStocks;
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -155,6 +155,8 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
     FinancialTransactionController financialTransactionController;
     @Inject
     SessionController sessionController;
+    @javax.ejb.EJB
+    private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
     @Inject
     SearchController searchController;
     @Inject
@@ -953,6 +955,58 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
 //            calculateBillItemForEditing(tbi);
         }
         calculateTotals();
+    }
+
+    // ===================================================================
+    // On-demand substitute (alternative) medicines (issue #21697)
+    // ===================================================================
+    private BillItem itemForSubstitution;
+    private Stock selectedSubstituteStock;
+    private List<Stock> substituteStocks;
+
+    public void prepareSubstitute(BillItem bi) {
+        itemForSubstitution = bi;
+        selectedSubstituteStock = null;
+        substituteStocks = new ArrayList<>();
+        if (bi == null || bi.getItem() == null) {
+            return;
+        }
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment());
+    }
+
+    public void replaceSelectedSubstitute() {
+        if (itemForSubstitution == null || selectedSubstituteStock == null) {
+            JsfUtil.addErrorMessage("Please select a substitute stock.");
+            return;
+        }
+        if (pharmacySubstituteService.swapStockIntoBillItem(itemForSubstitution, selectedSubstituteStock)) {
+            calculateAllRates();
+            JsfUtil.addSuccessMessage("Stock replaced successfully.");
+        }
+    }
+
+    public BillItem getItemForSubstitution() {
+        return itemForSubstitution;
+    }
+
+    public void setItemForSubstitution(BillItem itemForSubstitution) {
+        this.itemForSubstitution = itemForSubstitution;
+    }
+
+    public Stock getSelectedSubstituteStock() {
+        return selectedSubstituteStock;
+    }
+
+    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+        this.selectedSubstituteStock = selectedSubstituteStock;
+    }
+
+    public List<Stock> getSubstituteStocks() {
+        return substituteStocks;
+    }
+
+    public void setSubstituteStocks(List<Stock> substituteStocks) {
+        this.substituteStocks = substituteStocks;
     }
 
     public void calculateRates(BillItem bi) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyFastRetailSaleController.java
@@ -971,7 +971,8 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
         if (bi == null || bi.getItem() == null) {
             return;
         }
-        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment());
+        double requiredQty = bi.getQty() == null ? 0d : bi.getQty();
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment(), requiredQty);
     }
 
     public void replaceSelectedSubstitute() {
@@ -982,6 +983,8 @@ public class PharmacyFastRetailSaleController implements Serializable, Controlle
         if (pharmacySubstituteService.swapStockIntoBillItem(itemForSubstitution, selectedSubstituteStock)) {
             calculateAllRates();
             JsfUtil.addSuccessMessage("Stock replaced successfully.");
+        } else {
+            JsfUtil.addErrorMessage("Could not replace the stock — the selected substitute may no longer be available. Please try again.");
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1752,7 +1752,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         if (bi == null || bi.getItem() == null) {
             return;
         }
-        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment());
+        double requiredQty = bi.getQty() == null ? 0d : bi.getQty();
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment(), requiredQty);
     }
 
     public void replaceSelectedSubstitute() {
@@ -1763,6 +1764,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         if (pharmacySubstituteService.swapStockIntoBillItem(itemForSubstitution, selectedSubstituteStock)) {
             calculateBillItemsAndBillTotalsOfPreBill();
             JsfUtil.addSuccessMessage("Stock replaced successfully.");
+        } else {
+            JsfUtil.addErrorMessage("Could not replace the stock — the selected substitute may no longer be available. Please try again.");
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -1742,8 +1742,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     // On-demand substitute (alternative) medicines (issue #21697)
     // ===================================================================
     private BillItem itemForSubstitution;
-    private Stock selectedSubstituteStock;
-    private List<Stock> substituteStocks;
+    private com.divudi.core.data.dto.StockDTO selectedSubstituteStock;
+    private List<com.divudi.core.data.dto.StockDTO> substituteStocks;
 
     public void prepareSubstitute(BillItem bi) {
         itemForSubstitution = bi;
@@ -1774,19 +1774,19 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
         this.itemForSubstitution = itemForSubstitution;
     }
 
-    public Stock getSelectedSubstituteStock() {
+    public com.divudi.core.data.dto.StockDTO getSelectedSubstituteStock() {
         return selectedSubstituteStock;
     }
 
-    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+    public void setSelectedSubstituteStock(com.divudi.core.data.dto.StockDTO selectedSubstituteStock) {
         this.selectedSubstituteStock = selectedSubstituteStock;
     }
 
-    public List<Stock> getSubstituteStocks() {
+    public List<com.divudi.core.data.dto.StockDTO> getSubstituteStocks() {
         return substituteStocks;
     }
 
-    public void setSubstituteStocks(List<Stock> substituteStocks) {
+    public void setSubstituteStocks(List<com.divudi.core.data.dto.StockDTO> substituteStocks) {
         this.substituteStocks = substituteStocks;
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleController.java
@@ -175,6 +175,8 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
     @EJB
     private PharmacyBean pharmacyBean;
     @EJB
+    private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
+    @EJB
     private PersonFacade personFacade;
     @EJB
     private PatientFacade patientFacade;
@@ -1734,6 +1736,58 @@ public class PharmacySaleController implements Serializable, ControllerWithPatie
 
     public void calTotal() {
         calculateBillItemsAndBillTotalsOfPreBill();
+    }
+
+    // ===================================================================
+    // On-demand substitute (alternative) medicines (issue #21697)
+    // ===================================================================
+    private BillItem itemForSubstitution;
+    private Stock selectedSubstituteStock;
+    private List<Stock> substituteStocks;
+
+    public void prepareSubstitute(BillItem bi) {
+        itemForSubstitution = bi;
+        selectedSubstituteStock = null;
+        substituteStocks = new ArrayList<>();
+        if (bi == null || bi.getItem() == null) {
+            return;
+        }
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment());
+    }
+
+    public void replaceSelectedSubstitute() {
+        if (itemForSubstitution == null || selectedSubstituteStock == null) {
+            JsfUtil.addErrorMessage("Please select a substitute stock.");
+            return;
+        }
+        if (pharmacySubstituteService.swapStockIntoBillItem(itemForSubstitution, selectedSubstituteStock)) {
+            calculateBillItemsAndBillTotalsOfPreBill();
+            JsfUtil.addSuccessMessage("Stock replaced successfully.");
+        }
+    }
+
+    public BillItem getItemForSubstitution() {
+        return itemForSubstitution;
+    }
+
+    public void setItemForSubstitution(BillItem itemForSubstitution) {
+        this.itemForSubstitution = itemForSubstitution;
+    }
+
+    public Stock getSelectedSubstituteStock() {
+        return selectedSubstituteStock;
+    }
+
+    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+        this.selectedSubstituteStock = selectedSubstituteStock;
+    }
+
+    public List<Stock> getSubstituteStocks() {
+        return substituteStocks;
+    }
+
+    public void setSubstituteStocks(List<Stock> substituteStocks) {
+        this.substituteStocks = substituteStocks;
     }
 
     public double addBillItemSingleItem() {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -932,7 +932,8 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         if (item == null) {
             return;
         }
-        substituteStocks = pharmacySubstituteService.findSubstituteStocks(item, sessionController.getDepartment());
+        double requiredQty = Math.abs(bid.getQty());
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(item, sessionController.getDepartment(), requiredQty);
     }
 
     public void replaceSelectedSubstitute() {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -918,8 +918,8 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     // On-demand substitute (alternative) medicines (issue #21697)
     // ===================================================================
     private BillItemData itemDataForSubstitution;
-    private Stock selectedSubstituteStock;
-    private List<Stock> substituteStocks;
+    private com.divudi.core.data.dto.StockDTO selectedSubstituteStock;
+    private List<com.divudi.core.data.dto.StockDTO> substituteStocks;
 
     public void prepareSubstitute(BillItemData bid) {
         itemDataForSubstitution = bid;
@@ -937,34 +937,32 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
     public void replaceSelectedSubstitute() {
         if (itemDataForSubstitution == null || selectedSubstituteStock == null
-                || selectedSubstituteStock.getItemBatch() == null) {
+                || selectedSubstituteStock.getStockId() == null) {
             JsfUtil.addErrorMessage("Please select a substitute stock.");
             return;
         }
 
-        Stock stock = selectedSubstituteStock;
-        ItemBatch itemBatch = stock.getItemBatch();
-        Item substituteItem = itemBatch.getItem();
+        com.divudi.core.data.dto.StockDTO sub = selectedSubstituteStock;
         BillItemData bid = itemDataForSubstitution;
 
-        // Same quantity as the line being substituted.
+        // Same quantity as the line being substituted. All rate/batch fields come
+        // from the single native lookup already on the DTO - no extra queries.
         double qty = Math.abs(bid.getQty());
 
-        double[] batchRates = fetchBatchRates(itemBatch.getId());
-        double batchRetailRate = batchRates[0];
-        double batchPurchaseRate = batchRates[1];
-        double batchWholesaleRate = batchRates[2];
-        Double batchCostRate = batchRates[3] > 0 ? batchRates[3] : null;
+        double batchRetailRate = sub.getRetailRate() != null ? sub.getRetailRate() : 0.0;
+        double batchPurchaseRate = sub.getPurchaseRate() != null ? sub.getPurchaseRate() : 0.0;
+        double batchWholesaleRate = sub.getWholesaleRate() != null ? sub.getWholesaleRate() : 0.0;
+        Double batchCostRate = (sub.getCostRate() != null && sub.getCostRate() > 0) ? sub.getCostRate() : null;
 
-        long ampItemId = resolveAmpItemId(substituteItem.getId());
+        long ampItemId = resolveAmpItemId(sub.getItemId());
 
-        bid.setItemId(substituteItem.getId());
-        bid.setItemName(substituteItem.getName());
+        bid.setItemId(sub.getItemId());
+        bid.setItemName(sub.getItemName());
         bid.setAmpItemId(ampItemId);
-        bid.setStockId(stock.getId());
-        bid.setItemBatchId(itemBatch.getId());
+        bid.setStockId(sub.getStockId());
+        bid.setItemBatchId(sub.getItemBatchId());
         bid.setPbiQty(-Math.abs(qty));
-        bid.setRetailRate(itemBatch.getRetailsaleRate());
+        bid.setRetailRate(batchRetailRate);
         bid.setPurchaseRate(batchPurchaseRate);
         bid.setWholesaleRate(batchWholesaleRate);
         bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
@@ -972,15 +970,16 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         bid.setBatchPurchaseRate(batchPurchaseRate);
         bid.setBatchWholesaleRate(batchWholesaleRate);
         bid.setBatchCostRate(batchCostRate);
-        bid.setDoe(itemBatch.getDateOfExpire());
-        bid.setDescription(substituteItem.getName());
+        bid.setDoe(sub.getDateOfExpire());
+        bid.setDescription(sub.getItemName());
 
-        double lineRetailRate = itemBatch.getRetailsaleRate();
+        double lineRetailRate = batchRetailRate;
         double grossValue = lineRetailRate * qty;
         double discountPct = 0.0;
         double discountValue = 0.0;
         try {
-            if (Boolean.TRUE.equals(substituteItem.isDiscountAllowed())) {
+            Item substituteItem = itemFacade.find(sub.getItemId());
+            if (substituteItem != null && Boolean.TRUE.equals(substituteItem.isDiscountAllowed())) {
                 Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
                         paymentMethod, paymentScheme, sessionController.getDepartment(), substituteItem);
                 discountPct = pct != null ? pct : 0.0;
@@ -988,7 +987,7 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
             }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Discount lookup failed for substitute item {0}: {1}",
-                    new Object[]{substituteItem.getId(), e.getMessage()});
+                    new Object[]{sub.getItemId(), e.getMessage()});
         }
         double netValue = grossValue - discountValue;
         double netRate = qty > 0 ? netValue / qty : lineRetailRate;
@@ -1013,19 +1012,19 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         this.itemDataForSubstitution = itemDataForSubstitution;
     }
 
-    public Stock getSelectedSubstituteStock() {
+    public com.divudi.core.data.dto.StockDTO getSelectedSubstituteStock() {
         return selectedSubstituteStock;
     }
 
-    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+    public void setSelectedSubstituteStock(com.divudi.core.data.dto.StockDTO selectedSubstituteStock) {
         this.selectedSubstituteStock = selectedSubstituteStock;
     }
 
-    public List<Stock> getSubstituteStocks() {
+    public List<com.divudi.core.data.dto.StockDTO> getSubstituteStocks() {
         return substituteStocks;
     }
 
-    public void setSubstituteStocks(List<Stock> substituteStocks) {
+    public void setSubstituteStocks(List<com.divudi.core.data.dto.StockDTO> substituteStocks) {
         this.substituteStocks = substituteStocks;
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -36,6 +36,8 @@ import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.clinical.Prescription;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.pharmacy.ItemBatch;
 import com.divudi.core.facade.ItemBatchFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PatientFacade;
@@ -111,6 +113,8 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     private PharmacyService pharmacyService;
     @EJB
     private RetailSaleNativeSqlService nativeSqlService;
+    @EJB
+    private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
     @EJB
     private DiscountSchemeValidationService discountSchemeValidationService;
     @EJB
@@ -908,6 +912,121 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     public void listnerForPaymentMethodChange() {
         recalculateDiscountsForAll();
         calTotal();
+    }
+
+    // ===================================================================
+    // On-demand substitute (alternative) medicines (issue #21697)
+    // ===================================================================
+    private BillItemData itemDataForSubstitution;
+    private Stock selectedSubstituteStock;
+    private List<Stock> substituteStocks;
+
+    public void prepareSubstitute(BillItemData bid) {
+        itemDataForSubstitution = bid;
+        selectedSubstituteStock = null;
+        substituteStocks = new ArrayList<>();
+        if (bid == null || bid.getItemId() == null) {
+            return;
+        }
+        Item item = itemFacade.find(bid.getItemId());
+        if (item == null) {
+            return;
+        }
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(item, sessionController.getDepartment());
+    }
+
+    public void replaceSelectedSubstitute() {
+        if (itemDataForSubstitution == null || selectedSubstituteStock == null
+                || selectedSubstituteStock.getItemBatch() == null) {
+            JsfUtil.addErrorMessage("Please select a substitute stock.");
+            return;
+        }
+
+        Stock stock = selectedSubstituteStock;
+        ItemBatch itemBatch = stock.getItemBatch();
+        Item substituteItem = itemBatch.getItem();
+        BillItemData bid = itemDataForSubstitution;
+
+        // Same quantity as the line being substituted.
+        double qty = Math.abs(bid.getQty());
+
+        double[] batchRates = fetchBatchRates(itemBatch.getId());
+        double batchRetailRate = batchRates[0];
+        double batchPurchaseRate = batchRates[1];
+        double batchWholesaleRate = batchRates[2];
+        Double batchCostRate = batchRates[3] > 0 ? batchRates[3] : null;
+
+        long ampItemId = resolveAmpItemId(substituteItem.getId());
+
+        bid.setItemId(substituteItem.getId());
+        bid.setItemName(substituteItem.getName());
+        bid.setAmpItemId(ampItemId);
+        bid.setStockId(stock.getId());
+        bid.setItemBatchId(itemBatch.getId());
+        bid.setPbiQty(-Math.abs(qty));
+        bid.setRetailRate(itemBatch.getRetailsaleRate());
+        bid.setPurchaseRate(batchPurchaseRate);
+        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
+        bid.setBatchRetailRate(batchRetailRate);
+        bid.setBatchPurchaseRate(batchPurchaseRate);
+        bid.setBatchWholesaleRate(batchWholesaleRate);
+        bid.setBatchCostRate(batchCostRate);
+        bid.setDoe(itemBatch.getDateOfExpire());
+        bid.setDescription(substituteItem.getName());
+
+        double lineRetailRate = itemBatch.getRetailsaleRate();
+        double grossValue = lineRetailRate * qty;
+        double discountPct = 0.0;
+        double discountValue = 0.0;
+        try {
+            if (Boolean.TRUE.equals(substituteItem.isDiscountAllowed())) {
+                Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
+                        paymentMethod, paymentScheme, sessionController.getDepartment(), substituteItem);
+                discountPct = pct != null ? pct : 0.0;
+                discountValue = (discountPct / 100.0) * grossValue;
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Discount lookup failed for substitute item {0}: {1}",
+                    new Object[]{substituteItem.getId(), e.getMessage()});
+        }
+        double netValue = grossValue - discountValue;
+        double netRate = qty > 0 ? netValue / qty : lineRetailRate;
+
+        bid.setRate(lineRetailRate);
+        bid.setNetRate(netRate);
+        bid.setDiscountPercent(discountPct);
+        bid.setDiscountValue(discountValue);
+        bid.setMarginValue(0.0);
+        bid.setNetValue(-netValue);
+        bid.setGrossValue(-grossValue);
+
+        calTotal();
+        JsfUtil.addSuccessMessage("Stock replaced successfully.");
+    }
+
+    public BillItemData getItemDataForSubstitution() {
+        return itemDataForSubstitution;
+    }
+
+    public void setItemDataForSubstitution(BillItemData itemDataForSubstitution) {
+        this.itemDataForSubstitution = itemDataForSubstitution;
+    }
+
+    public Stock getSelectedSubstituteStock() {
+        return selectedSubstituteStock;
+    }
+
+    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+        this.selectedSubstituteStock = selectedSubstituteStock;
+    }
+
+    public List<Stock> getSubstituteStocks() {
+        return substituteStocks;
+    }
+
+    public void setSubstituteStocks(List<Stock> substituteStocks) {
+        this.substituteStocks = substituteStocks;
     }
 
     public void recalculateDiscountsForAll() {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1294,9 +1294,7 @@ public class PharmacyBean {
         }
 
         if (item instanceof Amp) {
-            List<Amp> list = new ArrayList<>();
-            list.add((Amp) item);
-            return list;
+            return resolveAmpWithVmpSiblings((Amp) item);
         }
 
         if (item instanceof Ampp) {
@@ -1304,9 +1302,7 @@ public class PharmacyBean {
             if (amp == null) {
                 return new ArrayList<>();
             }
-            List<Amp> list = new ArrayList<>();
-            list.add(amp);
-            return list;
+            return resolveAmpWithVmpSiblings(amp);
         }
 
         if (item instanceof Vmp) {
@@ -1333,6 +1329,33 @@ public class PharmacyBean {
         }
 
         return new ArrayList<>();
+    }
+
+    /**
+     * Resolve an AMP to itself plus its sibling AMPs that share the same VMP
+     * (true alternative brands of the same virtual product). The original AMP
+     * is always included even if its VMP is null or has no siblings.
+     */
+    private List<Amp> resolveAmpWithVmpSiblings(Amp amp) {
+        List<Amp> list = new ArrayList<>();
+        if (amp == null) {
+            return list;
+        }
+        list.add(amp);
+        Vmp vmp = amp.getVmp();
+        if (vmp == null) {
+            return list;
+        }
+        List<Amp> siblings = findAmpsForVmp(vmp);
+        if (siblings != null) {
+            for (Amp sibling : siblings) {
+                if (sibling != null && sibling.getId() != null
+                        && !sibling.getId().equals(amp.getId())) {
+                    list.add(sibling);
+                }
+            }
+        }
+        return list;
     }
 
     public List<Amp> findAmpsForVtm(Vtm vtm) {

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1283,7 +1283,17 @@ public class PharmacyBean {
     }
 
     /**
-     * Resolve the underlying AMP records for any pharmacy Item subclass.
+     * Resolve the underlying AMP records for any pharmacy Item subclass,
+     * <b>exactly</b> — an AMP (or Ampp) resolves to itself only. This preserves
+     * brand-faithful stock lookup for prescription / discharge-dispensing flows
+     * (e.g. {@code PharmacySaleBhtController.findFefoStockDtosForItem},
+     * {@code PatientEncounterController}), where the prescribed brand must not be
+     * silently swapped for a sibling. VMP/VMPP/VTM/ATM still resolve to every AMP
+     * under that node, as those are inherently generic.
+     *
+     * <p>For the on-demand "Alternatives" substitute panel, which deliberately
+     * offers sibling brands of the same VMP for the cashier to choose, use
+     * {@link #resolveSubstituteAmps(Item)} instead.
      *
      * @param item item to resolve
      * @return list of AMP objects, or an empty list if none found
@@ -1294,7 +1304,9 @@ public class PharmacyBean {
         }
 
         if (item instanceof Amp) {
-            return resolveAmpWithVmpSiblings((Amp) item);
+            List<Amp> list = new ArrayList<>();
+            list.add((Amp) item);
+            return list;
         }
 
         if (item instanceof Ampp) {
@@ -1302,7 +1314,9 @@ public class PharmacyBean {
             if (amp == null) {
                 return new ArrayList<>();
             }
-            return resolveAmpWithVmpSiblings(amp);
+            List<Amp> list = new ArrayList<>();
+            list.add(amp);
+            return list;
         }
 
         if (item instanceof Vmp) {
@@ -1329,6 +1343,35 @@ public class PharmacyBean {
         }
 
         return new ArrayList<>();
+    }
+
+    /**
+     * Resolve the candidate AMPs for the on-demand "Alternatives" substitute
+     * panel (issue #21697). Unlike {@link #resolveAmps(Item)} this expands an
+     * AMP / Ampp to itself <b>plus its sibling AMPs sharing the same VMP</b>
+     * (alternative brands of the same virtual product), so the cashier can pick
+     * a different brand. For VMP/VMPP/VTM/ATM the result is identical to
+     * {@code resolveAmps} (those are already generic and cover every brand).
+     *
+     * <p>This is intentionally separate from {@code resolveAmps} so that
+     * brand-faithful prescription / dispensing flows are never affected — only
+     * the explicit substitute path opts into sibling expansion.
+     *
+     * @param item item to resolve substitute candidates for
+     * @return AMP list including sibling brands, or empty if none found
+     */
+    public List<Amp> resolveSubstituteAmps(Item item) {
+        if (item == null) {
+            return new ArrayList<>();
+        }
+        if (item instanceof Amp) {
+            return resolveAmpWithVmpSiblings((Amp) item);
+        }
+        if (item instanceof Ampp) {
+            return resolveAmpWithVmpSiblings(((Ampp) item).getAmp());
+        }
+        // VMP / VMPP / VTM / ATM are already generic — same as exact resolution.
+        return resolveAmps(item);
     }
 
     /**

--- a/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
@@ -36,8 +36,11 @@ import javax.persistence.PersistenceContext;
  * ({@code PharmacyFastRetailSaleController}) and Sale for Cashier
  * ({@code PharmacyFastRetailSaleForCashierController}).
  *
- * <p>Alternative AMP resolution reuses {@link PharmacyBean#resolveAmps(Item)}
- * (exact AMP &rarr; same-strength sibling AMPs &rarr; VMP/VTM siblings); the
+ * <p>Alternative AMP resolution uses
+ * {@link PharmacyBean#resolveSubstituteAmps(Item)} (exact AMP &rarr;
+ * same-VMP sibling brands; VMP/VMPP/VTM/ATM &rarr; every AMP under the node).
+ * This is intentionally distinct from {@code PharmacyBean.resolveAmps}, which
+ * stays brand-exact for prescription / dispensing flows. The
  * in-stock, non-expired stock lookup is done with <b>native SQL</b> (FEFO
  * ordered) per issue #21697 requirement 2, consistent with the native retail
  * sale performance path ({@code RetailSaleNativeSqlService}). EclipseLink
@@ -78,21 +81,31 @@ public class PharmacySubstituteService {
      * {@code findWithItemBatch} per result row, keeping the on-demand click fast
      * even when an AMP has many sibling brands across many batches.
      *
-     * @param item       the bill item's current item to find alternatives for
-     * @param department the current department whose stock should be considered
+     * @param item        the bill item's current item to find alternatives for
+     * @param department  the current department whose stock should be considered
+     * @param requiredQty the bill-item quantity that must be covered; batches
+     *                    with less stock than this are excluded so the cashier
+     *                    can never pick an under-stocked substitute. Values
+     *                    {@code <= 0} fall back to requiring any positive stock.
      * @return list of {@link StockDTO}, FEFO-ordered, never null
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public List<StockDTO> findSubstituteStocks(Item item, Department department) {
+    public List<StockDTO> findSubstituteStocks(Item item, Department department, double requiredQty) {
         List<StockDTO> result = new ArrayList<>();
         if (item == null || department == null || department.getId() == null) {
             return result;
         }
 
-        List<Amp> amps = pharmacyBean.resolveAmps(item);
+        List<Amp> amps = pharmacyBean.resolveSubstituteAmps(item);
         if (amps == null || amps.isEmpty()) {
             return result;
         }
+
+        // Never offer a batch that cannot cover the existing line quantity. The
+        // normal add/edit paths already guard qty > stock; mirror that here so a
+        // selected substitute is always valid for the current line. Default to
+        // any positive stock when the caller has no meaningful quantity.
+        double minStock = requiredQty > 0 ? requiredQty : 0d;
 
         List<Long> ampIds = new ArrayList<>();
         for (Amp amp : amps) {
@@ -104,9 +117,12 @@ public class PharmacySubstituteService {
             return result;
         }
 
-        // Native SQL: in-stock (> 0), non-expired (expiry strictly in the
-        // future), current department, item in resolved AMPs; FEFO ordered.
+        // Native SQL: stock covering the line qty, non-expired (expiry strictly
+        // in the future), current department, item in resolved AMPs, and not
+        // retired (Stock, ItemBatch or Item) — retired rows are admin
+        // soft-deletes and must never be offered as substitutes. FEFO ordered.
         // All display + swap fields are returned in one round-trip.
+        // Params: ?1 = department, ?2 = min stock, ?3.. = AMP ids.
         StringBuilder sql = new StringBuilder();
         sql.append("SELECT s.ID, s.itemBatch_ID, ib.item_ID, i.name, i.code, ")
                 .append("ib.retailsaleRate, s.stock, ib.dateOfExpire, ib.batchNo, ")
@@ -115,11 +131,14 @@ public class PharmacySubstituteService {
                 .append("JOIN ").append(itemBatchTable()).append(" ib ON s.itemBatch_ID = ib.ID ")
                 .append("JOIN ").append(itemTable()).append(" i ON ib.item_ID = i.ID ")
                 .append("WHERE s.department_ID = ?1 ")
-                .append("AND s.stock > 0 ")
+                .append("AND s.stock >= ?2 AND s.stock > 0 ")
                 .append("AND ib.dateOfExpire > NOW() ")
+                .append("AND (s.retired = 0 OR s.retired IS NULL) ")
+                .append("AND (ib.retired = 0 OR ib.retired IS NULL) ")
+                .append("AND (i.retired = 0 OR i.retired IS NULL) ")
                 .append("AND ib.item_ID IN (");
         for (int i = 0; i < ampIds.size(); i++) {
-            sql.append("?").append(i + 2);
+            sql.append("?").append(i + 3);
             if (i < ampIds.size() - 1) {
                 sql.append(",");
             }
@@ -128,8 +147,9 @@ public class PharmacySubstituteService {
 
         javax.persistence.Query q = em.createNativeQuery(sql.toString());
         q.setParameter(1, department.getId());
+        q.setParameter(2, minStock);
         for (int i = 0; i < ampIds.size(); i++) {
-            q.setParameter(i + 2, ampIds.get(i));
+            q.setParameter(i + 3, ampIds.get(i));
         }
 
         @SuppressWarnings("unchecked")
@@ -183,6 +203,12 @@ public class PharmacySubstituteService {
         }
         ItemBatch itemBatch = substituteStock.getItemBatch();
 
+        // ItemBatch#getCostRate() is nullable in this codebase (null cost rate
+        // with purcahseRate == 0). Coalesce to 0.0 so unboxing into the
+        // primitive setters / BigDecimal.valueOf below never NPEs. Mirrors the
+        // native lookup, which already maps null cost rates to 0.0.
+        double costRate = itemBatch.getCostRate() == null ? 0d : itemBatch.getCostRate();
+
         billItem.setItem(itemBatch.getItem());
 
         PharmaceuticalBillItem phItem = billItem.getPharmaceuticalBillItem();
@@ -200,8 +226,8 @@ public class PharmacySubstituteService {
         phItem.setRetailRateInUnit(itemBatch.getRetailsaleRate());
         phItem.setPurchaseRatePack(itemBatch.getPurcahseRate());
         phItem.setRetailRatePack(itemBatch.getRetailsaleRate());
-        phItem.setCostRate(itemBatch.getCostRate());
-        phItem.setCostRatePack(itemBatch.getCostRate());
+        phItem.setCostRate(costRate);
+        phItem.setCostRatePack(costRate);
 
         BillItemFinanceDetails financeDetails = billItem.getBillItemFinanceDetails();
         if (financeDetails != null) {
@@ -209,11 +235,11 @@ public class PharmacySubstituteService {
             BigDecimal saleRate = BigDecimal.valueOf(itemBatch.getRetailsaleRate());
             financeDetails.setLineGrossRate(saleRate);
             financeDetails.setLineNetRate(saleRate);
-            financeDetails.setLineCostRate(BigDecimal.valueOf(itemBatch.getCostRate()));
+            financeDetails.setLineCostRate(BigDecimal.valueOf(costRate));
             financeDetails.setRetailSaleRate(saleRate);
 
             BigDecimal qty = financeDetails.getQuantity() != null ? financeDetails.getQuantity() : BigDecimal.ONE;
-            financeDetails.setValueAtCostRate(BigDecimal.valueOf(itemBatch.getCostRate()).multiply(qty));
+            financeDetails.setValueAtCostRate(BigDecimal.valueOf(costRate).multiply(qty));
             financeDetails.setValueAtPurchaseRate(BigDecimal.valueOf(itemBatch.getPurcahseRate()).multiply(qty));
             financeDetails.setValueAtRetailRate(saleRate.multiply(qty));
         }

--- a/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
@@ -203,11 +203,15 @@ public class PharmacySubstituteService {
         }
         ItemBatch itemBatch = substituteStock.getItemBatch();
 
-        // ItemBatch#getCostRate() is nullable in this codebase (null cost rate
-        // with purcahseRate == 0). Coalesce to 0.0 so unboxing into the
-        // primitive setters / BigDecimal.valueOf below never NPEs. Mirrors the
-        // native lookup, which already maps null cost rates to 0.0.
-        double costRate = itemBatch.getCostRate() == null ? 0d : itemBatch.getCostRate();
+        // Use the raw cost rate carried by the DTO from the native lookup
+        // (ib.costRate read directly, already coalesced to 0.0 when null).
+        // Do NOT call itemBatch.getCostRate() here: that getter derives and
+        // ASSIGNS costRate = purcahseRate when costRate is null, which dirties
+        // the managed ItemBatch (writes back to the entity / triggers an UPDATE)
+        // and returns purchaseRate rather than 0.0. Reading the DTO keeps this
+        // swap non-mutating on the batch row.
+        Double rawCost = selected.getCostRate();
+        double costRate = rawCost == null ? 0d : rawCost;
 
         billItem.setItem(itemBatch.getItem());
 
@@ -238,7 +242,16 @@ public class PharmacySubstituteService {
             financeDetails.setLineCostRate(BigDecimal.valueOf(costRate));
             financeDetails.setRetailSaleRate(saleRate);
 
-            BigDecimal qty = financeDetails.getQuantity() != null ? financeDetails.getQuantity() : BigDecimal.ONE;
+            // getBillItemFinanceDetails() lazily creates a fresh details object
+            // with a null quantity, so fall back to the bill-item quantity (not
+            // 1) to value multi-quantity substitute lines correctly.
+            BigDecimal qty = financeDetails.getQuantity();
+            if (qty == null) {
+                double billQty = billItem.getQty() == null ? 0d : Math.abs(billItem.getQty());
+                qty = BigDecimal.valueOf(billQty);
+                financeDetails.setQuantity(qty);
+                financeDetails.setTotalQuantity(qty);
+            }
             financeDetails.setValueAtCostRate(BigDecimal.valueOf(costRate).multiply(qty));
             financeDetails.setValueAtPurchaseRate(BigDecimal.valueOf(itemBatch.getPurcahseRate()).multiply(qty));
             financeDetails.setValueAtRetailRate(saleRate.multiply(qty));

--- a/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
@@ -1,0 +1,213 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.entity.pharmacy.Amp;
+import com.divudi.core.entity.pharmacy.ItemBatch;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.ejb.PharmacyBean;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * Shared, on-demand substitute-medicine (alternatives) logic for the three
+ * pharmacy sale pages: Retail Sale ({@code PharmacySaleController} /
+ * {@code RetailSaleNativeSqlController}), Fast Sale
+ * ({@code PharmacyFastRetailSaleController}) and Sale for Cashier
+ * ({@code PharmacyFastRetailSaleForCashierController}).
+ *
+ * <p>Alternative AMP resolution reuses {@link PharmacyBean#resolveAmps(Item)}
+ * (exact AMP &rarr; same-strength sibling AMPs &rarr; VMP/VTM siblings); the
+ * in-stock, non-expired stock lookup is done with <b>native SQL</b> (FEFO
+ * ordered) per issue #21697 requirement 2, consistent with the native retail
+ * sale performance path ({@code RetailSaleNativeSqlService}). EclipseLink
+ * positional parameters ({@code ?1}, {@code ?2}&hellip;) are used and table
+ * names are resolved case-insensitively via {@code INFORMATION_SCHEMA} so the
+ * query works across customer DBs regardless of table-name case.
+ *
+ * Issue: #21697
+ */
+@Stateless
+public class PharmacySubstituteService {
+
+    private static final Logger LOGGER = Logger.getLogger(PharmacySubstituteService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @EJB
+    private PharmacyBean pharmacyBean;
+
+    @EJB
+    private StockFacade stockFacade;
+
+    private String tStock;
+    private String tItemBatch;
+
+    /**
+     * Resolve in-stock, non-expired substitute stocks for the given item in the
+     * given department, FEFO-ordered (earliest expiry first).
+     *
+     * @param item       the bill item's current item to find alternatives for
+     * @param department the current department whose stock should be considered
+     * @return list of {@link Stock} (loaded with item batch), never null
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public List<Stock> findSubstituteStocks(Item item, Department department) {
+        List<Stock> result = new ArrayList<>();
+        if (item == null || department == null || department.getId() == null) {
+            return result;
+        }
+
+        List<Amp> amps = pharmacyBean.resolveAmps(item);
+        if (amps == null || amps.isEmpty()) {
+            return result;
+        }
+
+        List<Long> ampIds = new ArrayList<>();
+        for (Amp amp : amps) {
+            if (amp != null && amp.getId() != null) {
+                ampIds.add(amp.getId());
+            }
+        }
+        if (ampIds.isEmpty()) {
+            return result;
+        }
+
+        // Native SQL: in-stock (> 0), non-expired (expiry strictly in the
+        // future), current department, item in resolved AMPs; FEFO ordered.
+        StringBuilder sql = new StringBuilder();
+        sql.append("SELECT s.ID ")
+                .append("FROM ").append(stockTable()).append(" s ")
+                .append("JOIN ").append(itemBatchTable()).append(" ib ON s.itemBatch_ID = ib.ID ")
+                .append("WHERE s.department_ID = ?1 ")
+                .append("AND s.stock > 0 ")
+                .append("AND ib.dateOfExpire > NOW() ")
+                .append("AND ib.item_ID IN (");
+        for (int i = 0; i < ampIds.size(); i++) {
+            sql.append("?").append(i + 2);
+            if (i < ampIds.size() - 1) {
+                sql.append(",");
+            }
+        }
+        sql.append(") ORDER BY ib.dateOfExpire ASC");
+
+        javax.persistence.Query q = em.createNativeQuery(sql.toString());
+        q.setParameter(1, department.getId());
+        for (int i = 0; i < ampIds.size(); i++) {
+            q.setParameter(i + 2, ampIds.get(i));
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Object> stockIdRows = q.getResultList();
+        for (Object row : stockIdRows) {
+            if (row == null) {
+                continue;
+            }
+            Long stockId = ((Number) row).longValue();
+            Stock loaded = stockFacade.findWithItemBatch(stockId);
+            if (loaded != null) {
+                result.add(loaded);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Swap the selected substitute stock into the bill item: updates item,
+     * batch, stock and all rate + finance-detail fields. Bill totals must be
+     * recalculated by the caller using that controller's own rate-recalc method
+     * (each sale controller derives line values from
+     * {@code pharmaceuticalBillItem.stock.itemBatch}).
+     *
+     * @param billItem        the bill item to update
+     * @param substituteStock the chosen substitute stock
+     * @return true if the swap succeeded
+     */
+    public boolean swapStockIntoBillItem(BillItem billItem, Stock substituteStock) {
+        if (billItem == null || substituteStock == null || substituteStock.getItemBatch() == null) {
+            return false;
+        }
+        ItemBatch itemBatch = substituteStock.getItemBatch();
+
+        billItem.setItem(itemBatch.getItem());
+
+        PharmaceuticalBillItem phItem = billItem.getPharmaceuticalBillItem();
+        if (phItem == null) {
+            phItem = new PharmaceuticalBillItem();
+            phItem.setBillItem(billItem);
+            billItem.setPharmaceuticalBillItem(phItem);
+        }
+
+        phItem.setStock(substituteStock);
+        phItem.setItemBatch(itemBatch);
+        phItem.setDoe(itemBatch.getDateOfExpire());
+        // Do NOT "fix" the intentional typo purcahseRate (DB compatibility).
+        phItem.setPurchaseRate(itemBatch.getPurcahseRate());
+        phItem.setRetailRateInUnit(itemBatch.getRetailsaleRate());
+        phItem.setPurchaseRatePack(itemBatch.getPurcahseRate());
+        phItem.setRetailRatePack(itemBatch.getRetailsaleRate());
+        phItem.setCostRate(itemBatch.getCostRate());
+        phItem.setCostRatePack(itemBatch.getCostRate());
+
+        BillItemFinanceDetails financeDetails = billItem.getBillItemFinanceDetails();
+        if (financeDetails != null) {
+            // Retail sale line value is at the retail (sale) rate.
+            BigDecimal saleRate = BigDecimal.valueOf(itemBatch.getRetailsaleRate());
+            financeDetails.setLineGrossRate(saleRate);
+            financeDetails.setLineNetRate(saleRate);
+            financeDetails.setLineCostRate(BigDecimal.valueOf(itemBatch.getCostRate()));
+            financeDetails.setRetailSaleRate(saleRate);
+
+            BigDecimal qty = financeDetails.getQuantity() != null ? financeDetails.getQuantity() : BigDecimal.ONE;
+            financeDetails.setValueAtCostRate(BigDecimal.valueOf(itemBatch.getCostRate()).multiply(qty));
+            financeDetails.setValueAtPurchaseRate(BigDecimal.valueOf(itemBatch.getPurcahseRate()).multiply(qty));
+            financeDetails.setValueAtRetailRate(saleRate.multiply(qty));
+        }
+        return true;
+    }
+
+    // -----------------------------------------------------------------------
+    // Case-insensitive table-name resolution (cross-deployment safety)
+    // -----------------------------------------------------------------------
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+                + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ?1 LIMIT 1")
+                .setParameter(1, upperName)
+                .getSingleResult();
+        return name.toString();
+    }
+
+    private String stockTable() {
+        if (tStock == null) {
+            tStock = resolveTable("STOCK");
+        }
+        return tStock;
+    }
+
+    private String itemBatchTable() {
+        if (tItemBatch == null) {
+            tItemBatch = resolveTable("ITEMBATCH");
+        }
+        return tItemBatch;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
@@ -5,6 +5,7 @@
  */
 package com.divudi.service.pharmacy;
 
+import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
 import com.divudi.core.entity.Department;
@@ -13,10 +14,12 @@ import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.entity.pharmacy.Amp;
 import com.divudi.core.entity.pharmacy.ItemBatch;
 import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.facade.ItemBatchFacade;
 import com.divudi.core.facade.StockFacade;
 import com.divudi.ejb.PharmacyBean;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
@@ -58,20 +61,30 @@ public class PharmacySubstituteService {
     @EJB
     private StockFacade stockFacade;
 
+    @EJB
+    private ItemBatchFacade itemBatchFacade;
+
     private String tStock;
     private String tItemBatch;
+    private String tItem;
 
     /**
      * Resolve in-stock, non-expired substitute stocks for the given item in the
      * given department, FEFO-ordered (earliest expiry first).
      *
+     * <p>Performance: the lookup is a <b>single</b> native-SQL round-trip that
+     * selects every display + swap field (item name/code, rates, batch, expiry,
+     * stock) directly into {@link StockDTO}. This avoids the previous N+1 of one
+     * {@code findWithItemBatch} per result row, keeping the on-demand click fast
+     * even when an AMP has many sibling brands across many batches.
+     *
      * @param item       the bill item's current item to find alternatives for
      * @param department the current department whose stock should be considered
-     * @return list of {@link Stock} (loaded with item batch), never null
+     * @return list of {@link StockDTO}, FEFO-ordered, never null
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public List<Stock> findSubstituteStocks(Item item, Department department) {
-        List<Stock> result = new ArrayList<>();
+    public List<StockDTO> findSubstituteStocks(Item item, Department department) {
+        List<StockDTO> result = new ArrayList<>();
         if (item == null || department == null || department.getId() == null) {
             return result;
         }
@@ -93,10 +106,14 @@ public class PharmacySubstituteService {
 
         // Native SQL: in-stock (> 0), non-expired (expiry strictly in the
         // future), current department, item in resolved AMPs; FEFO ordered.
+        // All display + swap fields are returned in one round-trip.
         StringBuilder sql = new StringBuilder();
-        sql.append("SELECT s.ID ")
+        sql.append("SELECT s.ID, s.itemBatch_ID, ib.item_ID, i.name, i.code, ")
+                .append("ib.retailsaleRate, s.stock, ib.dateOfExpire, ib.batchNo, ")
+                .append("ib.purcahseRate, ib.costRate, ib.wholesaleRate ")
                 .append("FROM ").append(stockTable()).append(" s ")
                 .append("JOIN ").append(itemBatchTable()).append(" ib ON s.itemBatch_ID = ib.ID ")
+                .append("JOIN ").append(itemTable()).append(" i ON ib.item_ID = i.ID ")
                 .append("WHERE s.department_ID = ?1 ")
                 .append("AND s.stock > 0 ")
                 .append("AND ib.dateOfExpire > NOW() ")
@@ -116,33 +133,52 @@ public class PharmacySubstituteService {
         }
 
         @SuppressWarnings("unchecked")
-        List<Object> stockIdRows = q.getResultList();
-        for (Object row : stockIdRows) {
+        List<Object[]> rows = q.getResultList();
+        for (Object[] row : rows) {
             if (row == null) {
                 continue;
             }
-            Long stockId = ((Number) row).longValue();
-            Stock loaded = stockFacade.findWithItemBatch(stockId);
-            if (loaded != null) {
-                result.add(loaded);
-            }
+            StockDTO dto = new StockDTO();
+            dto.setId(toLong(row[0]));
+            dto.setStockId(toLong(row[0]));
+            dto.setItemBatchId(toLong(row[1]));
+            dto.setItemId(toLong(row[2]));
+            dto.setItemName(row[3] == null ? "" : row[3].toString());
+            dto.setCode(row[4] == null ? "" : row[4].toString());
+            dto.setRetailRate(toDouble(row[5]));
+            dto.setStockQty(toDouble(row[6]));
+            dto.setDateOfExpire(row[7] instanceof Date ? (Date) row[7] : null);
+            dto.setBatchNo(row[8] == null ? "" : row[8].toString());
+            dto.setPurchaseRate(toDouble(row[9]));
+            dto.setCostRate(toDouble(row[10]));
+            dto.setWholesaleRate(toDouble(row[11]));
+            result.add(dto);
         }
         return result;
     }
 
     /**
-     * Swap the selected substitute stock into the bill item: updates item,
-     * batch, stock and all rate + finance-detail fields. Bill totals must be
-     * recalculated by the caller using that controller's own rate-recalc method
-     * (each sale controller derives line values from
-     * {@code pharmaceuticalBillItem.stock.itemBatch}).
+     * Swap the selected substitute stock (chosen from the FEFO alternatives
+     * list) into the bill item: updates item, batch, stock and all rate +
+     * finance-detail fields. Bill totals must be recalculated by the caller
+     * using that controller's own rate-recalc method (each sale controller
+     * derives line values from {@code pharmaceuticalBillItem.stock.itemBatch}).
      *
-     * @param billItem        the bill item to update
-     * @param substituteStock the chosen substitute stock
+     * <p>One entity load happens here (the chosen {@link Stock} with its batch)
+     * — acceptable, as this is a single deliberate user action, not the hot
+     * lookup path.
+     *
+     * @param billItem the bill item to update
+     * @param selected the chosen substitute stock DTO
      * @return true if the swap succeeded
      */
-    public boolean swapStockIntoBillItem(BillItem billItem, Stock substituteStock) {
-        if (billItem == null || substituteStock == null || substituteStock.getItemBatch() == null) {
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public boolean swapStockIntoBillItem(BillItem billItem, StockDTO selected) {
+        if (billItem == null || selected == null || selected.getStockId() == null) {
+            return false;
+        }
+        Stock substituteStock = stockFacade.findWithItemBatch(selected.getStockId());
+        if (substituteStock == null || substituteStock.getItemBatch() == null) {
             return false;
         }
         ItemBatch itemBatch = substituteStock.getItemBatch();
@@ -209,5 +245,20 @@ public class PharmacySubstituteService {
             tItemBatch = resolveTable("ITEMBATCH");
         }
         return tItemBatch;
+    }
+
+    private String itemTable() {
+        if (tItem == null) {
+            tItem = resolveTable("ITEM");
+        }
+        return tItem;
+    }
+
+    private static Long toLong(Object o) {
+        return o == null ? null : ((Number) o).longValue();
+    }
+
+    private static Double toDouble(Object o) {
+        return o == null ? 0.0 : ((Number) o).doubleValue();
     }
 }

--- a/src/main/webapp/pharmacy/fragments/substitute_dialog.xhtml
+++ b/src/main/webapp/pharmacy/fragments/substitute_dialog.xhtml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Reusable "Alternatives" (substitute medicines) dialog for the pharmacy sale
+    pages (issue #21697). Shared by the entity-backed sale controllers
+    (PharmacySaleController, PharmacyFastRetailSaleController and the inheriting
+    PharmacyFastRetailSaleForCashierController). All expose the same on-demand
+    substitute API: prepareSubstitute(BillItem), substituteStocks (List<Stock>),
+    selectedSubstituteStock and replaceSelectedSubstitute().
+
+    ui:params:
+      ctrl         - controller EL, e.g. #{pharmacySaleController}
+      updateTarget - space-separated update targets for the Replace action
+-->
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <p:dialog
+        id="substituteDlg"
+        widgetVar="substituteDialog"
+        modal="true"
+        position="top"
+        fitViewport="true"
+        appendTo="@(body)"
+        header="Alternatives"
+        width="60%">
+        <div class="mb-3 p-3 bg-light border rounded">
+            <h:outputLabel value="Selected Item: " styleClass="fw-bold text-primary"/>
+            <h:outputText value="#{ctrl.itemForSubstitution.item.name}" styleClass="fw-bold text-dark"/>
+        </div>
+        <p:dataTable
+            id="substituteTable"
+            value="#{ctrl.substituteStocks}"
+            var="sStock"
+            rowKey="#{sStock.id}"
+            paginator="true"
+            rows="10"
+            paginatorPosition="bottom"
+            emptyMessage="No substitute stocks found"
+            styleClass="table-striped">
+            <p:column headerText="Item">
+                <h:outputText value="#{sStock.itemBatch.item.name}"/>
+            </p:column>
+            <p:column headerText="Code">
+                <h:outputText value="#{sStock.itemBatch.item.code}"/>
+            </p:column>
+            <p:column headerText="Rate" style="text-align: right;">
+                <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
+                    <f:convertNumber pattern="#,##0.00"/>
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Stock" style="text-align: right;">
+                <h:outputText value="#{sStock.stock}">
+                    <f:convertNumber pattern="#,###.#"/>
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Expiry">
+                <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                </h:outputText>
+            </p:column>
+            <p:column headerText="Action" style="width: 8em;">
+                <p:commandButton
+                    id="btnReplace"
+                    value="Replace"
+                    action="#{ctrl.replaceSelectedSubstitute}"
+                    update="#{updateTarget}"
+                    oncomplete="PF('substituteDialog').hide();"
+                    process="@this">
+                    <f:setPropertyActionListener value="#{sStock}" target="#{ctrl.selectedSubstituteStock}" />
+                </p:commandButton>
+            </p:column>
+        </p:dataTable>
+    </p:dialog>
+</ui:composition>

--- a/src/main/webapp/pharmacy/fragments/substitute_dialog.xhtml
+++ b/src/main/webapp/pharmacy/fragments/substitute_dialog.xhtml
@@ -33,30 +33,30 @@
             id="substituteTable"
             value="#{ctrl.substituteStocks}"
             var="sStock"
-            rowKey="#{sStock.id}"
+            rowKey="#{sStock.stockId}"
             paginator="true"
             rows="10"
             paginatorPosition="bottom"
             emptyMessage="No substitute stocks found"
             styleClass="table-striped">
             <p:column headerText="Item">
-                <h:outputText value="#{sStock.itemBatch.item.name}"/>
+                <h:outputText value="#{sStock.itemName}"/>
             </p:column>
             <p:column headerText="Code">
-                <h:outputText value="#{sStock.itemBatch.item.code}"/>
+                <h:outputText value="#{sStock.code}"/>
             </p:column>
             <p:column headerText="Rate" style="text-align: right;">
-                <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
+                <h:outputText value="#{sStock.retailRate}">
                     <f:convertNumber pattern="#,##0.00"/>
                 </h:outputText>
             </p:column>
             <p:column headerText="Stock" style="text-align: right;">
-                <h:outputText value="#{sStock.stock}">
+                <h:outputText value="#{sStock.stockQty}">
                     <f:convertNumber pattern="#,###.#"/>
                 </h:outputText>
             </p:column>
             <p:column headerText="Expiry">
-                <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
+                <h:outputText value="#{sStock.dateOfExpire}">
                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                 </h:outputText>
             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -596,7 +596,7 @@
 
                                         <ui:include src="fragments/substitute_dialog.xhtml">
                                             <ui:param name="ctrl" value="#{pharmacySaleController}"/>
-                                            <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                            <ui:param name="updateTarget" value=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
                                         </ui:include>
                                     </p:panel>
 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale.xhtml
@@ -319,6 +319,16 @@
                                             <p:column headerText="Item" style="padding: 6px;">
                                                 <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
                                                 <p:commandLink id="showDetails" type="button" value="&nbsp;(+)" oncomplete="PF('dlg').show();" process="showDetails" update="#{p:resolveFirstComponentWithId('panDoc',view).clientId}" />
+                                                <p:commandButton
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show alternative medicines available during retail sale', true)}"
+                                                    id="btnSelectSubstitute"
+                                                    icon="pi pi-refresh"
+                                                    title="Show Alternatives"
+                                                    action="#{pharmacySaleController.prepareSubstitute(bi)}"
+                                                    update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                                    oncomplete="PF('substituteDialog').show();"
+                                                    process="@this"
+                                                    styleClass="ui-button-warning ui-button-icon-only mx-1" />
 
                                                 <p:dialog
                                                     id="panDoc"
@@ -583,6 +593,11 @@
 
 
                                         </p:dataTable>
+
+                                        <ui:include src="fragments/substitute_dialog.xhtml">
+                                            <ui:param name="ctrl" value="#{pharmacySaleController}"/>
+                                            <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                        </ui:include>
                                     </p:panel>
 
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -297,30 +297,30 @@
                                                 id="substituteTable"
                                                 value="#{retailSaleNativeSqlController.substituteStocks}"
                                                 var="sStock"
-                                                rowKey="#{sStock.id}"
+                                                rowKey="#{sStock.stockId}"
                                                 paginator="true"
                                                 rows="10"
                                                 paginatorPosition="bottom"
                                                 emptyMessage="No substitute stocks found"
                                                 styleClass="table-striped">
                                                 <p:column headerText="Item">
-                                                    <h:outputText value="#{sStock.itemBatch.item.name}"/>
+                                                    <h:outputText value="#{sStock.itemName}"/>
                                                 </p:column>
                                                 <p:column headerText="Code">
-                                                    <h:outputText value="#{sStock.itemBatch.item.code}"/>
+                                                    <h:outputText value="#{sStock.code}"/>
                                                 </p:column>
                                                 <p:column headerText="Rate" style="text-align: right;">
-                                                    <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
+                                                    <h:outputText value="#{sStock.retailRate}">
                                                         <f:convertNumber pattern="#,##0.00"/>
                                                     </h:outputText>
                                                 </p:column>
                                                 <p:column headerText="Stock" style="text-align: right;">
-                                                    <h:outputText value="#{sStock.stock}">
+                                                    <h:outputText value="#{sStock.stockQty}">
                                                         <f:convertNumber pattern="#,###.#"/>
                                                     </h:outputText>
                                                 </p:column>
                                                 <p:column headerText="Expiry">
-                                                    <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
+                                                    <h:outputText value="#{sStock.dateOfExpire}">
                                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                                     </h:outputText>
                                                 </p:column>
@@ -329,7 +329,7 @@
                                                         id="btnReplace"
                                                         value="Replace"
                                                         action="#{retailSaleNativeSqlController.replaceSelectedSubstitute}"
-                                                        update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                        update=":#{p:resolveFirstComponentWithId('tblBillItem', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
                                                         oncomplete="PF('substituteDialog').hide();"
                                                         process="@this">
                                                         <f:setPropertyActionListener value="#{sStock}" target="#{retailSaleNativeSqlController.selectedSubstituteStock}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -222,6 +222,16 @@
                                             </p:column>
                                             <p:column headerText="Item" style="padding: 6px;">
                                                 <h:outputLabel value="#{bi.itemName}" />
+                                                <p:commandButton
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show alternative medicines available during retail sale', true)}"
+                                                    id="btnSelectSubstitute"
+                                                    icon="pi pi-refresh"
+                                                    title="Show Alternatives"
+                                                    action="#{retailSaleNativeSqlController.prepareSubstitute(bi)}"
+                                                    update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                                    oncomplete="PF('substituteDialog').show();"
+                                                    process="@this"
+                                                    styleClass="ui-button-warning ui-button-icon-only mx-1" />
                                             </p:column>
                                             <p:column headerText="Rate" style="width: 5em; padding: 6px;">
                                                 <h:outputLabel value="#{bi.rate}">
@@ -269,6 +279,64 @@
                                                     style="display: inline-block;" />
                                             </p:column>
                                         </p:dataTable>
+
+                                        <p:dialog
+                                            id="substituteDlg"
+                                            widgetVar="substituteDialog"
+                                            modal="true"
+                                            position="top"
+                                            fitViewport="true"
+                                            appendTo="@(body)"
+                                            header="Alternatives"
+                                            width="60%">
+                                            <div class="mb-3 p-3 bg-light border rounded">
+                                                <h:outputLabel value="Selected Item: " styleClass="fw-bold text-primary"/>
+                                                <h:outputText value="#{retailSaleNativeSqlController.itemDataForSubstitution.itemName}" styleClass="fw-bold text-dark"/>
+                                            </div>
+                                            <p:dataTable
+                                                id="substituteTable"
+                                                value="#{retailSaleNativeSqlController.substituteStocks}"
+                                                var="sStock"
+                                                rowKey="#{sStock.id}"
+                                                paginator="true"
+                                                rows="10"
+                                                paginatorPosition="bottom"
+                                                emptyMessage="No substitute stocks found"
+                                                styleClass="table-striped">
+                                                <p:column headerText="Item">
+                                                    <h:outputText value="#{sStock.itemBatch.item.name}"/>
+                                                </p:column>
+                                                <p:column headerText="Code">
+                                                    <h:outputText value="#{sStock.itemBatch.item.code}"/>
+                                                </p:column>
+                                                <p:column headerText="Rate" style="text-align: right;">
+                                                    <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Stock" style="text-align: right;">
+                                                    <h:outputText value="#{sStock.stock}">
+                                                        <f:convertNumber pattern="#,###.#"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Expiry">
+                                                    <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Action" style="width: 8em;">
+                                                    <p:commandButton
+                                                        id="btnReplace"
+                                                        value="Replace"
+                                                        action="#{retailSaleNativeSqlController.replaceSelectedSubstitute}"
+                                                        update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                        oncomplete="PF('substituteDialog').hide();"
+                                                        process="@this">
+                                                        <f:setPropertyActionListener value="#{sStock}" target="#{retailSaleNativeSqlController.selectedSubstituteStock}" />
+                                                    </p:commandButton>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </p:dialog>
                                     </p:panel>
                                 </div>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -441,7 +441,7 @@
 
                                             <ui:include src="fragments/substitute_dialog.xhtml">
                                                 <ui:param name="ctrl" value="#{pharmacyFastRetailSaleController}"/>
-                                                <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                                <ui:param name="updateTarget" value=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
                                             </ui:include>
                                         </p:panel>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -208,6 +208,16 @@
                                                 <p:column headerText="Item" style="padding: 6px;">
                                                     <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
                                                     <p:commandLink id="showDetails" type="button" value="&nbsp;(+)" oncomplete="PF('dlg').show();" process="showDetails" update="#{p:resolveFirstComponentWithId('panDoc',view).clientId}" />
+                                                    <p:commandButton
+                                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Show alternative medicines available during retail sale', true)}"
+                                                        id="btnSelectSubstitute"
+                                                        icon="pi pi-refresh"
+                                                        title="Show Alternatives"
+                                                        action="#{pharmacyFastRetailSaleController.prepareSubstitute(bi)}"
+                                                        update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                                        oncomplete="PF('substituteDialog').show();"
+                                                        process="@this"
+                                                        styleClass="ui-button-warning ui-button-icon-only mx-1" />
 
                                                     <ui:include src="fragments/item_details_dialog.xhtml"/>
                                                 </p:column>
@@ -428,6 +438,11 @@
 
 
                                             </p:dataTable>
+
+                                            <ui:include src="fragments/substitute_dialog.xhtml">
+                                                <ui:param name="ctrl" value="#{pharmacyFastRetailSaleController}"/>
+                                                <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                            </ui:include>
                                         </p:panel>
 
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -436,7 +436,7 @@
 
                                             <ui:include src="fragments/substitute_dialog.xhtml">
                                                 <ui:param name="ctrl" value="#{pharmacyFastRetailSaleForCashierController}"/>
-                                                <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                                <ui:param name="updateTarget" value=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
                                             </ui:include>
                                         </p:panel>
 

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -203,6 +203,16 @@
                                                 <p:column headerText="Item" style="padding: 6px;">
                                                     <h:outputLabel value="#{bi.pharmaceuticalBillItem.itemBatch.item.name}" />
                                                     <p:commandLink id="showDetails" type="button" value="&nbsp;(+)" oncomplete="PF('dlg').show();" process="showDetails" update="#{p:resolveFirstComponentWithId('panDoc',view).clientId}" />
+                                                    <p:commandButton
+                                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Show alternative medicines available during retail sale', true)}"
+                                                        id="btnSelectSubstitute"
+                                                        icon="pi pi-refresh"
+                                                        title="Show Alternatives"
+                                                        action="#{pharmacyFastRetailSaleForCashierController.prepareSubstitute(bi)}"
+                                                        update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                                        oncomplete="PF('substituteDialog').show();"
+                                                        process="@this"
+                                                        styleClass="ui-button-warning ui-button-icon-only mx-1" />
 
                                                     <ui:include src="fragments/item_details_dialog.xhtml"/>
                                                 </p:column>
@@ -423,6 +433,11 @@
 
 
                                             </p:dataTable>
+
+                                            <ui:include src="fragments/substitute_dialog.xhtml">
+                                                <ui:param name="ctrl" value="#{pharmacyFastRetailSaleForCashierController}"/>
+                                                <ui:param name="updateTarget" value="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('panelPayment',view).clientId}"/>
+                                            </ui:include>
                                         </p:panel>
 
 


### PR DESCRIPTION
Closes #21697

## Summary

Restores the on-demand **Alternatives** (substitute medicines) flow on all pharmacy sale pages. A per-bill-item **Substitute** button opens a dialog listing in-stock, non-expired substitute stocks in the current department, **FEFO-ordered**, and lets the cashier swap one into the bill. Alternatives load **only on the button click** — never on autocomplete `query`/`itemSelect`.

## Pages & controllers

| Page | Controller |
|------|------------|
| `pharmacy_bill_retail_sale.xhtml` | `PharmacySaleController` |
| `pharmacy_bill_retail_sale_native.xhtml` | `RetailSaleNativeSqlController` |
| `pharmacy_fast_retail_sale.xhtml` | `PharmacyFastRetailSaleController` |
| `pharmacy_fast_retail_sale_for_cashier.xhtml` | `PharmacyFastRetailSaleForCashierController` (inherits) |

## What changed

- **New shared EJB `PharmacySubstituteService`** holds all reusable logic — no triplicated copy of the BHT code:
  - AMP resolution via `pharmacyBean.resolveAmps()`; `resolveAmps` now resolves an AMP to its **VMP sibling AMPs** too, so the list shows true alternative brands of the same virtual product (e.g. 10+ Rosuvastatin 10mg brands), not just other batches of one AMP.
  - **Native SQL** FEFO stock lookup (EclipseLink `?n` positional params, case-insensitive table-name resolution via `INFORMATION_SCHEMA`). Single round-trip into `StockDTO` selecting all display + swap fields — no N+1 per row.
  - Swap-into-bill-item rate/finance mapping (keeps the intentional `purcahseRate` typo).
- All four controllers delegate to the service; `ForCashier` inherits from `FastRetailSale`. The native DTO page rebuilds its `BillItemData` line in place from the DTO.
- Reusable `fragments/substitute_dialog.xhtml` for the entity-backed pages; inline DTO dialog for the native page.
- **Config-gated** by `Show alternative medicines available during retail sale` (default `true`); documented in `developer_docs/configuration/application-options.md`.

## Verification (Playwright, local Main Pharmacy)

- Config **OFF** → no Substitute UI, no query runs. Config **ON** → button appears.
- **Retail Sale**: FEFO dialog listed 6 batches earliest-expiry first; swap persisted (batch/stock/rate/value updated).
- **Fast Sale**: cross-AMP alternatives listed **10 Rosuvastatin 10mg brands**; selecting **ROSULIP 10MG** swapped item + rate (73.47→58.40) + value + expiry with immediate table refresh.
- Fixed a real bug found in testing: the Replace `update` couldn't resolve `tblBillItem` from the `appendTo="@(body)"` dialog context (swap was correct server-side but didn't repaint until reload) — now resolved via `p:resolveFirstComponentWithId` on all pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **“Show Alternatives”** action across retail pharmacy sale flows to display substitute medicines for a line item.
  * Introduced an **Alternatives** dialog/fragment that lists available substitute stocks and enables **Replace** with automatic recalculation.
* **Documentation**
  * Added the **“Pharmacy Retail Sale”** configuration section with **“Show alternative medicines available during retail sale”** (default **true**) to control visibility.
* **Bug Fixes**
  * Improved pricing/discount/total consistency after replacing an item with an alternative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->