### PR TITLE
refactor(reports): fix filter alignment, remove dup scrollbar

### DIFF
--- a/src/main/webapp/reports/managementReports/duration_service_report.xhtml
+++ b/src/main/webapp/reports/managementReports/duration_service_report.xhtml
@@ -1,382 +1,304 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 
-<h:body>
-
-<ui:composition template="/reports/index.xhtml">
-<ui:define name="subcontent">
-
-<h:form >
-
-    <p:panel header="Duration Service Report" styleClass="w-100">
-            <h:panelGrid columns="5" styleClass=""
-                         columnClasses="col-md-2,col-md-3,col-md-1,col-md-2,col-md-3">
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Discharge Date From" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true" 
-                    value="#{reportController.fromDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-                <p:spacer />
-
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Discharge Date To" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true" 
-                    value="#{reportController.toDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-
-                
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Service Added Date From" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true" 
-                    value="#{reportController.serviceAddedFromDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-                <p:spacer/>
-
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Service Added Date To" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true" 
-                    value="#{reportController.serviceAddedToDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-
-           
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Invoice Date From" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true" 
-                    value="#{reportController.invoiceFromDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-                <p:spacer />
-
-                <h:panelGroup >
-                    <h:outputText value="&#xf133;" styleClass="fa mr-2" />
-                    <p:outputLabel value="Invoice Date To" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:datePicker showTime="true"  
-                    value="#{reportController.invoiceToDate}"
-                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                    styleClass="w-100" inputStyleClass="w-100 mb-3"/>
-
-
-           
-                <h:panelGroup >
-                    <h:outputText value="&#xf19c;" styleClass="fa mr-2"/> 
-                    <h:outputLabel value="Service Name" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectOneMenu value="#{reportController.item}" 
-                                 styleClass="w-100 form-control mb-3">
-                    <f:selectItem itemLabel="All Services" itemValue="#{null}"/>
-                    <f:selectItems value="#{timedItemController.items}" var="s"
-                                   itemLabel="#{s.name}" itemValue="#{s}"/>
-                </p:selectOneMenu>
-
-                <p:spacer />
-
-                <h:panelGroup >
-                    <h:outputText value="&#xf084;" styleClass="fa mr-2"/> 
-                    <h:outputLabel value="Admission Types" for="admType" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectCheckboxMenu id="admType"
-                                      value="#{reportController.admissionTypes}"
-                                      converter="admissionTypeConverter"
-                                      styleClass="w-100 mb-3"
-                                      label="Select Types"
-                                      updateLabel="true">
-                    <f:selectItems value="#{admissionTypeController.items}" var="at"
-                                   itemLabel="#{at.name}" itemValue="#{at}"/>
-                </p:selectCheckboxMenu>
-
-
-            
-                <h:panelGroup >
-                    <h:outputText value="&#xf236;" styleClass="fa mr-2"/> 
-                    <h:outputLabel value="Room Categories" for="roomCat" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectCheckboxMenu id="roomCat"
-                                      value="#{reportController.roomCategories}"
-                                      converter="#{roomCategoryConverter}"
-                                      styleClass="w-100 mb-3"
-                                      label="Select Categories"
-                                      updateLabel="true">
-                    <f:selectItems value="#{roomCategoryController.items}" var="rc"
-                                   itemLabel="#{rc.name}" itemValue="#{rc}"/>
-                </p:selectCheckboxMenu>
-
-                <p:spacer />
-
-             
-                <h:panelGroup >
-                    <h:outputText styleClass="fa fa-hotel mr-2"/> 
-                    <h:outputLabel value="Service Department" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectOneMenu value="#{reportController.serviceDepartment}" styleClass="w-100 mb-3" filter="true">
-                    <f:selectItem itemLabel="All Service Departments" itemValue="#{null}"/>
-                    <f:selectItems value="#{departmentController.items}" var="d"
-                                   itemLabel="#{d.name}" itemValue="#{d}"/>
-                </p:selectOneMenu>
-
-
-               
-                <h:panelGroup >
-                    <h:outputText styleClass="fa fa-hotel mr-2"/> 
-                    <h:outputLabel value="Billed Department" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectOneMenu value="#{reportController.billedDepartment}" styleClass="w-100 mb-3" filter="true">
-                    <f:selectItem itemLabel="All Billed Departments" itemValue="#{null}"/>
-                    <f:selectItems value="#{departmentController.items}" var="d"
-                                   itemLabel="#{d.name}" itemValue="#{d}"/>
-                </p:selectOneMenu>
-
-                <p:spacer />
-
-    
-                <h:panelGroup >
-                    <h:outputText styleClass="fa fa-hotel mr-2"/> 
-                    <h:outputLabel value="Visit Type" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:selectOneMenu value="#{reportController.visitType}" styleClass="w-100 mb-3">
-                    <f:selectItem itemLabel="All" itemValue="#{null}"/>
-                    <f:selectItem itemLabel="OP" itemValue="OP"/>
-                    <f:selectItem itemLabel="IP" itemValue="IP"/>
-                </p:selectOneMenu>
-
-
-           
-                <h:panelGroup >
-                    <h:outputText styleClass="fa fa-hotel mr-2"/> 
-                    <h:outputLabel value="Service Group" class="mx-3"/>
-                </h:panelGroup>
-
-                <p:inputText value="#{reportController.serviceGroup}" styleClass="w-100 mb-3"/>
-
-            </h:panelGrid>
-
-
-      
-        <h:panelGrid columns="6" styleClass="my-3">
-            <p:spacer width="20"/>
-
-            <p:commandButton ajax="false" value="Process"
-                             icon="fas fa-cogs"
-                             action="#{reportController.createDurationServiceReport}"
-                             styleClass="ui-button-warning mx-1"/>
-
-            <p:commandButton ajax="false" value="To Print"
-                             icon="fas fa-print"
-                             action="duration_service_report_view?faces-redirect=true"
-                             styleClass="ui-button-info mx-1"/>
-
-<!--            <p:commandButton ajax="false" value="Print All"
-                             icon="fas fa-print"
-                             styleClass="ui-button-info mx-1">
-                <p:printer target="tbl"/>
-            </p:commandButton>-->
-
-            <p:commandButton ajax="false" value="Download"
-                             icon="fas fa-file-excel"
-                             styleClass="ui-button-success mx-1">
-                <p:dataExporter fileName="Duration_Service_Report" 
-                                type="xlsx"
-                                target="tbl"
-                                postProcessor="#{reportController.postProcessDurationServiceReportExcel}" />
-            </p:commandButton>
-
-            <p:commandButton ajax="false" value="PDF"
-                             icon="fas fa-file-pdf"
-                             styleClass="ui-button-danger mx-1"
-                             action="#{reportController.exportDurationServiceReportToPDF()}">
-            </p:commandButton>
-        </h:panelGrid>
-
-        <!-- TABLE with dual scrollbars (top + bottom) -->
-        <!-- Top mirror scrollbar -->
-        <div id="topScrollBar" style="overflow-x: auto; overflow-y: hidden; width: 100%; margin: 0 1em;">
-            <div id="topScrollBarInner" style="height: 1px;"></div>
-        </div>
-
-        <!-- Actual scrollable table container -->
-        <div id="tableScrollContainer" style="overflow-x: auto; overflow-y: visible; width: 100%; margin: 0.5em 1em 1em 1em;">
-        <p:panel styleClass="border-round-md shadow-1" style="width: 210em;">
-            <p:dataTable var="c" id="tbl"
-                         value="#{reportController.durationServiceReportRows}"
-                         style="width:206em;"
-                         rows="10"
-                         paginator="true"
-                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                         currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
-                         rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
-           
-
-           
-                <p:column headerText="BHT No" style="width: 100px">
-                    <h:outputText value="#{c.bhtNo}"/>
-                </p:column>
-                <p:column headerText="MRN No">
-                    <h:outputText value="#{c.mrnNo}"/>
-                </p:column>
-                <p:column headerText="Consultant Name">
-                    <h:outputText value="#{c.consultantName}"/>
-                </p:column>
-                <p:column headerText="Surgery Name">
-                    <h:outputText value="#{c.surgeryName}"/>
-                </p:column>
-                <p:column headerText="Service Department">
-                    <h:outputText value="#{c.serviceDepartmentName}"/>
-                </p:column>
-                <p:column headerText="Service Name">
-                    <h:outputText value="#{c.serviceName}"/>
-                </p:column>
-                <p:column headerText="Service Group">
-                    <h:outputText value="#{c.serviceGroupName}"/>
-                </p:column>
-                <p:column headerText="Start Time">
-                    <h:outputText value="#{c.startTime}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="End Time">
-                    <h:outputText value="#{c.endTime}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Duration">
-                    <h:outputText value="#{c.duration}"/>
-                </p:column>
-                <p:column headerText="Base Price">
-                    <h:outputText value="#{c.basePrice}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Discount Amount">
-                    <h:outputText value="#{c.discountAmount}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Sponsor Discount">
-                    <h:outputText value="#{c.sponsorDiscount}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Sponsor Net.">
-                    <h:outputText value="#{c.sponsorNet}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Patient Amt">
-                    <h:outputText value="#{c.patientAmount}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Adjusted Amt">
-                    <h:outputText value="#{c.adjustedAmount}">
-                        <f:convertNumber pattern="#,##0.00"/>
-                    </h:outputText>
-                </p:column>
-                <p:column headerText="Creator">
-                    <h:outputText value="#{c.creatorName}"/>
-                </p:column>
-                <p:column headerText="Checked By">
-                    <h:outputText value="#{c.checkedByName}"/>
-                </p:column>
-                <p:column headerText="Checked At">
-                    <h:outputText value="#{c.checkedAt}">
-                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                    </h:outputText>
-                </p:column>
-
-            </p:dataTable>
-        </p:panel>
-        </div><!-- end tableScrollContainer -->
-
-        <!-- JavaScript to sync top and bottom scrollbars -->
-        <script type="text/javascript">
-            (function() {
-                function initDualScroll() {
-                    var top    = document.getElementById('topScrollBar');
-                    var bottom = document.getElementById('tableScrollContainer');
-                    var inner  = document.getElementById('topScrollBarInner');
-
-                    if (!top || !bottom || !inner) return;
-
-                    // Match the inner div width to the scroll content width
-                    inner.style.width = bottom.scrollWidth + 'px';
-
-                    // Keep widths in sync when window resizes
-                    window.addEventListener('resize', function() {
-                        inner.style.width = bottom.scrollWidth + 'px';
-                    });
-
-                    var syncing = false;
-
-                    top.addEventListener('scroll', function() {
-                        if (syncing) return;
-                        syncing = true;
-                        bottom.scrollLeft = top.scrollLeft;
-                        syncing = false;
-                    });
-
-                    bottom.addEventListener('scroll', function() {
-                        if (syncing) return;
-                        syncing = true;
-                        top.scrollLeft = bottom.scrollLeft;
-                        inner.style.width = bottom.scrollWidth + 'px';
-                        syncing = false;
-                    });
-                }
-
-                // Run after page fully loads
-                if (document.readyState === 'complete') {
-                    initDualScroll();
-                } else {
-                    window.addEventListener('load', initDualScroll);
-                }
-                // Also try after a short delay for JSF/PrimeFaces rendering
-                setTimeout(initDualScroll, 500);
-            })();
-        </script>
-
-    </p:panel>
-
-</h:form>
-
-</ui:define>
-</ui:composition>
-
-</h:body>
+    <h:body>
+
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+
+                <h:form >
+
+                    <p:panel header="Duration Service Report" styleClass="w-100">
+
+                        <style>
+                            .drs-filter-grid {
+                                display: grid;
+                                grid-template-columns: repeat(2, minmax(0, 1fr));
+                                column-gap: 2.5em;
+                                row-gap: 0.75em;
+                                margin: 0 1em 1em 1em;
+                            }
+                            .drs-filter-row {
+                                display: grid;
+                                grid-template-columns: 13em 1fr;
+                                align-items: center;
+                                column-gap: 0.75em;
+                                margin-bottom: 1em;
+                            }
+                            .drs-filter-label {
+                                display: flex;
+                                align-items: center;
+                                gap: 0.5em;
+                                white-space: normal;
+                                line-height: 1.2;
+                            }
+                            .drs-filter-row .p-inputtext,
+                            .drs-filter-row .p-datepicker,
+                            .drs-filter-row .p-selectonemenu,
+                            .drs-filter-row .p-multiselect,
+                            .drs-filter-row .ui-selectcheckboxmenu-label-container {
+                                width: 100% !important;
+                            }
+                        </style>
+
+                        <div class="drs-filter-grid">
+
+                            <!-- LEFT COLUMN -->
+                            <div>
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Discharge Date From</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.fromDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Service Added Date From</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.serviceAddedFromDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Invoice Date From</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.invoiceFromDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf19c;" styleClass="fa"/> Service Name</span>
+                                    <p:selectOneMenu value="#{reportController.item}" styleClass="w-100 form-control">
+                                        <f:selectItem itemLabel="All Services" itemValue="#{null}"/>
+                                        <f:selectItems value="#{timedItemController.items}" var="s"
+                                                       itemLabel="#{s.name}" itemValue="#{s}"/>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf084;" styleClass="fa"/> Admission Types</span>
+                                    <p:selectCheckboxMenu id="admType"
+                                                          value="#{reportController.admissionTypes}"
+                                                          converter="admissionTypeConverter"
+                                                          styleClass="w-100"
+                                                          label="Select Types"
+                                                          updateLabel="true">
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at"
+                                                       itemLabel="#{at.name}" itemValue="#{at}"/>
+                                    </p:selectCheckboxMenu>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Billed Department</span>
+                                    <p:selectOneMenu value="#{reportController.billedDepartment}" styleClass="w-100" filter="true">
+                                        <f:selectItem itemLabel="All Billed Departments" itemValue="#{null}"/>
+                                        <f:selectItems value="#{departmentController.items}" var="d"
+                                                       itemLabel="#{d.name}" itemValue="#{d}"/>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Service Group</span>
+                                    <p:inputText value="#{reportController.serviceGroup}" styleClass="w-100"/>
+                                </div>
+                            </div>
+
+                            <!-- RIGHT COLUMN -->
+                            <div>
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Discharge Date To</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.toDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Service Added Date To</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.serviceAddedToDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Invoice Date To</span>
+                                    <p:datePicker showTime="true"
+                                                  value="#{reportController.invoiceToDate}"
+                                                  pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                  styleClass="w-100" inputStyleClass="w-100"/>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Service Department</span>
+                                    <p:selectOneMenu value="#{reportController.serviceDepartment}" styleClass="w-100" filter="true">
+                                        <f:selectItem itemLabel="All Service Departments" itemValue="#{null}"/>
+                                        <f:selectItems value="#{departmentController.items}" var="d"
+                                                       itemLabel="#{d.name}" itemValue="#{d}"/>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText value="&#xf236;" styleClass="fa"/> Room Categories</span>
+                                    <p:selectCheckboxMenu id="roomCat"
+                                                          value="#{reportController.roomCategories}"
+                                                          converter="#{roomCategoryConverter}"
+                                                          styleClass="w-100"
+                                                          label="Select Categories"
+                                                          updateLabel="true">
+                                        <f:selectItems value="#{roomCategoryController.items}" var="rc"
+                                                       itemLabel="#{rc.name}" itemValue="#{rc}"/>
+                                    </p:selectCheckboxMenu>
+                                </div>
+
+                                <div class="drs-filter-row">
+                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Visit Type</span>
+                                    <p:selectOneMenu value="#{reportController.visitType}" styleClass="w-100">
+                                        <f:selectItem itemLabel="All" itemValue="#{null}"/>
+                                        <f:selectItem itemLabel="OP" itemValue="OP"/>
+                                        <f:selectItem itemLabel="IP" itemValue="IP"/>
+                                    </p:selectOneMenu>
+                                </div>
+                            </div>
+
+                        </div>
+
+                        <h:panelGrid columns="5" styleClass="my-3">
+                            <p:spacer width="20"/>
+
+                            <p:commandButton ajax="false" value="Process"
+                                             icon="fas fa-cogs"
+                                             action="#{reportController.createDurationServiceReport}"
+                                             styleClass="ui-button-warning mx-1"/>
+
+                            <p:commandButton ajax="false" value="To Print"
+                                             icon="fas fa-print"
+                                             action="duration_service_report_view?faces-redirect=true"
+                                             styleClass="ui-button-info mx-1"/>
+
+                            <p:commandButton ajax="false" value="Download"
+                                             icon="fas fa-file-excel"
+                                             styleClass="ui-button-success mx-1">
+                                <p:dataExporter fileName="Duration_Service_Report" 
+                                                type="xlsx"
+                                                target="tbl"
+                                                postProcessor="#{reportController.postProcessDurationServiceReportExcel}" />
+                            </p:commandButton>
+
+                            <p:commandButton ajax="false" value="PDF"
+                                             icon="fas fa-file-pdf"
+                                             styleClass="ui-button-danger mx-1"
+                                             action="#{reportController.exportDurationServiceReportToPDF()}">
+                            </p:commandButton>
+                        </h:panelGrid>
+
+                        <div id="tableScrollContainer" style="overflow-x: auto; overflow-y: visible; width: 100%; margin: 0.5em 1em 1em 1em;">
+                            <p:panel styleClass="border-round-md shadow-1" style="width: 210em;">
+                                <p:dataTable var="c" id="tbl"
+                                             value="#{reportController.durationServiceReportRows}"
+                                             style="width:206em;"
+                                             rows="10"
+                                             paginator="true"
+                                             paginatorPosition="bottom"
+                                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                             currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                             rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                                    <p:column headerText="BHT No" style="width: 100px">
+                                        <h:outputText value="#{c.bhtNo}"/>
+                                    </p:column>
+                                    <p:column headerText="MRN No">
+                                        <h:outputText value="#{c.mrnNo}"/>
+                                    </p:column>
+                                    <p:column headerText="Consultant Name">
+                                        <h:outputText value="#{c.consultantName}"/>
+                                    </p:column>
+                                    <p:column headerText="Surgery Name">
+                                        <h:outputText value="#{c.surgeryName}"/>
+                                    </p:column>
+                                    <p:column headerText="Service Name">
+                                        <h:outputText value="#{c.serviceName}"/>
+                                    </p:column>
+                                    <p:column headerText="Service Department">
+                                        <h:outputText value="#{c.serviceDepartmentName}"/>
+                                    </p:column>
+                                    <p:column headerText="Service Group">
+                                        <h:outputText value="#{c.serviceGroupName}"/>
+                                    </p:column>
+                                    <p:column headerText="Start Time">
+                                        <h:outputText value="#{c.startTime}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="End Time">
+                                        <h:outputText value="#{c.endTime}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Duration">
+                                        <h:outputText value="#{c.duration}"/>
+                                    </p:column>
+                                    <p:column headerText="Base Price">
+                                        <h:outputText value="#{c.basePrice}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Discount Amount">
+                                        <h:outputText value="#{c.discountAmount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Sponsor Discount">
+                                        <h:outputText value="#{c.sponsorDiscount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Sponsor Net.">
+                                        <h:outputText value="#{c.sponsorNet}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Patient Amt">
+                                        <h:outputText value="#{c.patientAmount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Adjusted Amt">
+                                        <h:outputText value="#{c.adjustedAmount}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+                                    <p:column headerText="Creator">
+                                        <h:outputText value="#{c.creatorName}"/>
+                                    </p:column>
+                                    <p:column headerText="Checked By">
+                                        <h:outputText value="#{c.checkedByName}"/>
+                                    </p:column>
+                                    <p:column headerText="Checked At">
+                                        <h:outputText value="#{c.checkedAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                </p:dataTable>
+                            </p:panel>
+                        </div><!-- end tableScrollContainer -->
+
+                    </p:panel>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+
+    </h:body>
 </html>

