### PR TITLE
Direct Purchase: wholesale rate layout, config-driven policy, Config button, workflow parity

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -7,12 +7,17 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.ItemController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.data.dataStructure.BillListWithTotals;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dataStructure.PharmacyStockRow;
@@ -58,6 +63,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
 import java.math.RoundingMode;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -83,10 +89,6 @@ public class PharmacyDirectPurchaseController implements Serializable {
     private BillItem editingBillItem;
     private boolean printPreview;
     private boolean showAllBillFormats = false;
-    // Issue #21635 / #13103: allow a retail rate below the purchase rate only when the user
-    // explicitly opts in (clearance / loss-leader pricing). Default false so addItem() blocks
-    // accidental below-cost pricing.
-    private boolean allowRetailRateBelowPurchaseRate;
     private BillItem currentExpense;
     private List<BillItem> billExpenses;
     private String warningMessage;
@@ -145,7 +147,6 @@ public class PharmacyDirectPurchaseController implements Serializable {
         billExpenses = null;
         currentExpense = null;
         warningMessage = null;
-        allowRetailRateBelowPurchaseRate = false;
     }
 
     /**
@@ -252,11 +253,11 @@ public class PharmacyDirectPurchaseController implements Serializable {
             return;
         }
 
-        // Issue #21635: block a retail rate below the purchase rate (selling at a loss),
-        // unless the user explicitly ticks "Allow rate below purchase rate" (issue #13103,
-        // for clearance / loss-leader pricing). Normalize AMPP pack rates to per-unit before comparing.
-        if (!allowRetailRateBelowPurchaseRate && isRetailRateBelowPurchaseRate(item, f)) {
-            JsfUtil.addErrorMessage("Retail rate is below the purchase rate. Tick 'Allow rate below purchase rate' to proceed.");
+        // Issue #21635 / #13103 / #21837: block a retail rate below the purchase rate (selling
+        // at a loss) unless config allows it (clearance / loss-leader pricing). Normalize AMPP
+        // pack rates to per-unit before comparing.
+        if (!isAllowRetailRateBelowPurchaseRate() && isRetailRateBelowPurchaseRate(item, f)) {
+            JsfUtil.addErrorMessage("Retail rate is below the purchase rate. Enable 'Allow Retail Rate Below Purchase Rate in Pharmacy Purchasing' to proceed.");
             return;
         }
 
@@ -552,6 +553,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
     PharmacyCalculation pharmacyBillBean;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    PageMetadataRegistry pageMetadataRegistry;
     @Inject
     ConfigOptionController configOptionController;
     @Inject
@@ -1187,8 +1190,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
                 }
             }
 
-            if (!allowRetailRateBelowPurchaseRate && isRetailRateBelowPurchaseRate(item, f)) {
-                JsfUtil.addErrorMessage("Retail rate is below the purchase rate. Tick 'Allow rate below purchase rate' to proceed.");
+            if (!isAllowRetailRateBelowPurchaseRate() && isRetailRateBelowPurchaseRate(item, f)) {
+                JsfUtil.addErrorMessage("Retail rate is below the purchase rate. Enable 'Allow Retail Rate Below Purchase Rate in Pharmacy Purchasing' to proceed.");
                 return;
             }
 
@@ -2387,12 +2390,22 @@ public class PharmacyDirectPurchaseController implements Serializable {
         this.printPreview = printPreview;
     }
 
+    /**
+     * Issue #21635 / #13103: whether saving a retail rate below the purchase rate
+     * (clearance / loss-leader pricing) is allowed. Policy decision, config-driven
+     * rather than a free per-transaction user toggle.
+     */
     public boolean isAllowRetailRateBelowPurchaseRate() {
-        return allowRetailRateBelowPurchaseRate;
+        return configOptionApplicationController.getBooleanValueByKey(
+                "Allow Retail Rate Below Purchase Rate in Pharmacy Purchasing", false);
     }
 
-    public void setAllowRetailRateBelowPurchaseRate(boolean allowRetailRateBelowPurchaseRate) {
-        this.allowRetailRateBelowPurchaseRate = allowRetailRateBelowPurchaseRate;
+    /**
+     * Issue #21837: gates the Wholesale Rate field/columns on this page.
+     */
+    public boolean isWholesaleTransactionsAllowed() {
+        return configOptionApplicationController.getBooleanValueByKey(
+                "Allow Wholesale Transactions in Pharmacy Purchasing", false);
     }
 
     public BillItem getCurrentBillItem() {
@@ -2516,6 +2529,118 @@ public class PharmacyDirectPurchaseController implements Serializable {
     public String toggleShowAllBillFormats() {
         this.showAllBillFormats = !this.showAllBillFormats;
         return "";
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata(
+                "pharmacy/direct_purchase",
+                "Pharmacy Direct Purchase",
+                "Create and manage direct purchase bills for pharmacy stock",
+                "PharmacyDirectPurchaseController"
+        );
+
+        // Configuration Options - APPLICATION scope
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Allow Wholesale Transactions in Pharmacy Purchasing",
+                "Shows the Wholesale Rate field on the Add New Item row and item edit dialog",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Allow Retail Rate Below Purchase Rate in Pharmacy Purchasing",
+                "Allows saving a retail rate below the purchase rate (clearance / loss-leader pricing)",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Use Save Finalize Approve Workflow for Direct Purchase",
+                "Switches the page from single-step Settle to a Save Draft / Finalize / Approve workflow",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Enable Consignment in Pharmacy Purchasing",
+                "Shows or hides the consignment checkbox option in the purchasing details panel",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - A4",
+                "Renders the standard A4 print format for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - A4 (Custom 1)",
+                "Renders the A4 (Custom 1) print format for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - A4 Details",
+                "Renders the A4 format with costing details for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - Custom 1",
+                "Renders custom print format 1 with costing details for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - Custom 2",
+                "Renders custom print format 2 with costing details for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Direct Purchase Bill Print - Custom Letter Format",
+                "Renders the custom letter format with costing details for direct purchase bills",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Show Profit % in Direct Purchase Bill",
+                "Shows the profit percentage column on direct purchase bill printouts",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Show Retail Value in Direct Purchase Bill",
+                "Shows the retail value column on direct purchase bill printouts",
+                OptionScope.APPLICATION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+                "Admin",
+                "Administrative access to page configuration",
+                "Config button visibility"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "PharmacyDirectPurchaseSave",
+                "Permission to save a direct purchase draft",
+                "Save Draft button visibility"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "PharmacyDirectPurchaseFinalize",
+                "Permission to finalize a direct purchase draft",
+                "Finalize button visibility"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "PharmacyDirectPurchaseApprove",
+                "Permission to approve a finalized direct purchase draft",
+                "Controls access to the Approve Direct Purchase list page"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "ChangeReceiptPrintingPaperTypes",
+                "Access to receipt printing configuration settings",
+                "Controls visibility of the Settings button in print preview"
+        ));
+
+        pageMetadataRegistry.registerPage(metadata);
     }
 
 }

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -21,19 +21,23 @@
                             <div>
                                 <h:outputText styleClass="fas fa-shopping-bag"/>
                                 <h:outputText class="mx-4" value="Pharmacy Direct Purchase" />
+                                <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('Admin')}"
+                                    value="Config"
+                                    icon="fa fa-cog"
+                                    title="Page Configuration Management"
+                                    action="#{pageAdminController.navigateToPageAdmin('pharmacy/direct_purchase')}"
+                                    ajax="false"
+                                    styleClass="ui-button-secondary ms-3"/>
                             </div>
                             <div>
 
