### PR TITLE
fix(pharmacy): 7 disposal issue bugs — validation, expiry block, discard category, timestamps, draft save FK crash

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -265,6 +265,13 @@ public class PharmacyIssueController implements Serializable {
             OptionScope.APPLICATION
         ));
 
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Disposal Issue - Allow Issuing Expired Item Batches",
+            "When enabled, expired item batches can be added to a disposal issue with a warning instead of being blocked. Useful for hospitals that use disposal issue to physically discard expired stock.",
+            "pharmacy/pharmacy_issue",
+            OptionScope.APPLICATION
+        ));
+
         // Privileges
         metadata.addPrivilege(new PrivilegeInfo(
             "Admin",
@@ -496,10 +503,12 @@ public class PharmacyIssueController implements Serializable {
 
     public void setQty(Double qty) {
         if (qty != null && qty == 0) {
+            this.qty = null;
             JsfUtil.addErrorMessage("Quantity must be greater than 0");
             return;
         }
         if (qty != null && qty < 0) {
+            this.qty = null;
             JsfUtil.addErrorMessage("Cannot enter a negative quantity");
             return;
         }
@@ -914,19 +923,16 @@ public class PharmacyIssueController implements Serializable {
     }
 
     private boolean checkAllBillItem() {
-        if (getPreBill().getBillItems().isEmpty()) {
+        if (getActiveBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Please add items");
             return true;
         }
-        for (BillItem b : getPreBill().getBillItems()) {
-
+        for (BillItem b : getActiveBillItems()) {
             if (onEdit(b)) {
                 return true;
             }
         }
-
         return false;
-
     }
 
 //    public void settlePreBill() {
@@ -971,8 +977,8 @@ public class PharmacyIssueController implements Serializable {
         }
 
         // Validate department type consistency
-        if (getPreBill().getDepartmentType() != null && !getPreBill().getBillItems().isEmpty()) {
-            for (BillItem bi : getPreBill().getBillItems()) {
+        if (getPreBill().getDepartmentType() != null && !getActiveBillItems().isEmpty()) {
+            for (BillItem bi : getActiveBillItems()) {
                 if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
                     if (!bi.getItem().getDepartmentType().equals(getPreBill().getDepartmentType())) {
                         JsfUtil.addErrorMessage("Inconsistent department types detected. All items must belong to the same department type.");
@@ -1036,7 +1042,7 @@ public class PharmacyIssueController implements Serializable {
 
         if (getPreBill().getId() == null) {
             // First save — no persisted BillItems yet; safe to null the collection before create
-            List<BillItem> tmpBillItems = getPreBill().getBillItems();
+            List<BillItem> tmpBillItems = getActiveBillItems();
             getPreBill().setBillItems(null);
             getBillFacade().createAndFlush(getPreBill());
             for (BillItem tbi : tmpBillItems) {
@@ -1097,7 +1103,7 @@ public class PharmacyIssueController implements Serializable {
             JsfUtil.addErrorMessage("Cannot Issue to the Same Department");
             return null;
         }
-        if (getPreBill().getBillItems() == null || getPreBill().getBillItems().isEmpty()) {
+        if (getActiveBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Please add at least one item before finalizing.");
             return null;
         }
@@ -1447,7 +1453,7 @@ public class PharmacyIssueController implements Serializable {
             return false;
         }
 
-        for (BillItem bItem : getPreBill().getBillItems()) {
+        for (BillItem bItem : getActiveBillItems()) {
             if (bItem == null || bItem.getPharmaceuticalBillItem() == null ||
                 bItem.getPharmaceuticalBillItem().getStock() == null) {
                 continue;
@@ -1903,16 +1909,18 @@ public class PharmacyIssueController implements Serializable {
     public void removeBillItem(BillItem b) {
         userStockController.removeUserStock(b.getTransUserStock(), getSessionController().getLoggedUser());
 
-        // Soft-retire instead of hard-delete: removing from the list with orphanRemoval=true
-        // on Bill.billItems would trigger a cascade DELETE that violates the FK from
-        // PHARMACEUTICALBILLITEM.BILLITEM_ID. Mark retired and keep in the list.
-        b.setRetired(true);
-        b.setRetiredAt(new Date());
-        if (b.getId() != null) {
+        if (b.getId() == null) {
+            // Transient row — not yet persisted, safe to remove from the list entirely.
+            // Keeping it would let checkItemBatch() block re-adding the same batch.
+            getPreBill().getBillItems().remove(b);
+        } else {
+            // Persisted row — must soft-retire in place; removing from an orphanRemoval
+            // collection triggers cascade DELETE which violates the PHARMACEUTICALBILLITEM FK.
+            b.setRetired(true);
+            b.setRetiredAt(new Date());
             getBillItemFacade().edit(b);
         }
 
-        // Clear department type if no active items remain
         if (getActiveBillItems().isEmpty()) {
             getPreBill().setDepartmentType(null);
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -495,8 +495,12 @@ public class PharmacyIssueController implements Serializable {
     }
 
     public void setQty(Double qty) {
-        if (qty != null && qty <= 0) {
-            JsfUtil.addErrorMessage("Can not enter a minus value");
+        if (qty != null && qty == 0) {
+            JsfUtil.addErrorMessage("Quantity must be greater than 0");
+            return;
+        }
+        if (qty != null && qty < 0) {
+            JsfUtil.addErrorMessage("Cannot enter a negative quantity");
             return;
         }
         this.qty = qty;
@@ -789,7 +793,7 @@ public class PharmacyIssueController implements Serializable {
             return true;
         }
         if (preBill.getInvoiceNumber() == null || preBill.getInvoiceNumber().trim().isEmpty()) {
-            JsfUtil.addErrorMessage("Please Fill Invoice Number");
+            JsfUtil.addErrorMessage("Please Fill Request Number");
             return true;
         }
         return false;
@@ -1030,29 +1034,52 @@ public class PharmacyIssueController implements Serializable {
         getPreBill().setBillType(BillType.PharmacyDisposalIssue);
         getPreBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_PRE);
 
-        List<BillItem> tmpBillItems = getPreBill().getBillItems();
-        getPreBill().setBillItems(null);
-
         if (getPreBill().getId() == null) {
+            // First save — no persisted BillItems yet; safe to null the collection before create
+            List<BillItem> tmpBillItems = getPreBill().getBillItems();
+            getPreBill().setBillItems(null);
             getBillFacade().createAndFlush(getPreBill());
-        } else {
-            getBillFacade().editAndFlush(getPreBill());
-        }
-
-        // Persist items — NO stock deduction at this stage
-        for (BillItem tbi : tmpBillItems) {
-            tbi.setInwardChargeType(InwardChargeType.Medicine);
-            tbi.setBill(getPreBill());
-            if (tbi.getId() == null) {
+            for (BillItem tbi : tmpBillItems) {
+                tbi.setInwardChargeType(InwardChargeType.Medicine);
+                tbi.setBill(getPreBill());
                 tbi.setCreatedAt(new Date());
                 tbi.setCreater(sessionController.getLoggedUser());
                 getBillItemFacade().createAndFlush(tbi);
-            } else {
-                getBillItemFacade().editAndFlush(tbi);
+            }
+            getPreBill().setBillItems(tmpBillItems);
+        } else {
+            // Subsequent save — reload from DB before editing.
+            // Setting billItems(null) on a session-scoped entity and then calling
+            // editAndFlush triggers EclipseLink orphan-removal, which issues
+            // DELETE FROM BILLITEM and fails with FK violation on PHARMACEUTICALBILLITEM.
+            Bill freshBill = getBillFacade().find(getPreBill().getId());
+            if (freshBill == null) {
+                JsfUtil.addErrorMessage("Draft no longer exists.");
+                return null;
+            }
+            freshBill.setToDepartment(toDepartment);
+            freshBill.setFromDepartment(sessionController.getLoggedUser().getDepartment());
+            freshBill.setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+            freshBill.setComments(getPreBill().getComments());
+            freshBill.setInvoiceNumber(getPreBill().getInvoiceNumber());
+            freshBill.setReferenceNumber(getPreBill().getReferenceNumber());
+            freshBill.setDepartmentType(getPreBill().getDepartmentType());
+            getBillFacade().editAndFlush(freshBill);
+
+            // Persist new/updated BillItems individually — never touch freshBill.billItems
+            for (BillItem tbi : getActiveBillItems()) {
+                tbi.setInwardChargeType(InwardChargeType.Medicine);
+                tbi.setBill(getPreBill());
+                if (tbi.getId() == null) {
+                    tbi.setCreatedAt(new Date());
+                    tbi.setCreater(sessionController.getLoggedUser());
+                    getBillItemFacade().createAndFlush(tbi);
+                } else {
+                    getBillItemFacade().editAndFlush(tbi);
+                }
             }
         }
 
-        getPreBill().setBillItems(tmpBillItems);
         JsfUtil.addSuccessMessage("Disposal Issue Draft Saved Successfully");
         billPreview = false;
         return null;
@@ -1531,11 +1558,15 @@ public class PharmacyIssueController implements Serializable {
             return 0.0;
         }
 
-//        if (CheckDateAfterOneMonthCurrentDateTime(getStock().getItemBatch().getDateOfExpire())) {
-//            errorMessage = "This batch is Expire With in 31 Days.";
-//            JsfUtil.addErrorMessage("This batch is Expire With in 31 Days.");
-//            return 0.0;
-//        }
+        Date expiryDate = getStock().getItemBatch().getDateOfExpire();
+        if (expiryDate != null) {
+            Calendar expiryEnd = Calendar.getInstance();
+            expiryEnd.setTime(CommonFunctions.getEndOfDay(expiryDate));
+            if (expiryEnd.before(Calendar.getInstance())) {
+                JsfUtil.addErrorMessage("Cannot issue an expired item batch (expired: " + expiryDate + ")");
+                return 0.0;
+            }
+        }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);
         billItem.getPharmaceuticalBillItem().setQty(0 - Math.abs(qty));
 
@@ -1738,7 +1769,7 @@ public class PharmacyIssueController implements Serializable {
         // that were causing double-counting. Now using totalCost, totalPurchase, totalRetail, totalWholesale directly.
 
         for (BillItem bi : billItems) {
-            if (bi == null) {
+            if (bi == null || bi.isRetired()) {
                 continue;
             }
 
@@ -1865,14 +1896,35 @@ public class PharmacyIssueController implements Serializable {
 
     public void removeBillItem(BillItem b) {
         userStockController.removeUserStock(b.getTransUserStock(), getSessionController().getLoggedUser());
-        getPreBill().getBillItems().remove(b.getSearialNo());
 
-        // Clear department type if all items are removed
-        if (getPreBill().getBillItems().isEmpty()) {
+        // Soft-retire instead of hard-delete: removing from the list with orphanRemoval=true
+        // on Bill.billItems would trigger a cascade DELETE that violates the FK from
+        // PHARMACEUTICALBILLITEM.BILLITEM_ID. Mark retired and keep in the list.
+        b.setRetired(true);
+        b.setRetiredAt(new Date());
+        if (b.getId() != null) {
+            getBillItemFacade().edit(b);
+        }
+
+        // Clear department type if no active items remain
+        if (getActiveBillItems().isEmpty()) {
             getPreBill().setDepartmentType(null);
         }
 
         calTotal();
+    }
+
+    public List<BillItem> getActiveBillItems() {
+        if (getPreBill() == null || getPreBill().getBillItems() == null) {
+            return new ArrayList<>();
+        }
+        List<BillItem> active = new ArrayList<>();
+        for (BillItem bi : getPreBill().getBillItems()) {
+            if (bi != null && !bi.isRetired()) {
+                active.add(bi);
+            }
+        }
+        return active;
     }
 
     private BigDecimal determineIssueRate(ItemBatch itemBatch) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -1563,8 +1563,14 @@ public class PharmacyIssueController implements Serializable {
             Calendar expiryEnd = Calendar.getInstance();
             expiryEnd.setTime(CommonFunctions.getEndOfDay(expiryDate));
             if (expiryEnd.before(Calendar.getInstance())) {
-                JsfUtil.addErrorMessage("Cannot issue an expired item batch (expired: " + expiryDate + ")");
-                return 0.0;
+                boolean allowExpired = configOptionApplicationController.getBooleanValueByKey(
+                        "Disposal Issue - Allow Issuing Expired Item Batches", false);
+                if (allowExpired) {
+                    JsfUtil.addWarningMessage("Warning: issuing an expired item batch (expired: " + expiryDate + ")");
+                } else {
+                    JsfUtil.addErrorMessage("Cannot issue an expired item batch (expired: " + expiryDate + ")");
+                    return 0.0;
+                }
             }
         }
         billItem.getPharmaceuticalBillItem().setQtyInUnit(0 - qty);

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
@@ -70,9 +70,9 @@
                                     sortMode="multiple"
                                     resizableColumns="true"
                                     reflow="true">
-                                    <p:column headerText="Created" width="8em">
+                                    <p:column headerText="Created" width="10em">
                                         <h:outputLabel value="#{g.createdAt}">
-                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                                         </h:outputLabel>
                                     </p:column>
                                     <p:column headerText="From Dept" width="8em">

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
@@ -72,9 +72,9 @@
                             reflow="true"
                             size="small"
                             style="font-size: 0.9em;">
-                            <p:column headerText="Created" width="80px" sortBy="#{g.createdAt}" styleClass="text-center">
+                            <p:column headerText="Created" width="110px" sortBy="#{g.createdAt}" styleClass="text-center">
                                 <h:outputLabel value="#{g.createdAt}" styleClass="text-muted small">
-                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MM/yy"/>
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="From Dept" width="110px" sortBy="#{g.fromDepartment.name}">

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -518,7 +518,7 @@
                                                 id="selDepartmentType"
                                                 value="#{pharmacyIssueController.preBill.departmentType}"
                                                 class="w-100"
-                                                disabled="#{pharmacyIssueController.preBill.checkedBy ne null or (not empty pharmacyIssueController.preBill.billItems and pharmacyIssueController.preBill.billItems.size() > 0)}">
+                                                disabled="#{pharmacyIssueController.preBill.checkedBy ne null or not empty pharmacyIssueController.activeBillItems}">
                                                 <f:selectItem itemLabel="Select Department Type" itemValue="#{null}"/>
                                                 <f:selectItems value="#{sessionController.availableDepartmentTypesForPharmacyTransactions}"
                                                                var="dt"

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -386,7 +386,7 @@
                                         </f:facet>
                                         <p:dataTable
                                             id="tblBillItem"
-                                            value="#{pharmacyIssueController.preBill.billItems}"
+                                            value="#{pharmacyIssueController.activeBillItems}"
                                             var="bi"
                                             rowIndexVar="s"
                                             editable="true"
@@ -534,6 +534,10 @@
                                             <h:outputLabel value="Comment"/>
                                             <p:inputTextarea class="w-100" value="#{pharmacyIssueController.preBill.comments}" id="comment"
                                                              readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
+
+                                            <h:outputLabel value="Discard Category"/>
+                                            <p:inputText class="w-100" value="#{pharmacyIssueController.preBill.referenceNumber}" id="discardCategory"
+                                                         readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
 
                                         </h:panelGrid>
 


### PR DESCRIPTION
## Summary

Fixes all confirmed bugs from the disposal issue QA audit (master tracking issue #21722). All 7 fixes verified via Playwright E2E testing (Round 2 — all PASS).

- **#21715** — Validation message now correctly says "Please Fill Request Number" instead of "Invoice Number"
- **#21714** — Qty = 0 gives a distinct error ("Quantity must be greater than 0"); negative qty gives "Cannot enter a negative quantity" — no more silent failures
- **#14600 / #14081** — Expired item batches are now blocked at add-time with a clear error including the expiry date; the old commented-out 31-day check is replaced with a proper expiry check
- **#3924** — Discard Category field added to `pharmacy_issue.xhtml`, bound to `preBill.referenceNumber`; readonly once the draft is finalized
- **#21426** — Created column in list-to-finalize now shows date + time (`longDateTimeFormat`)
- **#21432** — Created column in list-to-approve now shows date + time (`longDateTimeFormat`)
- **500 error on second draft save** — `saveDisposalIssueDraft()` was calling `setBillItems(null)` then `editAndFlush(preBill)` on the edit path. EclipseLink orphan-removal fired, issuing `DELETE FROM BILLITEM`, which failed on the `PHARMACEUTICALBILLITEM` FK. Fix: on the edit path, reload bill from DB, apply only scalar field changes to the fresh entity, persist `BillItem`s individually — never null the `billItems` collection on a managed entity. (Port of ruhunu-prod `81b462634e`)

## Files changed

| File | Changes |
|------|---------|
| `PharmacyIssueController.java` | Qty validation, expiry check, `saveDisposalIssueDraft()` orphan-removal fix, `getActiveBillItems()` helper, retired-item skip in totals |
| `pharmacy_issue.xhtml` | Discard Category field |
| `pharmacy_disposal_issue_list_to_finalize.xhtml` | Created column — `longDateTimeFormat` + wider column |
| `pharmacy_disposal_issue_list_to_approve.xhtml` | Created column — `longDateTimeFormat` + wider column |

## Test plan

- [x] T-21715: Error message says "Please Fill Request Number" ✅
- [x] T-21429: Finalize confirm dialog fires ✅ (was already in place)
- [x] T-21426: Created column shows date + time in list-to-finalize ✅
- [x] T-21432: Created column shows date + time in list-to-approve ✅
- [x] T-21714 (zero): Error on qty = 0 ✅
- [x] T-21714 (negative): Error on qty = -1 ✅
- [x] T-14600/14081: Expired item batch blocked ✅
- [x] T-3924: Discard Category field visible and persists on save/reload ✅
- [x] Second draft save (edit path) no longer throws 500 FK error ✅

Closes #21715
Closes #21714
Closes #14600
Closes #14081
Closes #3924
Closes #21426
Closes #21432
Closes #21722

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bill detail field for discard category.
  * Approval and finalization lists now show created timestamps in a clearer date-time format.

* **Bug Fixes**
  * Improved quantity validation with clearer messages for zero and negative values.
  * Prevented issuing expired batches unless explicitly allowed.
  * Fixed draft saving and item removal so issue items are handled more reliably.
  * Updated bill totals to ignore retired items and improved the request-number validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->