### PR TITLE
fix(ward): render expired/expiring-soon badge correctly in BHT autocomplete

### DIFF
--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -108,11 +108,10 @@
                                                             styleClass="w-100"
                                                             inputStyleClass="w-100 form-control">
                                                 <p:column headerText="Item" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">
-                                                    <h:outputLabel value="#{i.itemBatch.item.name}"  style="width: 300px!important;">
-                                                        &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'true': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'true':'false'}" value="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'Expired ':
-                                                                                 commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'Expired Soon':''}"
-                                                                     severity="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'danger': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'warning':''}" />
-                                                    </h:outputLabel>
+                                                    <h:outputText value="#{i.itemBatch.item.name}" style="width: 300px!important;" />
+                                                    &nbsp;<p:tag rendered="#{commonFunctionsProxy.currentDateTime gt i.itemBatch.dateOfExpire or commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime gt i.itemBatch.dateOfExpire}"
+                                                                 value="#{commonFunctionsProxy.currentDateTime gt i.itemBatch.dateOfExpire ? 'Expired' : 'Expiring Soon'}"
+                                                                 severity="#{commonFunctionsProxy.currentDateTime gt i.itemBatch.dateOfExpire ? 'danger' : 'warning'}" />
                                                 </p:column>
                                                 <p:column headerText="Code" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal':
                                                                                                                commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">


### PR DESCRIPTION
## Summary
- Fixes raw CSS tag text appearing in the BHT medicine autocomplete dropdown for expired/expiring-soon items
- Root cause: `p:tag` was nested as a child of `h:outputLabel`, which caused the browser to render the badge markup as literal text in some PrimeFaces autocomplete panel contexts
- Fix: switch to `h:outputText` for the item name and make `p:tag` a sibling element — the same pattern used in `pharmacy_bill_retail_sale.xhtml` where expiry badges render correctly
- Also tightened the EL: replaced the ternary `'true'`/`'false'` string trick with a proper boolean `or` expression, and simplified the badge value/severity to a two-branch ternary guarded by the rendered check

## Test plan
- [ ] Navigate to Ward → Pharmacy → BHT Issue
- [ ] Search for a medicine that has an expired batch — confirm "Expired" badge renders as a styled red tag (not raw HTML text)
- [ ] Search for a medicine with a batch expiring within 3 months — confirm "Expiring Soon" badge renders as a styled yellow/orange tag
- [ ] Search for a medicine with a valid batch — confirm no badge appears
- [ ] Select an expired-batch item from the dropdown — confirm item name appears in the input (not HTML markup)

Closes #20607

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the item expiry display in the ward pharmacy issue screen.
  * Expiry status now appears as a separate badge only when relevant, with clearer labels: “Expired” and “Expiring Soon.”
  * Adjusted the display logic so item names and expiry indicators render more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->