### PR TITLE
feat(pharmacy): add Accept Returns from Ward to standalone Pharmacy menu

### DIFF
--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1173,6 +1173,13 @@
                                      value="BHT Issue Requests" icon="fas fa-clipboard-list"
                                      actionListener="#{pharmacySaleBhtController.resetAll()}"
                                      rendered="#{webUserController.hasPrivilege('PharmacyBhtIssueRequest')}" />
+                        <p:menuitem
+                            ajax="false"
+                            action="#{pharmacyReturnFromWardReceiveController.navigateToPendingList}"
+                            value="Accept Returns from Ward"
+                            icon="fa fa-truck-ramp-box"
+                            rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept')}" >
+                        </p:menuitem>
                         <p:menuitem  ajax="false" action="#{inwardReportControllerBht.navigateToInpatientPharmacyRequestedAndIssuedOverviewInPharmacy()}"  value="Pharmacy Requested &amp; Issued Drug Overview" icon="fas fa-list" rendered="#{webUserController.hasPrivilege('PharmacySummaryViews')}" ></p:menuitem>
 
                         <p:menuitem  ajax="false" action="#{searchController.navigateToInpatientDirectIssuesByBill()}"


### PR DESCRIPTION
## Summary
- Adds an "Accept Returns from Ward" menu item under **Pharmacy → Inpatient Medication Management**, next to "BHT Issue Requests"
- Reuses the existing `pharmacyReturnFromWardReceiveController.navigateToPendingList` action and `PharmacyBHTIssueAccept` privilege check (same as the existing Inward → Pharmacy menu item and the inpatient dashboard tile, #21471)
- No dashboard changes needed — the inpatient dashboard tile already exists (`Icon.java` → `INPATIENT_DIRECT_ISSUES`, wired in `home.xhtml`)

Closes #21789

## Test plan
- [ ] Log in as a user with the `Pharmacy` privilege (standalone Pharmacy menu) and `PharmacyBHTIssueAccept`, but without Inward menu access
- [ ] Confirm "Accept Returns from Ward" appears under Pharmacy → Inpatient Medication Management
- [ ] Click it and confirm it navigates to the pending returns list (`pharmacy_return_from_ward_receive_list.xhtml`)
- [ ] Confirm existing Inward → Pharmacy → Accept Returns from Ward entry still works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **“Accept Returns from Ward”** option under **Inpatient Medication Management**.
  * The new menu item takes users to the pending returns list and is shown only to users with the appropriate permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->