### PR TITLE
Convert Pharmacy Search Sale Bill Items page to DTO and fix View Bill navigation

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -417,8 +417,8 @@ before clicking Search.
 ## 19. Some `confirm()`-guarded `type="submit"` buttons never reach the server — prefer existing data
 
 On `pharmacy/pharmacy_bill_retail_sale_native.xhtml` ("Pharmacy Retail Sale"), the
-**Settle** button is a plain `<button type="submit" onclick="...confirm(...)...">`
-(no `p:commandButton`/AJAX). Across several approaches — real `browser_click` +
+**Settle** button is a PrimeFaces `p:commandButton` with `ajax="false"` and a
+`confirm(...)` guard. Across several approaches — real `browser_click` +
 `browser_handle_dialog`, overriding `window.confirm` before clicking, and dispatching
 a synthetic click via `browser_evaluate` — the click always ran the `onclick` handler
 (confirm dialog appeared/was accepted each time) but the browser never actually

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -414,6 +414,27 @@ can intercept subsequent clicks ("subtree intercepts pointer events") — click
 a neutral element on the page first (e.g. a heading) to dismiss the overlay
 before clicking Search.
 
+## 19. Some `confirm()`-guarded `type="submit"` buttons never reach the server — prefer existing data
+
+On `pharmacy/pharmacy_bill_retail_sale_native.xhtml` ("Pharmacy Retail Sale"), the
+**Settle** button is a plain `<button type="submit" onclick="...confirm(...)...">`
+(no `p:commandButton`/AJAX). Across several approaches — real `browser_click` +
+`browser_handle_dialog`, overriding `window.confirm` before clicking, and dispatching
+a synthetic click via `browser_evaluate` — the click always ran the `onclick` handler
+(confirm dialog appeared/was accepted each time) but the browser never actually
+submitted the form: no new request appeared in `browser_network_requests`, and the
+server log had no corresponding entries. Root cause not identified (possibly a
+`Tendered` client-side balance check, or a JS handler outside the visible `onclick`
+attribute, silently calling `preventDefault()`).
+
+**Workaround used:** rather than fighting this page, the existing `pharmacy_search_*`
+pages were verified against **pre-existing historical demo data** (CareCode Model
+Hospital ships with substantial seeded pharmacy sale history) instead of creating a
+fresh bill through this specific page. If a fresh bill genuinely must be created for a
+test, try the token-based "Sale for Cashier" flow instead — its item-add/quantity
+inputs worked fine in this session, only the retail-native page's Settle button was
+unreachable.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -3340,6 +3340,10 @@ public class SearchController implements Serializable {
         pharmacyBillSearch.fetchSaleSearchDtosFromNativeBills(true);
     }
 
