### PR TITLE
fix(reports): exclude Collecting Centre Agent Payment from All Cashier Summary

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -21110,6 +21110,10 @@ public class SearchController implements Serializable {
             //Start - Atomic Bill Type with Cash in and cash out added for 10088-all-cashier-summary-had-calculated-fund-bills
             List<BillTypeAtomic> btas = BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN);
             btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+            // Collecting Centre Agent Payment / Cancellation are agent commission payouts, not cashier
+            // collections - exclude them (issue #21840)
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT);
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT_CANCELLATION);
             jpql += "AND bill.billTypeAtomic in :btas ";
             parameters.put("btas", btas);
             // End - Atomic Bill Type with Cash in and cash out added FOR 10088-all-cashier-summary-had-calculated-fund-bills


### PR DESCRIPTION
## Summary
- Fixes All Cashier Summary silently including Collecting Centre Agent Payment (`CC_AGENT_PAYMENT`) / Cancellation (`CC_AGENT_PAYMENT_CANCELLATION`) bills in cashier totals.
- These bill types are agent/collecting-centre commission payouts, not cashier cash collections, and are already correctly excluded from Cashier Summary and Cashier Details.
- Root cause: `generateAllCashierSummary()` builds its bill-type filter from `BillTypeAtomic.findByFinanceType(CASH_IN/CASH_OUT)` — a mechanical sweep that happens to catch these two bill types since they're tagged with those finance types. The other two reports use an explicit curated whitelist instead, which never references these bill types.

## Reported by
Ruhunu Hospital — "Issue with All Cashier Summary Report – Incorrect Value Display for Agency Commission Transaction" (2026-07-03). Confirmed on production DB: 74 such bills since 2026-01-13 (latest 2026-07-01) across multiple cashiers/dates — this has been silently affecting the report since January.

Closes #21840

## Test plan
- [x] Compiles clean (`mvn compile`)
- [ ] Deploy to ruhunu-prod and confirm All Cashier Summary no longer shows a value for user 1418 on 11 June 2026
- [ ] Spot-check one of the other affected dates (e.g. 2026-07-01, user 1418) to confirm the fix applies retroactively to historical data too (report is computed live, not stored)