### PR TITLE
fix(pharmacy): disposal issue 3-step workflow — items on receipt + save/finalize/approve UX

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -1231,7 +1231,7 @@ public class PharmacyController implements Serializable {
      * avoid loading full entity graph
      */
     public void fillAmpsDto() {
-        String jpql = "SELECT new com.divudi.core.data.dto.AmpDTO("
+        String jpql = "SELECT new com.divudi.core.data.dto.AmpDto("
                 + "a.id, "
                 + "a.name, "
                 + "a.category.id, "

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -80,6 +80,7 @@ import javax.inject.Named;
 import com.divudi.core.util.CommonFunctions;
 import org.primefaces.event.RowEditEvent;
 import org.primefaces.event.SelectEvent;
+import com.divudi.service.BillService;
 import com.divudi.service.pharmacy.PharmacyCostingService;
 import java.math.RoundingMode;
 import javax.faces.component.UIComponent;
@@ -327,6 +328,8 @@ public class PharmacyIssueController implements Serializable {
     private CashTransactionBean cashTransactionBean;
     @EJB
     private DepartmentFacade departmentFacade;
+    @EJB
+    private BillService billService;
 /////////////////////////
     Item selectedAlternative;
     private PreBill preBill;
@@ -1012,43 +1015,20 @@ public class PharmacyIssueController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Department");
             return null;
         }
-        boolean canIssueToSameDept = configOptionApplicationController
-                .getBooleanValueByKey("Disposal Issue can be done for the same department", false);
-        if (!canIssueToSameDept) {
-            if (Objects.equals(toDepartment, sessionController.getLoggedUser().getDepartment())) {
-                JsfUtil.addErrorMessage("Cannot Issue to the Same Department");
-                return null;
-            }
-        }
-        if (getPreBill().getDepartmentType() != null && !getPreBill().getBillItems().isEmpty()) {
-            for (BillItem bi : getPreBill().getBillItems()) {
-                if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
-                    if (!bi.getItem().getDepartmentType().equals(getPreBill().getDepartmentType())) {
-                        JsfUtil.addErrorMessage("Inconsistent department types detected. All items must belong to the same department type.");
-                        return null;
-                    }
-                }
-            }
-        }
-        if (checkAllBillItem()) {
-            return null;
-        }
-        if (errorCheckForSaleBill()) {
-            return null;
-        }
 
-        getPreBill().setDepartment(sessionController.getLoggedUser().getDepartment());
-        getPreBill().setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
-        getPreBill().setCreatedAt(new Date());
-        getPreBill().setCreater(sessionController.getLoggedUser());
+        if (getPreBill().getId() == null) {
+            getPreBill().setDepartment(sessionController.getLoggedUser().getDepartment());
+            getPreBill().setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+            getPreBill().setCreatedAt(new Date());
+            getPreBill().setCreater(sessionController.getLoggedUser());
+            getPreBill().setBillDate(new Date());
+            getPreBill().setBillTime(new Date());
+        }
         getPreBill().setToDepartment(toDepartment);
         getPreBill().setFromDepartment(sessionController.getLoggedUser().getDepartment());
         getPreBill().setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
         getPreBill().setBillType(BillType.PharmacyDisposalIssue);
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_PRE);
-        getPreBill().setBillDate(new Date());
-        getPreBill().setBillTime(new Date());
-        // completed/checkedBy intentionally left null — set at finalize/approve steps
 
         List<BillItem> tmpBillItems = getPreBill().getBillItems();
         getPreBill().setBillItems(null);
@@ -1072,12 +1052,141 @@ public class PharmacyIssueController implements Serializable {
             }
         }
 
+        getPreBill().setBillItems(tmpBillItems);
         JsfUtil.addSuccessMessage("Disposal Issue Draft Saved Successfully");
