### PR TITLE
fix(admin): auto-generate item code on save when field is left blank

### DIFF
--- a/src/main/java/com/divudi/bean/common/ServiceController.java
+++ b/src/main/java/com/divudi/bean/common/ServiceController.java
@@ -537,12 +537,12 @@ public class ServiceController implements Serializable {
             return;
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)) {
-            if (getCurrent().getId() == null) {
-                if (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty()) {
-                    String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
-                    getCurrent().setCode(code);
-                }
+        if (getCurrent().getId() == null
+                && (getCurrent().getCode() == null || getCurrent().getCode().trim().isEmpty())) {
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Item Codes Generate - Automatically create Item Codes by Department.", true)) {
+                String code = itemController.generateNextItemCode(getCurrent().getInstitution(), getCurrent().getDepartment());
+                getCurrent().setCode(code);
             }
         }
 


### PR DESCRIPTION
## Summary

- `ServiceController.saveSelected()` gated item-code generation behind a config key that defaulted to `false`, so new OPD services were saved with no code unless the admin explicitly enabled the setting
- Changed the default to `true`: when a new item's code field is blank, a department-based code is generated automatically on save
- Admins who want to disable auto-generation can still set the config key to `false`

## Root Cause

`getBooleanValueByKey("Item Codes Generate - Automatically create Item Codes by Department.", false)` — the `false` default meant no code was generated unless the setting was explicitly turned on in the config panel.

## Verification

Tested locally: created a new OPD service with Name, Category, Institution, Department and Inward Charge Type filled — Item Code left blank. After Save, the code field populated with `AL-001284`. Confirmed in DB.

## Test plan

- [ ] Navigate to Admin → Items → OPD Services
- [ ] Create a new service, leave Item Code blank, fill in Name / Category / Inward Charge Type / Department, click Save
- [ ] Verify the service is saved with an auto-generated department-based code
- [ ] Enter a code manually on a new service — verify it is kept as-is
- [ ] Edit an existing item — verify code is NOT overwritten

## Wiki

Updated [Admin-Creating-OPD-Services](https://github.com/hmislk/hmis/wiki/Admin-Creating-OPD-Services) to document the new auto-generation behaviour.

Closes #21392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted service code auto-generation so it only runs when the relevant setting is enabled, preventing unintended code creation for new entries.
  * Preserved the existing duplicate-code validation and save behavior for both new and updated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->