### PR TITLE
feat(inward): BHT direct issue UI improvements — columns, layout, config button, totals, compact table

### DIFF
--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -263,6 +263,30 @@ Rules:
 - Avoid placing decorative icons in every cell; reserve icons for headers or action columns.
 - Use neutral currency labels (e.g., `Requested Value`, `Net Amount`) and neutral icons such as `pi pi-money-bill` (or `fas fa-coins` when no PrimeFaces option exists) so pages stay multi-currency friendly.
 
+### DataTable Compact Size (required for data-entry and multi-column tables)
+
+Always add `styleClass="p-datatable-sm"` to `p:dataTable` components on data-entry and transaction pages. This is the PrimeFaces 14 standard for compact row padding and keeps more rows visible without scrolling.
+
+```xhtml
+<p:dataTable id="tbl"
+             value="#{bean.items}"
+             var="item"
+             styleClass="p-datatable-sm">
+```
+
+**Column width rules** — always use the `width` attribute on `p:column`, never `style="min-width:…"` (PrimeFaces ignores CSS min-width in its column width allocation algorithm):
+
+| Column type | Recommended width |
+|---|---|
+| Row index (`#`) | `2em` |
+| Item / description name | `15em` |
+| Quantity / short number | `6em` |
+| Currency value | `6em` |
+| Date | `6em` |
+| Actions | `8em`–`10em` |
+
+If the sum of all column widths exceeds the table container, add `scrollable="true"` to enable horizontal scroll rather than letting columns collapse to zero.
+
 ### Badge Usage for Status Indicators
 - **ALWAYS use PrimeFaces `p:badge`** instead of HTML/Bootstrap badge classes (`badge`, `badge-*`)
 - PrimeFaces badges provide better visibility and theming support

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -196,6 +196,11 @@ public class PharmacyConfigController implements Serializable {
     private boolean opdDoctorPaymentHideDetails;
     private boolean opdDoctorPaymentHideFiveFiveHeader;
 
+    // Inward BHT Direct Issue Bill Settings
+    private boolean bhtIssuePosPaper;
+    private boolean bhtIssueFiveFivePaper;
+    private boolean bhtIssueA4Paper;
+
     public PharmacyConfigController() {
     }
     
@@ -374,6 +379,11 @@ public class PharmacyConfigController implements Serializable {
         opdDoctorPaymentPosPaper = configOptionApplicationController.getBooleanValueByKey("OPD Doctor payment bill is POS paper", false);
         opdDoctorPaymentHideDetails = configOptionApplicationController.getBooleanValueByKey("Hide the details on the OPD Doctor Payment Bill", false);
         opdDoctorPaymentHideFiveFiveHeader = configOptionApplicationController.getBooleanValueByKey("Hide the Header Details on the OPD Doctor Payment 5x5 Bill", false);
+
+        // Inward BHT Direct Issue Bill Settings
+        bhtIssuePosPaper = configOptionController.getBooleanValueByKey("Pharmacy Inward Direct Issue Bill is POS Paper", false);
+        bhtIssueFiveFivePaper = configOptionController.getBooleanValueByKey("Pharmacy Inward Direct Issue Bill is FiveFive Paper", false);
+        bhtIssueA4Paper = configOptionController.getBooleanValueByKey("Pharmacy Inward Direct Issue Bill is A4 Paper", false);
 
     }
 
@@ -740,6 +750,24 @@ public class PharmacyConfigController implements Serializable {
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving Credit Settlement Cancellation configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Inward BHT Direct Issue Bill configuration changes specifically
+     */
+    public void saveBhtIssueConfig() {
+        try {
+            configOptionController.setBooleanValueByKey("Pharmacy Inward Direct Issue Bill is POS Paper", bhtIssuePosPaper);
+            configOptionController.setBooleanValueByKey("Pharmacy Inward Direct Issue Bill is FiveFive Paper", bhtIssueFiveFivePaper);
+            configOptionController.setBooleanValueByKey("Pharmacy Inward Direct Issue Bill is A4 Paper", bhtIssueA4Paper);
+
+            JsfUtil.addSuccessMessage("BHT Direct Issue Bill configuration saved successfully");
+
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving BHT Direct Issue Bill configuration: " + e.getMessage());
         }
     }
 
@@ -1812,6 +1840,31 @@ public class PharmacyConfigController implements Serializable {
 
     public void setGrnReceiptCustom3(boolean grnReceiptCustom3) {
         this.grnReceiptCustom3 = grnReceiptCustom3;
+    }
+
+    // Inward BHT Direct Issue Bill Getters and Setters
+    public boolean isBhtIssuePosPaper() {
+        return bhtIssuePosPaper;
+    }
+
+    public void setBhtIssuePosPaper(boolean bhtIssuePosPaper) {
+        this.bhtIssuePosPaper = bhtIssuePosPaper;
+    }
+
+    public boolean isBhtIssueFiveFivePaper() {
+        return bhtIssueFiveFivePaper;
+    }
+
+    public void setBhtIssueFiveFivePaper(boolean bhtIssueFiveFivePaper) {
+        this.bhtIssueFiveFivePaper = bhtIssueFiveFivePaper;
+    }
+
+    public boolean isBhtIssueA4Paper() {
+        return bhtIssueA4Paper;
+    }
+
+    public void setBhtIssueA4Paper(boolean bhtIssueA4Paper) {
+        this.bhtIssueA4Paper = bhtIssueA4Paper;
     }
 
 }

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -487,70 +487,37 @@
                 <h:panelGroup  rendered="#{pharmacySaleBhtController.billPreview}" >
                     <p:panel>
                         <f:facet name="header">
-                            <div class="d-flex justify-content-between">
+                            <div class="d-flex justify-content-between align-items-center">
                                 <div>
-                                    <h:outputText styleClass=" fa-solid fa-screwdriver-wrench fa-lg" />
+                                    <h:outputText styleClass="fa-solid fa-screwdriver-wrench fa-lg" />
                                     <p:outputLabel value="BHT Issue" class="mx-1"/>
                                 </div>
-                                <div class="d-flex gap-2">
-                                    <p:commandButton 
-                                        id="nullButton3"
-                                        icon="fa-solid fa-print"
-                                        class="ui-button-info" 
-                                        value="Print Bill" 
-                                        ajax="false"
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
-                                        action="#">
-                                        <p:printer target="gpBillPreviewFiveFiveCustom3"></p:printer>
-                                    </p:commandButton>
-
-                                    <p:commandButton 
-                                        id="btnPrint" 
-                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}" 
-                                        icon="fa-solid fa-print" 
-                                        class="ui-button-info" 
-                                        value="Print" 
-                                        ajax="false" 
-                                        >
-                                        <p:printer target="gpBillPreview" ></p:printer>
-                                    </p:commandButton>
-
-                                    <p:commandButton 
-                                        value="New Bill" 
-                                        ajax="false"
-                                        class="ui-button-warning"
-                                        icon ="fa-solid fa-plus"
-                                        action="pharmacy_bill_issue_bht?faces-redirect=true"
-                                        actionListener="#{pharmacySaleBhtController.resetAll}"  >
-                                    </p:commandButton>
-
+                                <div class="d-flex gap-2 align-items-center">
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                         <div class="d-flex gap-2">
                                             <p:commandButton
                                                 ajax="false"
                                                 value="Patient Lookup"
                                                 icon="fa fa-search"
-                                                class="ui-button-warning"
+                                                class="ui-button-info ui-button-outlined"
                                                 action="#{patientController.navigateToSearchPatients()}">
                                             </p:commandButton>
-
                                             <p:commandButton
                                                 ajax="false"
                                                 icon="fa fa-user"
                                                 value="Patient Profile"
-                                                class="ui-button-success"
+                                                class="ui-button-info ui-button-outlined"
                                                 action="#{patientController.navigateToOpdPatientProfile()}">
                                                 <f:setPropertyActionListener
                                                     value="#{pharmacySaleBhtController.patientEncounter.patient}"
                                                     target="#{patientController.current}" >
                                                 </f:setPropertyActionListener>
                                             </p:commandButton>
-
                                             <p:commandButton
                                                 ajax="false"
                                                 value="Inpatient Dashboard"
                                                 icon="fa fa-id-card"
-                                                class="ui-button-secondary"
+                                                class="ui-button-info ui-button-outlined"
                                                 action="#{admissionController.navigateToAdmissionProfilePage}">
                                                 <f:setPropertyActionListener
                                                     value="#{pharmacySaleBhtController.printBill.patientEncounter}"
@@ -559,16 +526,44 @@
                                             </p:commandButton>
                                         </div>
                                     </h:panelGroup>
-
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                        <p:commandButton 
-                                            value="Nursing WorkBench" 
-                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
+                                        <p:commandButton
+                                            value="Nursing WorkBench"
+                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                             ajax="false"
-                                            class="ui-button-operating-theatre"
+                                            class="ui-button-info ui-button-outlined"
                                             icon="fa fa-arrow-left">
                                         </p:commandButton>
                                     </h:panelGroup>
+                                </div>
+                                <div class="d-flex gap-2 align-items-center">
+                                    <p:commandButton
+                                        value="New Direct Issue Bill"
+                                        ajax="false"
+                                        class="ui-button-warning"
+                                        icon="fa-solid fa-plus"
+                                        action="pharmacy_bill_issue_bht?faces-redirect=true"
+                                        actionListener="#{pharmacySaleBhtController.resetAll}" >
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        id="nullButton3"
+                                        icon="fa-solid fa-print"
+                                        class="ui-button-success"
+                                        value="Print Bill"
+                                        ajax="false"
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                        action="#">
+                                        <p:printer target="gpBillPreviewFiveFiveCustom3"></p:printer>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        id="btnPrint"
+                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                        icon="fa-solid fa-print"
+                                        class="ui-button-success"
+                                        value="Print"
+                                        ajax="false" >
+                                        <p:printer target="gpBillPreview" ></p:printer>
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -13,6 +13,7 @@
     <ui:define name="content">
         <h:form id="bill" >
 
+            <p:defaultCommand target="btnAdd" />
             <p:growl id="panelErrorMsg" showDetail="true" life="4000" />
 
             <div id="settlingOverlay" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);z-index:99999;align-items:center;justify-content:center;">
