### PR TITLE
feat(security): add per-user IP-restricted login for the main web login

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1287,6 +1287,10 @@ public class SessionController implements Serializable, HttpSessionListener {
         for (WebUser u : allUsers) {
             if ((u.getName()).equalsIgnoreCase(userName)) {
                 if (SecurityController.matchPassword(password, u.getWebUserPassword())) {
+                    if (!u.isIpAllowed(populateRequestInfo().getIpAddress())) {
+                        JsfUtil.addErrorMessage("Login not allowed from this IP address for this user.");
+                        return false;
+                    }
                     if (!canLogToDept(u, department)) {
                         JsfUtil.addErrorMessage("No privilage to Login This Department");
                         return false;
@@ -1509,6 +1513,10 @@ public class SessionController implements Serializable, HttpSessionListener {
                     passwordIsOk = SecurityController.matchPassword(password, u.getWebUserPassword());
                 }
                 if (passwordIsOk) {
+                    if (!u.isIpAllowed(populateRequestInfo().getIpAddress())) {
+                        JsfUtil.addErrorMessage("Login not allowed from this IP address for this user.");
+                        return false;
+                    }
                     System.out.println("DEBUG: Password verification successful, loading departments...");
                     long deptStartTime = System.currentTimeMillis();
                     departments = listLoggableDepts(u);

--- a/src/main/java/com/divudi/core/entity/WebUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUser.java
@@ -110,6 +110,9 @@ public class WebUser implements Serializable {
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date lastPasswordResetAt;
 
+    private boolean restrictLoginByIp = false;
+    private String allowedIpAddresses;
+
     public Staff getStaff() {
         return staff;
     }
@@ -387,6 +390,37 @@ public class WebUser implements Serializable {
 
     public void setNeedToResetPassword(boolean needToResetPassword) {
         this.needToResetPassword = needToResetPassword;
+    }
+
+    public boolean isRestrictLoginByIp() {
+        return restrictLoginByIp;
+    }
+
+    public void setRestrictLoginByIp(boolean restrictLoginByIp) {
+        this.restrictLoginByIp = restrictLoginByIp;
+    }
+
+    public String getAllowedIpAddresses() {
+        return allowedIpAddresses;
+    }
+
+    public void setAllowedIpAddresses(String allowedIpAddresses) {
+        this.allowedIpAddresses = allowedIpAddresses;
+    }
+
+    public boolean isIpAllowed(String requestIp) {
+        if (!restrictLoginByIp) {
+            return true;
+        }
+        if (requestIp == null || allowedIpAddresses == null || allowedIpAddresses.trim().isEmpty()) {
+            return false;
+        }
+        for (String allowed : allowedIpAddresses.split(",")) {
+            if (allowed.trim().equalsIgnoreCase(requestIp.trim())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Institution getSite() {

--- a/src/main/webapp/admin/users/user.xhtml
+++ b/src/main/webapp/admin/users/user.xhtml
@@ -137,6 +137,22 @@
                             <p:selectBooleanCheckbox value="#{webUserController.current.activated}" >
                             </p:selectBooleanCheckbox>
 
+                            <p:outputLabel value="Restrict Login By IP" class=" m-1"></p:outputLabel>
+                            <p:outputLabel value=":" style="width: 20px;"/>
+                            <p:selectBooleanCheckbox value="#{webUserController.current.restrictLoginByIp}">
+                                <p:ajax update="allowedIpAddressesBlock" process="@this" />
+                            </p:selectBooleanCheckbox>
+
+                            <p:outputLabel value="Allowed IP Addresses " style="width: 100px;" for="allowedIpAddresses" />
+                            <p:outputLabel value=":" style="width: 20px;"/>
+                            <h:panelGroup id="allowedIpAddressesBlock">
+                                <p:inputText id="allowedIpAddresses"
+                                             value="#{webUserController.current.allowedIpAddresses}"
+                                             rendered="#{webUserController.current.restrictLoginByIp}"
+                                             title="Comma-separated IP addresses"
+                                             style="width: 300px;" />
+                            </h:panelGroup>
+
                         </h:panelGrid>
                     </p:panel>
                 </f:view>

--- a/src/main/webapp/admin/users/user.xhtml
+++ b/src/main/webapp/admin/users/user.xhtml
@@ -143,8 +143,8 @@
                                 <p:ajax update="allowedIpAddressesBlock" process="@this" />
                             </p:selectBooleanCheckbox>
 
-                            <p:outputLabel value="Allowed IP Addresses " style="width: 100px;" for="allowedIpAddresses" />
-                            <p:outputLabel value=":" style="width: 20px;"/>
+                            <p:outputLabel value="Allowed IP Addresses " style="width: 100px;" for="allowedIpAddresses" rendered="#{webUserController.current.restrictLoginByIp}" />
+                            <p:outputLabel value=":" style="width: 20px;" rendered="#{webUserController.current.restrictLoginByIp}"/>
                             <h:panelGroup id="allowedIpAddressesBlock">
                                 <p:inputText id="allowedIpAddresses"
                                              value="#{webUserController.current.allowedIpAddresses}"


### PR DESCRIPTION
## Summary
- Adds `restrictLoginByIp` (boolean) and `allowedIpAddresses` (comma-separated string) to `WebUser`, plus an `isIpAllowed(String)` helper that short-circuits (no-op) for the default case where the flag is off.
- Enforces the restriction in `SessionController.checkUsers()` and `checkUsersWithoutDepartment()` — the main JSF web login paths — rejecting login with a clear message when the requesting IP isn't in the user's allowed list.
- Adds a **Restrict Login By IP** checkbox and conditionally-shown **Allowed IP Addresses** field to the admin user edit page (`admin/users/user.xhtml`).

This lets a hospital confine specific users (e.g. cashiers) to logging in only from a known static IP, while every other user is completely unaffected (default `false`, zero extra cost at login).

Scope: only the main web login is gated, per discussion on the issue. API/webservice login paths (`loginForRequests`, `ChannelApi`, etc.) are explicitly out of scope for this issue.

Closes #21839

## Test plan
Verified end-to-end against a local deployment with Playwright + direct DB checks, using a non-critical existing test account (`Lawan`) to avoid disturbing the primary test login:

- [x] Admin UI renders the new checkbox + conditional IP field, and saving persists both fields to the DB.
- [x] With `restrictLoginByIp=1` and a deliberately wrong allowed IP, login is rejected with "Login not allowed from this IP address for this user." and no login-history row is created for the attempt.
- [x] After correcting the allowed IP to match the real request IP, login succeeds normally through department selection to the home page, and a new login-history row is created.
- [x] Regression check: an unrestricted user (`buddhika`) logs in with no behavior change.
- [x] Test account's restriction flag reset back to off afterward.

Screenshots and full write-up: issue comment https://github.com/hmislk/hmis/issues/21839#issuecomment-4881971454
User documentation: https://github.com/hmislk/hmis/wiki/Restrict-User-Login-By-IP-Address

**Outstanding**: DDL regeneration for the two new `webuser` columns is deferred to a manual `/generate-ddl` run (that skill is manual-invocation-only and temporarily disrupts the local deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Restrict Login By IP” setting for user accounts.
  * Added a configurable “Allowed IP Addresses” field (comma-separated) that appears when IP restriction is enabled.

* **Bug Fixes**
  * Login is now blocked when the current request IP is not included in the allowed list.
  * The IP restriction is enforced consistently during sign-in before the user session is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->