### PR TITLE
fix(pharmacy): native retail sale substitute expiry + multiple payments (#21702)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -117,6 +117,8 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     @EJB
     private RetailSaleNativeSqlService nativeSqlService;
     @EJB
+    private com.divudi.service.PaymentService paymentService;
+    @EJB
     private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
     @EJB
     private DiscountSchemeValidationService discountSchemeValidationService;
@@ -380,6 +382,16 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         recalculateDiscountsForAll();
         calTotal();
 
+        // For Multiple Payment Methods, the entered components must cover the net
+        // total (and balance-backed components must have sufficient balance)
+        // before the bill is settled as paid. Mirrors the legacy retail sale
+        // page validation (PharmacySaleController.errorCheck).
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods
+                && validateMultiplePaymentsFailed()) {
+            billSettlingStarted = false;
+            return null;
+        }
+
         // Save or update the patient record
         savePatientIfNeeded();
 
@@ -397,6 +409,9 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
         try {
             List<Payment> payments = nativeSqlService.settle(preBillEntity, saleBillEntity, billItemDataList, paymentMethod, getPaymentMethodData(), paymentScheme);
+            // Debit patient deposits and update staff/credit-company balances for
+            // balance-backed components (no-op for cash/card/etc.).
+            paymentService.updateBalances(payments);
             drawerController.updateDrawerForIns(payments);
 
             buildPrintBill(saleBillEntity);
@@ -1317,6 +1332,12 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     @Override
     public void recieveRemainAmountAutomatically() {
         double remainAmount = calculatRemainForMultiplePaymentTotal();
+        // Already fully covered (or over-paid): do not auto-fill a negative
+        // remaining amount into the last component, which would later persist a
+        // negative Payment.paidValue and distort drawer/balance updates.
+        if (remainAmount <= 0.0) {
+            return;
+        }
         if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
             int arrSize = getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().size();
             if (arrSize == 0) {
@@ -1391,6 +1412,107 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
                 }
             }
         }
