### PR TITLE
style(ui): standardize report filter layout and Save/Finalize/Approve workflow buttons

### DIFF
--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -201,7 +201,17 @@ Report filter panels use an 8-column `h:panelGrid` with the pattern: `label(1) |
 
 5. **Do not mix `p:spacer` counts to "push" a field rightward** as an alignment trick — this is fragile. If a field should appear in a specific column, count the cells from the start of the row.
 
-Reference implementation: `src/main/webapp/inward/report_admission_by_consultant.xhtml`
+6. **🚨 Institution / Site / Department MUST share one row and align on the same level.** When a report filters by location, the three location selectors always go together on their own row in this exact order and column position: `Institution(label+input) | spacer | Site(label+input) | spacer | Department(label+input)` = 8 cells. Never stagger them across multiple rows (the classic symptom of a `columns="2"` or `columns="4"` grid) or put another filter between them. They are a single visual unit and end users expect to scan them left-to-right on one line. This is the single most common filter-layout defect in the report pages.
+
+7. **Department is always four rendered `p:selectOneMenu` variants** keyed on the institution/site selection, wrapped in a single `<h:panelGroup id="...">` that the institution and site `p:ajax` re-render via `update`. Use the correct `DepartmentController` method per variant — they are NOT interchangeable:
+   - both null → `getDepartmentsOfInstitutionAndSite()`
+   - site only → `getDepartmentsOfInstitutionAndSite(site)`
+   - **institution only → `getDepartmentsOfInstitutionAndSiteForInstitution(institution)`** (NOT `getDepartmentsOfInstitutionAndSite(institution)` — that overload takes a *site* and silently filters by `d.site`, returning the wrong departments)
+   - both → `getDepartmentsOfInstitutionAndSite(institution, site)`
+
+Reference implementations:
+- `src/main/webapp/inward/report_admission_by_consultant.xhtml` (location filters as the last row)
+- `src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml` (Institution/Site/Department aligned on one row in an inventory report)
 
 ---
 
@@ -223,6 +233,35 @@ Reference implementation: `src/main/webapp/inward/report_admission_by_consultant
 </div>
 ```
 
+### Index / landing page menus (accordion-sidebar button lists)
+
+Module landing pages (e.g. `pharmacy/disbursement_index.xhtml`, `opd/analytics/index.xhtml`) place a vertical list of navigation buttons inside `p:accordionPanel` tabs in a narrow left sidebar, with the working area (`subcontent`) on the right. This is an ERP, not a marketing site — **maximise the data area and eliminate wasted whitespace in the menu.**
+
+**🚨 Use `<div class="d-grid gap-2">` to stack the buttons — never `<p:panelGrid columns="1">`.** `p:panelGrid` renders an HTML `<table>`: each button lands in a padded `<td>` that does not fill the tab width even with `w-100`, producing ragged button widths and wasted horizontal/vertical space. The Bootstrap `d-grid` makes every button truly full-width with a tight, uniform `gap-2`.
+
+```xhtml
+<p:tab title="Transfer Requests">
+    <div class="d-grid gap-2">
+        <p:commandButton value="Create Request"
+                         ajax="false"
+                         style="text-align: left"
+                         icon="fas fa-hand-holding-medical"
+                         class="ui-button-success w-100"
+                         action="#{...}"
+                         rendered="#{webUserController.hasPrivilege('...')}"/>
+        <!-- more buttons -->
+    </div>
+</p:tab>
+```
+
+Rules:
+- Each button: `class="... w-100"`, `style="text-align: left"` (vertical menus read better left-aligned), and a leading `icon` reflecting the workflow stage (create / pending / approve / completed — same icon vocabulary as the navigation block above).
+- Keep semantic colour classes (`ui-button-success` create, `ui-button-warning` finalize, `ui-button-info` approve, `ui-button-secondary` completed) consistent across tabs.
+- Wrap the whole accordion in a single `<h:form>` and use `activeIndex` for tab persistence (see § Forms & State).
+- Favour a narrow menu column (`col-2`) over a wide one so the data area gets the space; only widen to `col-md-3` when button labels genuinely need it.
+
+Reference implementations: `src/main/webapp/pharmacy/disbursement_index.xhtml`, `src/main/webapp/opd/analytics/index.xhtml`.
+
 ### Primary data actions (row-level)
 | Action | Style class | Icon suggestion | Notes |
 |--------|-------------|-----------------|-------|
@@ -234,6 +273,34 @@ Reference implementation: `src/main/webapp/inward/report_admission_by_consultant
 
 Supporting rules:
 - Use `p:growl` for feedback after actions.