@@ -286,7 +287,7 @@
                                                     process="acStockWithoutTotalStock"
                                                     update="txtRate txtValue focusQty" />
                                                 <p:column headerText="Item" style="padding: 8px;" styleClass="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'ui-messages-warn':''}">
-                                                    <h:outputText value="#{i.itemName}"  style="width: 300px!important;">
+                                                    <h:outputText value="#{i.itemName}"  style="width: 300px!important; white-space: nowrap;">
                                                         &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'Expired ': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'Expired Soon':''}" severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ?'warning':''}" />
                                                     </h:outputText>
                                                 </p:column>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -157,36 +157,26 @@
             <h:panelGroup  rendered="#{pharmacySaleBhtController.patientEncounter ne null}">
                 <p:panel rendered="#{!pharmacySaleBhtController.billPreview}">
                     <f:facet name="header">
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center">
                             <div>
                                 <h:outputText styleClass="fa-solid fa-pills fa-lg" />
                                 <p:outputLabel value="Direct Issue of Medicines to Inpatients" class="mx-4" />
                             </div>
-                            <div class="d-flex gap-2">
-
-                                <p:commandButton
-                                    value="New Bill"
-                                    ajax="false"
-                                    class="ui-button-warning"
-                                    icon ="fa-solid fa-plus"
-                                    action="pharmacy_bill_issue_bht"
-                                    actionListener="#{pharmacySaleBhtController.resetAll}" >
-                                </p:commandButton>
-
+                            <div class="d-flex gap-2 align-items-center">
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                     <div class="d-flex gap-2">
                                         <p:commandButton
                                             ajax="false"
                                             value="Patient Lookup"
                                             icon="fa fa-search"