--- a/src/main/webapp/reports/managementReports/duration_service_report.xhtml
+++ b/src/main/webapp/reports/managementReports/duration_service_report.xhtml
@@ -12,7 +12,7 @@
         <ui:composition template="/reports/index.xhtml">
             <ui:define name="subcontent">
 
-                <h:form >
+                <h:form id="drsForm">
 
                     <p:panel header="Duration Service Report" styleClass="w-100">
 
@@ -52,7 +52,10 @@
                             <!-- LEFT COLUMN -->
                             <div>
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Discharge Date From</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Discharge Date From"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.fromDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -60,7 +63,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Service Added Date From</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Service Added Date From"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.serviceAddedFromDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -68,7 +74,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Invoice Date From</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Invoice Date From"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.invoiceFromDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -76,7 +85,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf19c;" styleClass="fa"/> Service Name</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf19c;" styleClass="fa"/>
+                                        <h:outputText value="Service Name"/>
+                                    </span>
                                     <p:selectOneMenu value="#{reportController.item}" styleClass="w-100 form-control">
                                         <f:selectItem itemLabel="All Services" itemValue="#{null}"/>
                                         <f:selectItems value="#{timedItemController.items}" var="s"
@@ -85,7 +97,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf084;" styleClass="fa"/> Admission Types</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf084;" styleClass="fa"/>
+                                        <h:outputText value="Admission Types"/>
+                                    </span>
                                     <p:selectCheckboxMenu id="admType"
                                                           value="#{reportController.admissionTypes}"
                                                           converter="admissionTypeConverter"