+
+### 🚨 Three-Stage Transaction Workflow (Save → Finalize → Approve) — MANDATORY STANDARD
+
+Many transaction workflows in the system (pharmacy transfer request/issue/receive, disposals, GRN returns, purchase orders, etc.) progress through three stages: **Save (Draft) → Finalize → Approve.** Historically each page chose its own colour and icon — most stages were all green (`ui-button-success`) with random icons (`pi pi-save`, `pi pi-check`, `fas fa-check`, `fas fa-check-circle`), so a user could not tell the stages apart. **This is now standardised through dedicated CSS classes** so the palette is defined once and every workflow button follows. The colour temperature progresses with the workflow (blue → amber → green) and each stage has one fixed icon:
+
+| Stage | Meaning | Style class (colour) | Icon | Confirm? |
+|-------|---------|----------------------|------|----------|
+| **Save / Save Draft** | Editable draft, nothing committed yet | `ui-button-stage-save` (blue) | `fas fa-floppy-disk` | No |
+| **Finalize** | Locks the draft; sends it forward for approval | `ui-button-stage-finalize` (amber) | `fas fa-lock` | Yes — `onclick="return confirm('…?')"` |
+| **Approve** | Final sign-off, completes the transaction | `ui-button-stage-approve` (green) | `fas fa-check-double` | Yes — `onclick="return confirm('…?')"` |
+
+The three `ui-button-stage-*` classes are defined **once** in `src/main/webapp/resources/css/ohmis.css` (loaded globally by the template) and are the single source of truth for the workflow palette. Use them via `styleClass` instead of `ui-button-info/warning/success` — to re-theme every workflow button across the system, edit those three classes, not the pages. The matching **icon stays on the markup** (PrimeFaces renders button icons natively), so each button carries `styleClass="ui-button-stage-…"` **and** the `icon` listed above.
+
+```xhtml
+<p:commandButton id="btnSave"     value="Save"     icon="fas fa-floppy-disk"  styleClass="mx-1 ui-button-stage-save"     ajax="false" action="#{ctrl.save()}" />
+<p:commandButton id="btnFinalize" value="Finalize" icon="fas fa-lock"         styleClass="mx-1 ui-button-stage-finalize" ajax="false" action="#{ctrl.finalize()}" onclick="return confirm('Are you sure you want to finalize? This cannot be undone.');" />
+<p:commandButton id="btnApprove"  value="Approve"  icon="fas fa-check-double" styleClass="mx-1 ui-button-stage-approve"  ajax="false" action="#{ctrl.approve()}" onclick="return confirm('Are you sure you want to approve?');" />
+```
+
+Rules:
+- Always use the `ui-button-stage-*` class (not the raw `ui-button-info/warning/success`) for any Save/Finalize/Approve button so the palette stays centralised. Use `styleClass`, not `class` (canonical PrimeFaces attribute).
+- Apply the **same** stage class + icon everywhere it appears — on the action page header, in list-page row actions ("Edit and Finalize", "Edit and Approve"), and in landing-page menus. The "Edit and …" list variants keep the destination stage's class/icon (e.g. "Edit and Finalize" = `ui-button-stage-finalize` + `fas fa-lock`).
+- Finalize and Approve are irreversible transitions → always guard with native `confirm()` (see Confirmation Dialogs below).
+- Never reuse the green Approve class for Save or Finalize, and never reuse `pi pi-check` / `fas fa-check-circle` for these three stages — those collisions are exactly what this standard removes.
+- This overrides the generic row-level "Finalize / Approve" rows in the table above for any button that is part of a three-stage transaction workflow.
+
+CSS source: `src/main/webapp/resources/css/ohmis.css` (search "Three-Stage Transaction Workflow buttons").
+Reference implementation: `src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml` (Save + Finalize), `src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml` (Approve).
 
 ### Confirmation Dialogs
 

--- a/src/main/webapp/pharmacy/disbursement_index.xhtml
+++ b/src/main/webapp/pharmacy/disbursement_index.xhtml
@@ -20,10 +20,11 @@
                     <p:accordionPanel activeIndex="#{searchController.activeIndexForDisbursement}" >
                         <p:ajax event="tabChange" process="@this"/>
                         <p:tab title="Transfer Requests" >
-                            <p:panelGrid columns="1" >
+                            <div class="d-grid gap-2">
                                 <p:commandButton
                                     value="Create Request"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{transferRequestController.navigateToCreateANewTransferRequest()}"
                                     class="ui-button-success w-100"
                                     icon="fas fa-hand-holding-medical"
@@ -31,34 +32,38 @@
                                 <p:commandButton
                                     value="Finalize Requests"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToTransferRequestFinalize}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-warning w-100"
-                                    icon="fas fa-tasks"
+                                    styleClass="ui-button-stage-finalize w-100"
+                                    icon="fas fa-lock"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}" />
                                 <p:commandButton
                                     value="Approve Requests"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToTransferRequestApprove()}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-info w-100"
