### PR TITLE
fix(pharmacy): itemise multiple payments on native retail sale printout (#21707)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -622,14 +622,23 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         // paid is the sum of the entered components. Show that (and a zero
         // balance) instead of the unused single cashPaid (which is 0.0).
         double tendered = cashPaid;
+        double printedBalance = tendered - netTot;
         if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
             tendered = 0.0;
             for (PrintBillData.PaymentLine line : pbd.getPayments()) {
                 tendered += line.getValue();
             }
+            // settle accepts the split when it is within 1.0 of the net total
+            // (validateMultiplePaymentsFailed); clamp the printed balance to zero
+            // within the same tolerance so an already-settled bill never shows a
+            // residual balance.
+            printedBalance = tendered - netTot;
+            if (Math.abs(printedBalance) <= 1.0) {
+                printedBalance = 0.0;
+            }
         }
         pbd.setCashPaid(tendered);
-        pbd.setBalance(tendered - netTot);
+        pbd.setBalance(printedBalance);
 
         printBill = pbd;
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -587,6 +587,9 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
         // Payment
         pbd.setPaymentMethodLabel(paymentMethod != null ? paymentMethod.getLabel() : "");
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            pbd.setPayments(buildPrintPaymentLines());
+        }
         if (paymentScheme != null) {
             pbd.setPaymentSchemePrintingName(
                     paymentScheme.getPrintingName() != null ? paymentScheme.getPrintingName() : paymentScheme.getName());
@@ -615,8 +618,18 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         pbd.setDiscount(discTot);
         pbd.setNetTotal(netTot);
         pbd.setDiscountPercentPharmacy(grossTot > 0 ? (discTot / grossTot) * 100.0 : 0.0);
-        pbd.setCashPaid(cashPaid);
-        pbd.setBalance(cashPaid - netTot);
+        // For Multiple Payment Methods the Tendered field is not used; the amount
+        // paid is the sum of the entered components. Show that (and a zero
+        // balance) instead of the unused single cashPaid (which is 0.0).
+        double tendered = cashPaid;
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            tendered = 0.0;
+            for (PrintBillData.PaymentLine line : pbd.getPayments()) {
+                tendered += line.getValue();
+            }
+        }
+        pbd.setCashPaid(tendered);
+        pbd.setBalance(tendered - netTot);
 
         printBill = pbd;
 
@@ -634,6 +647,79 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
             printCopy.add(p);
         }
         printBillItems = printCopy;
