### PR TITLE
fix(admin): correct validation message in Manage Banking Branch

### DIFF
--- a/src/main/java/com/divudi/bean/common/InstitutionBranchController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionBranchController.java
@@ -110,7 +110,7 @@ public class InstitutionBranchController implements Serializable {
     public void saveSelected() {
         getCurrent().setInstitutionType(InstitutionType.branch);
         if (getCurrent().getInstitution() == null) {
-            JsfUtil.addErrorMessage("Select the Institution");
+            JsfUtil.addErrorMessage("Select the Bank");
             return;
         }
         if (getCurrent().getName() == null || getCurrent().getName().trim().isEmpty()) {


### PR DESCRIPTION
## Summary
- The Save button in **Admin → Institutions → Banking Branch** showed the error _"Select the Institution"_ when no bank was chosen, but the page has no field labelled "Institution" — the field is labelled **"Bank"**
- Fixed by changing the validation message in `InstitutionBranchController.saveSelected()` to _"Select the Bank"_
- One-line Java change; no data model or UI changes

## Test plan
- [ ] Open Admin → Institutions → Banking Branch (or navigate via the Banking tab in Administration)
- [ ] Click **Add New**, leave the Bank dropdown on _"-- Select Bank --"_, click **Save**
- [ ] Confirm the error growl now reads **"Select the Bank"** (previously "Select the Institution")
- [ ] Select a bank, enter a branch name, click **Save** — confirm success message appears and the branch appears in the list

Closes #20992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the validation message shown when no institution is selected to say **“Select the Bank”** instead of **“Select the Institution”**.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->