### PR TITLE
fix(pharmacy): stamp departmentType on transfer-receive and issue-return bills

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -505,8 +505,8 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setToDepartment(originalBill.getToDepartment()); // Same consumption department
             getReturnBill().setFromDepartment(originalBill.getFromDepartment()); // Same pharmacy department
             getReturnBill().setDepartment(sessionController.getDepartment());
-            if (sessionController.getDepartment() != null) {
-                getReturnBill().setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            if (originalBill.getDepartmentType() != null) {
+                getReturnBill().setDepartmentType(originalBill.getDepartmentType());
             }
             getReturnBill().setInstitution(sessionController.getInstitution());
             getReturnBill().setSite(sessionController.getLoggedSite());

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -505,6 +505,9 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setToDepartment(originalBill.getToDepartment()); // Same consumption department
             getReturnBill().setFromDepartment(originalBill.getFromDepartment()); // Same pharmacy department
             getReturnBill().setDepartment(sessionController.getDepartment());
+            if (sessionController.getDepartment() != null) {
+                getReturnBill().setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            }
             getReturnBill().setInstitution(sessionController.getInstitution());
             getReturnBill().setSite(sessionController.getLoggedSite());
             getReturnBill().setCreatedAt(new Date());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1000,6 +1000,9 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setBillType(BillType.PharmacyTransferReceive);
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE);
         getReceivedBill().setBackwardReferenceBill(getIssuedBill());
+        if (getIssuedBill().getDepartmentType() != null) {
+            getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
+        }
         List<BillItem> itemsToAdd = new ArrayList<>();
 
         for (BillItem i : getReceivedBill().getBillItems()) {
@@ -1124,8 +1127,8 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE);
         getReceivedBill().setBackwardReferenceBill(getIssuedBill());
         getReceivedBill().setFromStaff(getIssuedBill().getToStaff());
-        if (sessionController.getDepartment() != null) {
-            getReceivedBill().setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        if (getIssuedBill().getDepartmentType() != null) {
+            getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
         }
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1124,6 +1124,9 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE);
         getReceivedBill().setBackwardReferenceBill(getIssuedBill());
         getReceivedBill().setFromStaff(getIssuedBill().getToStaff());
+        if (sessionController.getDepartment() != null) {
+            getReceivedBill().setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        }
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());


### PR DESCRIPTION
## Summary

- **TransferReceiveController.saveBill()**: set `departmentType` from the session department on the received bill, so transfer-receive transactions appear in department-type-filtered reports
- **IssueReturnController.saveBill()**: set `departmentType` from the session department on the return bill (guarded inside the `id == null` new-bill block only)
- Both assignments are null-guarded (`sessionController.getDepartment() != null`) for safety in non-interactive contexts

## Test plan

- [ ] Create a pharmacy transfer receive from a ward: verify `departmentType` column is populated on the resulting bill row
- [ ] Create a pharmacy issue return from a ward: verify `departmentType` is populated on the return bill
- [ ] Run a department-type-filtered pharmacy report and confirm transfer-receive/issue-return transactions now appear

Closes #21077
Closes #21078

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when creating pharmacy return bills if the current session has no department selected.
  * Improved handling of received transfer bills so department details are only set when available, avoiding null-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->