-                                    icon="fas fa-check-circle"
+                                    styleClass="ui-button-stage-approve w-100"
+                                    icon="fas fa-check-double"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}" />
                                 <p:commandButton
                                     value="Approved Requests"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="/pharmacy/pharmacy_transfer_request_list_approved?faces-redirect=true"
                                     actionListener="#{searchController.makeListNull()}"
                                     class="ui-button-secondary w-100"
                                     icon="fas fa-check-double"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}" />
-                            </p:panelGrid>
+                            </div>
                         </p:tab>
                         <p:tab title="Issues" >
-                            <p:panelGrid columns="1" >
+                            <div class="d-grid gap-2">
                                 <p:commandButton
                                     value="Issue for Requests"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{transferIssueController.navigateToListPharmacyIssueRequests}"
                                     actionListener="#{searchController.makeListNull()}"
                                     class="ui-button-success w-100"
@@ -67,34 +72,38 @@
                                 <p:commandButton
                                     value="Finalize Issues"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToIssueForRequestListToFinalize()}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-warning w-100"
-                                    icon="fas fa-tasks"
+                                    styleClass="ui-button-stage-finalize w-100"
+                                    icon="fas fa-lock"
                                     rendered="#{webUserController.hasPrivilege('PharmacyIssueForRequestFinalize')}" />
                                 <p:commandButton
                                     value="Approve Issues"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToIssueForRequestListToApprove()}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-info w-100"
-                                    icon="fas fa-check-circle"
+                                    styleClass="ui-button-stage-approve w-100"
+                                    icon="fas fa-check-double"
                                     rendered="#{webUserController.hasPrivilege('PharmacyIssueForRequestApprove')}" />
                                 <p:commandButton
                                     value="Direct Issue"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{transferIssueDirectController.navigateToDirectPharmacyIssue}"
                                     actionListener="#{transferIssueController.makeNull()}"
                                     class="ui-button-info w-100"
                                     icon="fas fa-pills"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementDirectIssue')}" />
-                            </p:panelGrid>
+                            </div>
                         </p:tab>
                         <p:tab title="Receive" >
-                            <p:panelGrid columns="1" >
+                            <div class="d-grid gap-2">
                                 <p:commandButton
                                     value="Receive Issued Items"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="/pharmacy/pharmacy_transfer_issued_list?faces-redirect=true"
                                     actionListener="#{searchController.makeListNull()}"
                                     class="ui-button-success w-100"
@@ -103,31 +112,34 @@
                                 <p:commandButton
                                     value="Finalize Receives"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToReceiveListToFinalize()}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-warning w-100"
-                                    icon="fas fa-tasks"
+                                    styleClass="ui-button-stage-finalize w-100"
+                                    icon="fas fa-lock"
                                     rendered="#{webUserController.hasPrivilege('PharmacyReceiveFinalize')}" />
                                 <p:commandButton
                                     value="Approve Receives"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{searchController.navigateToReceiveListToApprove()}"
                                     actionListener="#{searchController.makeListNull()}"
-                                    class="ui-button-info w-100"
-                                    icon="fas fa-check-circle"
+                                    styleClass="ui-button-stage-approve w-100"
+                                    icon="fas fa-check-double"
                                     rendered="#{webUserController.hasPrivilege('PharmacyReceiveApprove')}" />
-                            </p:panelGrid>
+                            </div>
                         </p:tab>
                         <p:tab title="Reports" >
-                            <p:panelGrid columns="1">
+                            <div class="d-grid gap-2">
                                 <p:commandButton
                                     value="Transfer Reports"
                                     ajax="false"
+                                    style="text-align: left"
                                     action="#{reportsTransfer.navigateToPharmacyTransferReports()}"
                                     class="ui-button-info w-100"
                                     icon="fas fa-file-alt"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDisbursementReports')}" />
-                            </p:panelGrid>
+                            </div>
                         </p:tab>
                     </p:accordionPanel>
                 </h:form>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
@@ -93,7 +93,7 @@
                                     <p:column headerText="Actions" styleClass="text-center" exportable="false" width="130">
                                         <p:commandButton
                                             id="btnApprove"
-                                            class="ui-button-success"
+                                            styleClass="ui-button-stage-approve"
                                             icon="fas fa-eye"
                                             value="View / Approve"
                                             title="View and Approve Disposal Issue #{g.id}"

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
@@ -92,7 +92,7 @@
                             <p:column headerText="Action" styleClass="text-center" exportable="false" width="140px">
                                 <p:commandButton
                                     id="btnFinalize"
-                                    styleClass="ui-button ui-button-warning ui-button-sm"
+                                    styleClass="ui-button ui-button-stage-finalize ui-button-sm"
                                     icon="fas fa-eye"
                                     value="View / Finalize"
                                     title="View and Finalize Disposal Issue #{g.id}"