@@ -98,7 +113,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Billed Department</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText styleClass="fa fa-hotel"/>
+                                        <h:outputText value="Billed Department"/>
+                                    </span>
                                     <p:selectOneMenu value="#{reportController.billedDepartment}" styleClass="w-100" filter="true">
                                         <f:selectItem itemLabel="All Billed Departments" itemValue="#{null}"/>
                                         <f:selectItems value="#{departmentController.items}" var="d"
@@ -107,7 +125,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Service Group</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText styleClass="fa fa-hotel"/>
+                                        <h:outputText value="Service Group"/>
+                                    </span>
                                     <p:inputText value="#{reportController.serviceGroup}" styleClass="w-100"/>
                                 </div>
                             </div>
@@ -115,7 +136,10 @@
                             <!-- RIGHT COLUMN -->
                             <div>
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Discharge Date To</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Discharge Date To"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.toDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -123,7 +147,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Service Added Date To</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Service Added Date To"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.serviceAddedToDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -131,7 +158,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf133;" styleClass="fa"/> Invoice Date To</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf133;" styleClass="fa"/>
+                                        <h:outputText value="Invoice Date To"/>
+                                    </span>
                                     <p:datePicker showTime="true"
                                                   value="#{reportController.invoiceToDate}"
                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
@@ -139,7 +169,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Service Department</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText styleClass="fa fa-hotel"/>
+                                        <h:outputText value="Service Department"/>
+                                    </span>
                                     <p:selectOneMenu value="#{reportController.serviceDepartment}" styleClass="w-100" filter="true">
                                         <f:selectItem itemLabel="All Service Departments" itemValue="#{null}"/>
                                         <f:selectItems value="#{departmentController.items}" var="d"
