### PR TITLE
fix: search families by any member's NIC or phone number

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -927,7 +927,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
         quickSearchPhoneNumber = null;
         admissionController.setPatientAllergies(null);
         admissionController.setCurrentReservation(null);
-        
+
         admissionController.setPatientForiegner(false);
         return "/inward/inward_admission?faces-redirect=true";
 
@@ -2423,7 +2423,12 @@ public class PatientController implements Serializable, ControllerWithPatient {
         String jpql = "Select f "
                 + "from Family f "
                 + "where f.retired=false "
-                + "and (f.phoneNo = :pn or f.membershipCardNo = :mcn) ";
+                + "and (f.phoneNo = :pn "
+                + "     or f.membershipCardNo = :mcn "
+                + "     or exists (select fm from FamilyMember fm "
+                + "                where fm.family=f and fm.retired=false "
+                + "                and (fm.patient.person.phone=:pn or fm.patient.person.mobile=:pn))) ";
+        
         Map params = new HashMap();
         Long mcn;
         try {
@@ -2498,7 +2503,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
         String jpql = "Select f "
                 + " from Family f "
                 + " where f.retired=false "
-                + " and f.chiefHouseHolder.person.nic like :nic "
+                + " and (f.chiefHouseHolder.person.nic like :nic "
+                + " or exists (select fm from FamilyMember fm "
+                + " where fm.family=f and fm.retired=false "
+                + " and fm.patient.person.nic like :nic)) "
                 + " order by f.chiefHouseHolder.person.name";
         Map params = new HashMap();
         params.put("nic", "%" + searchNic.trim().toUpperCase() + "%");
@@ -2595,7 +2603,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 + " from FamilyMember fm"
                 + " where fm.retired=false "
                 + " and fm.family.retired=false "
-                + " and (fm.family.phoneNo=:pn or fm.family.membershipCardNo=:mcn or fm.patient.person.mobile=:mobile or fm.patient.person.phone=:phone) ";
+                + " and (fm.family.phoneNo=:pn or fm.family.membershipCardNo=:mcn "
+                + "      or fm.patient.person.mobile=:mobile or fm.patient.person.phone=:phone "
+                + "      or fm.patient.person.nic=:nic) ";
+
         Map m = new HashMap();
         Long mcn;
         try {
@@ -2607,6 +2618,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
         m.put("mcn", mcn);
         m.put("mobile", searchText);
         m.put("phone", searchText);
+        m.put("nic", searchText);
 
         List<FamilyMember> fs = familyMemberFacade.findByJpql(j, m);
         if (fs == null) {
@@ -3631,7 +3643,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
                 return nm;
         }
     }
-    
+
     public String capitalizeFirstLetter(String str) {
         if (str == null || str.isEmpty()) {
             return str;


### PR DESCRIPTION
Family search previously matched only the Chief Householder's NIC and the Family's own phone number, so lookups by a non-CHH member's NIC or phone silently returned no results even though the member was registered.

- searchFamily(): also match FamilyMember.patient.person.phone/mobile via EXISTS, in addition to Family.phoneNo and membershipCardNo
- searchFamilyByNIC(): also match FamilyMember.patient.person.nic via EXISTS, in addition to the CHH's NIC
- searchFamilyMember(): add missing NIC condition alongside the existing phone/card matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved family and membership search so results can now be found using additional linked patient details, including phone, mobile, and NIC.
  * Enhanced family lookup matching to include related non-retired family members, making searches more complete and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->