-                                            class="ui-button-warning"
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToSearchPatients()}" >
                                         </p:commandButton>
                                         <p:commandButton
                                             ajax="false"
                                             icon="fa fa-user"
                                             value="Patient Profile"
-                                            class="ui-button-success"
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToOpdPatientProfile()}" >
                                             <f:setPropertyActionListener
                                                 value="#{pharmacySaleBhtController.patientEncounter.patient}"
@@ -197,7 +187,7 @@
                                             ajax="false"
                                             icon="fa fa-id-card"
                                             value="Inpatient Dashboard"
-                                            class="ui-button-secondary"
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{admissionController.navigateToAdmissionProfilePage}" >
                                             <f:setPropertyActionListener
                                                 value="#{pharmacySaleBhtController.patientEncounter}"
@@ -206,37 +196,40 @@
                                         </p:commandButton>
                                     </div>
                                 </h:panelGroup>
-
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                    <p:commandButton 
-                                        value="Nursing WorkBench" 
-                                        action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
+                                    <p:commandButton
+                                        value="Nursing WorkBench"
+                                        action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                         ajax="false"
-                                        class="ui-button-operating-theatre"
+                                        class="ui-button-info ui-button-outlined"
                                         icon="fa fa-arrow-left">
                                     </p:commandButton>
                                 </h:panelGroup>
                             </div>
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:commandButton
+                                    value="New Direct Issue Bill"
+                                    ajax="false"
+                                    class="ui-button-warning"
+                                    icon="fa-solid fa-plus"
+                                    action="pharmacy_bill_issue_bht"
+                                    actionListener="#{pharmacySaleBhtController.resetAll}" >
+                                </p:commandButton>
+                                <p:commandButton
+                                    id="btnSettleInpatientDirectIssue"
+                                    value="Settle"
+                                    ajax="true"
+                                    onclick="if(!confirm('Are you sure you want to settle this pharmacy bill issue?')){return false;} var o=document.getElementById('settlingOverlay'); o.style.display='flex'; o.style.pointerEvents='all';"
+                                    oncomplete="document.getElementById('settlingOverlay').style.display='none';"
+                                    ondblclick="return false;"
+                                    action="#{pharmacySaleBhtController.settlePharmacyBhtIssue()}"
+                                    update="@form"
+                                    class="ui-button-success"
+                                    icon="fa-solid fa-check">
+                                </p:commandButton>
+                            </div>
                         </div>