-                                <!-- Single-step Settle: shown when draft workflow is NOT active -->
                                 <p:commandButton
-                                    id="btnSettle"
-                                    value="Settle"
-                                    onclick="if (!confirm('Are you sure?')) return false"
-                                    action="#{pharmacyDirectPurchaseController.settleDirectPurchaseBillFinally}"
-                                    styleClass="ui-button-success"
+                                    value="New Direct Purchase Bill"
                                     ajax="false"
-                                    icon="pi pi-check-circle"
-                                    rendered="#{!pharmacyDirectPurchaseController.draftMode and !configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false)}"
+                                    styleClass="ui-button-warning"
+                                    icon="pi pi-plus"
+                                    action="#{pharmacyDirectPurchaseController.navigateToStartNewDirectPurchaseBill()}"
                                     style="margin-right: 8px;">
                                 </p:commandButton>
 
@@ -62,26 +66,17 @@
                                     style="margin-right: 8px;">
                                 </p:commandButton>
 
-                                <!-- Approve: shown when draft is finalized but not yet approved -->
+                                <!-- Single-step Settle: shown when draft workflow is NOT active. Primary action, rightmost per UI guidelines. -->
                                 <p:commandButton
-                                    id="btnApprove"
-                                    value="Approve"
-                                    onclick="if (!confirm('Approve this Direct Purchase? Stock will be updated.')) return false"
-                                    action="#{pharmacyDirectPurchaseController.approveDirectPurchaseDraft}"
+                                    id="btnSettle"
+                                    value="Settle"
+                                    onclick="if (!confirm('Are you sure?')) return false"
+                                    action="#{pharmacyDirectPurchaseController.settleDirectPurchaseBillFinally}"
                                     styleClass="ui-button-success"
                                     ajax="false"
                                     icon="pi pi-check-circle"