+    public void createPharmacySaleBillItems() {
+        pharmacyBillSearch.fetchSaleBillItemSearchDtos(getMaxResult());
+    }
+
     public void createPharmacyAddToStockBills() {
         Date startTime = new Date();
         createPharmacyAddToBills(BillType.PharmacyAddtoStock, true);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -4934,7 +4934,7 @@ public class PharmacyBillSearch implements Serializable {
                 + "AND b.department = :ldep "
                 + "AND b.billType = :bType "
                 + "AND rb.billType = :rBType "
-                + "AND bi.createdAt BETWEEN :fromDate AND :toDate";
+                + "AND rb.createdAt BETWEEN :fromDate AND :toDate";
 
         if (searchController.getSearchKeyword().getPatientName() != null && !searchController.getSearchKeyword().getPatientName().trim().isEmpty()) {
             sql += " AND pp.name LIKE :patientName";

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -188,6 +188,7 @@ public class PharmacyBillSearch implements Serializable {
     // Bill id used when navigating directly from DTO tables
     private Long billId;
     private List<PharmacySaleSearchDTO> saleBillDtos;
+    private List<com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO> saleBillItemDtos;
     private List<com.divudi.core.data.dto.PharmacyTransferRequestListDTO> transferRequestSearchDtos;
     private List<PharmacyTransferIssueSearchDTO> transferIssueSearchDtos;
     private List<com.divudi.core.data.dto.PharmacyTransferReceivedListDTO> transferReceiveSearchDtos;
@@ -4887,6 +4888,92 @@ public class PharmacyBillSearch implements Serializable {
     @Deprecated
     public void fetchSaleSearchDtosFromNativeBills(boolean maxNum) {
         fetchSaleSearchDtosFromNativeBills(maxNum ? 25 : 0);
+    }
+
+    public List<com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO> getSaleBillItemDtos() {
+        return saleBillItemDtos;
+    }
+
+    public void setSaleBillItemDtos(List<com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO> saleBillItemDtos) {
+        this.saleBillItemDtos = saleBillItemDtos;
+    }
+
+    /**
+     * Fetches pharmacy retail sale bill items (via PreBill -> BilledBill) as DTOs.
+     * Used by pharmacy_search_sale_bill_item.xhtml (issue #21792).
+     *
+     * @param maxResult the maximum number of rows to return; 0 or negative means unlimited
+     */
+    @SuppressWarnings("unchecked")
+    public void fetchSaleBillItemSearchDtos(int maxResult) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("class", com.divudi.core.entity.PreBill.class);
+        m.put("rClass", com.divudi.core.entity.BilledBill.class);
+        m.put("bType", com.divudi.core.data.BillType.PharmacyPre);
+        m.put("rBType", com.divudi.core.data.BillType.PharmacySale);
+        m.put("fromDate", searchController.getFromDate());
+        m.put("toDate", searchController.getToDate());
+        m.put("ins", sessionController.getInstitution());
+        m.put("ldep", sessionController.getLoggedUser().getDepartment());
+
+        String sql = "SELECT new com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO("
+                + "rb.id, rb.deptId, rb.createdAt, "
+                + "it.id, COALESCE(it.name, ''), COALESCE(it.code, ''), "
+                + "bi.qty, bi.netValue, "
+                + "COALESCE(pp.name, ''), "
+                + "rb.cancelled, rb.refunded) "
+                + "FROM BillItem bi "
+                + "JOIN bi.bill b "
+                + "JOIN b.referenceBill rb "
+                + "LEFT JOIN bi.item it "
+                + "LEFT JOIN b.patient p "
+                + "LEFT JOIN p.person pp "
+                + "WHERE type(b) = :class "
+                + "AND type(rb) = :rClass "
+                + "AND b.institution = :ins "
+                + "AND b.department = :ldep "
+                + "AND b.billType = :bType "
+                + "AND rb.billType = :rBType "
+                + "AND bi.createdAt BETWEEN :fromDate AND :toDate";
+
+        if (searchController.getSearchKeyword().getPatientName() != null && !searchController.getSearchKeyword().getPatientName().trim().isEmpty()) {
+            sql += " AND pp.name LIKE :patientName";
+            m.put("patientName", "%" + searchController.getSearchKeyword().getPatientName().trim().toUpperCase() + "%");
+        }
+        if (searchController.getSearchKeyword().getBillNo() != null && !searchController.getSearchKeyword().getBillNo().trim().isEmpty()) {
+            sql += " AND rb.deptId LIKE :billNo";
+            m.put("billNo", "%" + searchController.getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
+        }
+        if (searchController.getSearchKeyword().getTotal() != null && !searchController.getSearchKeyword().getTotal().trim().isEmpty()) {
+            try {
+                double total = Double.parseDouble(searchController.getSearchKeyword().getTotal().trim());
+                sql += " AND bi.netValue = :total";
+                m.put("total", total);
+            } catch (NumberFormatException e) {
+                // ignore invalid numeric input, skip filter
+            }
+        }
+        if (searchController.getSearchKeyword().getItemName() != null && !searchController.getSearchKeyword().getItemName().trim().isEmpty()) {
+            sql += " AND it.name LIKE :itm";
+            m.put("itm", "%" + searchController.getSearchKeyword().getItemName().trim().toUpperCase() + "%");
+        }
+        if (searchController.getSearchKeyword().getCode() != null && !searchController.getSearchKeyword().getCode().trim().isEmpty()) {
+            sql += " AND it.code LIKE :cde";
+            m.put("cde", "%" + searchController.getSearchKeyword().getCode().trim().toUpperCase() + "%");
+        }
+
+        sql += " ORDER BY bi.id DESC";
+
+        if (maxResult > 0) {
+            saleBillItemDtos = (List<com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO>) getBillItemFacade()
+                    .findLightsByJpql(sql, m, TemporalType.TIMESTAMP, maxResult);
+        } else {
+            saleBillItemDtos = (List<com.divudi.core.data.dto.PharmacySaleBillItemSearchDTO>) getBillItemFacade()
+                    .findLightsByJpql(sql, m, TemporalType.TIMESTAMP);
+        }
+        if (saleBillItemDtos == null) {
+            saleBillItemDtos = new ArrayList<>();
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/com/divudi/core/data/dto/PharmacySaleBillItemSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacySaleBillItemSearchDTO.java
@@ -1,0 +1,84 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for pharmacy retail sale bill item search.
+ * Used in pharmacy/pharmacy_search_sale_bill_item.xhtml.
+ */
+public class PharmacySaleBillItemSearchDTO implements Serializable {
+
+    private Long billId;
+    private String deptId;
+    private Date billDate;
+    private Long itemId;
+    private String itemName;
+    private String itemCode;
+    private Double qty;
+    private Double netValue;
+    private String patientName;
+    private Boolean cancelled;
+    private Boolean refunded;
+
+    public PharmacySaleBillItemSearchDTO() {
+    }
+
+    public PharmacySaleBillItemSearchDTO(
+            Long billId,
+            String deptId,
+            Date billDate,
+            Long itemId,
+            String itemName,
+            String itemCode,
+            Double qty,
+            Double netValue,
+            String patientName,
+            Boolean cancelled,
+            Boolean refunded) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.billDate = billDate;
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.netValue = netValue;
+        this.patientName = patientName;
+        this.cancelled = cancelled;
+        this.refunded = refunded;
+    }
+
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+
+    public Date getBillDate() { return billDate; }
+    public void setBillDate(Date billDate) { this.billDate = billDate; }
+
+    public Long getItemId() { return itemId; }
+    public void setItemId(Long itemId) { this.itemId = itemId; }
+
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+
+    public String getItemCode() { return itemCode; }
+    public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+
+    public Double getQty() { return qty; }
+    public void setQty(Double qty) { this.qty = qty; }
+
+    public Double getNetValue() { return netValue; }
+    public void setNetValue(Double netValue) { this.netValue = netValue; }
+
+    public String getPatientName() { return patientName; }
+    public void setPatientName(String patientName) { this.patientName = patientName; }
+
+    public Boolean getCancelled() { return cancelled; }
+    public void setCancelled(Boolean cancelled) { this.cancelled = cancelled; }
+
+    public Boolean getRefunded() { return refunded; }
+    public void setRefunded(Boolean refunded) { this.refunded = refunded; }
+}

--- a/src/main/webapp/pharmacy/pharmacy_search_sale_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_sale_bill_item.xhtml
@@ -10,7 +10,7 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
                 <h:form>
-                    <p:panel header="Search Sale Per Bill Items">
+                    <p:panel header="Search Sale Bill Items">
                         <div class="row">
                             <div class="col-md-2">
 
@@ -43,7 +43,7 @@
                                     icon="fa fa-search"
                                     class="w-100 ui-button-warning mt-2 mb-3"
                                     value="Search" 
-                                    action="#{searchController.createPharmacyBillItemTable()}"/>
+                                    action="#{searchController.createPharmacySaleBillItems()}"/>
 
 
                                 <h:outputLabel value="Bill No"/>
@@ -65,7 +65,7 @@
                                     id="tblBills" 
                                     paginatorPosition="bottom"
                                     rows="10"
-                                    value="#{searchController.billItems}" 
+                                    value="#{pharmacyBillSearch.saleBillItemDtos}"
                                     var="pi" 
                                     paginator="true"
                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
@@ -76,42 +76,28 @@
                                     </p:column>
                                     
                                     <p:column headerText="Bill No" styleClass="alignTop"  >
-                                        <h:outputLabel value="#{pi.bill.deptId}"/>
+                                        <h:outputLabel value="#{pi.deptId}"/>
                                     </p:column>
-                                    
+
                                     <p:column headerText="Item Name"  styleClass="alignTop" >
-                                        <h:outputLabel value="#{pi.item.name}" />    
+                                        <h:outputLabel value="#{pi.itemName}" />
                                     </p:column>
 
                                     <p:column headerText="Item Code">
                                         <f:facet name="header">
                                             <h:outputLabel value="Code"/>
                                         </f:facet>
-                                        <h:outputLabel value="#{pi.item.code}" style="width: 100px!important;" ></h:outputLabel>
+                                        <h:outputLabel value="#{pi.itemCode}" style="width: 100px!important;" ></h:outputLabel>
                                     </p:column>
 
                                     <p:column headerText="Billed At"  >
-                                        <h:outputLabel value="#{pi.bill.createdAt}" >
+                                        <h:outputLabel value="#{pi.billDate}" >
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                         </h:outputLabel>
                                         <br/>
-                                        <h:panelGroup rendered="#{pi.bill.referenceBill.cancelled}" >
-                                            <h:outputLabel style="color: red;" value="Cancelled at " />
-                                            <h:outputLabel style="color: red;" 
-                                                           rendered="#{pi.bill.referenceBill.cancelled}" 
-                                                           value="#{pi.bill.referenceBill.cancelledBill.createdAt}" >
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{pi.bill.referenceBill.refunded}" >
-                                            <h:outputLabel style="color: red;" value="Refunded at " />
-                                            <h:outputLabel style="color: red;" 
-                                                           rendered="#{pi.bill.referenceBill.refunded}" 
-                                                           value="#{pi.referanceBillItem.bill.createdAt}" >
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </h:panelGroup>
-                                    </p:column>     
+                                        <p:badge value="Cancelled" severity="danger" rendered="#{pi.cancelled}"/>
+                                        <p:badge value="Refunded" severity="warning" rendered="#{pi.refunded}"/>
+                                    </p:column>
                                     <p:column headerText="Qty" >
                                         <h:outputLabel value="#{pi.qty}" >
                                             <f:convertNumber pattern="#0.00"/>
@@ -125,17 +111,17 @@
                                     </p:column>
 
                                     <p:column headerText="Patient"  styleClass="alignTop" >
-                                        <h:outputLabel value="#{pi.bill.patient.person.nameWithTitle}" >
-                                        </h:outputLabel>                             
+                                        <h:outputLabel value="#{pi.patientName}" >
+                                        </h:outputLabel>
                                     </p:column>
-                                    
+
                                     <p:column headerText="Action" width="50px">
-                                        <p:commandButton 
+                                        <p:commandButton
                                             id="btnViewBill"
-                                            ajax="false" 
+                                            ajax="false"
                                             icon="fas fa-file-invoice"
-                                            action="pharmacy_reprint_bill_sale">
-                                            <f:setPropertyActionListener value="#{pi.bill.referenceBill}" target="#{pharmacyBillSearch.bill}"/>                                     
+                                            action="#{pharmacyBillSearch.navigatePharmacyReprintRetailBill()}">
+                                            <f:setPropertyActionListener value="#{pi.billId}" target="#{pharmacyBillSearch.billId}"/>
                                         </p:commandButton>
                                         
                                         <p:tooltip for="btnViewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>


### PR DESCRIPTION
## Summary
- Convert `pharmacy/pharmacy_search_sale_bill_item.xhtml` from an entity-based `BillItem` query to a new `PharmacySaleBillItemSearchDTO`, eliminating N+1 lazy loads on item name/code, bill number, patient name, and cancelled/refunded flags (mirrors the pattern already used by the sibling `pharmacy_search_sale_bill.xhtml` / `PharmacySaleSearchDTO`).
- Fix a display bug: Bill No / Billed At now come from the **finalized BilledBill** (`bi.bill.referenceBill`) instead of the **draft PreBill** — settlement (`PharmacyPreSettleController.saveSaleBill()`) can assign a different bill number and always assigns a different `createdAt`.
- Route "View Bill" through `pharmacyBillSearch.navigatePharmacyReprintRetailBill()` + `billId`, matching the sibling page, instead of setting the session-scoped bean's `bill` field directly from a lazily-loaded relation.
- Add department scoping (`b.department = sessionController.getLoggedUser().getDepartment()`) to match the sibling page's search behavior.
- `SearchController.billItems` / `createPharmacyBillItemTable()` are left untouched — they're still used by `pharmacy_wholesale/pharmacy_search_sale_bill_item.xhtml`, a separate page not in scope here.
- Record a new Playwright testing gotcha (confirm()-guarded `type="submit"` buttons that never reach the server) in the e2e workflow doc.

Closes #21792

## Test plan
Verified end-to-end with Playwright against a local deployment (CareCode Model Hospital demo data) and cross-checked against the MySQL DB:

- [x] Searched Search Sale Bill Items with a wide date range — page loads and lists historical sale bill items with no errors (DTO query executes cleanly).
- [x] Item Name filter (`Zaart`) — returns only matching rows.
- [x] Item Code filter (`za50`) — returns only matching rows.
- [x] "View Bill" navigates to the correct settled bill (`MP/SALE/120178` on `pharmacy_reprint_bill_sale.xhtml`).
- [x] DB cross-check on bill `MP/SALE/120178` (PreBill id `13848556` → BilledBill id `13848715`): page's displayed date (`21:50:18`) matches the **BilledBill's** `createdAt`, not the PreBill's (`21:49:15`) — confirms the date bug fix. Item qty/net value/name/code and patient name all match DB exactly.
- [x] Department scoping confirmed — results restricted to "Main Pharmacy".
- [x] Confirmed the sibling wholesale page and its backing `SearchController` methods are unaffected.

Screenshots (Playwright verification):

![Search Sale Bill Items filtered by Item Code](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-21792-search-sale-bill-items-filtered.png)

![View Bill navigation to the correct settled bill](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-21792-view-bill-navigation.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the “Search Sale Bill Items” results page with clearer columns, patient display, and improved “View Bill” behavior.
  * Added richer bill item details in the results (bill info, item code/name, quantity, amounts, patient name, and cancelled/refunded status).

* **Bug Fixes**
  * Updated the search results wiring so bill item listings come from the correct sale-bill-item source and show the intended status rendering.

* **Documentation**
  * Added testing guidance for a Playwright E2E case where confirm-guarded submit buttons may not reach the server, including recommended verification using existing demo data or the token-based “Sale for Cashier” flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->