### PR TITLE
fix(patient-deposit): correct misspelled button labels (Trancefer/Recive)

### DIFF
--- a/src/main/webapp/patient_deposit/index.xhtml
+++ b/src/main/webapp/patient_deposit/index.xhtml
@@ -63,7 +63,7 @@
                                             <p:commandButton
                                                 icon="pi pi-arrow-right-arrow-left"
                                                 ajax="false"
-                                                value="Patient Deposit Trancefer"
+                                                value="Patient Deposit Transfer"
                                                 title="Transfer patient deposits"
                                                 action="/patient_deposit/report_collecting_center_referece_book?faces-redirect=true"
                                                 class="w-100 m-1 ui-button-warning"/>
@@ -71,7 +71,7 @@
                                             <p:commandButton
                                                 icon="pi pi-download"
                                                 ajax="false"
-                                                value="Patient Deposit Recive"
+                                                value="Patient Deposit Receive"
                                                 title="Receive patient deposits"
                                                 action="/patient_deposit/cc_update_credit_limit?faces-redirect=true"
                                                 actionListener="#{institutionController.makeNull()}"
@@ -81,7 +81,7 @@
                                             <p:commandButton
                                                 icon="pi pi-search"
                                                 ajax="false"
-                                                value="Search Patient Deposit Trancefers"
+                                                value="Search Patient Deposit Transfers"
                                                 title="Search for patient deposit transfers"
                                                 action="#{collectingCentreController.navigateToPayToCollectingCentre()}"
                                                 class="w-100 m-1 ui-button-info"/>


### PR DESCRIPTION
## Summary

Corrects three user-facing spelling errors in the **Patient Deposit Management** button labels on `patient_deposit/index.xhtml`.

| Before | After |
|--------|-------|
| `Patient Deposit Trancefer` | `Patient Deposit Transfer` |
| `Patient Deposit Recive` | `Patient Deposit Receive` |
| `Search Patient Deposit Trancefers` | `Search Patient Deposit Transfers` |

## Why this is safe

- **Display text only** — only the `value` attributes of three `p:commandButton`s change. No `action` URLs, `actionListener`s, backing-bean methods, component IDs, or privileges are touched.
- The buttons' `title` tooltips are **already spelled correctly** ("Transfer patient deposits", "Receive patient deposits", "Search for patient deposit transfers"), confirming these are genuine typos, not intentional identifiers.
- This does **not** fall under the "don't fix intentional typos (e.g. `purcahseRate`)" rule — that protects DB-linked Java identifiers, whereas these are end-user labels.
- XHTML-only; per project guidelines JSF-only changes don't require compilation/tests. CRLF line endings preserved, so the diff is **exactly 3 lines**.

## Testing

Static/label change only — verified the diff touches nothing but the three button labels.

Closes #17829
Closes #17828
Closes #17830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected several misspelled labels in the Patient Deposit “Manage” section.
  * Updated button text for deposit transfer and receive actions to display properly.
  * Fixed the “Search Patient Deposit Transfers” label for clearer, more polished wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->