+    }
+
+    /**
+     * Validates a Multiple Payment Methods bill before settling: there must be
+     * at least one component, balance-backed components (Patient Deposit, Staff,
+     * Staff Welfare) must have sufficient balance, and the sum of the entered
+     * component values must match the bill net total (within a 1.0 tolerance).
+     * Adds a user-facing error message and returns {@code true} when settling
+     * must be aborted. Mirrors {@code PharmacySaleController.errorCheck}.
+     */
+    private boolean validateMultiplePaymentsFailed() {
+        if (getPaymentMethodData().getPaymentMethodMultiple() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().isEmpty()) {
+            JsfUtil.addErrorMessage("No Details on multiple payment methods given");
+            return true;
+        }
+
+        double netTotal = Math.abs(getPreBill().getNetTotal());
+        double multiplePaymentMethodTotalValue = 0.0;
+        for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            switch (cd.getPaymentMethod()) {
+                case Cash:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCash().getTotalValue();
+                    break;
+                case Card:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCreditCard().getTotalValue();
+                    break;
+                case Cheque:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCheque().getTotalValue();
+                    break;
+                case ewallet:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getEwallet().getTotalValue();
+                    break;
+                case Slip:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getSlip().getTotalValue();
+                    break;
+                case OnlineSettlement:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getOnlineSettlement().getTotalValue();
+                    break;
+                case IOU:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getIou().getTotalValue();
+                    break;
+                case Credit:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCredit().getTotalValue();
+                    break;
+                case PatientDeposit: {
+                    double value = cd.getPaymentMethodData().getPatient_deposit().getTotalValue();
+                    PatientDeposit pd = patientDepositController.getDepositOfThePatient(getPatient(), sessionController.getDepartment());
+                    if (pd == null) {
+                        JsfUtil.addErrorMessage("No Patient Deposit.");
+                        return true;
+                    }
+                    if (value > pd.getBalance()) {
+                        JsfUtil.addErrorMessage("No Sufficient Patient Deposit");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                case Staff: {
+                    double value = cd.getPaymentMethodData().getStaffCredit().getTotalValue();
+                    Staff selectedStaff = cd.getPaymentMethodData().getStaffCredit().getToStaff();
+                    if (value == 0.0 || selectedStaff == null) {
+                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
+                        return true;
+                    }
+                    if (selectedStaff.getCurrentCreditValue() + value > selectedStaff.getCreditLimitQualified()) {
+                        JsfUtil.addErrorMessage("No enough Credit.");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                case Staff_Welfare: {
+                    double value = cd.getPaymentMethodData().getStaffWelfare().getTotalValue();
+                    Staff welfareStaff = cd.getPaymentMethodData().getStaffWelfare().getToStaff();
+                    if (value == 0.0 || welfareStaff == null) {
+                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
+                        return true;
+                    }
+                    if (Math.abs(welfareStaff.getAnnualWelfareUtilized()) + value > welfareStaff.getAnnualWelfareQualified()) {
+                        JsfUtil.addErrorMessage("No enough credit.");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        if (Math.abs(netTotal - multiplePaymentMethodTotalValue) > 1.0) {
+            JsfUtil.addErrorMessage("Mismatch in differences of multiple payment method total and bill total");
+            return true;
+        }
+        return false;
     }
 
     public PaymentMethodData getPaymentMethodData() {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -8,6 +8,7 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.cashTransaction.DrawerController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.ControllerWithMultiplePayments;
 import com.divudi.bean.common.ControllerWithPatient;
 import com.divudi.service.DiscountSchemeValidationService;
 import com.divudi.bean.common.PatientDepositController;
@@ -17,8 +18,10 @@ import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.BooleanMessage;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.entity.PatientDeposit;
 import com.divudi.core.data.dto.PrintBillData;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.entity.Bill;
@@ -82,7 +85,7 @@ import org.primefaces.event.SelectEvent;
  */
 @Named
 @SessionScoped
-public class RetailSaleNativeSqlController implements Serializable, ControllerWithPatient {
+public class RetailSaleNativeSqlController implements Serializable, ControllerWithPatient, ControllerWithMultiplePayments {
 
     private static final Logger LOGGER = Logger.getLogger(RetailSaleNativeSqlController.class.getName());
 
@@ -393,8 +396,8 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         }
 
         try {
-            Payment payment = nativeSqlService.settle(preBillEntity, saleBillEntity, billItemDataList, paymentMethod, getPaymentMethodData(), paymentScheme);
-            drawerController.updateDrawerForIns(payment);
+            List<Payment> payments = nativeSqlService.settle(preBillEntity, saleBillEntity, billItemDataList, paymentMethod, getPaymentMethodData(), paymentScheme);
+            drawerController.updateDrawerForIns(payments);
 
             buildPrintBill(saleBillEntity);
             clearBill();
@@ -1255,6 +1258,139 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
     public void setPaymentScheme(PaymentScheme paymentScheme) {
         this.paymentScheme = paymentScheme;
+    }
+
+    @Override
+    public double calculatRemainForMultiplePaymentTotal() {
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            double multiplePaymentMethodTotalValue = 0.0;
+            for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+                if (cd == null) {
+                    continue;
+                }
+                if (cd.getPaymentMethodData() != null && cd.getPaymentMethod() != null) {
+                    // Only add the value from the selected payment method for this ComponentDetail
+                    switch (cd.getPaymentMethod()) {
+                        case Cash:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCash().getTotalValue();
+                            break;
+                        case Card:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCreditCard().getTotalValue();
+                            break;
+                        case Cheque:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCheque().getTotalValue();
+                            break;
+                        case ewallet:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getEwallet().getTotalValue();
+                            break;
+                        case PatientDeposit:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getPatient_deposit().getTotalValue();
+                            break;
+                        case Slip:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getSlip().getTotalValue();
+                            break;
+                        case Staff:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getStaffCredit().getTotalValue();
+                            break;
+                        case Staff_Welfare:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getStaffWelfare().getTotalValue();
+                            break;
+                        case Credit:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCredit().getTotalValue();
+                            break;
+                        case OnlineSettlement:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getOnlineSettlement().getTotalValue();
+                            break;
+                        case IOU:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getIou().getTotalValue();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            return getPreBill().getNetTotal() - multiplePaymentMethodTotalValue;
+        }
+        return getPreBill().getTotal();
+    }
+
+    @Override
+    public void recieveRemainAmountAutomatically() {
+        double remainAmount = calculatRemainForMultiplePaymentTotal();
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            int arrSize = getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().size();
+            if (arrSize == 0) {
+                return; // No payment methods added yet
+            }
+            ComponentDetail pm = getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().get(arrSize - 1);
+            if (pm.getPaymentMethodData() == null) {
+                return; // Payment method data not initialized
+            }
+            if (pm.getPaymentMethod() == PaymentMethod.Cash) {
+                // Only set value automatically if not already set by user
+                if (pm.getPaymentMethodData().getCash().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCash().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Card) {
+                if (pm.getPaymentMethodData().getCreditCard().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCreditCard().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Cheque) {
+                if (pm.getPaymentMethodData().getCheque().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCheque().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Slip) {
+                if (pm.getPaymentMethodData().getSlip().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getSlip().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.ewallet) {
+                if (pm.getPaymentMethodData().getEwallet().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getEwallet().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.PatientDeposit) {
+                if (patient == null || patient.getId() == null) {
+                    pm.getPaymentMethodData().getPatient_deposit().setTotalValue(0.0);
+                    return; // Patient not selected yet, ignore
+                }
+                // Initialize patient deposit data for UI component
+                pm.getPaymentMethodData().getPatient_deposit().setPatient(patient);
+                PatientDeposit pd = patientDepositController.getDepositOfThePatient(patient, sessionController.getDepartment());
+                if (pd != null && pd.getId() != null) {
+                    pm.getPaymentMethodData().getPatient_deposit().getPatient().setHasAnAccount(true);
+                    pm.getPaymentMethodData().getPatient_deposit().setPatientDepost(pd);
+                    // Set total value to remain amount only if there's sufficient balance, otherwise set to available balance
+                    double availableBalance = pd.getBalance();
+                    if (availableBalance >= remainAmount) {
+                        pm.getPaymentMethodData().getPatient_deposit().setTotalValue(remainAmount);
+                    } else {
+                        pm.getPaymentMethodData().getPatient_deposit().setTotalValue(availableBalance);
+                    }
+                } else {
+                    pm.getPaymentMethodData().getPatient_deposit().getPatient().setHasAnAccount(false);
+                    pm.getPaymentMethodData().getPatient_deposit().setTotalValue(0.0);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Credit) {
+                if (pm.getPaymentMethodData().getCredit().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCredit().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Staff) {
+                if (pm.getPaymentMethodData().getStaffCredit().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getStaffCredit().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Staff_Welfare) {
+                if (pm.getPaymentMethodData().getStaffWelfare().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getStaffWelfare().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.OnlineSettlement) {
+                if (pm.getPaymentMethodData().getOnlineSettlement().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getOnlineSettlement().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.IOU) {
+                if (pm.getPaymentMethodData().getIou().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getIou().setTotalValue(remainAmount);
+                }
+            }
+        }
     }
 
     public PaymentMethodData getPaymentMethodData() {

--- a/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacySubstituteService.java
@@ -167,7 +167,7 @@ public class PharmacySubstituteService {
             dto.setCode(row[4] == null ? "" : row[4].toString());
             dto.setRetailRate(toDouble(row[5]));
             dto.setStockQty(toDouble(row[6]));
-            dto.setDateOfExpire(row[7] instanceof Date ? (Date) row[7] : null);
+            dto.setDateOfExpire(toDate(row[7]));
             dto.setBatchNo(row[8] == null ? "" : row[8].toString());
             dto.setPurchaseRate(toDouble(row[9]));
             dto.setCostRate(toDouble(row[10]));
@@ -299,5 +299,41 @@ public class PharmacySubstituteService {
 
     private static Double toDouble(Object o) {
         return o == null ? 0.0 : ((Number) o).doubleValue();
+    }
+
+    /**
+     * Converts a raw JDBC date/time object to {@link java.util.Date}.
+     *
+     * <p>MySQL Connector/J 8.x (with {@code useLegacyDatetimeCode=false}, the
+     * default) returns {@code datetime} columns as {@link java.time.LocalDateTime}
+     * — which is NOT a {@code java.util.Date}. A bare {@code instanceof Date}
+     * cast therefore silently yields {@code null}, leaving the substitute
+     * panel's Expiry column (and the swapped bill line's expiry) blank. Handle
+     * {@code Timestamp}, {@code java.sql.Date}, {@code java.util.Date} and the
+     * Java-8 time types, mirroring the other native-SQL services
+     * (e.g. {@code TransferReceiveNativeSqlService.toDate}).
+     */
+    private static Date toDate(Object o) {
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof java.sql.Timestamp) {
+            return new Date(((java.sql.Timestamp) o).getTime());
+        }
+        if (o instanceof java.sql.Date) {
+            return new Date(((java.sql.Date) o).getTime());
+        }
+        if (o instanceof Date) {
+            return (Date) o;
+        }
+        if (o instanceof java.time.LocalDateTime) {
+            return Date.from(((java.time.LocalDateTime) o)
+                    .atZone(java.time.ZoneId.systemDefault()).toInstant());
+        }
+        if (o instanceof java.time.LocalDate) {
+            return Date.from(((java.time.LocalDate) o)
+                    .atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -6,6 +6,7 @@
 package com.divudi.service.pharmacy;
 
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dto.BillItemData;
 import com.divudi.core.data.dto.PrintBillData;
@@ -72,7 +73,7 @@ public class RetailSaleNativeSqlService {
     // -----------------------------------------------------------------------
 
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public Payment settle(PreBill preBill, BilledBill saleBill, List<BillItemData> items,
+    public List<Payment> settle(PreBill preBill, BilledBill saleBill, List<BillItemData> items,
                           PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
                           PaymentScheme paymentScheme) {
         if (items == null || items.isEmpty()) {
@@ -255,22 +256,31 @@ public class RetailSaleNativeSqlService {
                 .setParameter(5, billId)
                 .executeUpdate();
 
-        // Step 6: Insert Payment record against BilledBill
-        Payment payment = insertPayment(saleBill, billId, billTotals[1], paymentMethod, paymentMethodData, paymentScheme);
+        // Step 6: Insert Payment record(s) against BilledBill. A single payment
+        // for ordinary methods; one Payment per component for MultiplePaymentMethods.
+        List<Payment> payments = insertPayment(saleBill, billId, billTotals[1], paymentMethod, paymentMethodData, paymentScheme);
 
         LOGGER.log(Level.INFO, "[RetailNativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});
 
-        return payment;
+        return payments;
     }
 
     // -----------------------------------------------------------------------
     // Payment
     // -----------------------------------------------------------------------
 
-    private Payment insertPayment(Bill bill, long billId, double netTotal,
+    private List<Payment> insertPayment(Bill bill, long billId, double netTotal,
                                    PaymentMethod paymentMethod, PaymentMethodData pmd,
                                    PaymentScheme paymentScheme) {
+        // MultiplePaymentMethods: persist one Payment per component (Cash, Card,
+        // Cheque, ...), each carrying its own entered value and reference fields.
+        // Mirrors PharmacySaleController.createMultiplePayments for parity with
+        // the legacy retail sale page.
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            return insertMultiplePayments(bill, billId, pmd);
+        }
+
         Payment p = new Payment();
         p.setBill(em.getReference(Bill.class, billId));
         p.setInstitution(bill.getInstitution());
@@ -342,7 +352,124 @@ public class RetailSaleNativeSqlService {
 
         em.persist(p);
         em.flush();
-        return p;
+        List<Payment> result = new ArrayList<>();
+        result.add(p);
+        return result;
+    }
+
+    /**
+     * Persists one {@link Payment} per selected component of a
+     * MultiplePaymentMethods bill. Each component's own entered value and
+     * method-specific reference fields are copied onto its Payment, mirroring
+     * {@code PharmacySaleController.createMultiplePayments}. Components with no
+     * payment method or no data are skipped.
+     */
+    private List<Payment> insertMultiplePayments(Bill bill, long billId, PaymentMethodData pmd) {
+        List<Payment> result = new ArrayList<>();
+        if (pmd == null
+                || pmd.getPaymentMethodMultiple() == null
+                || pmd.getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null) {
+            return result;
+        }
+        for (ComponentDetail cd : pmd.getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd == null || cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            Payment p = new Payment();
+            p.setBill(em.getReference(Bill.class, billId));
+            p.setInstitution(bill.getInstitution());
+            p.setDepartment(bill.getDepartment());
+            p.setCreatedAt(new Date());
+            p.setCreater(bill.getCreater());
+            p.setPaymentMethod(cd.getPaymentMethod());
+
+            PaymentMethodData cpmd = cd.getPaymentMethodData();
+            switch (cd.getPaymentMethod()) {
+                case Card:
+                    p.setBank(cpmd.getCreditCard().getInstitution());
+                    p.setCreditCardRefNo(cpmd.getCreditCard().getNo());
+                    p.setPaidValue(cpmd.getCreditCard().getTotalValue());
+                    p.setComments(cpmd.getCreditCard().getComment());
+                    break;
+                case Cheque:
+                    p.setChequeDate(cpmd.getCheque().getDate());
+                    p.setChequeRefNo(cpmd.getCheque().getNo());
+                    p.setBank(cpmd.getCheque().getInstitution());
+                    p.setPaidValue(cpmd.getCheque().getTotalValue());
+                    p.setComments(cpmd.getCheque().getComment());
+                    break;
+                case Cash:
+                    p.setPaidValue(cpmd.getCash().getTotalValue());
+                    break;
+                case ewallet:
+                    p.setPaidValue(cpmd.getEwallet().getTotalValue());
+                    p.setPolicyNo(cpmd.getEwallet().getReferralNo());
+                    p.setComments(cpmd.getEwallet().getComment());
+                    p.setReferenceNo(cpmd.getEwallet().getReferenceNo());
+                    p.setBank(cpmd.getEwallet().getInstitution());
+                    break;
+                case Agent:
+                case PatientDeposit:
+                    p.setPaidValue(cpmd.getPatient_deposit().getTotalValue());
+                    break;
+                case Credit:
+                    p.setPolicyNo(cpmd.getCredit().getReferralNo());
+                    p.setReferenceNo(cpmd.getCredit().getReferenceNo());
+                    p.setCreditCompany(cpmd.getCredit().getInstitution());
+                    p.setPaidValue(cpmd.getCredit().getTotalValue());
+                    p.setComments(cpmd.getCredit().getComment());
+                    break;
+                case Slip:
+                    p.setPaidValue(cpmd.getSlip().getTotalValue());
+                    p.setBank(cpmd.getSlip().getInstitution());
+                    p.setRealizedAt(cpmd.getSlip().getDate());
+                    p.setPaymentDate(cpmd.getSlip().getDate());
+                    p.setComments(cpmd.getSlip().getComment());
+                    p.setReferenceNo(cpmd.getSlip().getReferenceNo());
+                    break;
+                case OnlineSettlement:
+                    p.setPaidValue(cpmd.getOnlineSettlement().getTotalValue());
+                    p.setBank(cpmd.getOnlineSettlement().getInstitution());
+                    p.setRealizedAt(cpmd.getOnlineSettlement().getDate());
+                    p.setPaymentDate(cpmd.getOnlineSettlement().getDate());
+                    p.setReferenceNo(cpmd.getOnlineSettlement().getReferenceNo());
+                    p.setComments(cpmd.getOnlineSettlement().getComment());
+                    break;
+                case IOU:
+                    p.setPaidValue(cpmd.getIou().getTotalValue());
+                    p.setBank(cpmd.getIou().getInstitution());
+                    p.setRealizedAt(cpmd.getIou().getDate());
+                    p.setPaymentDate(cpmd.getIou().getDate());
+                    p.setReferenceNo(cpmd.getIou().getReferenceNo());
+                    p.setComments(cpmd.getIou().getComment());
+                    break;
+                case Staff:
+                    p.setPaidValue(cpmd.getStaffCredit().getTotalValue());
+                    if (cpmd.getStaffCredit().getToStaff() != null) {
+                        p.setToStaff(cpmd.getStaffCredit().getToStaff());
+                        if (bill.getToStaff() == null) {
+                            bill.setToStaff(cpmd.getStaffCredit().getToStaff());
+                        }
+                    }
+                    break;
+                case Staff_Welfare:
+                    p.setPaidValue(cpmd.getStaffWelfare().getTotalValue());
+                    if (cpmd.getStaffWelfare().getToStaff() != null) {
+                        p.setToStaff(cpmd.getStaffWelfare().getToStaff());
+                        if (bill.getToStaff() == null) {
+                            bill.setToStaff(cpmd.getStaffWelfare().getToStaff());
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            em.persist(p);
+            result.add(p);
+        }
+        em.flush();
+        return result;
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -465,6 +465,12 @@ public class RetailSaleNativeSqlService {
                     break;
             }
 
+            // Skip components with no entered value — the controller has already
+            // validated that the selected components cover the net total, so a
+            // zero here is an unfilled row that should not create a Payment.
+            if (p.getPaidValue() <= 0.0) {
+                continue;
+            }
             em.persist(p);
             result.add(p);
         }


### PR DESCRIPTION
## Summary

Fixes the defects reported in #21702 on the new **Pharmacy Retail Sale (native)** page (`pharmacy/pharmacy_bill_retail_sale_native.xhtml`). All four were tested end-to-end on a local deployment and pass.

## Defects & fixes

### 1 & 2 — Alternatives panel and substituted line showed a blank expiry
`PharmacySubstituteService` mapped the native `dateOfExpire` column with a bare `row[7] instanceof java.util.Date` cast. **MySQL Connector/J 8.x returns `datetime` columns as `java.time.LocalDateTime`** (not a `java.util.Date`), so the cast silently produced `null`, leaving the Alternatives panel's Expiry column blank — and, because `replaceSelectedSubstitute` copies the DTO's expiry onto the bill line, the swapped line's expiry was blank too.

**Fix:** added a `toDate(...)` helper handling `Timestamp`, `java.sql.Date`, `java.util.Date`, `LocalDateTime` and `LocalDate`, mirroring the other native-SQL services (e.g. `TransferReceiveNativeSqlService.toDate`).

### 3 — Insufficient-stock substitutes offered with active Replace
The `s.stock >= requiredQty` filter **already exists in source** (added in #21697 review follow-up). The live page was running an older WAR without it. No code change — resolved by redeploy and verified.

### 4 — Multiple Payment Methods showed no entry UI (and would not persist split payments)
The `<pa:multiple_payment_methods>` composite requires its `controller` to be a `ControllerWithMultiplePayments`. The native controller only implemented `ControllerWithPatient`, so the composite never rendered.

**Fix (two layers):**
- `RetailSaleNativeSqlController` now `implements ControllerWithMultiplePayments` — added `calculatRemainForMultiplePaymentTotal()` and `recieveRemainAmountAutomatically()` (ported from `PharmacySaleController`). The panel now renders Balance Amount / **+ Add Payment** / the Multiple Payments table, matching the legacy page.
- `RetailSaleNativeSqlService.settle(...)` now returns `List<Payment>` and creates **one `Payment` per component** for `MultiplePaymentMethods` (new `insertMultiplePayments`), with the drawer updated per payment. Ordinary methods are unchanged (single payment, now wrapped in a list).

## Files changed
- `PharmacySubstituteService.java` — `toDate()` helper; use it for `dateOfExpire`.
- `RetailSaleNativeSqlController.java` — implement `ControllerWithMultiplePayments`; consume `List<Payment>` from settle.
- `RetailSaleNativeSqlService.java` — `settle` returns `List<Payment>`; `insertMultiplePayments` for split payments.

## Testing
Verified on local deployment (Main Pharmacy):
- ✅ Alternatives panel shows batch expiry for every row.
- ✅ Substituted bill line carries the expiry.
- ✅ Batches with stock below the line quantity no longer offered.
- ✅ "Multiple Payment Methods" renders the full entry UI; a split (e.g. Cash + Card) settles and persists one `Payment` per component.

Closes #21702

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retail sales now support settling a bill with multiple payment methods in one transaction.
  * Payment details are now saved and processed separately for each selected payment type.

* **Bug Fixes**
  * Improved automatic remaining-amount handling when using mixed payment methods.
  * Fixed substitute stock expiry dates so they display correctly across different date formats.
  * Added better handling for patient deposit payments, including balance limits and UI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->