+    }
+
+    /**
+     * Builds one {@link PrintBillData.PaymentLine} per entered component of a
+     * Multiple Payment Methods bill, so the printout itemises each payment
+     * (e.g. "Cash 50.00", "Credit Card 145.90") instead of showing the bundled
+     * "Multiple Payment Methods" label with a single value. Components with no
+     * value are skipped (matching the settle path).
+     */
+    private List<PrintBillData.PaymentLine> buildPrintPaymentLines() {
+        List<PrintBillData.PaymentLine> lines = new ArrayList<>();
+        if (getPaymentMethodData().getPaymentMethodMultiple() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null) {
+            return lines;
+        }
+        for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd == null || cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            PaymentMethodData cpmd = cd.getPaymentMethodData();
+            double value = 0.0;
+            String reference = "";
+            switch (cd.getPaymentMethod()) {
+                case Cash:
+                    value = cpmd.getCash().getTotalValue();
+                    break;
+                case Card:
+                    value = cpmd.getCreditCard().getTotalValue();
+                    reference = cpmd.getCreditCard().getNo();
+                    break;
+                case Cheque:
+                    value = cpmd.getCheque().getTotalValue();
+                    reference = cpmd.getCheque().getNo();
+                    break;
+                case ewallet:
+                    value = cpmd.getEwallet().getTotalValue();
+                    reference = cpmd.getEwallet().getReferenceNo();
+                    break;
+                case Slip:
+                    value = cpmd.getSlip().getTotalValue();
+                    reference = cpmd.getSlip().getReferenceNo();
+                    break;
+                case OnlineSettlement:
+                    value = cpmd.getOnlineSettlement().getTotalValue();
+                    reference = cpmd.getOnlineSettlement().getReferenceNo();
+                    break;
+                case IOU:
+                    value = cpmd.getIou().getTotalValue();
+                    reference = cpmd.getIou().getReferenceNo();
+                    break;
+                case Credit:
+                    value = cpmd.getCredit().getTotalValue();
+                    reference = cpmd.getCredit().getReferenceNo();
+                    break;
+                case PatientDeposit:
+                    value = cpmd.getPatient_deposit().getTotalValue();
+                    break;
+                case Staff:
+                    value = cpmd.getStaffCredit().getTotalValue();
+                    break;
+                case Staff_Welfare:
+                    value = cpmd.getStaffWelfare().getTotalValue();
+                    break;
+                default:
+                    break;
+            }
+            if (value <= 0.0) {
+                continue;
+            }
+            lines.add(new PrintBillData.PaymentLine(
+                    cd.getPaymentMethod().getLabel(), value, reference == null ? "" : reference));
+        }
+        return lines;
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/core/data/dto/PrintBillData.java
+++ b/src/main/java/com/divudi/core/data/dto/PrintBillData.java
@@ -1,7 +1,9 @@
 package com.divudi.core.data.dto;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 public class PrintBillData implements Serializable {
 
@@ -41,6 +43,10 @@ public class PrintBillData implements Serializable {
     private double cashPaid;
     private double balance;
     private double margin;
+
+    // Individual payment lines (one per component) for Multiple Payment Methods.
+    // Empty for single-method bills.
+    private List<PaymentLine> payments = new ArrayList<>();
 
     // Credit / Staff / Dept targets (shown on bill when applicable)
     private String toStaffName;
@@ -136,6 +142,9 @@ public class PrintBillData implements Serializable {
     public double getMargin() { return margin; }
     public void setMargin(double margin) { this.margin = margin; }
 
+    public List<PaymentLine> getPayments() { return payments; }
+    public void setPayments(List<PaymentLine> payments) { this.payments = payments; }
+
     // --- Targets ---
 
     public String getToStaffName() { return toStaffName; }
@@ -146,4 +155,37 @@ public class PrintBillData implements Serializable {
 
     public String getToInstitutionName() { return toInstitutionName; }
     public void setToInstitutionName(String toInstitutionName) { this.toInstitutionName = toInstitutionName; }
+
+    /**
+     * One settled payment line for printing. {@code paymentMethodLabel} is the
+     * human-readable method name (e.g. "Cash", "Credit Card") and {@code reference}
+     * carries any method-specific detail to show (card last digits, cheque/slip
+     * reference, etc.); it may be empty.
+     */
+    public static class PaymentLine implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private String paymentMethodLabel;
+        private double value;
+        private String reference;
+
+        public PaymentLine() {
+        }
+
+        public PaymentLine(String paymentMethodLabel, double value, String reference) {
+            this.paymentMethodLabel = paymentMethodLabel;
+            this.value = value;
+            this.reference = reference;
+        }
+
+        public String getPaymentMethodLabel() { return paymentMethodLabel; }
+        public void setPaymentMethodLabel(String paymentMethodLabel) { this.paymentMethodLabel = paymentMethodLabel; }
+
+        public double getValue() { return value; }
+        public void setValue(double value) { this.value = value; }
+
+        public String getReference() { return reference; }
+        public void setReference(String reference) { this.reference = reference; }
+    }
 }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -908,6 +908,7 @@ public class RetailSaleNativeSqlService {
         // (and derive the amount paid from their sum) so reprinted/reopened bills
         // match what the settle-time printout shows.
         double cashPaid = bill.getCashPaid();
+        double balance = cashPaid - net;
         if (bill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
             List<PrintBillData.PaymentLine> lines = buildPrintPaymentLinesFromPersisted(bill);
             pbd.setPayments(lines);
@@ -915,9 +916,16 @@ public class RetailSaleNativeSqlService {
             for (PrintBillData.PaymentLine line : lines) {
                 cashPaid += line.getValue();
             }
+            // The split is accepted at settle when within 1.0 of the net total;
+            // clamp the reprinted balance to zero within the same tolerance so a
+            // settled bill never shows a residual balance.
+            balance = cashPaid - net;
+            if (Math.abs(balance) <= 1.0) {
+                balance = 0.0;
+            }
         }
         pbd.setCashPaid(cashPaid);
-        pbd.setBalance(cashPaid - net);
+        pbd.setBalance(balance);
 
         // Items are on the BilledBill. For legacy plain-Bill records (pre two-bill structure)
         // or PreBill IDs passed in, fall back to referenceBill if the bill has no items.

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -902,8 +902,22 @@ public class RetailSaleNativeSqlService {
         pbd.setTotal(gross);
         pbd.setDiscount(disc);
         pbd.setDiscountPercentPharmacy(gross > 0 ? (disc / gross) * 100.0 : 0.0);
-        pbd.setCashPaid(bill.getCashPaid());
-        pbd.setBalance(bill.getCashPaid() - net);
+
+        // For Multiple Payment Methods, bill.cashPaid stays 0 and the methods are
+        // recorded as individual Payment rows. Rebuild the itemised payment lines
+        // (and derive the amount paid from their sum) so reprinted/reopened bills
+        // match what the settle-time printout shows.
+        double cashPaid = bill.getCashPaid();
+        if (bill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
+            List<PrintBillData.PaymentLine> lines = buildPrintPaymentLinesFromPersisted(bill);
+            pbd.setPayments(lines);
+            cashPaid = 0.0;
+            for (PrintBillData.PaymentLine line : lines) {
+                cashPaid += line.getValue();
+            }
+        }
+        pbd.setCashPaid(cashPaid);
+        pbd.setBalance(cashPaid - net);
 
         // Items are on the BilledBill. For legacy plain-Bill records (pre two-bill structure)
         // or PreBill IDs passed in, fall back to referenceBill if the bill has no items.
@@ -939,5 +953,47 @@ public class RetailSaleNativeSqlService {
         }
 
         return new Object[]{pbd, itemList};
+    }
+
+    /**
+     * Rebuilds the itemised payment lines for a reprinted/reopened Multiple
+     * Payment Methods bill from the persisted {@link Payment} rows. Each line
+     * carries the method label, paid value and a method-specific reference
+     * (card/cheque/slip/ewallet/online/credit reference) when available.
+     */
+    private List<PrintBillData.PaymentLine> buildPrintPaymentLinesFromPersisted(Bill bill) {
+        List<PrintBillData.PaymentLine> lines = new ArrayList<>();
+        List<Payment> payments = em.createQuery(
+                "select p from Payment p where p.bill = :bill"
+                + " and p.retired = false"
+                + " order by p.id", Payment.class)
+                .setParameter("bill", bill)
+                .getResultList();
+        for (Payment p : payments) {
+            if (p.getPaymentMethod() == null || p.getPaidValue() <= 0.0) {
+                continue;
+            }
+            String reference = "";
+            switch (p.getPaymentMethod()) {
+                case Card:
+                    reference = safeStr(p.getCreditCardRefNo());
+                    break;
+                case Cheque:
+                    reference = safeStr(p.getChequeRefNo());
+                    break;
+                case ewallet:
+                case Slip:
+                case OnlineSettlement:
+                case IOU:
+                case Credit:
+                    reference = safeStr(p.getReferenceNo());
+                    break;
+                default:
+                    break;
+            }
+            lines.add(new PrintBillData.PaymentLine(
+                    p.getPaymentMethod().getLabel(), p.getPaidValue(), reference));
+        }
+        return lines;
     }
 }

--- a/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
@@ -78,7 +78,7 @@
                         </td>
                         <td>:</td>
                         <td style="width: 30%;">
-                            <h:outputLabel value="#{cc.attrs.bill.paymentMethodLabel}" class="billDetails"/>
+                            <h:outputLabel value="#{empty cc.attrs.bill.payments ? cc.attrs.bill.paymentMethodLabel : 'Multiple'}" class="billDetails"/>
                         </td>
                         <td style="width: 10%;"/>
                         <td style="width: 15%;"/>

--- a/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_native.xhtml
@@ -84,6 +84,24 @@
                         <td style="width: 15%;"/>
                         <td style="width: 30%;"/>
                     </tr>
+                    <ui:repeat value="#{cc.attrs.bill.payments}" var="ps">
+                        <tr>
+                            <td style="width: 15%; text-align: left;">
+                                <h:outputLabel value="#{ps.paymentMethodLabel}" class="billDetails"/>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;">
+                                <h:outputLabel value="#{ps.value}" class="billDetails">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                                <h:outputLabel rendered="#{ps.reference ne null and ps.reference ne ''}"
+                                               value=" (#{ps.reference})" class="billDetails"/>
+                            </td>
+                            <td style="width: 10%;"/>
+                            <td style="width: 15%;"/>
+                            <td style="width: 30%;"/>
+                        </tr>
+                    </ui:repeat>
                     <h:panelGroup rendered="#{cc.attrs.bill.patientName ne null}">
                         <tr>
                             <td style="width: 15%; text-align: left;">


### PR DESCRIPTION
## Issue
Closes #21707

## Problem
On the native retail sale page (`pharmacy_bill_retail_sale_native.xhtml`), settling a bill with **Multiple Payment Methods** produced a printout with a single bundled line — **"Multiple Payment Methods"** with the full bill value, and a Tendered/Cash of `0.00`.

## Fix
- **`PrintBillData`**: add a `List<PaymentLine> payments` field plus a small `PaymentLine` value object (method label, value, optional reference).
- **`RetailSaleNativeSqlController.buildPrintPaymentLines()`**: build one `PaymentLine` per entered component for Multiple Payment Methods bills — method label, value, and method-specific reference (card no., cheque no., slip/ewallet/online reference). Zero-value components are skipped to match the settle path. The printed amount-paid is the sum of the components (balance computed from that sum), instead of the unused single `cashPaid` (0.0).
- **`saleBill_native.xhtml`**: `ui:repeat` over `bill.payments` renders each line under the Method row; reference shown in parentheses when present.

Single-method bills are unaffected (`payments` is empty).

## Result
The printout now itemises each payment, e.g.:
```
Cash       : 50.00
Credit Card: 145.90 (1234)
```

## Notes
Follow-up to #21702 / PR #21705. The settle path already persisted one `Payment` per component; only the print layer bundled them.

## Testing
- `mvn compile` — BUILD SUCCESS (`PrintBillData$PaymentLine` generated).
- Manual print verification on the native page with a two-method (Cash + Card) bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bills can now display multiple payment methods on the printed receipt.
  * Each payment component can show its label, amount, and optional reference details.
* **Bug Fixes**
  * Improved cash and balance display for split-payment bills so totals are calculated correctly.
  * Receipt printing now handles multi-payment transactions more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->