### PR TITLE
fix(pharmacy): add confirm dialog before opening disposal issue for finalization

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
@@ -94,6 +94,7 @@
                                         value="View / Finalize"
                                         title="View and Finalize Disposal Issue #{g.id}"
                                         ajax="false"
+                                        onclick="return confirm('Open disposal issue ##{g.id} for finalization?');"
                                         action="#{pharmacyIssueController.loadDraftForEdit(g.id)}"/>
                                     <p:commandButton
                                         id="btnCancel"


### PR DESCRIPTION
## Summary

The "View / Finalize" button on `pharmacy_disposal_issue_list_to_finalize.xhtml` navigated directly to the draft edit page without any confirmation. The adjacent "Cancel" button already used `onclick="return confirm(...)"` for protection; the Finalize button lacked the same guard.

Added `onclick="return confirm('Open disposal issue ##{g.id} for finalization?');"` to the Finalize button so users get a checkpoint before proceeding.

**Note**: The actual finalization action (on `pharmacy_issue.xhtml` line 144) already has its own confirm: `"return confirm('Finalize this disposal issue? It will be queued for approval.');"`. This PR adds an earlier checkpoint at the list level, consistent with how other pharmacy workflow pages guard navigation into destructive flows.

Closes #21429

## Test plan

- [ ] Navigate to Pharmacy → Disposal Issues → List to Finalize
- [ ] Click the **View / Finalize** button on any row
- [ ] A browser confirm dialog should appear: "Open disposal issue #N for finalization?"
- [ ] Clicking Cancel should stay on the list; clicking OK should navigate to the edit page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)