### PR TITLE
Microbiology report hotfix: manual antibiotic groups, memo-only navigation, spacing, and external image display

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LabTestHistoryController.java
+++ b/src/main/java/com/divudi/bean/lab/LabTestHistoryController.java
@@ -255,6 +255,14 @@ public class LabTestHistoryController implements Serializable {
     public void addExportPDFReportHistory(PatientInvestigation patientInvestigation, PatientReport patientReport) {
         labTestHistoryService.addExportPDFReportHistory(patientInvestigation, patientReport, sessionController.getInstitution(), sessionController.getDepartment(), sessionController.getLoggedUser());
     }
+
+    public void addUnapprovedReportPrintHistory(PatientInvestigation patientInvestigation, PatientReport patientReport) {
+        labTestHistoryService.addUnapprovedReportPrintHistory(patientInvestigation, patientReport, sessionController.getInstitution(), sessionController.getDepartment(), sessionController.getLoggedUser());
+    }
+
+    public void addUnapprovedReportExportPDFHistory(PatientInvestigation patientInvestigation, PatientReport patientReport) {
+        labTestHistoryService.addUnapprovedReportExportPDFHistory(patientInvestigation, patientReport, sessionController.getInstitution(), sessionController.getDepartment(), sessionController.getLoggedUser());
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Data Recive from Analyzer">

--- a/src/main/java/com/divudi/bean/lab/LaboratoryManagementController.java
+++ b/src/main/java/com/divudi/bean/lab/LaboratoryManagementController.java
@@ -2636,6 +2636,46 @@ public class LaboratoryManagementController implements Serializable {
         }
     }
 
+    public void addUnapprovedReportPrintHistory(Long reportID) {
+        if (reportID == null) {
+            JsfUtil.addErrorMessage("Error in Report ID");
+            return;
+        }
+
+        PatientReport currentReport = patientReportFacade.findWithoutCache(reportID);
+
+        if (currentReport == null) {
+            JsfUtil.addErrorMessage("Report not found");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
+            if (configOptionApplicationController.getBooleanValueByKey("Need to record the history of printing lab reports.", false)) {
+                labTestHistoryController.addUnapprovedReportPrintHistory(currentReport.getPatientInvestigation(), currentReport);
+            }
+        }
+    }
+
+    public void addUnapprovedReportExportHistory(Long reportID) {
+        if (reportID == null) {
+            JsfUtil.addErrorMessage("Error in Report ID");
+            return;
+        }
+
+        PatientReport currentReport = patientReportFacade.findWithoutCache(reportID);
+
+        if (currentReport == null) {
+            JsfUtil.addErrorMessage("Report not found");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
+            if (configOptionApplicationController.getBooleanValueByKey("Need to record the history of issuing lab reports.", false)) {
+                labTestHistoryController.addUnapprovedReportExportPDFHistory(currentReport.getPatientInvestigation(), currentReport);
+            }
+        }
+    }
+
     @Deprecated
     public void searchPatientReports() {
         reportTimerController.trackReportExecution(() -> {

--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -5277,6 +5277,27 @@ public class PatientInvestigationController implements Serializable {
         return antibioticItems;
     }
 
+    /**
+     * Rebuilds the antibiotic sensitivity test columns from the currently
+     * viewed patient report. Called lazily from the column getters so the
+     * lists are always populated for the current report even on a page
+     * refresh (a GET that does not re-run the navigation action).
+     */
+    private void populateAntibioticListsFromCurrentReport() {
+        if (patientReportController == null
+                || patientReportController.getCurrentPatientReport() == null
+                || patientReportController.getCurrentPatientReport().getPatientReportItemValues() == null) {
+            if (column1AntibioticList == null) {
+                column1AntibioticList = new ArrayList<>();
+            }
+            if (column2AntibioticList == null) {
+                column2AntibioticList = new ArrayList<>();
+            }
+            return;
+        }
+        findAntibioticForMicrobiologyReport(patientReportController.getCurrentPatientReport().getPatientReportItemValues());
+    }
+
     public void markSelectedAsReceived() {
         for (PatientInvestigation pi : getSelectedToReceive()) {
             pi.setReceived(Boolean.TRUE);
@@ -6079,6 +6100,7 @@ public class PatientInvestigationController implements Serializable {
     }
 
     public List<PatientReportItemValue> getColumn1AntibioticList() {
+        populateAntibioticListsFromCurrentReport();
         return column1AntibioticList;
     }
 
@@ -6087,6 +6109,7 @@ public class PatientInvestigationController implements Serializable {
     }
 
     public List<PatientReportItemValue> getColumn2AntibioticList() {
+        populateAntibioticListsFromCurrentReport();
         return column2AntibioticList;
     }
 

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -3069,22 +3069,17 @@ public class PatientReportController implements Serializable {
     }
 
     public String navigateToCreatedPatientReport(PatientInvestigation pi) {
-        System.out.println("navigateToCreatedPatientReport() = called");
         String link;
         if (pi == null) {
             JsfUtil.addErrorMessage("No Patient Investigation");
             return null;
         }
-        System.out.println("pi = " + pi);
-        System.out.println("pi.getInvestigation() = " + pi.getInvestigation());
-        System.out.println("isAlternativeReportAllowed = " + pi.getInvestigation().isAlternativeReportAllowed());
 
         if (pi.getInvestigation().isAlternativeReportAllowed()) {
             link = patientInvestigationController.navigateToAlternativeReportSelector(pi);
         } else {
             link = navigateToNewlyCreatedPatientReport(pi);
         }
-        System.out.println("link = " + link);
         return link;
     }
 

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -1995,47 +1995,19 @@ public class PatientReportController implements Serializable {
             return;
         }
 
-        PatientReportGroup newlyAddedGroup = addPatientReportGroup();
+        // Persist the group first (so it gets a real id), then create a fresh
+        // antibiotic sensitivity list assigned to that group.
+        PatientReportGroup newlyAddedGroup = getPrBean()
+                .addAntibioticGroupWithValues(currentPatientReport, groupName, sessionController.getLoggedUser());
 
         if (newlyAddedGroup == null) {
+            JsfUtil.addErrorMessage("Could not add the antibiotic group");
             return;
         }
 
-        int groupCount = currentPatientReport.getPatientReportGroups().size();
-
-        if (groupCount == 1) {
-            for (PatientReportItemValue pvm : currentPatientReport.getPatientReportItemValues()) {
-                if (pvm.getInvestigationItem() != null
-                        && pvm.getInvestigationItem().getIxItemType() != null
-                        && pvm.getInvestigationItem().getIxItemType() == InvestigationItemType.Antibiotic) {
-                    pvm.setPatientReportGroup(newlyAddedGroup);
-                }
-            }
-        } else {
-            PatientReportGroup firstGroup = currentPatientReport.getPatientReportGroups().get(0);
-            // Step 1: Filter the base items first
-            List<PatientReportItemValue> baseAntibioticItems = new ArrayList<>();
-            for (PatientReportItemValue basePvm : currentPatientReport.getPatientReportItemValues()) {
-                if (basePvm.getInvestigationItem() != null
-                        && basePvm.getInvestigationItem().getIxItemType() != null
-                        && basePvm.getInvestigationItem().getIxItemType() == InvestigationItemType.Antibiotic
-                        && basePvm.getPatientReportGroup().equals(firstGroup)) {
-                    baseAntibioticItems.add(basePvm);
-                }
-            }
-
-            // Step 2: Safely clone and add
-            for (PatientReportItemValue basePvm : baseAntibioticItems) {
-                PatientReportItemValue clonedPvm = basePvm.clone();
-                clonedPvm.setStrValue(null);
-                clonedPvm.setLobValue(null);
-                clonedPvm.setDisplayValue(null);
-                clonedPvm.setPatientReportGroup(newlyAddedGroup);
-                currentPatientReport.getPatientReportItemValues().add(clonedPvm);
-            }
-        }
         savePatientReport();
         setGroupName(null);
+        JsfUtil.addSuccessMessage("Antibiotic group added");
     }
 
     public PatientReportGroup addPatientReportGroup() {
@@ -2987,6 +2959,7 @@ public class PatientReportController implements Serializable {
     }
 
     public PatientReport createNewMicrobiologyReport(PatientInvestigation pi, Investigation ix) {
+        System.out.println("createNewMicrobiologyReport() = called");
         PatientReport r = null;
         if (pi != null && pi.getId() != null && ix != null) {
             r = new PatientReport();
@@ -3005,18 +2978,26 @@ public class PatientReportController implements Serializable {
                 ReportFormat nrf = reportFormatController.getValidReportFormat();
                 r.setReportFormat(nrf);
             }
+            System.out.println("r.getReportFormat() = " + r.getReportFormat());
             getFacade().create(r);
+            System.out.println("r created, r.getId() = " + r.getId());
             r.setPatientInvestigation(pi);
-            getPrBean().addMicrobiologyReportItemValuesForReport(r);
-//            getEjbFacade().edit(r);
+            // Only create the non-antibiotic values (memos, etc.) on navigation.
+            // The antibiotic sensitivity list is added manually per group via "Add Group".
+            getPrBean().addMicrobiologyNonAntibioticReportItemValuesForReport(r);
+            System.out.println("addMicrobiologyNonAntibioticReportItemValuesForReport done, itemValues size = " + (r.getPatientReportItemValues() == null ? "null" : r.getPatientReportItemValues().size()));
+
             setCurrentPatientReport(r);
             pi.getPatientReports().add(r);
-            setGroupName("Antibiotic Sensitivity Test");
-            addPatientReportGroupForMicrobiology();
+
+            // Prefill the group name field so the user can add the first antibiotic group.
+            String gName = configOptionApplicationController.getLongTextValueByKey("First Antibiotic List Group Name in Microbiology Report", "Antibiotic Sensitivity Test");
+            setGroupName(gName);
             getCommonReportItemController().setCategory(ix.getReportFormat());
         } else {
             JsfUtil.addErrorMessage("No ptIx or Ix selected to add");
         }
+        System.out.println("createNewMicrobiologyReport() returning r = " + r);
         return r;
     }
 
@@ -3077,17 +3058,22 @@ public class PatientReportController implements Serializable {
     }
 
     public String navigateToCreatedPatientReport(PatientInvestigation pi) {
+        System.out.println("navigateToCreatedPatientReport() = called");
         String link;
         if (pi == null) {
             JsfUtil.addErrorMessage("No Patient Investigation");
             return null;
         }
+        System.out.println("pi = " + pi);
+        System.out.println("pi.getInvestigation() = " + pi.getInvestigation());
+        System.out.println("isAlternativeReportAllowed = " + pi.getInvestigation().isAlternativeReportAllowed());
 
         if (pi.getInvestigation().isAlternativeReportAllowed()) {
             link = patientInvestigationController.navigateToAlternativeReportSelector(pi);
         } else {
             link = navigateToNewlyCreatedPatientReport(pi);
         }
+        System.out.println("link = " + link);
         return link;
     }
 
@@ -3170,6 +3156,7 @@ public class PatientReportController implements Serializable {
     }
 
     public String navigateToNewlyCreatedPatientReport(PatientInvestigation pi) {
+        System.out.println("navigateToNewlyCreatedPatientReport() = called");
         if (pi == null) {
             JsfUtil.addErrorMessage("No Patient Report");
             return null;
@@ -3190,15 +3177,20 @@ public class PatientReportController implements Serializable {
         if (ix.getReportedAs() != null) {
             ix = (Investigation) pi.getInvestigation().getReportedAs();
         }
+        System.out.println("ix = " + ix);
+        System.out.println("ix.getReportType() = " + ix.getReportType());
 
         currentReportInvestigation = ix;
         currentPtIx = pi;
         PatientReport newlyCreatedReport = null;
         if (ix.getReportType() == InvestigationReportType.Microbiology) {
+            System.out.println("branch = Microbiology");
             newlyCreatedReport = createNewMicrobiologyReport(pi, ix);
         } else {
+            System.out.println("branch = Standard");
             newlyCreatedReport = createNewPatientReport(pi, ix);
         }
+        System.out.println("newlyCreatedReport = " + newlyCreatedReport);
 
         if (newlyCreatedReport == null) {
             JsfUtil.addErrorMessage("Error");

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -3162,7 +3162,6 @@ public class PatientReportController implements Serializable {
     }
 
     public String navigateToNewlyCreatedPatientReport(PatientInvestigation pi) {
-        System.out.println("navigateToNewlyCreatedPatientReport() = called");
         if (pi == null) {
             JsfUtil.addErrorMessage("No Patient Report");
             return null;
@@ -3183,20 +3182,15 @@ public class PatientReportController implements Serializable {
         if (ix.getReportedAs() != null) {
             ix = (Investigation) pi.getInvestigation().getReportedAs();
         }
-        System.out.println("ix = " + ix);
-        System.out.println("ix.getReportType() = " + ix.getReportType());
 
         currentReportInvestigation = ix;
         currentPtIx = pi;
         PatientReport newlyCreatedReport = null;
         if (ix.getReportType() == InvestigationReportType.Microbiology) {
-            System.out.println("branch = Microbiology");
             newlyCreatedReport = createNewMicrobiologyReport(pi, ix);
         } else {
-            System.out.println("branch = Standard");
             newlyCreatedReport = createNewPatientReport(pi, ix);
         }
-        System.out.println("newlyCreatedReport = " + newlyCreatedReport);
 
         if (newlyCreatedReport == null) {
             JsfUtil.addErrorMessage("Error");

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -2975,7 +2975,6 @@ public class PatientReportController implements Serializable {
     }
 
     public PatientReport createNewMicrobiologyReport(PatientInvestigation pi, Investigation ix) {
-        System.out.println("createNewMicrobiologyReport() = called");
         PatientReport r = null;
         if (pi != null && pi.getId() != null && ix != null) {
             r = new PatientReport();
@@ -2994,14 +2993,11 @@ public class PatientReportController implements Serializable {
                 ReportFormat nrf = reportFormatController.getValidReportFormat();
                 r.setReportFormat(nrf);
             }
-            System.out.println("r.getReportFormat() = " + r.getReportFormat());
             getFacade().create(r);
-            System.out.println("r created, r.getId() = " + r.getId());
             r.setPatientInvestigation(pi);
             // Only create the non-antibiotic values (memos, etc.) on navigation.
             // The antibiotic sensitivity list is added manually per group via "Add Group".
             getPrBean().addMicrobiologyNonAntibioticReportItemValuesForReport(r);
-            System.out.println("addMicrobiologyNonAntibioticReportItemValuesForReport done, itemValues size = " + (r.getPatientReportItemValues() == null ? "null" : r.getPatientReportItemValues().size()));
 
             setCurrentPatientReport(r);
             pi.getPatientReports().add(r);
@@ -3013,7 +3009,6 @@ public class PatientReportController implements Serializable {
         } else {
             JsfUtil.addErrorMessage("No ptIx or Ix selected to add");
         }
-        System.out.println("createNewMicrobiologyReport() returning r = " + r);
         return r;
     }
 

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -2574,6 +2574,22 @@ public class PatientReportController implements Serializable {
         laboratoryManagementController.addReportExportHistory(currentPatientReport.getId());
     }
 
+    public void printUnapprovedReport() {
+        if (currentPatientReport == null) {
+            JsfUtil.addErrorMessage("Nothing to print");
+            return;
+        }
+        laboratoryManagementController.addUnapprovedReportPrintHistory(currentPatientReport.getId());
+    }
+
+    public void exportUnapprovedReport() {
+        if (currentPatientReport == null) {
+            JsfUtil.addErrorMessage("Nothing to export");
+            return;
+        }
+        laboratoryManagementController.addUnapprovedReportExportHistory(currentPatientReport.getId());
+    }
+
     public void printPatientLabReport() {
         if (currentPatientReport == null) {
             JsfUtil.addErrorMessage("Nothing to approve");

--- a/src/main/java/com/divudi/core/data/lab/TestHistoryType.java
+++ b/src/main/java/com/divudi/core/data/lab/TestHistoryType.java
@@ -48,6 +48,8 @@ public enum TestHistoryType {
     REPORT_VIEWED,
     REPORT_PRINTED,
     REPORT_EXPORT_AS_PDF,
+    UNAPPROVED_REPORT_PRINTED,
+    UNAPPROVED_REPORT_EXPORT_AS_PDF,
     REPORT_REMOVE,
     REPORT_ISSUE_PATIENT,
     REPORT_ISSUE_STAFF,
@@ -151,6 +153,10 @@ public enum TestHistoryType {
                 return "Report Printed";
             case REPORT_EXPORT_AS_PDF:
                 return "Report Export as PDF";
+            case UNAPPROVED_REPORT_PRINTED:
+                return "Unapproved Report Printed";
+            case UNAPPROVED_REPORT_EXPORT_AS_PDF:
+                return "Unapproved Report Export as PDF";
             case REPORT_ISSUE_PATIENT:
                 return "Report Issue to Patient";
             case REPORT_ISSUE_STAFF:

--- a/src/main/java/com/divudi/core/facade/PatientReportGroupFacade.java
+++ b/src/main/java/com/divudi/core/facade/PatientReportGroupFacade.java
@@ -1,0 +1,30 @@
+/*
+* Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.lab.PatientReportGroup;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class PatientReportGroupFacade extends AbstractFacade<PatientReportGroup> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if(em == null){}return em;
+    }
+
+    public PatientReportGroupFacade() {
+        super(PatientReportGroup.class);
+    }
+
+}

--- a/src/main/java/com/divudi/ejb/LabTestHistoryService.java
+++ b/src/main/java/com/divudi/ejb/LabTestHistoryService.java
@@ -216,6 +216,14 @@ public class LabTestHistoryService {
     public void addExportPDFReportHistory(PatientInvestigation pi, PatientReport pr, Institution institution, Department department, WebUser createdBy) {
         addNewHistoryWithUser(TestHistoryType.REPORT_EXPORT_AS_PDF, null, null, pi, pr, null, null, null, null, null, null, null, null, institution, department, createdBy);
     }
+
+    public void addUnapprovedReportPrintHistory(PatientInvestigation pi, PatientReport pr, Institution institution, Department department, WebUser createdBy) {
+        addNewHistoryWithUser(TestHistoryType.UNAPPROVED_REPORT_PRINTED, null, null, pi, pr, null, null, null, null, null, null, null, null, institution, department, createdBy);
+    }
+
+    public void addUnapprovedReportExportPDFHistory(PatientInvestigation pi, PatientReport pr, Institution institution, Department department, WebUser createdBy) {
+        addNewHistoryWithUser(TestHistoryType.UNAPPROVED_REPORT_EXPORT_AS_PDF, null, null, pi, pr, null, null, null, null, null, null, null, null, institution, department, createdBy);
+    }
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Data Receive from Analyzer">

--- a/src/main/java/com/divudi/ejb/PatientReportBean.java
+++ b/src/main/java/com/divudi/ejb/PatientReportBean.java
@@ -13,7 +13,10 @@ import com.divudi.core.entity.lab.Investigation;
 import com.divudi.core.entity.lab.InvestigationItem;
 import com.divudi.core.entity.lab.InvestigationItemValueFlag;
 import com.divudi.core.entity.lab.PatientInvestigation;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.lab.PatientReport;
+import com.divudi.core.entity.lab.PatientReportGroup;
+import com.divudi.core.facade.PatientReportGroupFacade;
 import com.divudi.core.entity.lab.PatientReportItemValue;
 import com.divudi.core.entity.lab.ReportItem;
 import com.divudi.core.facade.AntibioticFacade;
@@ -47,6 +50,8 @@ public class PatientReportBean {
     private InvestigationItemFacade ixItemFacade;
     @EJB
     private PatientReportItemValueFacade ptRivFacade;
+    @EJB
+    private PatientReportGroupFacade patientReportGroupFacade;
     @EJB
     private PatientReportFacade prFacade;
     @EJB
@@ -435,6 +440,101 @@ public class PatientReportBean {
         }
         //System.err.println("items :" + ptReport.getPatientReportItemValues());
 
+    }
+
+    /**
+     * Adds only the non-antibiotic report item values (Value / DynamicLabel of
+     * Memo type) for a microbiology report. The antibiotic sensitivity list is
+     * NOT created here - antibiotic groups are added manually afterwards using
+     * {@link #addAntibioticReportItemValuesForGroup(PatientReport, PatientReportGroup)}.
+     */
+    public void addMicrobiologyNonAntibioticReportItemValuesForReport(PatientReport ptReport) {
+        String sql;
+        Investigation temIx = (Investigation) ptReport.getItem();
+        for (ReportItem ii : temIx.getReportItems()) {
+            if (ii.isRetired()) {
+                continue;
+            }
+            PatientReportItemValue val = null;
+            if ((ii.getIxItemType() == InvestigationItemType.Value || ii.getIxItemType() == InvestigationItemType.DynamicLabel)) {
+                if (ii.getIxItemValueType() == InvestigationItemValueType.Memo) {
+                    sql = "select i from PatientReportItemValue i where i.patientReport=:ptRp"
+                            + " and i.investigationItem=:inv ";
+                    HashMap hm = new HashMap();
+                    hm.put("ptRp", ptReport);
+                    hm.put("inv", ii);
+                    val = getPtRivFacade().findFirstByJpql(sql, hm);
+                    if (val == null) {
+                        val = new PatientReportItemValue();
+                        val.setLobValue(getDefaultMemoValue((InvestigationItem) ii, ptReport.getPatientInvestigation().getPatient()));
+                        val.setInvestigationItem((InvestigationItem) ii);
+                        val.setPatient(ptReport.getPatientInvestigation().getPatient());
+                        val.setPatientEncounter(ptReport.getPatientInvestigation().getEncounter());
+                        val.setPatientReport(ptReport);
+                        getPtRivFacade().create(val);
+                        ptReport.getPatientReportItemValues().add(val);
+                    }
+                }
+            } else if (ii.getIxItemType() == InvestigationItemType.ExternalImage) {
+                sql = "select i from PatientReportItemValue i where i.patientReport=:ptRp"
+                        + " and i.investigationItem=:inv ";
+                HashMap hm = new HashMap();
+                hm.put("ptRp", ptReport);
+                hm.put("inv", ii);
+                val = getPtRivFacade().findFirstByJpql(sql, hm);
+                if (val == null) {
+                    val = new PatientReportItemValue();
+                    val.setInvestigationItem((InvestigationItem) ii);
+                    val.setPatient(ptReport.getPatientInvestigation().getPatient());
+                    val.setPatientEncounter(ptReport.getPatientInvestigation().getEncounter());
+                    val.setPatientReport(ptReport);
+                    getPtRivFacade().create(val);
+                    ptReport.getPatientReportItemValues().add(val);
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new antibiotic group for the report and populates it with a
+     * fresh antibiotic sensitivity list (one row per active antibiotic).
+     *
+     * The group is persisted and flushed first so its generated id is assigned
+     * to the same instance; the antibiotic values are then created referencing
+     * that managed group. This avoids the detached-merge pitfall where the
+     * group id stays null (which previously caused the values to fail to
+     * persist and the group to be duplicated on the next merge).
+     *
+     * The new group and values are also added to the report's in-memory
+     * collections so the UI reflects them immediately after an AJAX update.
+     */
+    public PatientReportGroup addAntibioticGroupWithValues(PatientReport ptReport, String groupName, WebUser creator) {
+        PatientReportGroup group = new PatientReportGroup();
+        group.setGroupName(groupName);
+        group.setPatientReport(ptReport);
+        group.setCreatedAt(new Date());
+        group.setCreater(creator);
+        patientReportGroupFacade.createAndFlush(group);
+
+        if (ptReport.getPatientReportGroups() == null) {
+            ptReport.setPatientReportGroups(new ArrayList<>());
+        }
+        ptReport.getPatientReportGroups().add(group);
+
+        List<Antibiotic> abs = getAntibioticFacade().findByJpql("select a from Antibiotic a where a.retired=false order by a.name");
+        for (Antibiotic a : abs) {
+            InvestigationItem ii = investigationItemForAntibiotic(a, ptReport.getPatientInvestigation().getInvestigation());
+            PatientReportItemValue val = new PatientReportItemValue();
+            val.setStrValue("");
+            val.setInvestigationItem(ii);
+            val.setPatient(ptReport.getPatientInvestigation().getPatient());
+            val.setPatientEncounter(ptReport.getPatientInvestigation().getEncounter());
+            val.setPatientReport(ptReport);
+            val.setPatientReportGroup(group);
+            getPtRivFacade().create(val);
+            ptReport.getPatientReportItemValues().add(val);
+        }
+        return group;
     }
 
     @EJB

--- a/src/main/webapp/admin/lims/import_report_format.xhtml
+++ b/src/main/webapp/admin/lims/import_report_format.xhtml
@@ -53,6 +53,12 @@
                                 <p:column headerText="Name" style="padding: 6px;" >
                                     <h:outputLabel value="#{apt.name}" ></h:outputLabel>
                                 </p:column>
+                                <p:column headerText="Institution" style="padding: 6px;" >
+                                    <h:outputLabel value="#{apt.institution.name}" ></h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Department" style="padding: 6px;" >
+                                    <h:outputLabel value="#{apt.department.name}" ></h:outputLabel>
+                                </p:column>
                             </p:autoComplete> 
 
                         </div>

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -170,7 +170,7 @@
                                                 class="ui-button-channelling"
                                                 icon="fas fa-file-pdf"
                                                 rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved}"
-                                                onclick="recordUnapprovedExportHistory(); downloadPdf();"
+                                                onclick="printDraftReport();"
                                                 type="button"
                                                 ajax="false">
                                             </p:commandButton>
@@ -1076,20 +1076,29 @@
                                     // scoped @media print rule. Self-contained so it does not depend on
                                     // the PrimeFaces p:printer behaviour.
                                     function printDraftReport() {
-                                        if (typeof recordUnapprovedPrintHistory === 'function') {
-                                            recordUnapprovedPrintHistory();
-                                        }
+                                        console.log("Downloading PDF...");
+                                        recordUnapprovedPrintHistory();
+                                        console.log("Add History to Downloading PDF ...");
                                         const element = document.getElementById('pdf');
-                                        if (element) {
-                                            element.classList.remove('print-only');
-                                        }
-                                        const cleanup = function () {
-                                            document.body.classList.remove('draft-printing');
-                                            window.removeEventListener('afterprint', cleanup);
+                                        element.classList.remove('print-only');
+
+                                        const opt = {
+                                            margin: [0, 0, 0, 0], // top, left, bottom, right
+                                            filename: '#{patientReportController.currentPatientReport.patientInvestigation.billItem.bill.patient.person.nameWithTitle} - #{patientReportController.currentPatientReport.patientInvestigation.investigation.name}.pdf',
+                                            image: {type: 'jpeg', quality: 1.00},
+                                            html2canvas: {
+                                                scale: 2,
+                                                useCORS: true,
+                                                allowTaint: false
+                                            },
+                                            jsPDF: {unit: 'mm', format: [210, 297], orientation: 'portrait'}
                                         };
-                                        window.addEventListener('afterprint', cleanup);
-                                        document.body.classList.add('draft-printing');
-                                        window.print();
+
+                                        html2pdf().from(element).set(opt).toPdf().get('pdf').then(function (pdf) {
+                                            pdf.deletePage(2); // Remove the second page if it exists
+                                        }).save().then(() => {
+                                            element.classList.add('print-only');
+                                        });
                                     }
                                 </script>
 

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -120,13 +120,24 @@
                                                              async="true">
                                             </p:remoteCommand>
 
-                                            <p:commandButton 
-                                                value="Export PDF" 
-                                                class="ui-button-channelling" 
-                                                icon="fas fa-file-pdf" 
-                                                disabled="#{!patientReportController.currentPatientReport.approved or userPreferenceController.userPreference.canPrintWithoutPermission}"
+                                            <p:remoteCommand name="recordUnapprovedExportHistory"
+                                                             actionListener="#{patientReportController.exportUnapprovedReport()}"
+                                                             async="true">
+                                            </p:remoteCommand>
+
+                                            <p:remoteCommand name="recordUnapprovedPrintHistory"
+                                                             actionListener="#{patientReportController.printUnapprovedReport()}"
+                                                             async="true">
+                                            </p:remoteCommand>
+
+                                            <p:commandButton
+                                                value="Export PDF"
+                                                class="ui-button-channelling"
+                                                icon="fas fa-file-pdf"
+                                                rendered="#{!sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed and not (patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved)}"
+                                                disabled="#{not patientReportController.currentPatientReport.approved}"
                                                 onclick="downloadPdf()"
-                                                type="button"  
+                                                type="button"
                                                 ajax="false">
                                             </p:commandButton>
 
@@ -134,7 +145,7 @@
                                                 type="button"
                                                 icon="fa-solid fa-print"
                                                 class="mx-1 ui-button-info"
-                                                rendered="#{!sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed}"
+                                                rendered="#{!sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed and not (patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved)}"
                                                 value="Print"
                                                 onclick="recordPrintHistory();"
                                                 disabled="#{!patientReportController.currentPatientReport.approved or userPreferenceController.userPreference.canPrintWithoutPermission}">
@@ -145,19 +156,40 @@
                                                 type="button"
                                                 icon="fa-solid fa-print"
                                                 class="mx-1 ui-button-info"
-                                                rendered="#{sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed}"
+                                                rendered="#{sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed and not (patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved)}"
                                                 value="Print"
                                                 onclick="recordPrintHistory();"
                                                 disabled="#{!patientReportController.currentPatientReport.approved or userPreferenceController.userPreference.canPrintWithoutPermission or patientReportController.currentPtIx.billItem.bill.backwardReferenceBill.balance ne 0}">
                                                 <p:printer target="divPrint" />
                                             </p:commandButton>
+                                            <!-- Interim Export/Print for microbiology reports that are not yet
+                                                 approved. Only shown for unapproved microbiology reports; history
+                                                 is recorded via the shared remoteCommands above. -->
+                                            <p:commandButton
+                                                value="Draft Export PDF"
+                                                class="ui-button-channelling"
+                                                icon="fas fa-file-pdf"
+                                                rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved}"
+                                                onclick="recordUnapprovedExportHistory(); downloadPdf();"
+                                                type="button"
+                                                ajax="false">
+                                            </p:commandButton>
 
-                                            <p:commandButton    
-                                                value="Patient Report Search" 
+                                            <p:commandButton
+                                                type="button"
+                                                icon="fa-solid fa-print"
+                                                class="mx-1 ui-button-info"
+                                                rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology' and not patientReportController.currentPatientReport.approved}"
+                                                value="Draft Print"
+                                                onclick="printDraftReport();">
+                                            </p:commandButton>
+
+                                            <p:commandButton
+                                                value="Patient Report Search"
                                                 icon="fa-solid fa-search"
                                                 rendered="false"
                                                 class=" ui-button-warning"
-                                                action="/lab/patient_reports_search?faces-redirect=true" 
+                                                action="/lab/patient_reports_search?faces-redirect=true"
                                                 ajax="false" >
                                             </p:commandButton>
 
@@ -990,6 +1022,24 @@
                                             position: static !important;
                                         }
                                         /* Repeat for other elements as needed */
+
+                                        /* Draft print: show only the report (#pdf) and hide the rest of
+                                           the page. Scoped to a body class so it only applies when the
+                                           Draft Print button triggers window.print(), never affecting the
+                                           regular p:printer button or Ctrl+P. */
+                                        body.draft-printing * {
+                                            visibility: hidden !important;
+                                        }
+                                        body.draft-printing #pdf,
+                                        body.draft-printing #pdf * {
+                                            visibility: visible !important;
+                                        }
+                                        body.draft-printing #pdf {
+                                            position: absolute;
+                                            left: 0;
+                                            top: 0;
+                                            width: 100%;
+                                        }
                                     }
 
                                 </style>
@@ -1019,6 +1069,27 @@
                                         }).save().then(() => {
                                             element.classList.add('print-only');
                                         });
+                                    }
+
+                                    // Draft print for unapproved microbiology reports: record the
+                                    // draft-print history, then print only the report (#pdf) via a
+                                    // scoped @media print rule. Self-contained so it does not depend on
+                                    // the PrimeFaces p:printer behaviour.
+                                    function printDraftReport() {
+                                        if (typeof recordUnapprovedPrintHistory === 'function') {
+                                            recordUnapprovedPrintHistory();
+                                        }
+                                        const element = document.getElementById('pdf');
+                                        if (element) {
+                                            element.classList.remove('print-only');
+                                        }
+                                        const cleanup = function () {
+                                            document.body.classList.remove('draft-printing');
+                                            window.removeEventListener('afterprint', cleanup);
+                                        };
+                                        window.addEventListener('afterprint', cleanup);
+                                        document.body.classList.add('draft-printing');
+                                        window.print();
                                     }
                                 </script>
 

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -136,7 +136,8 @@
                                                 class="mx-1 ui-button-info"
                                                 rendered="#{!sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed}"
                                                 value="Print"
-                                                onclick="recordPrintHistory();">
+                                                onclick="recordPrintHistory();"
+                                                disabled="#{!patientReportController.currentPatientReport.approved or userPreferenceController.userPreference.canPrintWithoutPermission}">
                                                 <p:printer target="divPrint" />
                                             </p:commandButton>
 

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -15,7 +15,7 @@
             <ui:define name="content" rendered="#{webUserController.hasPrivilege('LabAutherizing') eq true or webUserController.hasPrivilege('LabDataentry') eq true or webUserController.hasPrivilege('LabPrinting') eq true   }" >
                 <h:form>
                     <h:outputStylesheet library="css" name="lab.css" ></h:outputStylesheet>
-                    
+
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.min.js" integrity="sha512-pdCVFUWsxl1A4g0uV6fyJ3nrnTGeWnZN2Tl/56j45UvZ1OMdm9CIbctuIHj+yBIRTUUyv6I9+OivXj4i0LPEYA==" crossorigin="anonymous"></script>
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.3.1/jspdf.umd.min.js" integrity="sha512-VKjwFVu/mmKGk0Z0BxgDzmn10e590qk3ou/jkmRugAkSTMSIRkd4nEnk+n7r5WBbJquusQEQjBidrBD3IQQISQ==" crossorigin="anonymous"></script>
 
@@ -101,7 +101,8 @@
                                                 rendered ="#{(webUserController.hasPrivilege('LabDeAutherizing') eq true and patientReportController.currentPatientReport.approved eq true)}"   
                                                 value="Cancel Approval"
                                                 icon="fa-solid fa-times"
-                                                onclick="if (!confirm('Are you sure you want to cancel the approval of this report?')) return false;"
+                                                onclick="if (!confirm('Are you sure you want to cancel the approval of this report?'))
+                                                            return false;"
                                                 class=" ui-button-danger"
                                                 action="#{patientReportController.reverseApprovalOfPatientReport()}" ajax="false"   >
                                             </p:commandButton>
@@ -135,8 +136,7 @@
                                                 class="mx-1 ui-button-info"
                                                 rendered="#{!sessionController.departmentPreference.partialPaymentOfOpdBillsAllowed}"
                                                 value="Print"
-                                                onclick="recordPrintHistory();"
-                                                disabled="#{!patientReportController.currentPatientReport.approved or userPreferenceController.userPreference.canPrintWithoutPermission}">
+                                                onclick="recordPrintHistory();">
                                                 <p:printer target="divPrint" />
                                             </p:commandButton>
 
@@ -444,26 +444,40 @@
                                     header="Microbiology"    
                                     id="panelDataEntryForMicrobiology"
                                     rendered="#{patientReportController.currentPatientReport.transInvestigation.reportType eq 'Microbiology'}" >
-                                    <f:view contentType="text/html">
                                         <h:panelGroup >
                                             <table class="w-100">
-                                                <ui:repeat id="tblMicValsExceptAntibiotics" 
+                                                <ui:repeat id="tblMicValsExceptAntibiotics"
                                                            value="#{patientReportController.currentPatientReport.patientReportItemValues}"  
                                                            var="pvm"   
                                                            >
                                                     <h:panelGroup rendered="#{pvm.investigationItem.ixItemType eq 'Value'}" >
                                                         <tr>
-                                                            <td  style="min-width: 280px!important;">
+                                                            <td  style="width: 280px!important;">
                                                                 <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
                                                             </td>
                                                             <td >
                                                                 <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
-                                                                    <p:inputTextarea 
-                                                                        rendered="true" id="txtMicMemoVal" queryDelay="0" class="w-100 mt-1"  minQueryLength="1" 
-                                                                        completeMethod="#{investigationItemValueController.completeValues}" disabled="#{patientReportController.currentPatientReport.approved}"
+                                                                    <p:textEditor
+                                                                        id="txtMicMemoVal"
+                                                                        class="w-100 mt-1"
+                                                                        secure="false"
+                                                                        allowFormatting="true"
+                                                                        disabled="#{patientReportController.currentPatientReport.approved}"
                                                                         value="#{pvm.lobValue}" >
+                                                                        <f:facet name="toolbar">
+                                                                            <span class="ql-formats">
+                                                                                <button class="ql-bold"></button>
+                                                                                <button class="ql-italic"></button>
+                                                                                <button class="ql-underline"></button>
+                                                                                <button class="ql-strike"></button>
+                                                                            </span>
+                                                                            <span class="ql-formats">
+                                                                                <select class="ql-font"></select>
+                                                                                <select class="ql-size"></select>
+                                                                            </span>
+                                                                        </f:facet>
                                                                         <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
-                                                                    </p:inputTextarea>
+                                                                    </p:textEditor>
                                                                 </h:panelGroup>
                                                             </td>
                                                         </tr>
@@ -472,8 +486,10 @@
                                             </table>
                                         </h:panelGroup>
 
-                                        <p:divider >
-                                            <b>Add Group</b>
+                                        <p:divider>
+                                            <div class="d-flex justify-content-center">
+                                                <b>Add Antibiotic Group</b>
+                                            </div>
                                         </p:divider>
                                         <div class="d-flex gap-3 justify-content-between">
                                             <p:outputLabel 
@@ -486,54 +502,18 @@
                                                 class="w-50"
                                                 value="#{patientReportController.groupName}" >
                                             </p:inputText>
-                                            <p:commandButton 
+                                            <p:commandButton
                                                 id="btnAddPatientReportGroupForMicrobiology"
                                                 value="Add Group"
                                                 icon="fa fa-plus"
-                                                ajax="false"
+                                                process="@this txtGroupName"
+                                                update=":#{p:resolveFirstComponentWithId('panelDataEntryForMicrobiology',view).clientId}"
                                                 class="ui-button-warning"
                                                 action="#{patientReportController.addPatientReportGroupForMicrobiology()}">
                                             </p:commandButton>
                                         </div>
 
                                         <p:divider />
-
-                                        <h:panelGroup rendered="#{empty patientReportController.currentPatientReport.patientReportGroups}">
-                                            <table >
-                                                <ui:repeat id="tblMicVals" 
-                                                           value="#{patientReportController.currentPatientReport.patientReportItemValues}"  
-                                                           var="pvm"   
-                                                           >
-                                                    <h:panelGroup rendered="#{pvm.investigationItem.ixItemType eq 'Value' or pvm.investigationItem.ixItemType eq 'Antibiotic' }" >
-                                                        <tr>
-                                                            <td  style="min-width: 280px!important;">
-                                                                <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
-                                                            </td>
-                                                            <td >
-
-                                                                <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
-                                                                    <p:inputTextarea rendered="true" id="txtMicMemoVal" queryDelay="0" class="w-100 mt-1"  minQueryLength="1" 
-                                                                                     completeMethod="#{investigationItemValueController.completeValues}" disabled="#{patientReportController.currentPatientReport.approved}"
-                                                                                     value="#{pvm.lobValue}" >
-                                                                        <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
-                                                                    </p:inputTextarea>
-                                                                </h:panelGroup>
-                                                                <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Varchar'}">
-                                                                    <p:selectOneMenu id="cmbMicStrVal" class="mt-1" value="#{pvm.strValue}" editable="true"  style="min-width: 300px!important;" disabled="#{patientReportController.currentPatientReport.approved}">
-                                                                        <f:selectItem itemLabel="SENSITIVE" itemValue="SENSITIVE" ></f:selectItem>
-                                                                        <f:selectItem itemLabel="RESISTANT" itemValue="Resistant" ></f:selectItem>
-                                                                        <f:selectItem itemLabel="INTERMEDIATE" itemValue="Intermediate" ></f:selectItem>
-                                                                        <f:ajax event="change"  execute="@this" 
-                                                                                listener="#{patientReportController.savePatientReportItemValues()}" ></f:ajax>
-                                                                    </p:selectOneMenu>
-                                                                </h:panelGroup>
-
-                                                            </td>
-                                                        </tr>
-                                                    </h:panelGroup>
-                                                </ui:repeat>
-                                            </table>
-                                        </h:panelGroup>
 
                                         <h:panelGroup rendered="#{not empty patientReportController.currentPatientReport.patientReportGroups}">
                                             <table >
@@ -603,9 +583,6 @@
                                                 </ui:repeat>
                                             </table>
                                         </h:panelGroup>
-
-
-                                    </f:view>
 
                                 </p:panel>
 
@@ -1024,17 +1001,17 @@
                                         const element = document.getElementById('pdf');
                                         element.classList.remove('print-only');
 
-                                                        const opt = {
-                                                            margin: [0, 0, 0, 0], // top, left, bottom, right
-                                                            filename: '#{patientReportController.currentPatientReport.patientInvestigation.billItem.bill.patient.person.nameWithTitle} - #{patientReportController.currentPatientReport.patientInvestigation.investigation.name}.pdf',
-                                                            image: {type: 'jpeg', quality: 1.00},
-                                                            html2canvas: {
-                                                                scale: 2,
-                                                                useCORS: true,
-                                                                allowTaint: false
-                                                            },
-                                                            jsPDF: {unit: 'mm', format: [210, 297], orientation: 'portrait'}
-                                                        };
+                                        const opt = {
+                                            margin: [0, 0, 0, 0], // top, left, bottom, right
+                                            filename: '#{patientReportController.currentPatientReport.patientInvestigation.billItem.bill.patient.person.nameWithTitle} - #{patientReportController.currentPatientReport.patientInvestigation.investigation.name}.pdf',
+                                            image: {type: 'jpeg', quality: 1.00},
+                                            html2canvas: {
+                                                scale: 2,
+                                                useCORS: true,
+                                                allowTaint: false
+                                            },
+                                            jsPDF: {unit: 'mm', format: [210, 297], orientation: 'portrait'}
+                                        };
 
                                         html2pdf().from(element).set(opt).toPdf().get('pdf').then(function (pdf) {
                                             pdf.deletePage(2); // Remove the second page if it exists

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -16,6 +16,20 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
 
+        <style>
+            /* Collapse the default paragraph/list margins that the rich-text
+               (Quill) editor adds, so multi-line memo results are not spaced out. */
+            .micMemoValue p,
+            .micMemoValue ol,
+            .micMemoValue ul {
+                margin: 0;
+                padding: 0;
+            }
+            .micMemoValue {
+                line-height: 1.45;
+            }
+        </style>
+
         <h:panelGroup rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology'}"  >
 
             <div id="divReportM"  class="labReport"   >
@@ -24,28 +38,23 @@
                                   patientReport="#{patientReportController.currentPatientReport}"/>
                 <div style="position: absolute; top: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Lab Report Height')}%; width: 97%; left: 1%; text-align: center; font-family:Cambria, Georgia, serif; font-size: 14px; height: 70%; vertical-align: top;" >
                     <div id="ixName" >
-                        <h:outputLabel value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}" 
-                                       style="font-weight: bold;font-size: 21px!important; "/>
+                        <h:outputLabel value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}" style="font-weight: bold;font-size: 21px!important; "/>
                     </div>
                     <div id="labelsAndValues" style="left:5%; margin-top: 7px; width: 90%; display: inline-block; vertical-align: top; " >
                         <div style="vertical-align: top; width: 100%; padding: 1px;margin: auto;display: inline-block;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 15px;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop lt 50 }" >
+                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 15px; margin-bottom: 12px;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop lt 50 }" >
                                     <div style="display: inline-block; float: left; width: 1%; clear: left; " ></div>
                                     <div style="display: inline-block; top: 0px; float: left; width: 30%; text-align: left; padding-top: 0.1%; padding-bottom: 0.1%; ">
                                         <h:outputLabel value="#{prv.investigationItem.name}"   escape="false"/>
                                     </div>
                                     <div style="display: inline-block; float: left; width: 3%; " ></div>
-                                    <div style="display: inline-block; text-align: left; float:left; width: 60%; padding-top: 0.1%; padding-bottom: 0.1%; ">
+                                    <div class="micMemoValue" style="display: inline-block; text-align: left; float:left; width: 60%; padding-top: 0.1%; padding-bottom: 0.1%; ">
                                         <h:outputLabel value="#{fn:replace(prv.lobValue,'\\n','&lt;br/&gt;')}"   escape="false"   />
                                     </div>
                                 </h:panelGroup>
                             </ui:repeat>
                         </div>
-
-                        <h:outputLabel 
-                            value="#{patientInvestigationController.findAntibioticForMicrobiologyReport(patientReportController.currentPatientReport.patientReportItemValues)}"
-                            style="display:none;"/>
 
                         <h:panelGroup rendered="#{empty patientReportController.currentPatientReport.patientReportGroups}">
 
@@ -180,13 +189,14 @@
 
                         <div style="vertical-align: top; text-align: left; font-size: 16px;  padding-top: 0%; padding-bottom: 0%; clear: left;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                                <h:panelGroup rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
+                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div style="float: left;width: 5%; " ></div>
                                     <div style=" float: left; text-align: left; width: 20%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
                                         <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                     </div>
-                                    <div style="float: left;width: 5%;  " ></div>
-                                    <div style=" text-align: left; float:left;width: 60%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
+                                    <div class="micMemoValue" style=" text-align: left; float:left; margin-left: 5%; width: 90%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
                                         <h:outputLabel value="#{fn:replace(prv.lobValue,'\\n','&lt;br/&gt;')}"    escape="false" />
                                     </div>
                                 </h:panelGroup>
@@ -194,24 +204,26 @@
                         </div>
 
                         <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                            <div style="#{prv.investigationItem.cssStyle}; position:absolute;">
-                                <p:graphicImage value="https://upload.wikimedia.org/wikipedia/en/e/e2/IMG_Academy_Logo.svg"
-                                                style="width: #{prv.investigationItem.wtPix};overflow: visible; display: block;" 
-                                                height="#{prv.investigationItem.htPix}"
-
-                                                width="#{prv.investigationItem.wtPix}">
-                                </p:graphicImage>
-                            </div>
+                            <h:panelGroup
+                                layout="block"
+                                style="#{prv.investigationItem.cssStyle}; position:absolute;"
+                                rendered="#{prv.investigationItem.ixItemType eq 'ExternalImage' and prv.investigationItem.retired ne true}" >
+                                <div style="position: relative; width: #{prv.investigationItem.wtPix}; height:#{prv.investigationItem.htPix};">
+                                    <img
+                                        alt='ExternalImage'
+                                        style="width: #{prv.investigationItem.wtPix}; height:#{prv.investigationItem.htPix}; display: block; z-index: 800; user-select: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; pointer-events: none;"
+                                        src="#{prv.investigationItem.htmltext}"
+                                        oncontextmenu="return false;"
+                                        ondragstart="return false;"
+                                        onselectstart="return false;">
+                                    </img>
+                                    <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 801; background: transparent;"></div>
+                                </div>
+                            </h:panelGroup>
                         </ui:repeat>
-
-                    </div>
-                    <div style="clear: left;padding-top: 2%;">
-                        <h:outputLabel value="--- End of Report ---" style="font-size: 16px; font-weight: bold; "></h:outputLabel>
                     </div>
                 </div>
             </div>
         </h:panelGroup>
-
-
     </cc:implementation>
 </html>

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -33,9 +33,20 @@
         <h:panelGroup rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology'}"  >
 
             <div id="divReportM"  class="labReport"   >
-                <ez:common_report showBackground="#{patientReportController.showBackground or cc.attrs.showBackground}" 
+                <ez:common_report showBackground="#{patientReportController.showBackground or cc.attrs.showBackground}"
                                   commonReportFormat="#{patientReportController.currentPatientReport.reportFormat}"
                                   patientReport="#{patientReportController.currentPatientReport}"/>
+
+                <!-- Watermark for microbiology reports that are not yet approved.
+                     Text is configurable; approved reports show no watermark. -->
+                <h:panelGroup layout="block"
+                              rendered="#{not patientReportController.currentPatientReport.approved}"
+                              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 900; pointer-events: none; display: flex; align-items: center; justify-content: center; overflow: hidden;">
+                    <span style="transform: rotate(-30deg); font-size: 100px; color: rgba(200,0,0,0.15); font-weight: bold; white-space: normal; word-break: break-word; max-width: 80%; text-transform: uppercase; letter-spacing: 6px; line-height: 1.1; text-align: center; margin: 40px;">
+                        #{configOptionApplicationController.getShortTextValueByKey('Microbiology Not Approved Report Watermark Text', 'NOT APPROVED')}
+                    </span>
+                </h:panelGroup>
+                
                 <div style="position: absolute; top: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Lab Report Height')}%; width: 97%; left: 1%; text-align: center; font-family:Cambria, Georgia, serif; font-size: 14px; height: 70%; vertical-align: top;" >
                     <div id="ixName" >
                         <h:outputLabel value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}" style="font-weight: bold;font-size: 21px!important; "/>
@@ -167,19 +178,14 @@
                                                         <h:outputLabel value="#{prv.strValue}" escape="false"
                                                                        style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: uppercase;" />
                                                     </div>
-
                                                 </h:panelGroup>
-
                                             </h:panelGroup>
                                         </ui:repeat>
                                     </div>
                                 </div>
 
-
                             </ui:repeat>
                         </h:panelGroup>
-
-
 
                         <div style="vertical-align: top; text-align: left; padding-top: 3px; clear: left;">
                             <h:panelGroup rendered="#{patientReportController.currentPatientReport.patientReportItemValues.size()gt 0}">


### PR DESCRIPTION
## Summary

Hotfix for the **coop production** Microbiology patient report. Delivered as three task-scoped commits:

1. **Backend + data entry** — On navigation, create only non-antibiotic memo values; antibiotic groups added manually via **Add Group** (each populated with a fresh sensitivity list, persisted via the new `PatientReportGroupFacade`); create `PatientReportItemValue`s for `ExternalImage` items; enlarge the memo editor; lazily rebuild antibiotic columns for the current report.
2. **Report view** — Render external images (wrap the `ExternalImage` panel in a `ui:repeat` so its loop variable resolves) and tidy memo line spacing.
3. **Report format import** — Show Institution and Department columns in the format autocomplete.

## Notes
- `persistence.xml` local dev config is intentionally **not** included.
- The external-image fix applies to **newly created** microbiology reports; reports created before this change won't have the ExternalImage value row.

Closes #21807