--- a/src/main/webapp/pharmacy/pharmacy_issue_for_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue_for_request_list_to_approve.xhtml
@@ -90,8 +90,8 @@
                                     <p:column headerText="Actions" styleClass="text-center" exportable="false" width="100">
                                         <p:commandButton
                                             id="btnApprove"
-                                            class="ui-button-success"
-                                            icon="fas fa-check"
+                                            styleClass="ui-button-stage-approve"
+                                            icon="fas fa-check-double"
                                             value="Approve"
                                             title="Open and Approve Issue"
                                             ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_issue_for_request_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue_for_request_list_to_finalize.xhtml
@@ -89,8 +89,8 @@
                             <p:column headerText="Action" styleClass="text-center" exportable="false" width="120px">
                                 <p:commandButton
                                     id="btnFinalize"
-                                    styleClass="ui-button ui-button-warning ui-button-sm"
-                                    icon="fas fa-check-circle"
+                                    styleClass="ui-button ui-button-stage-finalize ui-button-sm"
+                                    icon="fas fa-lock"
                                     value="Finalize"
                                     title="Open and Finalize Issue"
                                     ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_approve.xhtml
@@ -90,8 +90,8 @@
                                     <p:column headerText="Actions" styleClass="text-center" exportable="false" width="120">
                                         <p:commandButton
                                             id="btnApprove"
-                                            class="ui-button-success"
-                                            icon="fas fa-check"
+                                            styleClass="ui-button-stage-approve"
+                                            icon="fas fa-check-double"
                                             value="Approve"
                                             title="Open and Approve Receive #{g.id}"
                                             ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_receive_list_to_finalize.xhtml
@@ -89,8 +89,8 @@
                             <p:column headerText="Action" styleClass="text-center" exportable="false" width="130px">
                                 <p:commandButton
                                     id="btnFinalize"
-                                    styleClass="ui-button ui-button-warning ui-button-sm"
-                                    icon="fas fa-check-circle"
+                                    styleClass="ui-button ui-button-stage-finalize ui-button-sm"
+                                    icon="fas fa-lock"
                                     value="Finalize"
                                     title="Open and Finalize Receive #{g.id}"
                                     ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -187,34 +187,34 @@
                                 <p:commandButton
                                     id="btnSaveDraftIssue"
                                     value="Save Draft"
-                                    icon="fas fa-save"
+                                    icon="fas fa-floppy-disk"
                                     actionListener="#{transferIssueForRequestsController.saveDraftIssue()}"
                                     style="float: right;"
                                     onclick="if (!confirm('Save this issue as a draft?')) return false;"
                                     ajax="false"
-                                    class="ui-button-warning mx-2"
+                                    styleClass="ui-button-stage-save mx-2"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Issue for Requests', false) and !transferIssueForRequestsController.issuedBill.completed and webUserController.hasPrivilege('PharmacyIssueForRequestSave')}"/>
 
                                 <p:commandButton
                                     id="btnFinalizeIssue"
                                     value="Finalize"
-                                    icon="fas fa-clipboard-check"
+                                    icon="fas fa-lock"
                                     actionListener="#{transferIssueForRequestsController.finalizeDraftIssue()}"
                                     style="float: right;"
                                     onclick="if (!confirm('Finalize this issue draft?')) return false;"
                                     ajax="false"
-                                    class="ui-button-warning mx-2"
+                                    styleClass="ui-button-stage-finalize mx-2"
                                     rendered="#{transferIssueForRequestsController.draftMode and transferIssueForRequestsController.issuedBill.id ne null and !transferIssueForRequestsController.issuedBill.completed and webUserController.hasPrivilege('PharmacyIssueForRequestFinalize')}"/>
 
                                 <p:commandButton
                                     id="btnApproveIssue"
                                     value="Approve"
-                                    icon="fas fa-check-circle"
+                                    icon="fas fa-check-double"
                                     action="#{transferIssueForRequestsController.approveDraftIssue()}"
                                     style="float: right;"
                                     onclick="if (!confirm('Approve this issue? Stock will be moved.')) return false;"
                                     ajax="false"
-                                    class="ui-button-success mx-2"
+                                    styleClass="ui-button-stage-approve mx-2"
                                     rendered="#{transferIssueForRequestsController.draftMode and transferIssueForRequestsController.issuedBill.completed and !transferIssueForRequestsController.issuedBill.checked and webUserController.hasPrivilege('PharmacyIssueForRequestApprove')}"/>
 
                                 <p:commandButton

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_native.xhtml
@@ -48,9 +48,9 @@
                         <p:commandButton
                             id="btnSaveDraftNative"
                             value="Save Draft"
-                            icon="fas fa-save"
+                            icon="fas fa-floppy-disk"
                             style="float: right;"