-
                     </f:facet>
-
-                    <div class="row mb-3">
-                        <div class="d-flex justify-content-end align-items-center">
-                            <p:commandButton
-                                id="btnSettleInpatientDirectIssue"
-                                value="Settle"
-                                ajax="true"
-                                onclick="if(!confirm('Are you sure you want to settle this pharmacy bill issue?')){return false;} var o=document.getElementById('settlingOverlay'); o.style.display='flex'; o.style.pointerEvents='all';"
-                                oncomplete="document.getElementById('settlingOverlay').style.display='none';"
-                                ondblclick="return false;"
-                                action="#{pharmacySaleBhtController.settlePharmacyBhtIssue()}"
-                                update="@form"
-                                class="ui-button-success mx-2"
-                                icon="fa-solid fa-check">
-                            </p:commandButton>
-                        </div>
-                    </div>
 
                     <div class="row">
 

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -398,14 +398,14 @@
                                     <p:column headerText="Item" width="2em">
                                         <h:outputText value="#{s+1}" ></h:outputText>
                                     </p:column>
-                                    <p:column headerText="Item" style="min-width: 20em;" >
+                                    <p:column headerText="Item" width="15em">
                                         <h:outputLabel value="#{bi.pharmaceuticalBillItem.transDisplayItemName}" >
                                             &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > bi.pharmaceuticalBillItem.doe ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > bi.pharmaceuticalBillItem.doe ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > bi.pharmaceuticalBillItem.doe ?'Expired ':
                                                                      commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > bi.pharmaceuticalBillItem.doe ?'Expired Soon':''}"
                                                          severity="#{commonFunctionsProxy.currentDateTime > bi.pharmaceuticalBillItem.doe ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > bi.pharmaceuticalBillItem.doe ?'warning':''}" />
                                         </h:outputLabel>
                                     </p:column>
