### PR TITLE
fix(inward): disable Add Service button on click to prevent double-submit

### DIFF
--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -10,7 +10,7 @@
 
 
     <ui:define name="content">
-        <h:form>    
+        <h:form id="formTimedServiceConsume" onkeypress="if(event.keyCode == 13 &amp;&amp; event.target.type != 'textarea') { return false; }">
             <h:panelGroup class="row" rendered="#{inwardTimedItemController.current.patientEncounter eq null}"> 
                 <div class="col-12">
                     <h:panelGroup>

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -245,7 +245,7 @@
                                             class="mx-2 ui-button-success"
                                             value="Add Service"
                                             ajax="false"
-                                            onclick="this.disabled=true;"
+                                            onclick="if(this.alreadyClicked) return false; this.alreadyClicked=true; var btn=this; setTimeout(function(){ btn.alreadyClicked=false; }, 5000);"
                                             action="#{inwardTimedItemController.save}">
                                         </p:commandButton>
                                     </div>

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -240,10 +240,12 @@
 
                                 <div class="row">
                                     <div class="col-4">
-                                        <p:commandButton 
-                                            class="mx-2 ui-button-success" 
-                                            value="Add Service" 
+                                        <p:commandButton
+                                            id="btnAddTimedService"
+                                            class="mx-2 ui-button-success"
+                                            value="Add Service"
                                             ajax="false"
+                                            onclick="this.disabled=true;"
                                             action="#{inwardTimedItemController.save}">
                                         </p:commandButton>
                                     </div>


### PR DESCRIPTION
## Summary
- The Add Service button on `inward_timed_service_consume.xhtml` had no double-click protection
- Rapid clicks before the non-AJAX page reload could create duplicate timed service entries
- Added `onclick="this.disabled=true;"` to disable immediately on first click
- Added stable `id="btnAddTimedService"` for accessibility

## Test plan
- [ ] Click Add Service rapidly — only one entry should be created
- [ ] Single click still works; button re-enables after page reload

Closes #21576
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental form submissions when pressing Enter, except when interacting with a textarea.
  * Improved the “Add Service” action to reduce duplicate requests by adding a client-side guard that blocks rapid repeated clicks for a short period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->