-                            class="ui-button-secondary mx-2"
+                            styleClass="ui-button-stage-save mx-2"
                             actionListener="#{transferIssueNativeSqlController.saveDraftNativeIssue()}"
                             ajax="false"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Issue for Requests', false) and !transferIssueNativeSqlController.draftMode and webUserController.hasPrivilege('PharmacyIssueForRequestSave')}"/>
@@ -59,22 +59,24 @@
                         <p:commandButton
                             id="btnFinalizeNative"
                             value="Finalize"
-                            icon="fas fa-tasks"
+                            icon="fas fa-lock"
                             style="float: right;"
-                            class="ui-button-warning mx-2"
+                            styleClass="ui-button-stage-finalize mx-2"
                             actionListener="#{transferIssueNativeSqlController.finalizeDraftNativeIssue()}"
                             ajax="false"
+                            onclick="if (!confirm('Finalize this issue draft? This cannot be undone.')) return false;"
                             rendered="#{transferIssueNativeSqlController.draftMode and transferIssueNativeSqlController.issuedBill.id ne null and !transferIssueNativeSqlController.issuedBill.completed and webUserController.hasPrivilege('PharmacyIssueForRequestFinalize')}"/>
 
                         <!-- Approve (draft finalized, not yet checked) -->
                         <p:commandButton
                             id="btnApproveNative"
                             value="Approve"
-                            icon="fas fa-check-circle"
+                            icon="fas fa-check-double"
                             style="float: right;"
-                            class="ui-button-success mx-2"
+                            styleClass="ui-button-stage-approve mx-2"
                             action="#{transferIssueNativeSqlController.approveDraftNativeIssue()}"
                             ajax="false"
+                            onclick="if (!confirm('Approve this issue? Stock will be moved.')) return false;"
                             rendered="#{transferIssueNativeSqlController.draftMode and transferIssueNativeSqlController.issuedBill.completed and !transferIssueNativeSqlController.issuedBill.checked and webUserController.hasPrivilege('PharmacyIssueForRequestApprove')}"/>
 
                         <!-- Cancel Draft -->

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -155,8 +155,8 @@
                                         ajax="false"
                                         value="Finalize"
                                         title="Finalize pending receive for #{p.deptId}"
-                                        class="ui-button-warning mx-1"
-                                        icon="fas fa-check"
+                                        styleClass="ui-button-stage-finalize mx-1"
+                                        icon="fas fa-lock"
                                         action="#{transferReceiveNativeSqlController.loadPendingReceiveForFinalize(p.pendingReceiveBillId)}"/>
                                     <p:commandButton
                                         id="btnCancelPendingReceive"
@@ -175,7 +175,7 @@
                                         ajax="false"
                                         value="Approve"
                                         title="Approve finalized receive for #{p.deptId}"
-                                        class="ui-button-success mx-1"
+                                        styleClass="ui-button-stage-approve mx-1"
                                         icon="fas fa-check-double"
                                         action="#{transferReceiveNativeSqlController.loadPendingReceiveForApprove(p.pendingReceiveBillId)}"/>
                                     <p:commandButton

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
@@ -39,15 +39,16 @@
                         <p:commandButton
                             value="Finalize"
                             action="#{transferReceiveNativeSqlController.finalizeRequest()}"
-                            class="ui-button-warning mx-1"
-                            icon="fas fa-check"
+                            styleClass="ui-button-stage-finalize mx-1"
+                            icon="fas fa-lock"
                             ajax="false"
+                            onclick="return confirm('Are you sure you want to finalize this receive? This cannot be undone.');"
                             style="float: right;">
                         </p:commandButton>
                         <p:commandButton
                             value="Save"
                             action="#{transferReceiveNativeSqlController.saveRequest()}"
-                            class="ui-button-success mx-1"
+                            styleClass="ui-button-stage-save mx-1"
                             icon="fas fa-floppy-disk"
                             ajax="false"
                             style="float: right;">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -33,16 +33,17 @@
                         <p:commandButton
                             value="Finalize"
                             action="#{transferReceiveController.finalizeRequest()}"
-                            class="ui-button-warning mx-1"
-                            icon="fas fa-check"
+                            styleClass="ui-button-stage-finalize mx-1"
+                            icon="fas fa-lock"
                             ajax="false"
                             disabled="#{transferReceiveController.receivedBill.checkedBy ne null}"
+                            onclick="return confirm('Are you sure you want to finalize this receive? This cannot be undone.');"
                             style="float: right;">
                         </p:commandButton>
                         <p:commandButton
                             value="Save"
                             action="#{transferReceiveController.saveRequest()}"