-                                    <p:column headerText="Quantity"  width="8em"  class="text-end">
+                                    <p:column headerText="Quantity" width="6em" class="text-end">
                                         <p:inputText
                                             autocomplete="off"
                                             id="ipTblQty"
@@ -419,12 +419,12 @@
                                                 update=":bill:pBis panelErrorMsg" />
                                         </p:inputText>
                                     </p:column>
-                                    <p:column headerText="Rate"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Rate" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.netRate}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </p:column>
-                                    <p:column headerText="Gross Value"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Gross Value" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.grossValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
@@ -434,7 +434,7 @@
                                             </h:outputText>
                                         </f:facet>
                                     </p:column>
-                                    <p:column headerText="Discount"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Discount" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.discount}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
@@ -444,7 +444,7 @@
                                             </h:outputText>
                                         </f:facet>
                                     </p:column>
-                                    <p:column headerText="Margin"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Margin" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.marginValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
@@ -454,7 +454,7 @@
                                             </h:outputText>
                                         </f:facet>
                                     </p:column>
-                                    <p:column headerText="Net Value"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Net Value" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.netValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
@@ -464,7 +464,7 @@
                                             </h:outputText>
                                         </f:facet>
                                     </p:column>
-                                    <p:column headerText="Expiry" width="8em" class="text-end">
+                                    <p:column headerText="Expiry" width="6em" class="text-end">
                                         <h:outputLabel value="#{bi.pharmaceuticalBillItem.doe}" >
                                             <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"  ></f:convertDateTime>
                                         </h:outputLabel>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -585,42 +585,29 @@
                                         ajax="false" >
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        class="ui-button-secondary"
+                                        type="button"
+                                        onclick="PF('bhtIssueConfigDialog').show();" />
                                 </div>
                             </div>
                         </f:facet>
 
-
-                        <div class="d-flex m-2" style="float: right">
-                            <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                            <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
-                                <f:selectItem itemLabel="Please Select Paper Type" />
-                                <f:selectItems value="#{enumController.paperTypes}" />
-                            </p:selectOneMenu>
-                            <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
-                        </div>
-
                         <h:panelGroup id="gpBillPreview" >
 
-                            <h:panelGroup id="gpBillPreviewPos" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper'}">
+                            <h:panelGroup id="gpBillPreviewPos" rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS Paper', false)}">
                                 <phe:issueBill bill="#{pharmacySaleBhtController.printBill}"/>
                             </h:panelGroup>
 
-                            <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper'}">
-
-                                <div >
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                        <phi:saleBill_five_five_1 bill="#{pharmacySaleBhtController.printBill}"></phi:saleBill_five_five_1>
-                                    </h:panelGroup>
-                                </div>
+                            <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive Paper', false)}">
+                                <phi:saleBill_five_five_1 bill="#{pharmacySaleBhtController.printBill}"/>
                             </h:panelGroup>
 
-                            <h:panelGroup id="gpBillPreviewA4" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'A4Paper'}">
-
-                                <div >
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                        <phe:A4_paper_with_headings bill="#{pharmacySaleBhtController.printBill}"/>
-                                    </h:panelGroup>
-                                </div>
+                            <h:panelGroup id="gpBillPreviewA4" rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4 Paper', false)}">
+                                <phe:A4_paper_with_headings bill="#{pharmacySaleBhtController.printBill}"/>
                             </h:panelGroup>
 
                             <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',true)}">
@@ -641,6 +628,58 @@
             </h:panelGroup>
 
         </h:form>
