### PR TITLE
fix(pharmacy): populate item code in stock-take Excel sheets + blockUI on Generate

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -821,9 +821,8 @@ public class PharmacyStockTakeController implements Serializable {
                 cId.setCellValue(dto.getBillItemId() != null ? dto.getBillItemId() : 0L);
                 cId.setCellStyle(integerLocked);
 
-                // Code — not stored in SnapshotBillItemDTO
                 Cell cCode = row.createCell(c++);
-                cCode.setCellValue("");
+                cCode.setCellValue(dto.getItemCode() != null ? dto.getItemCode() : "");
                 cCode.setCellStyle(textLocked);
 
                 Cell cName = row.createCell(c++);
@@ -2827,7 +2826,7 @@ public class PharmacyStockTakeController implements Serializable {
             // so EAGER relationships (billFees, patientInvestigation, etc.) never fire.
             String jpql = "SELECT bi.id, bi.qty, bi.descreption, bi.catId, bi.netValue, "
                     + "pbi.costRate, pbi.purchaseRate, pbi.retailRate, "
-                    + "pbi.doe, pbi.stringValue, pbi.description, i.departmentType "
+                    + "pbi.doe, pbi.stringValue, pbi.description, i.departmentType, i.code "
                     + "FROM BillItem bi "
                     + "LEFT JOIN bi.pharmaceuticalBillItem pbi "
                     + "LEFT JOIN bi.item i "
@@ -2853,6 +2852,7 @@ public class PharmacyStockTakeController implements Serializable {
                         toLong(r[0]),          // billItemId
                         toDouble(r[1]),        // qty
                         r[2] != null ? r[2].toString() : null,  // itemName
+                        r[12] != null ? r[12].toString() : null, // itemCode
                         r[3] != null ? r[3].toString() : null,  // categoryName
                         toDouble(r[4]),        // netValue
                         toDouble(r[5]),        // costRate
@@ -4392,9 +4392,9 @@ public class PharmacyStockTakeController implements Serializable {
                 cId.setCellValue(dto.getBillItemId() != null ? dto.getBillItemId() : 0L);
                 cId.setCellStyle(integerLocked);
 
-                // Code — not stored in SnapshotBillItemDTO, leave blank
+                // Code
                 Cell cCode = row.createCell(c++);
-                cCode.setCellValue("");
+                cCode.setCellValue(dto.getItemCode() != null ? dto.getItemCode() : "");
                 cCode.setCellStyle(textLocked);
 
                 // Category

--- a/src/main/java/com/divudi/core/data/dto/SnapshotBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/SnapshotBillItemDTO.java
@@ -16,6 +16,7 @@ public class SnapshotBillItemDTO implements Serializable {
     private Long billItemId;
     private Double qty;
     private String itemName;
+    private String itemCode;
     private String categoryName;
     private Double netValue;
     private Double costRate;
@@ -53,6 +54,15 @@ public class SnapshotBillItemDTO implements Serializable {
         this.departmentType = departmentType;
     }
 
+    public SnapshotBillItemDTO(Long billItemId, Double qty, String itemName, String itemCode,
+                                String categoryName, Double netValue, Double costRate, Double purchaseRate,
+                                Double retailRate, Date expiryDate, String batchNo, String dosageForm,
+                                DepartmentType departmentType) {
+        this(billItemId, qty, itemName, categoryName, netValue, costRate, purchaseRate, retailRate,
+                expiryDate, batchNo, dosageForm, departmentType);
+        this.itemCode = itemCode;
+    }
+
     public Long getBillItemId() { return billItemId; }
     public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
 
@@ -61,6 +71,21 @@ public class SnapshotBillItemDTO implements Serializable {
 
     public String getItemName() { return itemName; }
     public void setItemName(String itemName) { this.itemName = itemName; }
+
+    public String getItemCode() { return itemCode; }
+    public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+
+    /**
+     * Item name with the item code appended in parentheses, for on-screen
+     * display where there is no separate code column. Falls back to just the
+     * name when no code is available.
+     */
+    public String getItemNameWithCode() {
+        if (itemCode == null || itemCode.trim().isEmpty()) {
+            return itemName;
+        }
+        return (itemName != null ? itemName : "") + " (" + itemCode + ")";
+    }
 
     public String getCategoryName() { return categoryName; }
     public void setCategoryName(String categoryName) { this.categoryName = categoryName; }

--- a/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take.xhtml
@@ -11,8 +11,16 @@
     <h:body>
         <ui:composition template="/pharmacy/adjustments/pharmacy_adjustment_index.xhtml">
             <ui:define name="subcontent">
-                <h:form>
+                <h:form id="stockTakeForm">
                     <p:growl id="growl" life="3000" />
+
+                    <p:blockUI block="stockTakeForm" trigger="btnGenerateStockCount">
+                        <div style="text-align:center; padding: 20px; color: white;">
+                            <i class="fa fa-spinner fa-spin fa-3x" style="margin-bottom: 12px;"></i>
+                            <div style="font-size: 1.1em; font-weight: bold;">Generating initial stock counts, please wait...</div>
+                            <div style="font-size: 0.9em; margin-top: 6px;">This may take several minutes for departments with many items. Please do not close or refresh this page.</div>
+                        </div>
+                    </p:blockUI>
 
                     <p:panel header="Pharmacy Stock Take" styleClass="mb-3">
                         <!-- Location Selection Section -->
@@ -179,6 +187,7 @@
                         <!-- Action Section -->
                         <div class="d-flex flex-wrap gap-2 mt-3">
                             <p:commandButton
+                                id="btnGenerateStockCount"
                                 value="Generate Stock Taking Initial Stock Counts"
                                 action="#{pharmacyStockTakeController.generateStockCountBill}"
                                 ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_print.xhtml
@@ -271,7 +271,7 @@
                                         <p:column headerText="Item Description" sortBy="#{bi.itemName}"
                                                   filterBy="#{bi.itemName}" filterMatchMode="contains"
                                                   style="min-width: 200px;">
-                                            <h:outputText value="#{bi.itemName}"
+                                            <h:outputText value="#{bi.itemNameWithCode}"
                                                           style="color: #495057; font-weight: 500;"/>
                                         </p:column>
 


### PR DESCRIPTION
## Summary

- Fixes empty **Code** column in the guided/blind stock-take download sheets: `SnapshotBillItemDTO` now carries `itemCode`, the JPQL scalar query selects `i.code`, and both `generateSheet` / `generateFilteredSheet` write the value instead of an empty string
- Print page (`pharmacy_stock_take_print.xhtml`) now shows item code appended to the item name via `getItemNameWithCode()` so the on-screen table is also informative
- Adds a `p:blockUI` spinner overlay on the Generate Stock Count button, matching the existing pattern on the review page, to prevent user confusion during the long synchronous request

Ported from hotfix PR #21633 (`stock-take-please-wait-and-item-code-hotfix`).

Closes #21414

## Test plan
- [ ] Generate a stock count snapshot for a department with multiple items
- [ ] Download the **Guided Sheet** — verify the Code column is populated for all rows
- [ ] Download the **Blind Sheet** — verify the Code column is populated for all rows
- [ ] Open the print page — verify item descriptions show `ItemName (CODE)` format
- [ ] Click **Generate Stock Taking Initial Stock Counts** — verify the blockUI spinner appears and the page is blocked until the request completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)