-                            class="ui-button-success mx-1"
+                            styleClass="ui-button-stage-save mx-1"
                             icon="fas fa-floppy-disk"
                             disabled="#{transferReceiveController.receivedBill.checkedBy ne null}"
                             ajax="false"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -118,16 +118,16 @@
                                         value="Save"
                                         action="#{transferRequestController.saveTranserRequestPreBill()}"
                                         ajax="false"
-                                        icon="pi pi-save"
-                                        class="mx-1 ui-button-success"
+                                        icon="fas fa-floppy-disk"
+                                        styleClass="mx-1 ui-button-stage-save"
                                         />
                                     <p:commandButton
                                         id="btnFinalize"
                                         value="Finalize"
                                         action="#{transferRequestController.finalizeTranserRequestPreBill()}"
                                         ajax="false"
-                                        icon="pi pi-check"
-                                        class="mx-1 ui-button-success"
+                                        icon="fas fa-lock"
+                                        styleClass="mx-1 ui-button-stage-finalize"
                                         onclick="return confirm('Are you sure you want to finalize this transfer request? This action cannot be undone.');"
                                         />
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -34,8 +34,9 @@
                                     value="Approve"
                                     action="#{transferRequestController.approveTransferRequestBill}"
                                     ajax="false"
-                                    icon="fas fa-check"
-                                    class="mx-1 ui-button-success">
+                                    icon="fas fa-check-double"
+                                    styleClass="mx-1 ui-button-stage-approve"
+                                    onclick="return confirm('Are you sure you want to approve this transfer request?');">
                                 </p:commandButton>
                             </div>
                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
@@ -61,7 +61,7 @@
                                     styleClass="mx-1 ui-button-stage-save">
                                 </p:commandButton>
                                 <p:commandButton
-                                    value="Send For Approvel"
+                                    value="Send For Approval"
                                     action="#{transferRequestController.finalizeTranserRequest}"
                                     ajax="false"
                                     icon="fas fa-lock"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
@@ -57,15 +57,16 @@
                                     value="Save"
                                     action="#{transferRequestController.saveTranserRequest()}"
                                     ajax="false"
-                                    icon="fas fa-check"
-                                    class="mx-1 ui-button-success">
+                                    icon="fas fa-floppy-disk"
+                                    styleClass="mx-1 ui-button-stage-save">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="Send For Approvel"
                                     action="#{transferRequestController.finalizeTranserRequest}"
                                     ajax="false"
-                                    icon="fas fa-check"
-                                    class="mx-1 ui-button-success">
+                                    icon="fas fa-lock"
+                                    styleClass="mx-1 ui-button-stage-finalize"
+                                    onclick="return confirm('Are you sure you want to send this request for approval? This cannot be undone.');">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="New Bill"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -74,7 +74,7 @@
                                     ajax="false"
                                     value="Approve Request"
                                     title="Approve Request"
-                                    icon="fas fa-check-double" class="ui-button-success mx-2"
+                                    icon="fas fa-check-double" styleClass="ui-button-stage-approve mx-2"
                                     action="#{transferRequestController.navigateToApproveRequest}"
                                     disabled="#{b.cancelled eq true}">
                                     <f:setPropertyActionListener target="#{transferRequestController.transferRequestBillPre}" value="#{b}"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_finalize.xhtml
@@ -82,7 +82,7 @@
                                     ajax="false" 
                                     value="Edit and Finalize Request"
                                     title="Edit and Finalize Request"
-                                    icon="fas fa-check-circle" class="ui-button-success mx-2"
+                                    icon="fas fa-lock" styleClass="ui-button-stage-finalize mx-2"
                                     action="#{transferRequestController.navigateToEditRequest}"
                                     disabled="#{b.checkedBy ne null or b.cancelled eq true}">
                                     <f:setPropertyActionListener target="#{transferRequestController.transferRequestBillPre}" value="#{b}"/>

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -25,38 +25,39 @@
                             </p:commandButton>
                         </f:facet>
 
-                        <p:panelGrid columns="4" class="w-100">
+                        <h:panelGrid columns="8" styleClass="w-100 form-grid" columnClasses="label-icon-column, input-column">
 
+                            <!-- Row 1: From | To | Department Type -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
                                 <p:outputLabel value="From Date" class="mx-3" for="fromDate"/>
                             </h:panelGroup>
                             <p:calendar
-                                class="w-100"
-                                inputStyleClass="w-100"
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
                                 id="fromDate"
                                 ariaLabel="From Date"
                                 value="#{pharmacyReportController.fromDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
-
+                            <p:spacer width="50" />
 
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText value="&#xf073;" styleClass="fa ml-3" />
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2" />
                                 <p:outputLabel value="To Date" class="mx-3" for="toDate"/>
                             </h:panelGroup>
                             <p:calendar
-                                class="w-100"
-                                inputStyleClass="w-100"
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
                                 id="toDate"
                                 ariaLabel="To Date"
                                 value="#{pharmacyReportController.toDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
