### PR TITLE
feat: add pagination to import-failures table on department fees upload page

### DIFF
--- a/src/main/webapp/admin/pricing/upload_to_add_department_fees_by_item_code.xhtml
+++ b/src/main/webapp/admin/pricing/upload_to_add_department_fees_by_item_code.xhtml
@@ -180,6 +180,8 @@
                                     <p:dataTable 
                                         value="#{itemController.importFailures}"
                                         var="m"
+                                        paginator="true"
+                                        rows="100"
                                         rendered="#{not empty itemController.importFailures}"
                                         class="table table-striped">
                                         <p:column headerText="Import Failures">


### PR DESCRIPTION
## Summary
- Adds `paginator="true"` and `rows="100"` to the import-failures `p:dataTable` on the department fees upload page (`upload_to_add_department_fees_by_item_code.xhtml`)
- Without pagination, large failure lists rendered as an unbounded table, making results hard to navigate

## Test plan
- [ ] Upload a file with more than 100 import failures and verify pagination controls appear
- [ ] Verify the success-path upload (no failures) still renders correctly — the table is `rendered="#{not empty itemController.importFailures}"` so it should remain hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Invalid Imports” list now paginates automatically, making it easier to review larger sets of failed items.
  * The table now shows up to 100 rows per page for smoother navigation and quicker scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->