### PR TITLE
fix(inward): lazy-load encounterCreditCompanys in BHT edit view

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -977,6 +977,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     }
 
     public List<EncounterCreditCompany> getEncounterCreditCompanys() {
+        if (encounterCreditCompanys == null && current != null) {
+            fillCreditCompaniesByPatient();
+        }
         return encounterCreditCompanys;
     }
 


### PR DESCRIPTION
## Summary
- `getEncounterCreditCompanys()` returned null when the user navigated directly to the BHT edit page without going through a navigation action that called `fillCreditCompaniesByPatient()`
- The credit company panel then showed no rows even though `EncounterCreditCompany` records existed in the DB
- Added null guard in the getter: if the list is null and a current encounter is set, `fillCreditCompaniesByPatient()` is called on demand

## Test plan
- [ ] Navigate directly to BHT edit for a patient with credit company records
- [ ] Credit Company panel should display the records without needing any extra action
- [ ] Adding a new credit company still works correctly

Closes #21244
🤖 Generated with [Claude Code](https://claude.com/claude-code)