-
+                            <p:spacer width="50" />
 
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <h:outputText value="&#xf0f0;" styleClass="fa mr-2"/>
                                 <p:outputLabel value="Department Type" class="mx-3" for="departmentTypeFilter"/>
                             </h:panelGroup>
                             <h:panelGroup layout="block" styleClass="form-group">
@@ -64,7 +65,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
-                                    class="w-100"
+                                    styleClass="w-100"
                                     filter="true"
                                     filterMatchMode="contains"
                                     showHeader="true"
@@ -79,14 +80,14 @@
                                 <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all departments." position="top"/>
                             </h:panelGroup>
 
-
+                            <!-- Row 2: Institution | Site | Department (aligned on one level) -->
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-university ml-3" />
+                                <h:outputText value="&#xf19c;" styleClass="fa mr-2" />
                                 <p:outputLabel value="Institution" class="mx-3" for="phmIns"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmIns"
-                                class="w-100"
+                                styleClass="w-100 form-control"
                                 ariaLabel="Institution"
                                 value="#{pharmacyReportController.institution}"
                                 filter="true">
@@ -96,14 +97,15 @@
                                 <p:ajax process="phmIns" update="phmDept"/>
                             </p:selectOneMenu>
 
+                            <p:spacer width="50" />
+
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-map-marker-alt ml-3" />
+                                <h:outputText value="&#xf3c5;" styleClass="fa mr-2" />
                                 <p:outputLabel value="Site" class="mx-3" for="phmSite"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmSite"
-                                class="w-100"
-                                styleClass="w-100"
+                                styleClass="w-100 form-control"
                                 ariaLabel="Site"
                                 value="#{pharmacyReportController.site}"
                                 filter="true">
@@ -113,8 +115,10 @@
                                 <p:ajax process="phmSite" update="phmDept"/>
                             </p:selectOneMenu>
 
+                            <p:spacer width="50" />
+
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-building ml-3" />
+                                <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
                                 <p:outputLabel value="Department" class="mx-3" for="phmDept"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
@@ -122,6 +126,7 @@
                                 <!-- Component 1: Without Institution and Site -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     ariaLabel="Department"
                                     filterMatchMode="contains"
@@ -137,6 +142,7 @@
                                 <!-- Component 2: With Site Only -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     ariaLabel="Department"
                                     filterMatchMode="contains"
@@ -152,13 +158,14 @@
                                 <!-- Component 3: With Institution Only -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
                                     <f:selectItems
-                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution)}"
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(pharmacyReportController.institution)}"
                                         var="dept"
                                         itemLabel="#{dept.name}"
                                         itemValue="#{dept}"/>
@@ -167,6 +174,7 @@
                                 <!-- Component 4: With Both Institution and Site -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     ariaLabel="Department"
                                     filterMatchMode="contains"
@@ -180,14 +188,15 @@
                                 </p:selectOneMenu>
                             </h:panelGroup>
 
+                            <!-- Row 3: Item + trailing spacers -->
                             <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-pills ml-3" />
+                                <h:outputText value="&#xf484;" styleClass="fa mr-2" />
                                 <p:outputLabel value="Item" class="mx-3" for="phmItem"/>
                             </h:panelGroup>
                             <p:autoComplete
                                 id="phmItem"
-                                class="w-100"
-                                inputStyleClass="w-100"
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
                                 ariaLabel="Item"
                                 value="#{pharmacyReportController.item}"
                                 completeMethod="#{itemController.completeItem}"
@@ -200,7 +209,14 @@
                                 </p:column>
                             </p:autoComplete>
 
-                        </p:panelGrid>
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+                            <p:spacer width="50" />
+
+                        </h:panelGrid>
 
                         <div class="d-flex align-items-center">
                             <p:commandButton class="ui-button-warning mx-1"

--- a/src/main/webapp/resources/css/ohmis.css
+++ b/src/main/webapp/resources/css/ohmis.css
@@ -836,6 +836,67 @@ th.align-right-header .ui-column-title {
     margin: 0 !important;
 }
 