+
+        <!-- BHT Direct Issue Printer Configuration Dialog -->
+        <p:dialog id="bhtIssueConfigDialog"
+                  header="BHT Direct Issue Printer Configuration"
+                  widgetVar="bhtIssueConfigDialog"
+                  modal="true"
+                  width="500"
+                  resizable="false"
+                  closeOnEscape="true">
+
+            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="bhtIssueConfigForm" />
+
+            <h:form id="bhtIssueConfigForm">
+                <div class="card">
+                    <div class="card-header">
+                        <h6><i class="fas fa-file-alt"></i> Paper Format Settings</h6>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="bhtIssuePos" value="#{pharmacyConfigController.bhtIssuePosPaper}" />
+                            <h:outputLabel for="bhtIssuePos" value="POS Paper" class="ms-2" />
+                            <small class="form-text text-muted d-block">Compact POS receipt format</small>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="bhtIssueFiveFive" value="#{pharmacyConfigController.bhtIssueFiveFivePaper}" />
+                            <h:outputLabel for="bhtIssueFiveFive" value="5x5 Paper" class="ms-2" />
+                            <small class="form-text text-muted d-block">Five-by-five paper format</small>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="bhtIssueA4" value="#{pharmacyConfigController.bhtIssueA4Paper}" />
+                            <h:outputLabel for="bhtIssueA4" value="A4 Paper" class="ms-2" />
+                            <small class="form-text text-muted d-block">Standard A4 paper format</small>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="d-flex gap-2 mt-3">
+                    <p:commandButton
+                        value="Apply &amp; Close"
+                        icon="fas fa-save"
+                        class="ui-button-success"
+                        ajax="false"
+                        action="#{pharmacyConfigController.saveBhtIssueConfig}" />
+                    <p:commandButton
+                        value="Cancel"
+                        icon="fas fa-times"
+                        class="ui-button-secondary"
+                        onclick="PF('bhtIssueConfigDialog').hide(); return false;"
+                        type="button" />
+                </div>
+            </h:form>
+        </p:dialog>
 
     </ui:define>
 

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -509,9 +509,16 @@
                     <p:panel>
                         <f:facet name="header">
                             <div class="d-flex justify-content-between align-items-center">
-                                <div>
+                                <div class="d-flex gap-2 align-items-center">
                                     <h:outputText styleClass="fa-solid fa-screwdriver-wrench fa-lg" />
                                     <p:outputLabel value="BHT Issue" class="mx-1"/>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        value="Settings"
+                                        icon="fas fa-cog"
+                                        class="ui-button-secondary"
+                                        type="button"
+                                        onclick="PF('bhtIssueConfigDialog').show();" />
                                 </div>
                                 <div class="d-flex gap-2 align-items-center">
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
@@ -585,13 +592,6 @@
                                         ajax="false" >
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
-                                    <p:commandButton
-                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-                                        value="Settings"
-                                        icon="fas fa-cog"
-                                        class="ui-button-secondary"
-                                        type="button"
-                                        onclick="PF('bhtIssueConfigDialog').show();" />
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -428,41 +428,21 @@
                                         <h:outputText value="#{bi.grossValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{pharmacySaleBhtController.preBill.total}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                            </h:outputText>
-                                        </f:facet>
                                     </p:column>
                                     <p:column headerText="Discount" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.discount}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{pharmacySaleBhtController.preBill.discount}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                            </h:outputText>
-                                        </f:facet>
                                     </p:column>
                                     <p:column headerText="Margin" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.marginValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{pharmacySaleBhtController.preBill.margin}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                            </h:outputText>
-                                        </f:facet>
                                     </p:column>
                                     <p:column headerText="Net Value" width="6em" class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.netValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
-                                        <f:facet name="footer" >
-                                            <h:outputText value="#{pharmacySaleBhtController.preBill.netTotal}" >
-                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
-                                            </h:outputText>
-                                        </f:facet>
                                     </p:column>
                                     <p:column headerText="Expiry" width="6em" class="text-end">
                                         <h:outputLabel value="#{bi.pharmaceuticalBillItem.doe}" >
@@ -480,6 +460,46 @@
                                     </p:column>
 
                                 </p:dataTable>
