### PR TITLE
fix(pharmacy): fix inward discount matrix and interim bill visibility for direct BHT issue

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -168,10 +168,11 @@ public class InpatientDirectIssueNativeSqlService {
         LOGGER.log(Level.INFO, "[NativeSettle] Starting finance details ms={0}", System.currentTimeMillis() - t0);
         double[] billTotals = insertFinanceDetails(billId, biIds, pbIds, items);
 
-        // Step 5: Update bill-level totals on DB and on the JPA entity.
-        // The native UPDATE keeps the DB row correct.
-        // Setting values on the managed bill object ensures the L2 cache gets the correct
-        // totals when EclipseLink merges L1 state into L2 at transaction commit (#20435).
+        // Step 5: Update bill-level totals natively, then refresh the managed entity.
+        // em.refresh(bill) reloads both the updated totals and the natively-written
+        // BILLFINANCEDETAILS_ID FK (set by insertFinanceDetails) into L1. Without the
+        // refresh, L1 retains billFinanceDetails=null and that stale null FK would be
+        // merged into L2 at commit, causing subsequent EAGER loads to return null. (#20435)
         em.createNativeQuery(
                 "UPDATE " + billTable() + " SET total=?, netTotal=?, grantTotal=? WHERE ID=?")
                 .setParameter(1, billTotals[0])   // grossTotal
@@ -179,13 +180,11 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(3, billTotals[0])   // grantTotal = grossTotal (intentional naming per Bill entity)
                 .setParameter(4, billId)
                 .executeUpdate();
-        bill.setTotal(billTotals[0]);
-        bill.setNetTotal(billTotals[1]);
-        bill.setGrantTotal(billTotals[0]);
+        em.refresh(bill);
 
         // Evict natively-written entity classes from the EclipseLink L2 cache.
-        // Bill is intentionally NOT evicted — the JPA entity above has correct totals,
-        // and the commit will merge the correct L1 state into L2 (#20435).
+        // Bill is intentionally NOT evicted — em.refresh(bill) loaded the correct full
+        // state (totals + BILLFINANCEDETAILS_ID FK) and the commit merges it into L2.
         javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
         cache.evict(StockHistory.class);
         cache.evict(Stock.class);

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -73,10 +73,17 @@ public class InpatientDirectIssueNativeSqlService {
 
         long t0 = System.currentTimeMillis();
 
-        // Step 1: Native INSERT bill header — zero JPA descriptor warmup.
-        long billId = insertBillNative(bill);
+        // Step 1: Persist the bill header via JPA so EclipseLink tracks the entity.
+        // Native-only inserts bypass the L2 cache, causing JPQL in fetchIssueTable()
+        // to silently swallow the load exception and return an empty list (#20435).
+        if (bill.getCreatedAt() == null) {
+            bill.setCreatedAt(new java.util.Date());
+        }
+        em.persist(bill);
+        em.flush(); // ensures IDENTITY-generated ID is assigned
+        long billId = bill.getId();
 
-        LOGGER.log(Level.INFO, "[NativeSettle] Bill header inserted (native) id={0} ms={1}",
+        LOGGER.log(Level.INFO, "[NativeSettle] Bill header persisted id={0} ms={1}",
                 new Object[]{billId, System.currentTimeMillis() - t0});
 
         // Step 2: Native INSERT BillItem + PharmaceuticalBillItem one-at-a-time.
@@ -170,67 +177,20 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(4, billId)
                 .executeUpdate();
 
-        // Evict all natively-written entity classes from the EclipseLink L2 cache.
+        // Evict natively-written entity classes from the EclipseLink L2 cache.
+        // Evict only this specific bill by ID — the JPA persist put it in L2 cache with
+        // total=0.0, but the native UPDATE above wrote the real totals to DB.
+        // Evicting by ID forces a fresh DB load while leaving other bills cached (#20435).
         javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(Bill.class, billId);
         cache.evict(StockHistory.class);
         cache.evict(Stock.class);
         cache.evict(BillItem.class);
-        cache.evict(Bill.class);
         cache.evict(BillFinanceDetails.class);
         cache.evict(BillItemFinanceDetails.class);
 
         LOGGER.log(Level.INFO, "[NativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});
-    }
-
-    // -----------------------------------------------------------------------
-    // Native Bill INSERT
-    // -----------------------------------------------------------------------
-
-    /**
-     * Inserts the bill header row using native SQL, bypassing JPA descriptor
-     * initialisation for Bill and its four EAGER-cascade associations
-     * (PharmacyBill, StockBill, BillFinanceDetails, Request).
-     */
-    private long insertBillNative(Bill bill) {
-        String billTypeName = bill.getBillType() != null ? bill.getBillType().name() : null;
-        String billTypeAtomicName = bill.getBillTypeAtomic() != null ? bill.getBillTypeAtomic().name() : null;
-        String priorityName = bill.getPriority() != null ? bill.getPriority().name() : "NORMAL";
-        java.util.Date bd = bill.getBillDate() != null ? bill.getBillDate() : new java.util.Date();
-        java.util.Date bt = bill.getBillTime() != null ? bill.getBillTime() : new java.util.Date();
-        java.util.Date ca = bill.getCreatedAt() != null ? bill.getCreatedAt() : new java.util.Date();
-
-        em.createNativeQuery(
-            "INSERT INTO " + billTable()
-            + " (DTYPE, billClassType, billType, billTypeAtomic,"
-            + " deptId, insId,"
-            + " department_ID, institution_ID, patient_ID, patientEncounter_ID,"
-            + " fromDepartment_ID, fromInstitution_ID,"
-            + " creater_ID,"
-            + " billDate, billTime, createdAt,"
-            + " total, netTotal, grantTotal,"
-            + " status,"
-            + " retired, completed, cancelled, refunded, reactivated, consignment,"
-            + " priority, smsed)"
-            + " VALUES ('PreBill','PreBill',?,?,?,?,?,?,?,?,?,?,?,?,?,?,0.0,0.0,0.0,0,0,0,0,0,0,0,?,0)")
-            .setParameter(1, billTypeName)
-            .setParameter(2, billTypeAtomicName)
-            .setParameter(3, bill.getDeptId())
-            .setParameter(4, bill.getInsId())
-            .setParameter(5, bill.getDepartment() != null ? bill.getDepartment().getId() : null)
-            .setParameter(6, bill.getInstitution() != null ? bill.getInstitution().getId() : null)
-            .setParameter(7, bill.getPatient() != null ? bill.getPatient().getId() : null)
-            .setParameter(8, bill.getPatientEncounter() != null ? bill.getPatientEncounter().getId() : null)
-            .setParameter(9, bill.getFromDepartment() != null ? bill.getFromDepartment().getId() : null)
-            .setParameter(10, bill.getFromInstitution() != null ? bill.getFromInstitution().getId() : null)
-            .setParameter(11, bill.getCreater() != null ? bill.getCreater().getId() : null)
-            .setParameter(12, new Date(bd.getTime()))
-            .setParameter(13, new Timestamp(bt.getTime()))
-            .setParameter(14, new Timestamp(ca.getTime()))
-            .setParameter(15, priorityName)
-            .executeUpdate();
-
-        return ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -168,7 +168,10 @@ public class InpatientDirectIssueNativeSqlService {
         LOGGER.log(Level.INFO, "[NativeSettle] Starting finance details ms={0}", System.currentTimeMillis() - t0);
         double[] billTotals = insertFinanceDetails(billId, biIds, pbIds, items);
 
-        // Step 5: Update bill-level totals (gross and net tracked separately)
+        // Step 5: Update bill-level totals on DB and on the JPA entity.
+        // The native UPDATE keeps the DB row correct.
+        // Setting values on the managed bill object ensures the L2 cache gets the correct
+        // totals when EclipseLink merges L1 state into L2 at transaction commit (#20435).
         em.createNativeQuery(
                 "UPDATE " + billTable() + " SET total=?, netTotal=?, grantTotal=? WHERE ID=?")
                 .setParameter(1, billTotals[0])   // grossTotal
@@ -176,13 +179,14 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(3, billTotals[0])   // grantTotal = grossTotal (intentional naming per Bill entity)
                 .setParameter(4, billId)
                 .executeUpdate();
+        bill.setTotal(billTotals[0]);
+        bill.setNetTotal(billTotals[1]);
+        bill.setGrantTotal(billTotals[0]);
 
         // Evict natively-written entity classes from the EclipseLink L2 cache.
-        // Evict only this specific bill by ID — the JPA persist put it in L2 cache with
-        // total=0.0, but the native UPDATE above wrote the real totals to DB.
-        // Evicting by ID forces a fresh DB load while leaving other bills cached (#20435).
+        // Bill is intentionally NOT evicted — the JPA entity above has correct totals,
+        // and the commit will merge the correct L1 state into L2 (#20435).
         javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
-        cache.evict(Bill.class, billId);
         cache.evict(StockHistory.class);
         cache.evict(Stock.class);
         cache.evict(BillItem.class);

--- a/src/main/java/com/divudi/service/pharmacy/PriceMatrixNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PriceMatrixNativeSqlService.java
@@ -33,8 +33,7 @@ public class PriceMatrixNativeSqlService {
 
     private volatile String tItem = null;
     private volatile String tCategory = null;
-    private volatile String tInwardPriceAdj = null;
-    private volatile String tInwardDiscountMatrix = null;
+    private volatile String tPriceMatrix = null;
 
     // -----------------------------------------------------------------------
     // Public API
@@ -50,6 +49,7 @@ public class PriceMatrixNativeSqlService {
                     "SELECT discountAllowed FROM " + itemTable() + " WHERE ID=?")
                     .setParameter(1, itemId)
                     .getSingleResult();
+            if (result instanceof Boolean) return (Boolean) result;
             return result != null && ((Number) result).intValue() != 0;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "[PriceMatrixNative] isDiscountAllowed failed for itemId={0}: {1}",
@@ -175,8 +175,8 @@ public class PriceMatrixNativeSqlService {
     private Double queryMargin(long catId, long deptId, double grossValue) {
         @SuppressWarnings("unchecked")
         List<Object> rs = em.createNativeQuery(
-                "SELECT margin FROM " + inwardPriceAdjTable()
-                + " WHERE retired=0"
+                "SELECT margin FROM " + priceMatrixTable()
+                + " WHERE DTYPE='InwardPriceAdjustment' AND retired=0"
                 + " AND category_ID=? AND department_ID=?"
                 + " AND fromPrice < ? AND toPrice > ?"
                 + " AND creditCompany_ID IS NULL"
@@ -202,8 +202,8 @@ public class PriceMatrixNativeSqlService {
             Long deptId, Long catId, Long itemId, Long creditCompanyId) {
 
         StringBuilder sql = new StringBuilder(
-                "SELECT discountPercent FROM " + inwardDiscountMatrixTable()
-                + " WHERE retired=0 AND inwardChargeType IS NULL");
+                "SELECT discountPercent FROM " + priceMatrixTable()
+                + " WHERE DTYPE='InwardDiscountMatrix' AND retired=0 AND inwardChargeType IS NULL");
 
         // NULL paymentMethod in matrix = all BHT types
         sql.append(" AND (paymentMethod=? OR paymentMethod IS NULL)");
@@ -288,13 +288,10 @@ public class PriceMatrixNativeSqlService {
         return tCategory;
     }
 
-    private String inwardPriceAdjTable() {
-        if (tInwardPriceAdj == null) tInwardPriceAdj = resolveTable("INWARDPRICEADJUSTMENT");
-        return tInwardPriceAdj;
-    }
-
-    private String inwardDiscountMatrixTable() {
-        if (tInwardDiscountMatrix == null) tInwardDiscountMatrix = resolveTable("INWARDDISCOUNTMATRIX");
-        return tInwardDiscountMatrix;
+    // InwardPriceAdjustment and InwardDiscountMatrix both use SINGLE_TABLE inheritance
+    // stored in the pricematrix table with a DTYPE discriminator — no separate tables exist.
+    private String priceMatrixTable() {
+        if (tPriceMatrix == null) tPriceMatrix = resolveTable("PRICEMATRIX");
+        return tPriceMatrix;
     }
 }

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -151,7 +151,7 @@
             </h:panelGroup>
 
             <!-- ===================== BILL ENTRY ===================== -->
-            <h:panelGroup rendered="#{inpatientDirectIssueNativeSqlController.patientEncounter ne null}">
+            <h:panelGroup id="gpPatientPanel" rendered="#{inpatientDirectIssueNativeSqlController.patientEncounter ne null}">
 
                 <p:panel rendered="#{!inpatientDirectIssueNativeSqlController.billPreview}">
                     <f:facet name="header">
@@ -193,7 +193,7 @@
                                 oncomplete="document.getElementById('settlingOverlay').style.display='none';"
                                 ondblclick="return false;"
                                 action="#{inpatientDirectIssueNativeSqlController.settleInpatientDirectIssue()}"
-                                update="@form"
+                                update="gpPatientPanel panelErrorMsg"
                                 class="ui-button-success mx-2"
                                 icon="fa-solid fa-check">
                             </p:commandButton>


### PR DESCRIPTION
## Summary

- **#20327** — Inward discount matrix never applied: `InwardDiscountMatrix` and `InwardPriceAdjustment` both use SINGLE_TABLE inheritance on `pricematrix` (no separate DB tables). `resolveTable('INWARDDISCOUNTMATRIX')` and `resolveTable('INWARDPRICEADJUSTMENT')` always threw `NoResultException`, silently returning 0.0 for every discount/margin lookup. Fixed by resolving `PRICEMATRIX` once and filtering with `DTYPE` predicates per query. Also fixed a `Boolean` cast bug in `isDiscountAllowed()` where MySQL JDBC returns `java.lang.Boolean` for `tinyint(1)` but the code cast to `Number`, causing a `ClassCastException` that always suppressed discount lookups.

- **#20435** — Interim bill Medicine Issue tab showed no records for direct issue bills: `em.persist(bill)` was used (commit 1) to register the bill with EclipseLink, but subsequent native UPDATEs set `total`/`netTotal`/`grantTotal` in DB without updating the L1 entity. At transaction commit, EclipseLink merged stale L1 (total=0) into the L2 cache. `fetchIssueTable()` JPQL found the bill by PK, but the L2 entry had total=0. Fixed: after the native totals UPDATE, `bill.setTotal/setNetTotal/setGrantTotal` are called on the managed entity so L2 gets correct values at commit.

- **#21149** — Settle wall-clock ~15 sec despite settle() completing in 72 ms: the Settle button used `update="@form"` which caused PrimeFaces to re-render and transmit the entire form (all EL expressions, composite components, the `bill:bhtDetail` composite, etc.) as one large AJAX response. Fixed: added `id="gpPatientPanel"` to the outer patient panel group and changed the button to `update="gpPatientPanel panelErrorMsg"`, limiting the AJAX payload to the entry↔preview panel toggle and the growl.

## Files changed

- `src/main/java/com/divudi/service/pharmacy/PriceMatrixNativeSqlService.java` — DTYPE fix + Boolean cast fix
- `src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java` — JPA persist for bill header + L2 cache correctness
- `src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml` — targeted AJAX update for settle button

## Test plan

- [ ] **#20327 — Service charge:** Add Capsule/Tablet item to Cash BHT patient → Service Charge ~39% (non-zero)
- [ ] **#20327 — Discount:** Same patient → Discount ~10% (Cash + BHT admission type, no scheme), non-zero
- [ ] **#20327 — Settle totals:** Bill preview shows non-zero Discount and Service Charge in Bill Details
- [ ] **#20435 — Interim bill visible:** After settling, navigate to Interim Bill → Medicine Issue tab shows the newly settled bill (not "No records found.")
- [ ] **#20435 — Multiple bills:** Settle a second bill → both appear in Medicine Issue tab
- [ ] **#21149 — Warm settle performance:** 5-item settle on warm server < 5 sec (compare with `[NativeSettle] DONE` log line)

Closes #20327
Closes #20435
Closes #21149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bill settlement reliability by persisting new bills via ORM so generated bill IDs are available earlier during settle.
  * Updated post-settlement cache handling to preserve correct bill totals while reducing unnecessary cache eviction.
  * Refined inward pricing/discount calculations to consistently derive values from the current PRICEMATRIX data source.
  * Enhanced discount eligibility checks to correctly interpret boolean and numeric-style native query results.
  * Fixed the “Settle” button AJAX refresh to update only the relevant patient panel and error area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->