### PR TITLE
fix(pharmacy): direct issue to BHTs shows previous bill print preview on navigation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -558,6 +558,7 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     // -----------------------------------------------------------------------
 
     public void resetAll() {
+        patientEncounter = null;
         preBill = null;
         printBill = null;
         printBillItems = null;

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -938,7 +938,7 @@
                             id="direct_issue_to_BHTs"
                             ajax="false"
                             action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
-                            actionListener="#{pharmacySaleBhtController.resetAll()}"
+                            actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"
                             styleClass="svg-link" >
                             <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="direct_issue_to_BHTs.svg" style="cursor: pointer;" width="80" height="80"/>
                             <h:outputText style="display: none;" value="Direct Issue to BHTs" />
@@ -953,7 +953,7 @@
                         <p:commandLink
                             id="direct_issue_to_BHTs_native"
                             ajax="false"
-                            action="/inward/pharmacy_bill_issue_bht_native?faces-redirect=true"
+                            action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
                             actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"
                             styleClass="svg-link" >
                             <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="direct_issue_to_BHTs_native.svg" style="cursor: pointer;" width="80" height="80"/>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -886,14 +886,14 @@
                                     <p:commandButton
                                         value="Direct Issue to BHTs"
                                         action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
-                                        actionListener="#{pharmacySaleBhtController.resetAll()}"
+                                        actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"
                                         rendered="#{webUserController.hasPrivilege('PharmacySale')}"
                                         icon="pi pi-check"
                                         class="w-100"
                                         ajax="false">
                                         <f:setPropertyActionListener
                                             value="#{admissionController.current}"
-                                            target="#{pharmacySaleBhtController.patientEncounter}" />
+                                            target="#{inpatientDirectIssueNativeSqlController.patientEncounter}" />
                                     </p:commandButton>
                                 </div>
                                 <div class="col-6">

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -615,12 +615,12 @@
                             value="Direct Issue to BHTs"
                             icon="fa fa-capsules"
                             rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                            actionListener="#{pharmacySaleBhtController.resetAll()}">
+                            actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}">
                         </p:menuitem>
 
                         <p:menuitem
                             ajax="false"
-                            action="/inward/pharmacy_bill_issue_bht_native?faces-redirect=true"
+                            action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
                             value="Direct Issue to BHTs (Native SQL)"
                             icon="fa fa-bolt"
                             rendered="#{webUserController.hasPrivilege('PharmacyDirectIssueToBht')}"
@@ -1156,8 +1156,8 @@
                         <p:menuitem ajax="false" action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
                                     value="Direct Issue to BHTs" icon="fas fa-prescription-bottle-alt"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDirectIssueToBht')}"
-                                    actionListener="#{pharmacySaleBhtController.resetAll()}"/>
-                        <p:menuitem ajax="false" action="/inward/pharmacy_bill_issue_bht_native?faces-redirect=true"
+                                    actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"/>
+                        <p:menuitem ajax="false" action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
                                     value="Direct Issue to BHTs (Native SQL)" icon="fa fa-bolt"
                                     rendered="#{webUserController.hasPrivilege('PharmacyDirectIssueToBht')}"
                                     actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"/>


### PR DESCRIPTION
## Summary

- Navigation to **Direct Issue to BHTs** (from inpatient profile, menu, or home icon) was calling `pharmacySaleBhtController.resetAll()` even though the page (`pharmacy_bill_issue_bht.xhtml`) was already migrated to `InpatientDirectIssueNativeSqlController`
- This left `billPreview = true` on the new controller, so the page opened showing the **print preview of the last settled bill** (possibly a different patient)
- Additionally, `resetAll()` on the new controller never cleared `patientEncounter`, so the previous patient persisted even after reset

## Changes

| File | Change |
|---|---|
| `InpatientDirectIssueNativeSqlController.java` | Add `patientEncounter = null` to `resetAll()` |
| `admission_profile.xhtml` | Call `inpatientDirectIssueNativeSqlController.resetAll()` and bind encounter to the new controller |
| `menu.xhtml` (×2) | Fix `actionListener` to call the correct controller; fix "Native SQL" dead links pointing to non-existent page |
| `home.xhtml` (×2) | Same controller and dead-link fixes |

## Test plan

- [ ] Settle a direct issue bill for any BHT (page ends in print-preview state)
- [ ] Navigate to any inpatient profile and click **Direct Issue to BHTs**
- [ ] Verify: page opens with an empty BHT selection form — no previous bill shown
- [ ] Use menu **Inpatient Medication Management → Direct Issue to BHTs** and home icon — confirm same fresh-form behaviour
- [ ] Confirm the "Native SQL" menu/home entries no longer 404

Closes #21747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Direct Issue to BHTs” now opens the correct inpatient issue screen from menus and admission-related actions.
  * The direct issue workflow now properly clears and resets the current patient context, helping prevent stale data from carrying over.
  * The “Direct Issue to BHTs (Native SQL)” entry now routes to the standard page for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->