### PR TITLE
fix(reports): exclude Collecting Centre Agent Payment from cashier reports + config to skip payment record

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -50,3 +50,9 @@ This document lists the configuration options used in the application and their 
 | ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `Cost of Goods Sold Report - Display Stock Correction Section`  | Boolean   | `true`  | Controls whether the Stock Correction section is displayed and calculated in the Cost of Goods Sold report. |
 
+## Collecting Centre
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ----------------------------------------------------------------  | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Collecting Centre Agent Payment - Skip Payment Record`         | Boolean   | `true`  | When true, `CollectingCentrePaymentController.createPayment()` does not create a `Payment` record for Collecting Centre Agent Payment / Cancellation bills (`CC_AGENT_PAYMENT`, `CC_AGENT_PAYMENT_CANCELLATION`). These are agent/collecting-centre commission payouts, not cashier cash collections, and should not appear in cashier reports (All Cashier Summary, Cashier Summary, Cashier Details). The `Bill` itself is still created for agent-balance history and printing. See issue #21840. |
+

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -64,6 +64,8 @@ public class CollectingCentrePaymentController implements Serializable {
     SessionController sessionController;
     @Inject
     AgentAndCcApplicationController agentAndCcApplicationController;
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
 // </editor-fold>
 
 // <editor-fold defaultstate="collapsed" desc="Variables">
@@ -587,6 +589,9 @@ public class CollectingCentrePaymentController implements Serializable {
     }
 
     public Payment createPayment(Bill bill, PaymentMethod pm) {
+        if (configOptionApplicationController.getBooleanValueByKey("Collecting Centre Agent Payment - Skip Payment Record", true)) {
+            return null;
+        }
         Payment p = new Payment();
         p.setBill(bill);
         setPaymentMethodData(p, pm);

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -21839,6 +21839,10 @@ public class SearchController implements Serializable {
             //Start - Atomic Bill Type with Cash in and cash out added for 10088-all-cashier-summary-had-calculated-fund-bills
             List<BillTypeAtomic> btas = BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN);
             btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+            // Collecting Centre Agent Payment / Cancellation are agent commission payouts, not cashier
+            // collections - exclude them (issue #21840)
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT);
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT_CANCELLATION);
             jpql += "AND bill.billTypeAtomic in :btas ";
             parameters.put("btas", btas);
             // End - Atomic Bill Type with Cash in and cash out added FOR 10088-all-cashier-summary-had-calculated-fund-bills


### PR DESCRIPTION
## Summary
- Same report-level fix as the ruhunu-prod hotfix (#21841): `generateAllCashierSummary()` no longer sweeps in `CC_AGENT_PAYMENT`/`CC_AGENT_PAYMENT_CANCELLATION` bills via the generic `CASH_IN`/`CASH_OUT` finance-type filter.
- New config option **`Collecting Centre Agent Payment - Skip Payment Record`** (Boolean, default `true`) in `CollectingCentrePaymentController.createPayment()`. When true (default), no `Payment` record is created at all for these bill types — the `Bill` itself is still created (needed for agent-balance history and printing), only the `Payment` row that feeds cashier reports is skipped.

## Why both a report fix and a config option
Discussed with Dushan (Ruhunu Hospital): these Collecting Centre Agent Payment transactions represent commission payouts to agents/collecting centres, not cashier cash handling, and should never appear in any cashier summary/detail report. The more correct long-term fix is to not create the `Payment` record in the first place (config, default on) rather than relying on every report to remember to filter the bill type out downstream. The report-level exclusion is kept as defense-in-depth in case the config is ever flipped off.

## Background
Reported by Ruhunu Hospital — "Issue with All Cashier Summary Report – Incorrect Value Display for Agency Commission Transaction" (2026-07-03). Confirmed on production DB: 74 such bills since 2026-01-13 (latest 2026-07-01) across multiple cashiers/dates.

Closes #21840

## Test plan
- [x] Compiles clean (`mvn compile`)
- [ ] Deploy locally, make a Collecting Centre Agent Payment, confirm no `Payment` row is created (config default true) and the Bill still shows correctly in agent history/print
- [ ] Toggle the config to `false`, confirm a `Payment` row is created as before (backward-compat path)
- [ ] Confirm All Cashier Summary excludes these bills regardless of config state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new collecting-centre setting to control whether payment records are created for agent payment and cancellation bills.
  * When enabled by default, these payouts still generate the bill for tracking and printing, but skip the payment record.

* **Bug Fixes**
  * Excluded collecting-centre agent payout and cancellation bills from cash in/out reporting, preventing them from appearing in cashier reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->