### PR TITLE
fix(inward): exclude refunded lab items from inpatient lab investigation list [coop-prod]

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -466,12 +466,14 @@ public class InwardReportControllerBht implements Serializable {
     public List<BillItem> fetchLabBillItems(PatientEncounter pt, List<BillTypeAtomic> billTypesAtomics) {
         String jpql = "select bi "
                 + "from BillItem bi "
-                + "where bi.bill.retired = :ret "
+                + "where bi.bill.retired = false "
+                + "and bi.bill.cancelled = false "
+                + "and bi.retired = false "
+                + "and bi.refunded = false "
                 + "and bi.bill.billTypeAtomic in :billTypesAtomics "
                 + "and bi.bill.patientEncounter = :pe ";
 
         HashMap<String, Object> params = new HashMap<>();
-        params.put("ret", false);
         params.put("pe", pt);
         params.put("billTypesAtomics", billTypesAtomics);
 


### PR DESCRIPTION
## Summary
Hotfix for coop-production — cherry-pick of #21719 (merged to `development`) and #21720 (merged to `coop-stg`).

Refunded lab investigation items were still appearing in the inpatient lab investigation list report at `/inward/reports/inpatient_lab_investigation_item_list.xhtml`.

`fetchLabBillItems()` JPQL was missing `bi.refunded = false`, `bi.retired = false`, and `bi.bill.cancelled = false` — so refunded items were not excluded from the list.

## Changes
Single file: `InwardReportControllerBht.java` — adds three filter conditions to the JPQL in `fetchLabBillItems()`.

Closes #21718

🤖 Generated with [Claude Code](https://claude.com/claude-code)