@@ -148,7 +181,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText value="&#xf236;" styleClass="fa"/> Room Categories</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText value="&#xf236;" styleClass="fa"/>
+                                        <h:outputText value="Room Categories"/>
+                                    </span>
                                     <p:selectCheckboxMenu id="roomCat"
                                                           value="#{reportController.roomCategories}"
                                                           converter="#{roomCategoryConverter}"
@@ -161,7 +197,10 @@
                                 </div>
 
                                 <div class="drs-filter-row">
-                                    <span class="drs-filter-label"><h:outputText styleClass="fa fa-hotel"/> Visit Type</span>
+                                    <span class="drs-filter-label">
+                                        <h:outputText styleClass="fa fa-hotel"/>
+                                        <h:outputText value="Visit Type"/>
+                                    </span>
                                     <p:selectOneMenu value="#{reportController.visitType}" styleClass="w-100">
                                         <f:selectItem itemLabel="All" itemValue="#{null}"/>
                                         <f:selectItem itemLabel="OP" itemValue="OP"/>
@@ -175,17 +214,17 @@
                         <h:panelGrid columns="5" styleClass="my-3">
                             <p:spacer width="20"/>
 
-                            <p:commandButton ajax="false" value="Process"
+                            <p:commandButton id="processBtn" ajax="false" value="Process"
                                              icon="fas fa-cogs"
                                              action="#{reportController.createDurationServiceReport}"
                                              styleClass="ui-button-warning mx-1"/>
 
