### PR TITLE
#18587

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -3656,7 +3656,11 @@ public class PharmacyBillSearch implements Serializable {
 
             CancelledBill cb = pharmacyCreateCancelBill();
             cb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
-
+            
+            cb.setInvoiceDate(getBill().getInvoiceDate());
+            cb.setInvoiceNumber(getBill().getInvoiceNumber());
+            cb.setFromInstitution(getBill().getFromInstitution());
+            
             // Handle Department ID generation (independent)
             String deptId;
             if (configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Department Id is Prefix Dept Ins Year Count", false)) {

--- a/src/main/webapp/pharmacy/pharmacy_cancel_purchase.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_purchase.xhtml
@@ -91,7 +91,9 @@
                     </h:panelGroup>
 
                     <h:panelGroup rendered="#{pharmacyBillSearch.printPreview}">
-                        <pharmacy:purhcase bill="#{pharmacyBillSearch.bill.cancelledBill}"/>
+                        <pharmacy:purhcase 
+                            bill="#{pharmacyBillSearch.bill.cancelledBill}"
+                            ShowRetailValue="#{configOptionApplicationController.getBooleanValueByKey('Show Retail Value in Direct Purchase Bill', true)}"/>
                     </h:panelGroup>
 
                 </h:form>

--- a/src/main/webapp/resources/pharmacy/purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/purhcase.xhtml
@@ -203,7 +203,8 @@
                                 </p:column>
                                 <p:column style="padding: 4px; width: 6em;"/>
                                 <p:column style="padding: 4px; width: 6em;" footerText="#{0-cc.attrs.bill.saleValue}"
-                                          class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }">
+                                          class="text-end #{configOptionApplicationController.getBooleanValueByKey('Print RetailValue in Direct Purchase Bill', true) ? 'showRetailValue' : 'hideRetailValue' }"
+                                          rendered="#{cc.attrs.ShowRetailValue}">
                                     <f:facet name="footer">
                                         <h:outputLabel value="#{cc.attrs.bill.saleValue}">
                                             <f:convertNumber pattern="#,##0.00"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation bills now carry over key invoice details, including invoice date, invoice number, and source institution.
  * The purchase cancellation print preview now correctly respects the “Show Retail Value” setting.
  * The retail value column is now fully hidden when that setting is turned off, improving printed and on-screen consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->