### PR TITLE
fix(inward): add grand-total footers to Itemized Service Summary table

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -2739,6 +2739,46 @@ public class SearchController implements Serializable {
                 .sum();
     }
 
+    public double getOpdSaleSummaryHospitalFeeTotal() {
+        if (opdSaleSummaryDtos == null || opdSaleSummaryDtos.isEmpty()) {
+            return 0.0;
+        }
+        return opdSaleSummaryDtos.stream()
+                .filter(dto -> dto.getHospitalFee() != null)
+                .mapToDouble(OpdSaleSummaryDTO::getHospitalFee)
+                .sum();
+    }
+
+    public double getOpdSaleSummaryProfessionalFeeTotal() {
+        if (opdSaleSummaryDtos == null || opdSaleSummaryDtos.isEmpty()) {
+            return 0.0;
+        }
+        return opdSaleSummaryDtos.stream()
+                .filter(dto -> dto.getProfessionalFee() != null)
+                .mapToDouble(OpdSaleSummaryDTO::getProfessionalFee)
+                .sum();
+    }
+
+    public double getOpdSaleSummaryGrossAmountTotal() {
+        if (opdSaleSummaryDtos == null || opdSaleSummaryDtos.isEmpty()) {
+            return 0.0;
+        }
+        return opdSaleSummaryDtos.stream()
+                .filter(dto -> dto.getGrossAmount() != null)
+                .mapToDouble(OpdSaleSummaryDTO::getGrossAmount)
+                .sum();
+    }
+
+    public double getOpdSaleSummaryDiscountTotal() {
+        if (opdSaleSummaryDtos == null || opdSaleSummaryDtos.isEmpty()) {
+            return 0.0;
+        }
+        return opdSaleSummaryDtos.stream()
+                .filter(dto -> dto.getDiscountAmount() != null)
+                .mapToDouble(OpdSaleSummaryDTO::getDiscountAmount)
+                .sum();
+    }
+
     public int getOpdAnalyticsIndex() {
         return opdAnalyticsIndex;
     }

--- a/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
+++ b/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
@@ -154,24 +154,44 @@
                     </p:column>
                     <p:column class="text-end">
                         <f:facet name="header"><h:outputText value="Hospital Fee" /></f:facet>
+                        <f:facet name="footer">
+                            <h:outputText value="#{searchController.opdSaleSummaryHospitalFeeTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
                         <h:outputText value="#{row.hospitalFee}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputText>
                     </p:column>
                     <p:column class="text-end">
                         <f:facet name="header"><h:outputText value="Professional Fee" /></f:facet>
+                        <f:facet name="footer">
+                            <h:outputText value="#{searchController.opdSaleSummaryProfessionalFeeTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
                         <h:outputText value="#{row.professionalFee}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputText>
                     </p:column>
                     <p:column class="text-end">
                         <f:facet name="header"><h:outputText value="Gross Amount" /></f:facet>
+                        <f:facet name="footer">
+                            <h:outputText value="#{searchController.opdSaleSummaryGrossAmountTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
                         <h:outputText value="#{row.grossAmount}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputText>
                     </p:column>
                     <p:column class="text-end">
                         <f:facet name="header"><h:outputText value="Discount" /></f:facet>
+                        <f:facet name="footer">
+                            <h:outputText value="#{searchController.opdSaleSummaryDiscountTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
                         <h:outputText value="#{row.discountAmount}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputText>


### PR DESCRIPTION
## Summary

The Itemized Service Summary (OPD + Inward) datatable showed a Grand Total footer only for the Net Amount column. Hospital Fee, Professional Fee, Gross Amount, and Discount had no totals.

- Added 4 new getter methods to `SearchController`: `getOpdSaleSummaryHospitalFeeTotal()`, `getOpdSaleSummaryProfessionalFeeTotal()`, `getOpdSaleSummaryGrossAmountTotal()`, `getOpdSaleSummaryDiscountTotal()` — same streaming pattern as the existing `getOpdSaleSummaryTotal()`
- Added `<f:facet name="footer">` to each of those four columns in `inward_itemized_service_summary_dto.xhtml`, matching the existing Net Amount footer style

**Note on "service charge column"**: The `OpdSaleSummaryDTO` has no `serviceCharge` field and there is no `serviceCharge` concept in the query or controller. The existing columns (Hospital Fee + Professional Fee + Gross Amount) appear to cover all billing components. If a separate Service Charge column is needed, the DTO and the underlying JPQL query would both need to be extended — that is out of scope for this fix.

Closes #21680

## Test plan

- [ ] Navigate to Inpatient Reports → Service Reports → Itemized Service Summary - OPD and Inward
- [ ] Click **View List** with any date range that has data
- [ ] Verify the Grand Total footer row shows totals for Hospital Fee, Professional Fee, Gross Amount, Discount, and Net Amount

🤖 Generated with [Claude Code](https://claude.ai/claude-code)