-                            <p:commandButton ajax="false" value="To Print"
+                            <p:commandButton id="printBtn" ajax="false" value="To Print"
                                              icon="fas fa-print"
                                              action="duration_service_report_view?faces-redirect=true"
                                              styleClass="ui-button-info mx-1"/>
 
-                            <p:commandButton ajax="false" value="Download"
+                            <p:commandButton id="downloadBtn" ajax="false" value="Download"
                                              icon="fas fa-file-excel"
                                              styleClass="ui-button-success mx-1">
                                 <p:dataExporter fileName="Duration_Service_Report" 
@@ -194,7 +233,7 @@
                                                 postProcessor="#{reportController.postProcessDurationServiceReportExcel}" />
                             </p:commandButton>
 
-                            <p:commandButton ajax="false" value="PDF"
+                            <p:commandButton id="pdfBtn" ajax="false" value="PDF"
                                              icon="fas fa-file-pdf"
                                              styleClass="ui-button-danger mx-1"
                                              action="#{reportController.exportDurationServiceReportToPDF()}">


### PR DESCRIPTION
Rework duration service report filters into a CSS grid layout for even spacing, swap Service Name/Department adjacency, drop the top mirror scrollbar + sync JS, and dedupe the bottom paginator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the report filter area to a cleaner, grid-based two-column layout for improved readability and spacing.
  * Refreshed the layout around the report action buttons (process, print, export to Excel, and PDF) for a more consistent presentation.

* **Bug Fixes**
  * Simplified the report table scrolling experience by removing the extra synchronized scrollbar behavior, while keeping the same report fields and table formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->