### PR TITLE
fix(pharmacy): flush before reading generated id in batch-create API

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmacyBatchApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyBatchApiService.java
@@ -319,7 +319,7 @@ public class PharmacyBatchApiService implements Serializable {
             ib.setWholesaleRate(wholesaleRate);
         }
 
-        itemBatchFacade.create(ib);
+        itemBatchFacade.createAndFlush(ib); // flush so getId() below is guaranteed populated
         return ib;
     }
 
@@ -328,7 +328,7 @@ public class PharmacyBatchApiService implements Serializable {
         stock.setItemBatch(itemBatch);
         stock.setDepartment(department);
         stock.setStock(0.0); // Always start with 0 quantity
-        stockFacade.create(stock);
+        stockFacade.createAndFlush(stock); // flush so getId() below is guaranteed populated
         return stock;
     }
 

--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyBatchApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyBatchApi.java
@@ -56,6 +56,9 @@ public class PharmacyBatchApi {
     private PharmacyBatchApiService batchService;
 
     private static final Gson gson = new GsonBuilder()
+            // Serialize nulls explicitly so an unexpected null field is visible
+            // in the response instead of being silently omitted (issue #21814)
+            .serializeNulls()
             // Support multiple date formats for expiryDate and other Date fields
             .registerTypeAdapter(Date.class, (JsonDeserializer<Date>) (JsonElement json, Type typeOfT, com.google.gson.JsonDeserializationContext context) -> {
                 if (json == null) {


### PR DESCRIPTION
## Summary

- `PharmacyBatchApiService.createBatch()` was reading `itemBatch.getId()` and `stock.getId()` immediately after `itemBatchFacade.create(...)`/`stockFacade.create(...)`, which only calls `entityManager.persist(entity)` — no flush.
- Both `ItemBatch` and `Stock` use `@GeneratedValue(strategy = GenerationType.IDENTITY)`, and with `eclipselink.jdbc.batch-writing=JDBC` enabled, the generated id isn't guaranteed to be populated at that point, so `stockId`/`batchId` could come back `null` under load.
- Since `PharmacyBatchApi`'s `Gson` instance wasn't configured with `.serializeNulls()`, a null `stockId` was silently **omitted** from the JSON response instead of appearing as an explicit `null` — callers got a missing-field error instead of a debuggable signal.

## Fix

- Switched both create calls to the existing `AbstractFacade.createAndFlush()` helper (`persist()` + `flush()`, entity stays managed) so ids are guaranteed populated before the response DTO is built.
- Added `.serializeNulls()` to `PharmacyBatchApi`'s `GsonBuilder` as defense-in-depth, so any future unexpected null is visible in the response.

## Scope

This addresses **part 1** of #21814 (the confirmed missing-`stockId` bug). Part 2 (suspected long-held lock on this endpoint) needs production-level concurrency/DB introspection (`SHOW PROCESSLIST` / `SHOW ENGINE INNODB STATUS`) to confirm and is out of scope here.

A background codebase search found the same `create()` → immediate `getId()` gap in 10 other REST API create endpoints (inward, clinical, common, pharmacy-discount, favourite-medicine APIs). Filing a follow-up issue to apply the same fix there rather than bundling it into this PR.

## Test plan

Verified locally (department 485 "Main Pharmacy", AMP 109754 "Leflox 250mg tablet"):
- [x] Single `POST /api/pharmacy_batches/create` call returns non-null `stockId`/`batchId`
- [x] 10 concurrent calls all returned non-null `stockId`/`batchId` (exercises the batch-writing timing window that caused the original intermittent null)
- [x] DB verification: every returned `stockId`/`batchId` matches a real row in `STOCK`/`ITEMBATCH`
- [x] Existing-batch reuse path (same AMP/batchNo/expiry, different department) still returns the correct existing `batchId`, a new `stockId` for the new department, and `message = "Used existing batch"`

Example response after fix:
```json
{"code":200,"data":{"batchId":13859524,"stockId":13859553,"batchNo":"TEST-21814-1", ...},"status":"success"}
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include fields with `null` values instead of omitting them.

* **Bug Fixes**
  * Batch creation now returns newly created record IDs more reliably right away, improving response consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->