### PR TITLE
fix(pharmacy): clear saleBillDtos in makeListNull to remove stale search results

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -1481,6 +1481,7 @@ public class SearchController implements Serializable {
         filterChannelBillsByBilledDate = true;
         settledBillType = null;
         total = 0.0;
+        pharmacyBillSearch.setSaleBillDtos(null);
     }
 
     public String navigateToSearchOpdBillsOfLoggedDepartment() {


### PR DESCRIPTION
## Summary
- `SearchController.makeListNull()` reset all local bill lists but left `pharmacyBillSearch.saleBillDtos` intact
- The sale bill search table reads from that DTO list, so reopening Search Sale Bill without a new search showed stale results from a prior query
- Added `pharmacyBillSearch.setSaleBillDtos(null)` to clear it alongside the other lists on every reset

## Test plan
- [ ] Run a sale bill search, then navigate away and reopen the Search Sale Bill page
- [ ] Table should be empty (no stale results shown)
- [ ] Running a new search after opening the page works correctly

Closes #20651
🤖 Generated with [Claude Code](https://claude.com/claude-code)