### PR TITLE
fix(pharmacy): scope serializeNulls() to batch-create response only

### DIFF
--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyBatchApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyBatchApi.java
@@ -55,38 +55,47 @@ public class PharmacyBatchApi {
     @Inject
     private PharmacyBatchApiService batchService;
 
+    // Support multiple date formats for expiryDate and other Date fields
+    private static final JsonDeserializer<Date> DATE_DESERIALIZER = (JsonElement json, Type typeOfT, com.google.gson.JsonDeserializationContext context) -> {
+        if (json == null) {
+            return null;
+        }
+        String s = json.getAsString();
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+
+        String value = s.trim();
+        String[] patterns = new String[]{
+                "yyyy-MM-dd HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm:ss",
+                "yyyy-MM-dd"
+        };
+
+        for (String p : patterns) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat(p);
+                sdf.setLenient(false);
+                return sdf.parse(value);
+            } catch (ParseException ignored) {
+            }
+        }
+
+        throw new JsonParseException("Invalid date format: " + value);
+    };
+
     private static final Gson gson = new GsonBuilder()
-            // Serialize nulls explicitly so an unexpected null field is visible
-            // in the response instead of being silently omitted (issue #21814)
+            .registerTypeAdapter(Date.class, DATE_DESERIALIZER)
+            .create();
+
+    // Used only for the batch-create response: serializes nulls explicitly so an
+    // unexpected null field is visible instead of being silently omitted
+    // (issue #21814). Kept separate from `gson` because searchOrCreateAmp/searchAmp
+    // share AmpResponseDTO, whose nullable genericName/categoryName would otherwise
+    // start appearing as explicit nulls for those existing consumers too.
+    private static final Gson gsonWithNulls = new GsonBuilder()
+            .registerTypeAdapter(Date.class, DATE_DESERIALIZER)
             .serializeNulls()
-            // Support multiple date formats for expiryDate and other Date fields
-            .registerTypeAdapter(Date.class, (JsonDeserializer<Date>) (JsonElement json, Type typeOfT, com.google.gson.JsonDeserializationContext context) -> {
-                if (json == null) {
-                    return null;
-                }
-                String s = json.getAsString();
-                if (s == null || s.trim().isEmpty()) {
-                    return null;
-                }
-
-                String value = s.trim();
-                String[] patterns = new String[]{
-                        "yyyy-MM-dd HH:mm:ss",
-                        "yyyy-MM-dd'T'HH:mm:ss",
-                        "yyyy-MM-dd"
-                };
-
-                for (String p : patterns) {
-                    try {
-                        SimpleDateFormat sdf = new SimpleDateFormat(p);
-                        sdf.setLenient(false);
-                        return sdf.parse(value);
-                    } catch (ParseException ignored) {
-                    }
-                }
-
-                throw new JsonParseException("Invalid date format: " + value);
-            })
             .create();
 
     public PharmacyBatchApi() {
@@ -164,7 +173,7 @@ public class PharmacyBatchApi {
 
             // Process batch creation
             BatchCreateResponseDTO response = batchService.createBatch(request, user);
-            return successResponse(response);
+            return successResponse(response, gsonWithNulls);
 
         } catch (Exception e) {
             return errorResponse("An error occurred: " + e.getMessage(), 500);
@@ -266,10 +275,14 @@ public class PharmacyBatchApi {
      * Create success response following existing pattern
      */
     private Response successResponse(Object data) {
+        return successResponse(data, gson);
+    }
+
+    private Response successResponse(Object data, Gson serializer) {
         Map<String, Object> response = new HashMap<>();
         response.put("status", "success");
         response.put("code", 200);
         response.put("data", data);
-        return Response.status(200).entity(gson.toJson(response)).build();
+        return Response.status(200).entity(serializer.toJson(response)).build();
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #21816 (merged before this fix was ready) — addresses a CodeRabbit finding on that PR that landed in `development` unfixed.

- `.serializeNulls()` was applied to the shared `Gson` instance in `PharmacyBatchApi`, used by all three endpoints (`amp/search_or_create`, `create`, `amp/search`).
- `searchOrCreateAmp` and `searchAmp` return `AmpResponseDTO`, which has nullable `genericName`/`categoryName`. With the shared instance, those fields now appear as explicit `"genericName": null` instead of being omitted — an unintended breaking response-shape change for any existing consumer of those two endpoints.

## Fix

Split into two `Gson` instances sharing the same date deserializer:
- `gson` (no `serializeNulls()`) — used for request parsing and the two AMP endpoints, unchanged behavior.
- `gsonWithNulls` — used only for the batch-create response.

## Verification

Rebuilt and redeployed locally:
- `POST /api/pharmacy_batches/create` → response still includes explicit values (verified no unexpected nulls slipped in)
- `GET /api/pharmacy_batches/amp/search?name=Amoxil` (an AMP with a null category locally) → `categoryName` correctly **omitted**, not emitted as `null`

Closes the gap flagged in the CodeRabbit review on #21816: https://github.com/hmislk/hmis/pull/21816#pullrequestreview-4621122980

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API responses so batch creation now returns complete details, including previously omitted null fields.
  * Standardized date handling in response payloads for more consistent output across related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->