+/* ============================================================
+   Three-Stage Transaction Workflow buttons (Save → Finalize → Approve)
+   Single source of truth for the COLOUR of each workflow stage. Use
+   these classes instead of repeating ui-button-info/warning/success
+   on every Save/Finalize/Approve button — change the palette here once
+   and every workflow button across the system follows.
+
+   The matching ICON stays on the markup (icon="fas fa-...") because
+   PrimeFaces renders button icons natively; see the standard in
+   developer_docs/ui/comprehensive-ui-guidelines.md:
+     Save (Draft) = ui-button-stage-save     + icon="fas fa-floppy-disk"
+     Finalize     = ui-button-stage-finalize + icon="fas fa-lock"
+     Approve      = ui-button-stage-approve  + icon="fas fa-check-double"
+   ============================================================ */
+
+/* Save (Draft) — blue */
+.ui-button.ui-button-stage-save,
+.ui-widget.ui-button-stage-save,
+.ui-state-default.ui-button-stage-save {
+    background-color: #007bff !important;
+    border-color: #0056b3 !important;
+    color: #ffffff !important;
+}
+.ui-button.ui-button-stage-save:hover,
+.ui-widget.ui-button-stage-save:hover,
+.ui-state-default.ui-button-stage-save:hover {
+    background-color: #0056b3 !important;
+    border-color: #003f7f !important;
+}
+
+/* Finalize — amber */
+.ui-button.ui-button-stage-finalize,
+.ui-widget.ui-button-stage-finalize,
+.ui-state-default.ui-button-stage-finalize {
+    background-color: #ffc107 !important;
+    border-color: #e0a800 !important;
+    color: #212529 !important;
+}
+.ui-button.ui-button-stage-finalize:hover,
+.ui-widget.ui-button-stage-finalize:hover,
+.ui-state-default.ui-button-stage-finalize:hover {
+    background-color: #e0a800 !important;
+    border-color: #c69500 !important;
+}
+
+/* Approve — green */
+.ui-button.ui-button-stage-approve,
+.ui-widget.ui-button-stage-approve,
+.ui-state-default.ui-button-stage-approve {
+    background-color: #28a745 !important;
+    border-color: #1e7e34 !important;
+    color: #ffffff !important;
+}
+.ui-button.ui-button-stage-approve:hover,
+.ui-widget.ui-button-stage-approve:hover,
+.ui-state-default.ui-button-stage-approve:hover {
+    background-color: #1e7e34 !important;
+    border-color: #155724 !important;
+}
+
+
 /* Optimised menu item — subtle green tinge */
 a.ui-menuitem-link.menu-item-optimised,
 a.ui-menuitem-link.menu-item-optimised .ui-menuitem-text,


### PR DESCRIPTION
## Summary

Three related UI standardization changes across pharmacy and report pages, each backed by an update to `developer_docs/ui/comprehensive-ui-guidelines.md` so future pages follow the same conventions.

### 1. Report filter layout — Institution / Site / Department on one level
`reports/inventoryReports/cost_of_goods_sold.xhtml` used a 4-column filter grid, which staggered Institution, Site and Department onto separate, misaligned rows. Converted to the standard **8-column grid** (`label | input | spacer …`) so the three location filters align on a single row, matching `cashier_reports/cashier_summary.xhtml` and the documented reference page.

Also fixes a **latent bug**: the "institution only" Department variant called `getDepartmentsOfInstitutionAndSite(institution)` — which resolves to the `(Institution site)` overload and filters by `d.site` — instead of `getDepartmentsOfInstitutionAndSiteForInstitution(institution)`.

### 2. Disbursement index — eliminate wasted button whitespace
`pharmacy/disbursement_index.xhtml` stacked its sidebar buttons with `p:panelGrid columns="1"`, which renders a padded HTML table (ragged widths, wasted space). Replaced with `d-grid gap-2` (full-width, tight, uniform gap), matching `opd/analytics/index.xhtml`. This is an ERP — the change maximises the data area.

### 3. Save → Finalize → Approve workflow buttons — standardized via CSS classes
Previously every page picked its own colour/icon for these stages (mostly all green with random icons), so users couldn't tell the stages apart. Introduced **three dedicated CSS classes** in `resources/css/ohmis.css` as the single source of truth for the palette:

| Stage | Class (colour) | Icon |
|---|---|---|
| Save / Draft | `ui-button-stage-save` (blue) | `fas fa-floppy-disk` |
| Finalize | `ui-button-stage-finalize` (amber) | `fas fa-lock` |
| Approve | `ui-button-stage-approve` (green) | `fas fa-check-double` |

Applied consistently across the pharmacy transfer / issue / receive / disposal workflow pages (action pages, list-page row actions, and the landing menu). Finalize and Approve are guarded with native `confirm()`. The icon stays on the markup (PrimeFaces renders button icons natively); only the colour is centralised, so re-theming is a one-file edit.

Colour/icon mapping researched against current UI/UX best practices (semantic colour temperature for workflow progression).

## Testing
JSF/XHTML + CSS only — no Java compilation. Visual change; verify in the running app after redeploy (hard-refresh for the cached `ohmis.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized workflow actions across pharmacy screens with clearer Save, Finalize, and Approve button styling and icons.
  * Improved report filter layout for the Cost of Goods Sold report, making filters more consistently arranged and easier to use.
* **Bug Fixes**
  * Updated several approval and finalize screens to use consistent button labels, icons, and confirmation prompts for safer workflow actions.
  * Refined landing page navigation button layouts for better readability and more usable sidebar spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->