-                                    rendered="#{pharmacyDirectPurchaseController.draftMode and pharmacyDirectPurchaseController.bill.completed and !pharmacyDirectPurchaseController.bill.checked and webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}"
-                                    style="margin-right: 8px;">
-                                </p:commandButton>
-
-                                <p:commandButton
-                                    value="New Direct Purchase Bill"
-                                    ajax="false"
-                                    styleClass="ui-button-warning"
-                                    icon="pi pi-plus"
-                                    action="#{pharmacyDirectPurchaseController.navigateToStartNewDirectPurchaseBill()}"
-                                    style="margin-right: 8px;">
+                                    rendered="#{!pharmacyDirectPurchaseController.draftMode and !configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false)}"
+                                    style="margin-right: 8px; min-width: 120px;">
                                 </p:commandButton>
                             </div>
                         </div>
@@ -276,7 +271,7 @@
                                         </p:inputText>
                                     </div>
 
-                                    <div class="col-1">
+                                    <h:panelGroup layout="block" styleClass="col-1" rendered="#{pharmacyDirectPurchaseController.isWholesaleTransactionsAllowed()}">
                                         <h:outputLabel
                                             class="w-100 m-1"
                                             style="white-space: nowrap;"
@@ -299,7 +294,7 @@
                                                 update="txtRetailValue txtPackOrUnit txtUnitsPerPack
                                                 :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}" />
                                         </p:inputText>
-                                    </div>
+                                    </h:panelGroup>
 
                                     <div class="col-1">
                                         <p:outputLabel
@@ -332,28 +327,21 @@
                                     </div>
 
                                     <div class="col-1">
-                                        <h:panelGroup layout="block" class="m-1" title="Tick to allow saving a retail rate that is below the purchase rate (e.g. clearance pricing). Issue #21635 / #13103.">
-                                            <h:selectBooleanCheckbox
-                                                id="chkAllowRateBelowPurchase"
-                                                value="#{pharmacyDirectPurchaseController.allowRetailRateBelowPurchaseRate}" />
-                                            <p:outputLabel
-                                                for="chkAllowRateBelowPurchase"
-                                                style="white-space: normal; font-size: 0.75rem;"
-                                                class="ms-1"
-                                                value="Allow rate below purchase" />
-                                        </h:panelGroup>
+                                        <h:outputLabel
+                                            class="w-100 m-1"
+                                            value="&#160;"/><br/>
                                         <p:commandButton
                                             id="btnAdd"
                                             value="Add"
                                             class="ui-button-success w-100"
                                             icon="fas fa-plus"
                                             action="#{pharmacyDirectPurchaseController.addItem}"
-                                            process="@this itemselectgrid chkAllowRateBelowPurchase :#{p:resolveFirstComponentWithId('selDepartmentType',view).clientId}"
+                                            process="@this itemselectgrid :#{p:resolveFirstComponentWithId('selDepartmentType',view).clientId}"
                                             update="itemList itemselectgrid tot focusItem :#{p:resolveFirstComponentWithId('lblGrossTotal',view).clientId} :#{p:resolveFirstComponentWithId('saleValue',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId} :#{p:resolveFirstComponentWithId('selDepartmentType',view).clientId} msg"/>
                                     </div>
 
                                     <div class="col-1 text-end">
-                                        <h:outputLabel 
+                                        <h:outputLabel
                                             class="w-100 m-1"
                                             style="white-space: nowrap;"
                                             value="Pack or Unit" />