-        userStockController.retiredAllUserStockContainer(sessionController.getLoggedUser());
+        billPreview = false;
+        return null;
+    }
+
+    public String finalizeCurrentDraft() {
+        if (toDepartment == null) {
+            JsfUtil.addErrorMessage("Please select a Department first.");
+            return null;
+        }
+        if (getPreBill().getBillItems() == null || getPreBill().getBillItems().isEmpty()) {
+            JsfUtil.addErrorMessage("Please add at least one item before finalizing.");
+            return null;
+        }
+        if (getPreBill().getId() == null) {
+            saveDisposalIssueDraft();
+            if (getPreBill().getId() == null) {
+                JsfUtil.addErrorMessage("Could not save draft. Cannot finalize.");
+                return null;
+            }
+        }
+        return finalizeDisposalIssue(getPreBill().getId());
+    }
+
+    public String loadDraftForEdit(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No draft selected.");
+            return null;
+        }
+        Bill draft = getBillFacade().find(billId);
+        if (draft == null || draft.isRetired()) {
+            JsfUtil.addErrorMessage("Draft not found.");
+            return null;
+        }
+        if (!BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_PRE.equals(draft.getBillTypeAtomic())) {
+            JsfUtil.addErrorMessage("Invalid bill type.");
+            return null;
+        }
+        if (!sessionController.getDepartment().equals(draft.getDepartment())) {
+            JsfUtil.addErrorMessage("This draft does not belong to your department.");
+            return null;
+        }
+        if (draft.getCheckedBy() != null) {
+            JsfUtil.addErrorMessage("This draft has already been finalized. Use View to Approve instead.");
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", billId);
+        List<BillItem> draftItems = getBillItemFacade().findByJpql(
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+
         clearBill();
         clearBillItem();
         billPreview = false;
-        return "/pharmacy/pharmacy_disposal_issue_list_to_finalize?faces-redirect=true";
+
+        if (draft instanceof PreBill) {
+            preBill = (PreBill) draft;
+        } else {
+            preBill = new PreBill();
+            preBill.setId(draft.getId());
+            preBill.setCheckedBy(draft.getCheckedBy());
+            preBill.setCompleted(draft.isCompleted());
+            preBill.setComments(draft.getComments());
+            preBill.setInvoiceNumber(draft.getInvoiceNumber());
+            preBill.setDepartmentType(draft.getDepartmentType());
+            preBill.setBillTypeAtomic(draft.getBillTypeAtomic());
+            preBill.setBillType(draft.getBillType());
+            preBill.setCreatedAt(draft.getCreatedAt());
+            preBill.setCreater(draft.getCreater());
+            preBill.setDepartment(draft.getDepartment());
+            preBill.setToDepartment(draft.getToDepartment());
+            preBill.setFromDepartment(draft.getFromDepartment());
+        }
+        preBill.setBillItems(draftItems);
+        toDepartment = draft.getToDepartment();
+        return "/pharmacy/pharmacy_issue?faces-redirect=true";
+    }
+
+    public String loadFinalizedForApprove(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No bill selected.");
+            return null;
+        }
+        Bill bill = getBillFacade().find(billId);
+        if (bill == null || bill.isRetired()) {
+            JsfUtil.addErrorMessage("Bill not found.");
+            return null;
+        }
+        if (!BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_PRE.equals(bill.getBillTypeAtomic())) {
+            JsfUtil.addErrorMessage("Invalid bill type for approval.");
+            return null;
+        }
+        if (!sessionController.getDepartment().equals(bill.getDepartment())) {
+            JsfUtil.addErrorMessage("This disposal issue does not belong to your department.");
+            return null;
+        }
+        if (bill.getCheckedBy() == null) {
+            JsfUtil.addErrorMessage("This bill has not been finalized yet.");
+            return null;
+        }
+        if (bill.isCompleted()) {
+            JsfUtil.addErrorMessage("This bill has already been approved.");
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", billId);
+        List<BillItem> items = getBillItemFacade().findByJpql(
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+
+        clearBill();
+        clearBillItem();
+        billPreview = false;
+
+        if (bill instanceof PreBill) {
+            preBill = (PreBill) bill;
+        } else {
+            preBill = new PreBill();
+            preBill.setId(bill.getId());
+            preBill.setCheckedBy(bill.getCheckedBy());
+            preBill.setCompleted(bill.isCompleted());
+            preBill.setComments(bill.getComments());
+            preBill.setInvoiceNumber(bill.getInvoiceNumber());
+            preBill.setDepartmentType(bill.getDepartmentType());
+            preBill.setBillTypeAtomic(bill.getBillTypeAtomic());
+            preBill.setBillType(bill.getBillType());
+            preBill.setCreatedAt(bill.getCreatedAt());
+            preBill.setCreater(bill.getCreater());
+            preBill.setDepartment(bill.getDepartment());
+            preBill.setToDepartment(bill.getToDepartment());
+            preBill.setFromDepartment(bill.getFromDepartment());
+        }
+        preBill.setBillItems(items);
+        toDepartment = bill.getToDepartment();
+        return "/pharmacy/pharmacy_issue?faces-redirect=true";
     }
 
     public String finalizeDisposalIssue(Long billId) {
@@ -1107,8 +1216,20 @@ public class PharmacyIssueController implements Serializable {
         draft.setEditor(sessionController.getLoggedUser());
         draft.setEditedAt(new Date());
         getBillFacade().edit(draft);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", billId);
+        List<BillItem> items = getBillItemFacade().findByJpql(
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+        if (preBill != null && preBill.getId() != null && preBill.getId().equals(billId)) {
+            preBill.setCheckedBy(draft.getCheckedBy());
+            preBill.setBillItems(items);
+        }
+        setPrintBill(draft);
+        getPrintBill().setBillItems(items);
+        billPreview = true;
         JsfUtil.addSuccessMessage("Disposal Issue Finalized Successfully");
-        return "/pharmacy/pharmacy_disposal_issue_list_to_approve?faces-redirect=true";
+        return null;
     }
 
     public String approveDisposalIssue(Long billId) {
@@ -1238,12 +1359,14 @@ public class PharmacyIssueController implements Serializable {
 
         setPrintBill(getBillFacade().find(billId));
         getPrintBill().setBillItems(items);
+        preBill = null;
+        toDepartment = null;
         billPreview = true;
         if (anyDeductionFailed) {
             JsfUtil.addErrorMessage("Warning: Insufficient stock for one or more items. Those items were recorded with zero quantity.");
         }
         JsfUtil.addSuccessMessage("Disposal Issue Approved Successfully");
-        return "/pharmacy/pharmacy_issue?faces-redirect=true";
+        return null;
     }
 
     public String cancelPendingDisposalIssue(Long billId) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -1063,16 +1063,27 @@ public class PharmacyIssueController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Department first.");
             return null;
         }
+        boolean canIssueToSameDept = configOptionApplicationController
+                .getBooleanValueByKey("Disposal Issue can be done for the same department", false);
+        if (!canIssueToSameDept
+                && Objects.equals(toDepartment, sessionController.getLoggedUser().getDepartment())) {
+            JsfUtil.addErrorMessage("Cannot Issue to the Same Department");
+            return null;
+        }
         if (getPreBill().getBillItems() == null || getPreBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Please add at least one item before finalizing.");
             return null;
         }
+        if (checkAllBillItem()) {
+            return null;
+        }
+        if (errorCheckForSaleBill()) {
+            return null;
+        }
+        saveDisposalIssueDraft();
         if (getPreBill().getId() == null) {
-            saveDisposalIssueDraft();
-            if (getPreBill().getId() == null) {
-                JsfUtil.addErrorMessage("Could not save draft. Cannot finalize.");
-                return null;
-            }
+            JsfUtil.addErrorMessage("Could not save draft. Cannot finalize.");
+            return null;
         }
         return finalizeDisposalIssue(getPreBill().getId());
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -1237,6 +1237,7 @@ public class PharmacyIssueController implements Serializable {
         }
 
         setPrintBill(getBillFacade().find(billId));
+        getPrintBill().setBillItems(items);
         billPreview = true;
         if (anyDeductionFailed) {
             JsfUtil.addErrorMessage("Warning: Insufficient stock for one or more items. Those items were recorded with zero quantity.");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -1102,7 +1102,7 @@ public class PharmacyIssueController implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("billId", billId);
         List<BillItem> draftItems = getBillItemFacade().findByJpql(
-                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId ORDER BY bi.inwardChargeType, bi.searialNo", params);
 
         clearBill();
         clearBillItem();
@@ -1160,7 +1160,7 @@ public class PharmacyIssueController implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("billId", billId);
         List<BillItem> items = getBillItemFacade().findByJpql(
-                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId ORDER BY bi.inwardChargeType, bi.searialNo", params);
 
         clearBill();
         clearBillItem();
@@ -1220,7 +1220,7 @@ public class PharmacyIssueController implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("billId", billId);
         List<BillItem> items = getBillItemFacade().findByJpql(
-                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId", params);
+                "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId ORDER BY bi.inwardChargeType, bi.searialNo", params);
         if (preBill != null && preBill.getId() != null && preBill.getId().equals(billId)) {
             preBill.setCheckedBy(draft.getCheckedBy());
             preBill.setBillItems(items);
@@ -1334,7 +1334,7 @@ public class PharmacyIssueController implements Serializable {
         getBillFacade().edit(draft);
 
         // Deduct stock for each saved item
-        String jpql = "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId";
+        String jpql = "SELECT bi FROM BillItem bi WHERE bi.retired = false AND bi.bill.id = :billId ORDER BY bi.inwardChargeType, bi.searialNo";
         Map<String, Object> params = new HashMap<>();
         params.put("billId", billId);
         List<BillItem> items = getBillItemFacade().findByJpql(jpql, params);

--- a/src/main/java/com/divudi/core/data/dto/AmpDto.java
+++ b/src/main/java/com/divudi/core/data/dto/AmpDto.java
@@ -172,6 +172,23 @@ public class AmpDto implements Serializable {
     }
 
     /**
+     * AMP list constructor with category — used by fillAmpsDto() JPQL.
+     * category path uses implicit inner join so only AMPs with a category are returned.
+     */
+    public AmpDto(Long id, String name, Long categoryId, String categoryName,
+                  Boolean discountAllowed, Boolean allowFractions,
+                  Boolean consumptionAllowed, Boolean refundsAllowed) {
+        this.id = id;
+        this.name = name;
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.discountAllowed = discountAllowed;
+        this.allowFractions = allowFractions;
+        this.consumptionAllowed = consumptionAllowed;
+        this.refundsAllowed = refundsAllowed;
+    }
+
+    /**
      * Comprehensive list constructor — all Details-Section fields for the Store AMP list page.
      * Used by getStoreAmpListDtos() JPQL query.
      *

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
@@ -94,12 +94,11 @@
                                         <p:commandButton
                                             id="btnApprove"
                                             class="ui-button-success"
-                                            icon="fas fa-check"
-                                            value="Approve"
-                                            title="Approve Disposal Issue #{g.id}"
+                                            icon="fas fa-eye"
+                                            value="View / Approve"
+                                            title="View and Approve Disposal Issue #{g.id}"
                                             ajax="false"
-                                            onclick="if(!confirm('Approve this disposal issue? Stock will be deducted.')) return false;"
-                                            action="#{pharmacyIssueController.approveDisposalIssue(g.id)}"
+                                            action="#{pharmacyIssueController.loadFinalizedForApprove(g.id)}"
                                             style="min-width: 80px;"/>
                                         <p:commandButton
                                             id="btnCancel"

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
@@ -93,12 +93,11 @@
                                 <p:commandButton
                                     id="btnFinalize"
                                     styleClass="ui-button ui-button-warning ui-button-sm"
-                                    icon="fas fa-check-circle"
-                                    value="Finalize"
-                                    title="Finalize Disposal Issue #{g.id}"
+                                    icon="fas fa-eye"
+                                    value="View / Finalize"
+                                    title="View and Finalize Disposal Issue #{g.id}"
                                     ajax="false"
-                                    onclick="if(!confirm('Finalize this disposal issue? It will be queued for approval.')) return false;"
-                                    action="#{pharmacyIssueController.finalizeDisposalIssue(g.id)}"
+                                    action="#{pharmacyIssueController.loadDraftForEdit(g.id)}"
                                     style="font-size: 0.85em; padding: 0.375rem 0.75rem;"/>
                                 <p:commandButton
                                     id="btnCancel"

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -72,13 +72,13 @@
                         </h:panelGroup>
 
                         <p:panel rendered="#{pharmacyIssueController.toDepartment ne null and pharmacyIssueController.toDepartment ne sessionController.loggedUser.department}">
-                            <f:facet name="header" >
-                                <div class="d-flex align-items-center justify-content-between">
-                                    <div>
-                                        <i class="fas fa-building mt-2" />
-                                        <h:outputLabel class="mx-2 mt-2" value="Department Disposal - Issue to #{pharmacyIssueController.toDepartment.name}" />
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between align-items-center w-100">
 
-                                        <!-- Config Button (Admin Only) -->
+                                    <!-- LEFT: title + config -->
+                                    <div class="d-flex align-items-center gap-2">
+                                        <i class="fas fa-building"/>
+                                        <h:outputText value="Department Disposal — Issue to #{pharmacyIssueController.toDepartment.name}"/>
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                             <p:commandButton
                                                 value="Config"
@@ -86,40 +86,80 @@
                                                 title="Page Configuration Management"
                                                 action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_issue')}"
                                                 ajax="false"
-                                                styleClass="ui-button-secondary mx-1">
-                                            </p:commandButton>
+                                                styleClass="ui-button-secondary ui-button-outlined"/>
                                         </h:panelGroup>
-
-
-
                                     </div>
-                                    <div class="float-end" >
+
+                                    <!-- CENTER: navigation -->
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Disposal Issues to Finalize"
+                                            icon="fas fa-tasks"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_disposal_issue_list_to_finalize?faces-redirect=true"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
+                                            title="View disposal issues waiting to be finalized"/>
+                                        <p:commandButton
+                                            value="Disposal Issues to Approve"
+                                            icon="fas fa-check-circle"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_disposal_issue_list_to_approve?faces-redirect=true"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
+                                            title="View disposal issues waiting for approval"/>
+                                    </div>
+
+                                    <!-- RIGHT: actions (left=least important → right=primary) -->
+                                    <div class="d-flex gap-2">
                                         <p:commandButton
                                             accesskey="n"
                                             value="New Disposal Issue Bill"
                                             icon="pi pi-plus"
-                                            class="ui-button-warning m-1"
+                                            styleClass="ui-button-warning"
                                             ajax="false"
                                             action="/pharmacy/pharmacy_issue"
-                                            actionListener="#{pharmacyIssueController.resetAll()}">
-                                        </p:commandButton>
+                                            actionListener="#{pharmacyIssueController.resetAll()}"/>
                                         <p:commandButton
-                                            id="btnIssue"
+                                            id="btnSave"
                                             accesskey="s"
                                             value="Save"
                                             icon="fas fa-floppy-disk"
-                                            class="ui-button-success m-1"
+                                            styleClass="ui-button-success"
                                             ajax="false"
                                             action="#{pharmacyIssueController.saveDisposalIssueDraft()}"
                                             onclick="return confirm('Save this disposal issue draft?');"
-                                            rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssue')}" />
+                                            rendered="#{pharmacyIssueController.preBill.checkedBy eq null and webUserController.hasPrivilege('PharmacyDisposalIssue')}"
+                                            style="min-width:100px"/>
+                                        <p:commandButton
+                                            id="btnFinalize"
+                                            accesskey="f"
+                                            value="Finalize"
+                                            icon="fas fa-check-circle"
+                                            styleClass="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyIssueController.finalizeCurrentDraft()}"
+                                            onclick="return confirm('Finalize this disposal issue? It will be queued for approval.');"
+                                            rendered="#{pharmacyIssueController.preBill.checkedBy eq null and webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
+                                            style="min-width:120px"/>
+                                        <p:commandButton
+                                            id="btnApprove"
+                                            accesskey="a"
+                                            value="Approve"
+                                            icon="fas fa-check-double"
+                                            styleClass="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyIssueController.approveDisposalIssue(pharmacyIssueController.preBill.id)}"
+                                            onclick="return confirm('Approve this disposal issue? Stock will be deducted.');"
+                                            rendered="#{pharmacyIssueController.preBill.checkedBy ne null and !pharmacyIssueController.preBill.completed and webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
+                                            style="min-width:120px"/>
                                     </div>
                                 </div>
                             </f:facet>
 
                             <div class="row">
                                 <div class="col-8">
-                                    <p:panel id="panelAddBillItem">
+                                    <p:panel id="panelAddBillItem" rendered="#{pharmacyIssueController.preBill.checkedBy eq null}">
                                         <f:facet name="header">
                                             <h:outputText styleClass="fa-solid fa-circle-plus" />
                                             <h:outputText class="mx-4" value="Add Items"/>
@@ -157,7 +197,7 @@
                                                     </p:column>
                                                     <p:column
                                                         style="padding: 3px"
-                                                        headerText="Purchase Rate"
+                                                        headerText="Pur. Rate"
                                                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}"
                                                         styleClass="text-end #{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
                                                         <h:outputLabel value="#{i.purchaseRate}" >
@@ -257,7 +297,7 @@
                                                 </p:inputText>
                                             </div>
                                             <div class="col-1 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
-                                                <p:outputLabel value="Purchase Rate" for="txtPurchaseRate" />
+                                                <p:outputLabel value="Pur Rate" for="txtPurchaseRate" />
                                                 <p:inputText
                                                     id="txtPurchaseRate"
                                                     readonly="true"
@@ -437,7 +477,7 @@
                                                 </h:outputLabel>
                                             </p:column>
 
-                                            <p:column headerText="Remove" style="padding: 6px; width: 59px;">
+                                            <p:column headerText="Remove" style="padding: 6px; width: 59px;" rendered="#{pharmacyIssueController.preBill.checkedBy eq null}">
                                                 <p:commandButton icon="fas fa-trash" class="ui-button-danger" action="#{pharmacyIssueController.removeBillItem(bi)}" ajax="false" >
                                                 </p:commandButton>
                                             </p:column>
@@ -464,6 +504,7 @@
                                                     title="Change Department"
                                                     class="ui-button-primary ui-button-sm"
                                                     ajax="false"
+                                                    rendered="#{pharmacyIssueController.preBill.checkedBy eq null}"
                                                     action="#{pharmacyIssueController.changeDepartment()}" />
                                             </h:panelGroup>
 
@@ -473,7 +514,7 @@
                                                 id="selDepartmentType"
                                                 value="#{pharmacyIssueController.preBill.departmentType}"
                                                 class="w-100"
-                                                disabled="#{not empty pharmacyIssueController.preBill.billItems and pharmacyIssueController.preBill.billItems.size() > 0}">
+                                                disabled="#{pharmacyIssueController.preBill.checkedBy ne null or (not empty pharmacyIssueController.preBill.billItems and pharmacyIssueController.preBill.billItems.size() > 0)}">
                                                 <f:selectItem itemLabel="Select Department Type" itemValue="#{null}"/>
                                                 <f:selectItems value="#{sessionController.availableDepartmentTypesForPharmacyTransactions}"
                                                                var="dt"
@@ -483,10 +524,12 @@
                                             </p:selectOneMenu>
 
                                             <h:outputLabel value="Request Number"/>
-                                            <p:inputText class="w-100" value="#{pharmacyIssueController.preBill.invoiceNumber}" id="req"/>
+                                            <p:inputText class="w-100" value="#{pharmacyIssueController.preBill.invoiceNumber}" id="req"
+                                                         readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
 
                                             <h:outputLabel value="Comment"/>
-                                            <p:inputTextarea class="w-100" value="#{pharmacyIssueController.preBill.comments}" id="comment"/>
+                                            <p:inputTextarea class="w-100" value="#{pharmacyIssueController.preBill.comments}" id="comment"
+                                                             readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
 
                                         </h:panelGrid>
 
@@ -560,34 +603,69 @@
                         </p:panel>
                     </p:panel>
 
-                    <p:panel rendered="#{pharmacyIssueController.billPreview}" >
+                    <p:panel rendered="#{pharmacyIssueController.billPreview}">
                         <f:facet name="header">
-                            <div class="float-end">
-                                <p:commandButton
-                                    accesskey="n"
-                                    value="New Disposal Issue Bill"
-                                    icon="pi pi-plus"
-                                    class="ui-button-warning m-1"
-                                    ajax="false"
-                                    action="/pharmacy/pharmacy_issue?faces-redirect=true"
-                                    actionListener="#{pharmacyIssueController.resetAll()}" >
-                                </p:commandButton>
-                                <p:commandButton
-                                    accesskey="p"
-                                    id="btnPrint"
-                                    icon="pi pi-print"
-                                    class="ui-button-primary m-1"
-                                    value="Print"
-                                    ajax="false" >
-                                    <p:printer target="gpBillPreview" ></p:printer>
-                                </p:commandButton>
-                                <p:commandButton
-                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-                                    value="Settings"
-                                    icon="fas fa-cog"
-                                    class="ui-button-secondary m-1"
-                                    type="button"
-                                    onclick="PF('disposalIssueConfigDialog').show();" />
+                            <div class="d-flex justify-content-between align-items-center w-100">
+
+                                <!-- LEFT: Print + Settings + status badge -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <p:commandButton
+                                        id="btnPrint"
+                                        accesskey="p"
+                                        value="Print"
+                                        icon="fas fa-print"
+                                        styleClass="ui-button-info"
+                                        style="min-width:100px"
+                                        ajax="false">
+                                        <p:printer target="gpBillPreview"/>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        styleClass="ui-button-secondary ui-button-outlined"
+                                        type="button"
+                                        onclick="PF('disposalIssueConfigDialog').show();"/>
+                                    <h:panelGroup rendered="#{pharmacyIssueController.printBill ne null and pharmacyIssueController.printBill.checkedBy ne null and !pharmacyIssueController.printBill.completed}">
+                                        <p:badge value="Finalized — Awaiting Approval" severity="warning"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{pharmacyIssueController.printBill ne null and pharmacyIssueController.printBill.completed}">
+                                        <p:badge value="Approved" severity="success"/>
+                                    </h:panelGroup>
+                                </div>
+
+                                <!-- CENTER: Navigation -->
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        value="Disposal Issues to Finalize"
+                                        icon="fas fa-tasks"
+                                        ajax="false"
+                                        action="/pharmacy/pharmacy_disposal_issue_list_to_finalize?faces-redirect=true"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
+                                        title="View disposal issues waiting to be finalized"/>
+                                    <p:commandButton
+                                        value="Disposal Issues to Approve"
+                                        icon="fas fa-check-circle"
+                                        ajax="false"
+                                        action="/pharmacy/pharmacy_disposal_issue_list_to_approve?faces-redirect=true"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
+                                        title="View disposal issues waiting for approval"/>
+                                </div>
+
+                                <!-- RIGHT: New bill -->
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        accesskey="n"
+                                        value="New Disposal Issue Bill"
+                                        icon="pi pi-plus"
+                                        styleClass="ui-button-warning"
+                                        ajax="false"
+                                        action="/pharmacy/pharmacy_issue"
+                                        actionListener="#{pharmacyIssueController.resetAll()}"/>
+                                </div>
+
                             </div>
                         </f:facet>
 

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -240,6 +240,7 @@
                                                     id="txtPRate"
                                                     readonly="true"
                                                     class="w-100 text-end"
+                                                    style="background-color: #e9ecef;"
                                                     value="#{pharmacyIssueController.billItem.billItemFinanceDetails.lineGrossRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
@@ -250,6 +251,7 @@
                                                     id="txtRate"
                                                     readonly="true"
                                                     class="w-100 text-end"
+                                                    style="background-color: #e9ecef;"
                                                     value="#{pharmacyIssueController.billItem.pharmaceuticalBillItem.itemBatch.retailsaleRate}">
                                                     <f:convertNumber pattern="#,##0.0000" />
                                                 </p:inputText>
@@ -260,6 +262,7 @@
                                                     id="txtPurchaseRate"
                                                     readonly="true"
                                                     class="w-100 text-end"
+                                                    style="background-color: #e9ecef;"
                                                     value="#{pharmacyIssueController.billItem.pharmaceuticalBillItem.itemBatch.purcahseRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
@@ -270,6 +273,7 @@
                                                     id="txtCostRate"
                                                     readonly="true"
                                                     class="w-100 text-end"
+                                                    style="background-color: #e9ecef;"
                                                     value="#{pharmacyIssueController.billItem.pharmaceuticalBillItem.itemBatch.costRate}">
                                                     <f:convertNumber pattern="#,##0.0000" />
                                                 </p:inputText>
@@ -281,7 +285,8 @@
                                                     id="txtPVal"
                                                     readonly="true"
                                                     class="w-100 text-end"
-                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
+                                                    style="background-color: #e9ecef;"
+                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtPurchaseRate lt 0 ? (0 - pharmacyIssueController.billItem.billItemFinanceDetails.valueAtPurchaseRate) : pharmacyIssueController.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
                                             </div>
@@ -291,7 +296,8 @@
                                                     id="txtRVal"
                                                     readonly="true"
                                                     class="w-100 text-end"
-                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtRetailRate}">
+                                                    style="background-color: #e9ecef;"
+                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtRetailRate lt 0 ? (0 - pharmacyIssueController.billItem.billItemFinanceDetails.valueAtRetailRate) : pharmacyIssueController.billItem.billItemFinanceDetails.valueAtRetailRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
                                             </div>
@@ -301,10 +307,11 @@
                                                     id="txtCostVal"
                                                     readonly="true"
                                                     class="w-100 text-end"
-                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtCostRate}">
+                                                    style="background-color: #e9ecef;"
+                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.valueAtCostRate lt 0 ? (0 - pharmacyIssueController.billItem.billItemFinanceDetails.valueAtCostRate) : pharmacyIssueController.billItem.billItemFinanceDetails.valueAtCostRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
-                                            </div>     
+                                            </div>
 
                                             <div class="col-2 d-grid" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                                 <p:outputLabel value="Issue Value" for="txtIssueVal" />
@@ -312,7 +319,8 @@
                                                     id="txtIssueVal"
                                                     readonly="true"
                                                     class="w-100 text-end"
-                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.lineNetTotal}">
+                                                    style="background-color: #e9ecef;"
+                                                    value="#{pharmacyIssueController.billItem.billItemFinanceDetails.lineNetTotal lt 0 ? (0 - pharmacyIssueController.billItem.billItemFinanceDetails.lineNetTotal) : pharmacyIssueController.billItem.billItemFinanceDetails.lineNetTotal}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </p:inputText>
                                             </div>                                        
@@ -352,7 +360,7 @@
                                                     class="ui-button-icon-only mx-3"/>
                                             </p:column>
                                             <p:column headerText="Qty" style="padding: 6px;">
-                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.qty}" ></h:outputLabel>
+                                                <h:outputLabel value="#{bi.pharmaceuticalBillItem.qty lt 0 ? (0 - bi.pharmaceuticalBillItem.qty) : bi.pharmaceuticalBillItem.qty}" ></h:outputLabel>
                                             </p:column>
                                             <p:column headerText="Issue Rate" style="padding: 6px;" styleClass="text-end" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                                 <h:outputLabel value="#{bi.billItemFinanceDetails.lineGrossRate}">
@@ -387,39 +395,39 @@
                                                 </h:outputLabel>
                                             </p:column>
 
-                                            <p:column 
-                                                headerText="Purchase Value" 
-                                                style="padding: 6px;" 
+                                            <p:column
+                                                headerText="Purchase Value"
+                                                style="padding: 6px;"
                                                 styleClass="text-end"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
-                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtPurchaseRate}">
+                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtPurchaseRate lt 0 ? (0 - bi.billItemFinanceDetails.valueAtPurchaseRate) : bi.billItemFinanceDetails.valueAtPurchaseRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column 
-                                                headerText="Retail Value" 
-                                                style="padding: 6px;" 
+                                            <p:column
+                                                headerText="Retail Value"
+                                                style="padding: 6px;"
                                                 styleClass="text-end"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
-                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtRetailRate}">
+                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtRetailRate lt 0 ? (0 - bi.billItemFinanceDetails.valueAtRetailRate) : bi.billItemFinanceDetails.valueAtRetailRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column 
-                                                headerText="Cost Value" 
-                                                style="padding: 6px;" 
+                                            <p:column
+                                                headerText="Cost Value"
+                                                style="padding: 6px;"
                                                 styleClass="text-end"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
-                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtCostRate}">
+                                                <h:outputLabel value="#{bi.billItemFinanceDetails.valueAtCostRate lt 0 ? (0 - bi.billItemFinanceDetails.valueAtCostRate) : bi.billItemFinanceDetails.valueAtCostRate}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column 
-                                                headerText="Issue Value" 
-                                                style="padding: 6px;" 
+                                            <p:column
+                                                headerText="Issue Value"
+                                                style="padding: 6px;"
                                                 styleClass="text-end"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
-                                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineNetTotal}">
+                                                <h:outputLabel value="#{bi.billItemFinanceDetails.lineNetTotal lt 0 ? (0 - bi.billItemFinanceDetails.lineNetTotal) : bi.billItemFinanceDetails.lineNetTotal}">
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
@@ -507,11 +515,11 @@
                                             <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                                 <div class="d-flex justify-content-between align-items-center">
                                                     <h:outputLabel class="fw-bold text-muted" value="Total Purchase Value:" />
-                                                    <p:inputText 
-                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalPurchaseValue}" 
+                                                    <p:inputText
+                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalPurchaseValue lt 0 ? (0 - pharmacyIssueController.preBill.billFinanceDetails.totalPurchaseValue) : pharmacyIssueController.preBill.billFinanceDetails.totalPurchaseValue}"
                                                         readonly="true"
                                                         class="text-end fw-bold"
-                                                        style="width: 150px; background-color: #f8f9fa; border: 1px solid #dee2e6;">
+                                                        style="width: 150px; background-color: #e9ecef; border: 1px solid #dee2e6;">
                                                         <f:convertNumber pattern="#,##0.0000" />
                                                     </p:inputText>
                                                 </div>
@@ -520,11 +528,11 @@
                                             <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                                 <div class="d-flex justify-content-between align-items-center">
                                                     <h:outputLabel class="fw-bold text-muted" value="Total Retail Value:" />
-                                                    <p:inputText 
-                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalRetailSaleValue}" 
+                                                    <p:inputText
+                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalRetailSaleValue lt 0 ? (0 - pharmacyIssueController.preBill.billFinanceDetails.totalRetailSaleValue) : pharmacyIssueController.preBill.billFinanceDetails.totalRetailSaleValue}"
                                                         readonly="true"
                                                         class="text-end fw-bold"
-                                                        style="width: 150px; background-color: #f8f9fa; border: 1px solid #dee2e6;">
+                                                        style="width: 150px; background-color: #e9ecef; border: 1px solid #dee2e6;">
                                                         <f:convertNumber pattern="#,##0.0000" />
                                                     </p:inputText>
                                                 </div>
@@ -533,11 +541,11 @@
                                             <div class="col-12" rendered="#{configOptionApplicationController.getBooleanValueByKey('Consumption - Show Rate and Value', false) and webUserController.hasPrivilege('ConsumptionViewRates')}">
                                                 <div class="d-flex justify-content-between align-items-center">
                                                     <h:outputLabel class="fw-bold text-muted" value="Total Cost Value:" />
-                                                    <p:inputText 
-                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalCostValue}" 
+                                                    <p:inputText
+                                                        value="#{pharmacyIssueController.preBill.billFinanceDetails.totalCostValue lt 0 ? (0 - pharmacyIssueController.preBill.billFinanceDetails.totalCostValue) : pharmacyIssueController.preBill.billFinanceDetails.totalCostValue}"
                                                         readonly="true"
                                                         class="text-end fw-bold"
-                                                        style="width: 150px; background-color: #f8f9fa; border: 1px solid #dee2e6;">
+                                                        style="width: 150px; background-color: #e9ecef; border: 1px solid #dee2e6;">
                                                         <f:convertNumber pattern="#,##0.0000" />
                                                     </p:inputText>
                                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -81,6 +81,7 @@
                                         <h:outputText value="Department Disposal — Issue to #{pharmacyIssueController.toDepartment.name}"/>
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                             <p:commandButton
+                                                id="btnConfig"
                                                 value="Config"
                                                 icon="fa fa-cog"
                                                 title="Page Configuration Management"
@@ -93,6 +94,7 @@
                                     <!-- CENTER: navigation -->
                                     <div class="d-flex gap-2">
                                         <p:commandButton
+                                            id="btnNavFinalize"
                                             value="Disposal Issues to Finalize"
                                             icon="fas fa-tasks"
                                             ajax="false"
@@ -101,6 +103,7 @@
                                             rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
                                             title="View disposal issues waiting to be finalized"/>
                                         <p:commandButton
+                                            id="btnNavApprove"
                                             value="Disposal Issues to Approve"
                                             icon="fas fa-check-circle"
                                             ajax="false"
@@ -113,6 +116,7 @@
                                     <!-- RIGHT: actions (left=least important → right=primary) -->
                                     <div class="d-flex gap-2">
                                         <p:commandButton
+                                            id="btnNew"
                                             accesskey="n"
                                             value="New Disposal Issue Bill"
                                             icon="pi pi-plus"
@@ -620,6 +624,7 @@
                                         <p:printer target="gpBillPreview"/>
                                     </p:commandButton>
                                     <p:commandButton
+                                        id="btnPrintSettings"
                                         rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
                                         value="Settings"
                                         icon="fas fa-cog"
@@ -637,6 +642,7 @@
                                 <!-- CENTER: Navigation -->
                                 <div class="d-flex gap-2">
                                     <p:commandButton
+                                        id="btnPrintNavFinalize"
                                         value="Disposal Issues to Finalize"
                                         icon="fas fa-tasks"
                                         ajax="false"
@@ -645,6 +651,7 @@
                                         rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
                                         title="View disposal issues waiting to be finalized"/>
                                     <p:commandButton
+                                        id="btnPrintNavApprove"
                                         value="Disposal Issues to Approve"
                                         icon="fas fa-check-circle"
                                         ajax="false"
@@ -657,6 +664,7 @@
                                 <!-- RIGHT: New bill -->
                                 <div class="d-flex gap-2">
                                     <p:commandButton
+                                        id="btnPrintNew"
                                         accesskey="n"
                                         value="New Disposal Issue Bill"
                                         icon="pi pi-plus"


### PR DESCRIPTION
## Summary

Fixes issue #21433 (item details missing on disposal bill after approval) and redesigns the full 3-step Save → Finalize → Approve workflow to match the GRN Return pattern.

### Root cause fix
- `approveDisposalIssue()` fetched the bill but never initialised the lazy `billItems` collection before redirecting; the detached entity arrived in the next GET request with empty items on the receipt
- Fix: populate `printBill.billItems` from the JPQL-fetched `items` list (already fully loaded with EAGER-associated item, batch and finance details) before setting `billPreview = true`

### Workflow redesign

**Controller (`PharmacyIssueController`)**
- `saveDisposalIssueDraft()` — removes all validation except `toDepartment == null`; stays on page; restores `billItems` on `preBill` after persist
- `finalizeCurrentDraft()` — new; validates, auto-saves if needed, then finalizes; shows print preview
- `finalizeDisposalIssue()` — after setting `checkedBy`, loads items, sets `printBill` + `billPreview = true`, stays on page
- `loadDraftForEdit(Long)` — new; loads a saved draft into `preBill`/`toDepartment` for editing (called from finalize list)
- `loadFinalizedForApprove(Long)` — new; loads a finalized bill in read-only mode with Approve button visible (called from approve list)
- `approveDisposalIssue()` — stays on page after showing receipt; clears `preBill`/`toDepartment`

**pharmacy_issue.xhtml**
- Three-zone panel header: Left (title + Config) | Centre (navigation outlined buttons) | Right (Save → Finalize → Approve)
- Save and Finalize hidden when `checkedBy != null`; Approve shown only when finalized and not yet completed
- Add Items panel and Remove column hidden when finalized (read-only approval view)
- Issue Details fields readonly/disabled when finalized
- Print preview header: Print + Settings on left; navigation to finalize/approve lists in centre; New bill on right; status badge (Finalized — Awaiting Approval / Approved)

**pharmacy_disposal_issue_list_to_finalize.xhtml**
- "View / Finalize" button navigates to pharmacy_issue with draft loaded (no blind direct-finalize)

**pharmacy_disposal_issue_list_to_approve.xhtml**
- "View / Approve" button navigates to pharmacy_issue with bill loaded read-only (no blind direct-approve)

## Test plan
- [ ] Save — page stays, items remain visible
- [ ] Finalize — print preview with "Finalized — Awaiting Approval" badge; nav buttons to both lists
- [ ] View / Finalize from list — edit form loads draft; Save + Finalize shown
- [ ] View / Approve from list — read-only form; Add Items hidden; only Approve shown
- [ ] Approve — receipt shows all item columns correctly; "Approved" badge shown; stock deducted

Closes #21433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer draft/finalize/approve workflow for pharmacy disposal issues, including new view-and-complete actions before final approval.
  * Updated the disposal issue screen with a revised toolbar, quicker navigation to finalize/approve lists, and improved print/preview status badges.

* **Bug Fixes**
  * Fixed AMP loading so item details display correctly in related lists and bulk-update flows.
  * Improved displayed values across disposal screens by preventing negative amounts from appearing in totals and item rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->