### PR TITLE
fix(pharmacy): stop retail/cost rate adjustment pages swapping the other rate

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
+++ b/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
@@ -123,7 +123,7 @@ public class StockSearchService {
                 "s.itemBatch.batchNo, " +
                 "s.itemBatch.purcahseRate, " +
                 "s.itemBatch.wholesaleRate, " +
-                "s.itemBatch.retailsaleRate, " +
+                "s.itemBatch.costRate, " +
                 "s.itemBatch.item.allowFractions) " +
                 "FROM Stock s " +
                 "WHERE s.department = :d " +
@@ -145,7 +145,7 @@ public class StockSearchService {
                 "s.itemBatch.id, " +
                 "s.itemBatch.item.name, " +
                 "s.itemBatch.item.code, " +
-                "s.itemBatch.costRate, " +
+                "s.itemBatch.retailsaleRate, " +
                 "s.stock, " +
                 "s.itemBatch.dateOfExpire, " +
                 "s.itemBatch.batchNo, " +


### PR DESCRIPTION
## Summary
- `findRetailRateStockDtos()` and `findCostRateStockDtos()` in `StockSearchService` each populated the "other rate" DTO field with a duplicate of their own target rate instead of the actual counterpart rate.
- Retail Sale Rate Adjustment page always showed **Cost Rate = Retail Rate**.
- Cost Rate Adjustment page always showed **Retail Rate = Cost Rate**.
- Fix swaps the two JPQL positional args so each page selects the correct counterpart rate from `ItemBatch`.

Verified both query methods (`findRetailRateStockDtos`, `findCostRateStockDtos`) are each used by exactly one caller in `PharmacyAdjustmentController`, so this change is isolated and does not affect any other constructor callers.

## Verification (Playwright, live batch: purchaseRate=12.00, retailsaleRate=25.00, costRate=12.00)

**Retail Sale Rate Adjustment page** — Cost Rate column now correctly shows 12.00 instead of duplicating Retail Rate (25.00):
![Retail Sale Rate Adjustment page fixed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/15785-retail-rate-adjustment-fixed.png)

**Cost Rate Adjustment page** — Retail Rate column now correctly shows 25.00 instead of duplicating Cost Rate (12.00):
![Cost Rate Adjustment page fixed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/15784-cost-rate-adjustment-fixed.png)

## Documentation
- Added wiki page: [Cost Rate Adjustment](https://github.com/hmislk/hmis/wiki/Cost-Rate-Adjustment)
- Linked from [Price Adjustment](https://github.com/hmislk/hmis/wiki/Price-Adjustment)

Closes #15785
Closes #15784

## Test plan
- [x] Rebuilt and redeployed locally
- [x] Verified Retail Sale Rate Adjustment page via Playwright against live DB data
- [x] Verified Cost Rate Adjustment page via Playwright against live DB data
- [x] Confirmed both affected query methods have a single caller each (no other callers impacted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)