### PR TITLE
fix(inward): exclude refunded lab items from inpatient lab investigation list

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -611,12 +611,14 @@ public class InwardReportControllerBht implements Serializable {
     public List<BillItem> fetchLabBillItems(PatientEncounter pt, List<BillTypeAtomic> billTypesAtomics) {
         String jpql = "select bi "
                 + "from BillItem bi "
-                + "where bi.bill.retired = :ret "
+                + "where bi.bill.retired = false "
+                + "and bi.bill.cancelled = false "
+                + "and bi.retired = false "
+                + "and bi.refunded = false "
                 + "and bi.bill.billTypeAtomic in :billTypesAtomics "
                 + "and bi.bill.patientEncounter = :pe ";
 
         HashMap<String, Object> params = new HashMap<>();
-        params.put("ret", false);
         params.put("pe", pt);
         params.put("billTypesAtomics", billTypesAtomics);
 


### PR DESCRIPTION
## Summary
- Refunded lab investigation items were still appearing in the inpatient lab investigation list report (`/inward/reports/inpatient_lab_investigation_item_list.xhtml`)
- Root cause: `fetchLabBillItems()` JPQL only filtered `bi.bill.retired = false`, missing `bi.refunded`, `bi.retired`, and `bi.bill.cancelled` at the `BillItem` level
- Fix adds those three conditions to the JPQL so refunded items are excluded at query time

## Why BillItem level, not Bill level
A single inward service bill can have 10 investigation items but only 1 may be refunded. `InwardServiceRefundController` already sets `original.setRefunded(true)` on each refunded `BillItem` individually, so filtering on `bi.refunded = false` is the correct granularity.

## Test plan
- [ ] Add multiple lab investigations for an inpatient
- [ ] Refund one of the items via `/inward/inward_bill_service_refund.xhtml`
- [ ] Navigate to `/inward/reports/inpatient_lab_investigation_item_list.xhtml`
- [ ] Confirm the refunded item no longer appears; remaining items are still listed

Closes #21718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lab bill item filtering so cancelled, retired, and refunded records are no longer included in results.
  * Search results for lab items should now be more accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->