+
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <div class="d-flex justify-content-end mt-2 me-1">
+                                        <table class="table table-sm table-borderless w-auto text-end" style="min-width:22em;">
+                                            <tr>
+                                                <td class="text-muted pe-4">Gross Total</td>
+                                                <td class="fw-semibold">
+                                                    <h:outputText value="#{pharmacySaleBhtController.preBill.total}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-muted pe-4">Discount</td>
+                                                <td class="fw-semibold">
+                                                    <h:outputText value="#{pharmacySaleBhtController.preBill.discount}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-muted pe-4">Margin</td>
+                                                <td class="fw-semibold">
+                                                    <h:outputText value="#{pharmacySaleBhtController.preBill.margin}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                            <tr class="border-top">
+                                                <td class="text-muted pe-4 pt-1"><strong>Net Total</strong></td>
+                                                <td class="fw-bold pt-1" style="font-size:1.1em;">
+                                                    <h:outputText value="#{pharmacySaleBhtController.preBill.netTotal}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </div>
+                                </h:panelGroup>
+
                             </p:panel>
                         </div>
                     </div>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -430,7 +430,37 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </p:column>
-                                    <p:column headerText="Value"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                    <p:column headerText="Gross Value"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                        <h:outputText value="#{bi.grossValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                        <f:facet name="footer" >
+                                            <h:outputText value="#{pharmacySaleBhtController.preBill.total}" >
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </h:outputText>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column headerText="Discount"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                        <h:outputText value="#{bi.discount}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                        <f:facet name="footer" >
+                                            <h:outputText value="#{pharmacySaleBhtController.preBill.discount}" >
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </h:outputText>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column headerText="Margin"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
+                                        <h:outputText value="#{bi.marginValue}" >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText>
+                                        <f:facet name="footer" >
+                                            <h:outputText value="#{pharmacySaleBhtController.preBill.margin}" >
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </h:outputText>
+                                        </f:facet>
+                                    </p:column>
+                                    <p:column headerText="Net Value"  width="8em"  class="text-end" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">
                                         <h:outputText value="#{bi.netValue}" >
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -393,6 +393,7 @@
                                     value="#{pharmacySaleBhtController.preBill.billItems}"
                                     var="bi"
                                     rowIndexVar="s"
+                                    styleClass="p-datatable-sm"
                                     sortBy="#{bi.searialNo}" >
                                     <p:column headerText="Item" width="2em">
                                         <h:outputText value="#{s+1}" ></h:outputText>

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -13,7 +13,7 @@
     <ui:define name="content">
         <h:form id="bill" >
 
-            <p:defaultCommand target="btnAdd" />
+            <p:defaultCommand target="btnAdd" rendered="#{pharmacySaleBhtController.patientEncounter ne null and !pharmacySaleBhtController.billPreview}" />
             <p:growl id="panelErrorMsg" showDetail="true" life="4000" />
 
             <div id="settlingOverlay" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);z-index:99999;align-items:center;justify-content:center;">

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -160,12 +160,13 @@
                         <div class="d-flex justify-content-between align-items-center">
                             <div>
                                 <h:outputText styleClass="fa-solid fa-pills fa-lg" />
-                                <p:outputLabel value="Direct Issue of Medicines to Inpatients" class="mx-4" />
+                                <h:outputText value="Direct Issue of Medicines to Inpatients" styleClass="mx-4" />
                             </div>
                             <div class="d-flex gap-2 align-items-center">
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                     <div class="d-flex gap-2">
                                         <p:commandButton
+                                            id="btnPatientLookup"
                                             ajax="false"
                                             value="Patient Lookup"
                                             icon="fa fa-search"
@@ -173,6 +174,7 @@
                                             action="#{patientController.navigateToSearchPatients()}" >
                                         </p:commandButton>
                                         <p:commandButton
+                                            id="btnPatientProfile"
                                             ajax="false"
                                             icon="fa fa-user"
                                             value="Patient Profile"
@@ -184,6 +186,7 @@
                                             </f:setPropertyActionListener>
                                         </p:commandButton>
                                         <p:commandButton
+                                            id="btnInpatientDashboard"
                                             ajax="false"
                                             icon="fa fa-id-card"
                                             value="Inpatient Dashboard"
@@ -198,6 +201,7 @@
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                     <p:commandButton
+                                        id="btnNursingWorkBench"
                                         value="Nursing WorkBench"
                                         action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                         ajax="false"
@@ -208,6 +212,7 @@
                             </div>
                             <div class="d-flex gap-2 align-items-center">
                                 <p:commandButton
