### PR TITLE
fix(hr): expand DOB calendar year range from 2016–2036 to 1900–present

### DIFF
--- a/src/main/webapp/hr/hr_staff_admin.xhtml
+++ b/src/main/webapp/hr/hr_staff_admin.xhtml
@@ -116,7 +116,7 @@
                                                     <p:inputTextarea class="w-100 mx-2"  value="#{staffController.current.person.address}"  />
 
                                                     <p:outputLabel value="Birthday "/>
-                                                    <p:calendar class="w-100 mx-2" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true" yearRange="1900:+10" >
+                                                    <p:calendar class="w-100 mx-2" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true" yearRange="c-100:c" >
                                                     </p:calendar>
 
                                                     <p:outputLabel  value="Gender" ></p:outputLabel>

--- a/src/main/webapp/hr/hr_staff_admin.xhtml
+++ b/src/main/webapp/hr/hr_staff_admin.xhtml
@@ -116,7 +116,7 @@
                                                     <p:inputTextarea class="w-100 mx-2"  value="#{staffController.current.person.address}"  />
 
                                                     <p:outputLabel value="Birthday "/>
-                                                    <p:calendar class="w-100 mx-2" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true" >
+                                                    <p:calendar class="w-100 mx-2" inputStyleClass="w-100" value="#{staffController.current.person.dob}" pattern="#{sessionController.applicationPreference.shortDateFormat}" navigator="true" yearRange="1900:+10" >
                                                     </p:calendar>
 
                                                     <p:outputLabel  value="Gender" ></p:outputLabel>


### PR DESCRIPTION
## Summary

- The Date of Birth calendar on the Staff Admin form (`hr/hr_staff_admin.xhtml`) lacked a `yearRange` attribute on its `<p:calendar navigator="true">` component
- PrimeFaces defaults to a ±10-year window around today when no `yearRange` is set, restricting year selection to approximately 2016–2036
- Added `yearRange="1900:+10"` so the year dropdown spans 1900 through 10 years into the future (137 years), covering all realistic staff birth years

## Change

```
src/main/webapp/hr/hr_staff_admin.xhtml — line 119
Added yearRange="1900:+10" to the DOB p:calendar
```

## Test plan

- [x] Deployed locally and confirmed year dropdown shows **1900 → 2036** (137 options) via Playwright
- [x] Only XHTML change — no Java changes, no data model changes
- [x] Wiki updated: `Admin-Staff-Management-Overview` now notes DOB year range

## Wiki

Updated [Admin-Staff-Management-Overview](https://github.com/hmislk/hmis/wiki/Admin-Staff-Management-Overview) to note that the Date of Birth field supports years from 1900.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Birthday date picker by adding a year range limit, helping users select more valid dates and reducing accidental out-of-range entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->