@@ -367,7 +355,7 @@
                                     </div>
 
                                     <div class="col-1 text-end">
-                                        <h:outputLabel 
+                                        <h:outputLabel
                                             class="w-100 m-1"
                                             style="white-space: nowrap;"
                                             value="Units per pack" />
@@ -655,12 +643,13 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:inputText>
 
-                                        <p:outputLabel for="editWR" value="Wholesale Rate" />
+                                        <p:outputLabel for="editWR" value="Wholesale Rate" rendered="#{pharmacyDirectPurchaseController.isWholesaleTransactionsAllowed()}" />
                                         <p:inputText
                                             id="editWR"
                                             class="w-100 text-end"
                                             autocomplete="off"
                                             onfocus="this.select()"
+                                            rendered="#{pharmacyDirectPurchaseController.isWholesaleTransactionsAllowed()}"
                                             value="#{pharmacyDirectPurchaseController.editingBillItem.billItemFinanceDetails.wholesaleRate}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </p:inputText>
@@ -836,20 +825,6 @@
                                     <h:outputText class="mx-4" value="Purchasing Details"/>
                                 </f:facet>
                                 <h:panelGrid class="w-100">
-                                    <h:outputLabel value="Department Type" for="selDepartmentType"/>
-                                    <p:selectOneMenu
-                                        id="selDepartmentType"
-                                        value="#{pharmacyDirectPurchaseController.bill.departmentType}"
-                                        class="w-100 my-2"
-                                        disabled="#{not empty pharmacyDirectPurchaseController.billItems and pharmacyDirectPurchaseController.billItems.size() > 0}">
-                                        <f:selectItem itemLabel="Select Department Type" itemValue="#{null}"/>
-                                        <f:selectItems value="#{sessionController.availableDepartmentTypesForPharmacyTransactions}"
-                                                       var="dt"
-                                                       itemLabel="#{dt.label}"
-                                                       itemValue="#{dt}"/>
-                                        <p:ajax process="@this" update="acItem" event="change"/>
-                                    </p:selectOneMenu>
-
                                     <p:outputLabel value="Select Supplier"/>
                                     <p:autoComplete
                                         id="acSupplier"
@@ -897,12 +872,30 @@
                                         <p:ajax event="change" process="cmbPs" ></p:ajax>
                                     </p:selectOneMenu>
 
-                                    <p:spacer class="my-1"  rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}"></p:spacer>
-                                    <h:panelGroup class="my-1" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
-                                        <p:selectBooleanCheckbox value="#{pharmacyDirectPurchaseController.bill.consignment}" itemLabel="Consignment"/>
-                                    </h:panelGroup>
-
                                 </h:panelGrid>
+
+                                <div class="row my-2 align-items-end">
+                                    <div class="col-6">
+                                        <h:outputLabel value="Department Type" for="selDepartmentType"/>
+                                        <p:selectOneMenu
+                                            id="selDepartmentType"
+                                            value="#{pharmacyDirectPurchaseController.bill.departmentType}"
+                                            class="w-100 my-2"
+                                            disabled="#{not empty pharmacyDirectPurchaseController.billItems and pharmacyDirectPurchaseController.billItems.size() > 0}">
+                                            <f:selectItem itemLabel="Select Department Type" itemValue="#{null}"/>
+                                            <f:selectItems value="#{sessionController.availableDepartmentTypesForPharmacyTransactions}"
+                                                           var="dt"
+                                                           itemLabel="#{dt.label}"
+                                                           itemValue="#{dt}"/>
+                                            <p:ajax process="@this" update="acItem" event="change"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                    <div class="col-6">
+                                        <h:panelGroup class="my-1" rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                            <p:selectBooleanCheckbox value="#{pharmacyDirectPurchaseController.bill.consignment}" itemLabel="Consignment"/>
+                                        </h:panelGroup>
+                                    </div>
+                                </div>
                             </p:panel>
                             <p:panel id="panelBillDetails" header="Bill details" class="m-1" >
                                 <f:facet name="header" >
@@ -912,7 +905,7 @@
                                 <p:tabView id="tot">
                                     <!-- Legacy Summary -->
                                     <p:tab title="Bill Summary">