+                                    id="btnNewDirectIssueBill"
                                     value="New Direct Issue Bill"
                                     ajax="false"
                                     class="ui-button-warning"
@@ -511,8 +516,9 @@
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="d-flex gap-2 align-items-center">
                                     <h:outputText styleClass="fa-solid fa-screwdriver-wrench fa-lg" />
-                                    <p:outputLabel value="BHT Issue" class="mx-1"/>
+                                    <h:outputText value="BHT Issue" styleClass="mx-1"/>
                                     <p:commandButton
+                                        id="btnBhtIssueSettings"
                                         rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
                                         value="Settings"
                                         icon="fas fa-cog"
@@ -524,6 +530,7 @@
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                         <div class="d-flex gap-2">
                                             <p:commandButton
+                                                id="btnPreviewPatientLookup"
                                                 ajax="false"
                                                 value="Patient Lookup"
                                                 icon="fa fa-search"
@@ -531,6 +538,7 @@
                                                 action="#{patientController.navigateToSearchPatients()}">
                                             </p:commandButton>
                                             <p:commandButton
+                                                id="btnPreviewPatientProfile"
                                                 ajax="false"
                                                 icon="fa fa-user"
                                                 value="Patient Profile"
@@ -542,6 +550,7 @@
                                                 </f:setPropertyActionListener>
                                             </p:commandButton>
                                             <p:commandButton
+                                                id="btnPreviewInpatientDashboard"
                                                 ajax="false"
                                                 value="Inpatient Dashboard"
                                                 icon="fa fa-id-card"
@@ -556,6 +565,7 @@
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                         <p:commandButton
+                                            id="btnPreviewNursingWorkBench"
                                             value="Nursing WorkBench"
                                             action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                             ajax="false"
@@ -566,6 +576,7 @@
                                 </div>
                                 <div class="d-flex gap-2 align-items-center">
                                     <p:commandButton
+                                        id="btnPreviewNewDirectIssueBill"
                                         value="New Direct Issue Bill"
                                         ajax="false"
                                         class="ui-button-warning"


### PR DESCRIPTION
## Summary

- Prevent item name wrapping in autocomplete dropdown (`white-space: nowrap` on `h:outputText`)
- Guard `p:defaultCommand` with same rendered condition as its target `btnAdd`, preventing PrimeFaces errors when the button is absent from the DOM
- Add Gross Value, Discount, Margin, and Net Value columns to the bill items table
- Apply `p-datatable-sm` compact PrimeFaces style to the bill items datatable; use `width` attribute (not `style min-width`) on `p:column` to avoid 0px column collapse
- Standardise panel header layout in both the issue panel and print preview panel: title + Settings left | outlined nav buttons centre | primary actions rightmost
- Add totals section (Gross Total, Discount, Margin, Net Total) below the bill items table, gated by `ShowDrugCharges` privilege
- Replace deprecated `p:selectOneMenu` paper-type dropdown in print preview with the standard Settings gear button + `p:dialog` config pattern; add `PharmacyConfigController` properties (`bhtIssuePosPaper`, `bhtIssueFiveFivePaper`, `bhtIssueA4Paper`) persisted per department via `configOptionController`

## Test plan

- [ ] BHT issue page loads; item name in autocomplete does not wrap
- [ ] Enter key in item search field adds item without clearing the form
- [ ] Bill items table shows all columns: Item, Qty, Rate, Gross Value, Discount, Margin, Net Value, Expiry, Actions
- [ ] Table uses compact row height (`p-datatable-sm`); item name column is visible (not 0px)
- [ ] Totals section shows below the table for users with `ShowDrugCharges` privilege; hidden otherwise
- [ ] Issue panel header: outlined nav buttons in centre, Settle rightmost, New Direct Issue Bill next to it
- [ ] Print preview panel header: Settings gear on the left, outlined nav buttons in centre, Print rightmost
- [ ] Settings dialog opens when gear is clicked (requires `ChangeReceiptPrintingPaperTypes` privilege); checkboxes reflect saved values; Apply saves and the selected format renders in the preview

Closes #20129

🤖 Generated with [Claude Code](https://claude.com/claude-code)