### PR TITLE
fix(pharmacy): stop retail/cost rate adjustment pages swapping the other rate

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
+++ b/src/main/java/com/divudi/service/pharmacy/StockSearchService.java
@@ -123,7 +123,7 @@ public class StockSearchService {
                 "s.itemBatch.batchNo, " +
                 "s.itemBatch.purcahseRate, " +
                 "s.itemBatch.wholesaleRate, " +
-                "s.itemBatch.retailsaleRate, " +
+                "s.itemBatch.costRate, " +
                 "s.itemBatch.item.allowFractions) " +
                 "FROM Stock s " +
                 "WHERE s.department = :d " +
@@ -145,7 +145,7 @@ public class StockSearchService {
                 "s.itemBatch.id, " +
                 "s.itemBatch.item.name, " +
                 "s.itemBatch.item.code, " +
-                "s.itemBatch.costRate, " +
+                "s.itemBatch.retailsaleRate, " +
                 "s.stock, " +
                 "s.itemBatch.dateOfExpire, " +
                 "s.itemBatch.batchNo, " +


### PR DESCRIPTION
## Summary
- Hotfix for BMS production: `findRetailRateStockDtos()` and `findCostRateStockDtos()` in `StockSearchService` each populated the "other rate" DTO field with a duplicate of their own target rate instead of the actual counterpart rate.
- The Retail Rate Adjustment page always showed Cost Rate = Retail Rate, and the Cost Rate Adjustment page always showed Retail Rate = Cost Rate.
- This is a clean cherry-pick of the already-verified fix (merged into `development`) onto `bms-prod`, with no unrelated changes.

## Test plan
- [x] Verified via Playwright against a live batch (purchaseRate=12.00, retailsaleRate=25.00, costRate=12.00) that both pages report correct, distinct values.
- [x] Confirmed both query methods are each used by exactly one caller in `PharmacyAdjustmentController`.

Closes #15785
Closes #15784