-                                        <p:panelGrid columns="2" >
+                                        <p:panelGrid columns="2" class="w-100" columnClasses="col-6,col-6" style="border-spacing: 0;">
                                             <p:outputLabel 
                                                 value="Gross Total" />
                                             <p:outputLabel 

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -905,7 +905,7 @@
                                 <p:tabView id="tot">
                                     <!-- Legacy Summary -->
                                     <p:tab title="Bill Summary">
-                                        <p:panelGrid columns="2" class="w-100" columnClasses="col-6,col-6" style="border-spacing: 0;">
+                                        <p:panelGrid columns="2" styleClass="ui-panelgrid compact-panelgrid w-100">
                                             <p:outputLabel 
                                                 value="Gross Total" />
                                             <p:outputLabel 

--- a/src/main/webapp/resources/css/ohmis.css
+++ b/src/main/webapp/resources/css/ohmis.css
@@ -3,6 +3,13 @@
     font-size: xx-large ;
 }
 
+/* Remove the browser's default <form> bottom margin on the top menu bar.
+   Without this, every page shows a ~16px gap between the menu and the
+   page's content panel (issue #21837). */
+form[id$=":menuForm"] {
+    margin-bottom: 0;
+}
+
 /* Custom styles for PrimeFaces panels */
 
 /* Cancelled Panel - header */
@@ -306,12 +313,6 @@ th.align-right-header .ui-column-title {
     padding: 2px !important;
     border: none !important; /* optional, if you want minimal borders */
 }
-
-/* Example: set a background to verify it’s applied */
-.compact-panelgrid.ui-panelgrid {
-    background-color: #eef !important;
-}
-
 
 
 .compact-column-borders {


### PR DESCRIPTION
## Summary
Fixes 9 UI/UX issues on `pharmacy/direct_purchase.xhtml` found during a Playwright walkthrough (issue #21837):

- Gate the Wholesale Rate field (Add row + edit dialog) behind a new config option `Allow Wholesale Transactions in Pharmacy Purchasing` (default off) so the Add button stays on row 1 in both states
- Replace the free per-user "Allow rate below purchase" checkbox with config option `Allow Retail Rate Below Purchase Rate in Pharmacy Purchasing`
- Add an admin Config button + full page metadata registration (12 config options, 5 privileges), following the same pattern already used on the Purchase Order Request page
- Move Department Type next to Consignment in Purchasing Details
- Reorder header buttons so the primary action is rightmost per the UI guidelines
- Tighten Bill Summary tab spacing by reusing the existing `.compact-panelgrid` utility class (an earlier attempt using `columnClasses` accidentally tripped PrimeFaces' responsive-grid CSS and made spacing worse)
- Fix a ~16px gap between the top menu bar and every page's content panel (browser default `<form>` margin) — this is an app-wide CSS fix, not Direct-Purchase-specific
- When the Save/Finalize/Approve workflow config is enabled, remove the inline Approve button — approval now goes exclusively through the existing "Approve Direct Purchase" list page, matching the Purchase Order flow

## Test plan
All verified end-to-end via Playwright against local Payara (Main Pharmacy department), with screenshots published to the wiki and linked from the issue:
- [x] Wholesale Rate hidden by default; Add stays on row 1
- [x] Toggling the wholesale config on via the new Config UI shows the field in both the Add row and Edit dialog, values persist correctly (verified with a real add-item flow, qty 10, wholesale rate 12.00)
- [x] Rate-below-purchase blocked/allowed correctly based on the new config value
- [x] Config button navigates to the page-admin view showing all 12 config options and 5 privileges
- [x] Save/Finalize/Approve workflow mode shows only Save Draft (+ Finalize once a draft exists), no Settle, no inline Approve
- [x] Confirmed in the local DB that both new config keys are stored with `APPLICATION` scope and `BOOLEAN` type
- [x] Confirmed via `getBoundingClientRect()` measurements that the panel gap and Bill Summary row spacing are both fixed

Closes #21837

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin **Config** action on the Direct Purchase screen.
  * Wholesale rate fields now appear only when wholesale purchasing is enabled.
  * Direct Purchase settings now follow application-level configuration for retail-below-purchase and wholesale access.

* **Bug Fixes**
  * Removed the in-page retail-below-purchase checkbox from the add-item flow and updated the related validation message.
  * Improved page spacing and compact layout styling for a cleaner purchase screen.

* **UI Improvements**
  * Reworked the settlement action placement and refreshed the purchasing details layout for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->