### PR TITLE
Improve UI guidelines for data-dense pages (scroll management, keyboard-first entry, lazy loading)

### DIFF
--- a/.claude/skills/ui-guidelines/SKILL.md
+++ b/.claude/skills/ui-guidelines/SKILL.md
@@ -77,3 +77,5 @@ When working on any UI/XHTML task, follow these rules and patterns.
 ## For complete reference
 
 Read [developer_docs/ui/comprehensive-ui-guidelines.md](../../developer_docs/ui/comprehensive-ui-guidelines.md) for the full UI handbook including responsive design, accessibility, datatables, dialogs, and more.
+
+For data-dense pages (large tables, many inputs, many buttons), also read [developer_docs/ui/data-dense-page-patterns.md](../../developer_docs/ui/data-dense-page-patterns.md) — sticky headers/action bars, keyboard-first entry (`p:defaultCommand`, `p:focus`), lazy loading, and busy indicators.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@
 
 ### When Working on UI/XHTML
 - [UI Development Handbook](developer_docs/ui/comprehensive-ui-guidelines.md) - Complete UI reference. **Authoring data-entry pages**: every actionable button needs a stable `id`; cap `p:autoComplete` with `maxResults`; guard the Enter key so it never clears/submits the form; make settle/issue/receive double-click-safe (JS `confirm()` + server-side re-entrancy guard). See § Accessibility-first development and § Data-entry components.
+- [Data-Dense Page Patterns](developer_docs/ui/data-dense-page-patterns.md) - **Required for pages with large tables / many inputs**: `stickyHeader` + `p-datatable-sm` on long tables, sticky action areas (`sticky-panel-header` / `sticky-action-bar`), `p:defaultCommand` + `p:focus` keyboard-first entry, lazy loading for large lists, button-clutter budget, busy indicators.
 - [Icon Management](developer_docs/ui/icon-management.md) - Standard icons and sizing
 
 ### When Testing with Playwright (E2E verification)

--- a/developer_docs/ui/comprehensive-ui-guidelines.md
+++ b/developer_docs/ui/comprehensive-ui-guidelines.md
@@ -53,8 +53,29 @@
 ---
 
 ## Layout, Typography, and Containers
-- Use **PrimeFaces components for interaction** (buttons, dialogs, tables) and **Bootstrap utilities for layout** (`row`, `col-*`, `d-flex`, spacing helpers).
+- Use **PrimeFaces components for interaction** (buttons, dialogs, tables) and **Bootstrap utilities for layout** (`row`, `col-*`, `d-flex`, spacing helpers). The full decision matrix is below — when in doubt: *if it does something, it's PrimeFaces; if it positions something, it's Bootstrap.*
 - Prefer `p:panelGrid` when you only need a grid with a header; only wrap in `p:panel` when you need facets or panel styling.
+
+### PrimeFaces vs Bootstrap — Decision Matrix
+
+Bootstrap 5.3 is loaded globally by the template, but it is a **layout toolkit only** in this project. Anything interactive or themed comes from PrimeFaces. Mixing the two for the same concern produces pages that look and behave differently module to module.
+
+| Concern | Use | Never use |
+|---|---|---|
+| Grid / columns / spacing / flex | Bootstrap `row`, `col-*`, `d-flex`, `gap-*`, `m*-*`/`p*-*`, `w-100`, `d-grid` | `p:panelGrid` for pure layout (renders a `<table>`) |
+| Buttons | `p:commandButton` / `p:button` + `ui-button-*` / `ui-button-stage-*` classes | Bootstrap `btn`, `btn-primary`, … |
+| Badges / status | `p:badge` with `severity` | Bootstrap `badge`, `bg-*` pills |
+| Tables of data | `p:dataTable` | Bootstrap `table`, `table-striped` (HTML tables only for print layouts) |
+| Form inputs | `p:inputText`, `p:selectOneMenu`, `p:autoComplete`, `p:datePicker` | Bootstrap `form-control` styling as a substitute for PF components |
+| Dialogs / overlays | `p:dialog`, `p:confirmDialog` (see Confirmation Dialogs), `p:tooltip` | Bootstrap modals, popovers, tooltips (JS conflicts with PrimeFaces) |
+| Tabs / accordions | `p:tabView`, `p:accordionPanel` | Bootstrap nav-tabs / collapse |
+| Alignment/emphasis utilities | Bootstrap `text-end`, `text-center`, `fw-bold`, `text-muted` | Custom inline CSS for the same effect |
+| Icons | PrimeFaces `pi`, then Font Awesome `fas` (see `icon-management.md`) | Bootstrap Icons (`bi-*`) in new code |
+
+Rules:
+- **Never attach Bootstrap component classes (`btn`, `badge`, `form-control`, `table`) to PrimeFaces components.** PF theming and Bootstrap component CSS fight each other; the result depends on load order.
+- Bootstrap **utility** classes (spacing, flex, text alignment, width) on PrimeFaces components are fine and encouraged — that is the sanctioned overlap.
+- Never initialize Bootstrap JavaScript components (modal, tooltip, dropdown) on a page — all interactive behaviour goes through PrimeFaces widgets.
 - Use `h:outputText` and `p:outputLabel` for **all text content** — headings, labels, messages, descriptions, static strings, and link labels. Never write bare text nodes directly inside JSF/PrimeFaces components. Attach Bootstrap utility classes for emphasis when needed.
 - Keep screens dense and business-focused; avoid marketing-style hero headers.
 
@@ -363,12 +384,13 @@ Rules:
 
 ### DataTable Compact Size (required for data-entry and multi-column tables)
 
-Always add `styleClass="p-datatable-sm"` to `p:dataTable` components on data-entry and transaction pages. This is the PrimeFaces 14 standard for compact row padding and keeps more rows visible without scrolling.
+Always add `styleClass="p-datatable-sm"` to `p:dataTable` components on data-entry and transaction pages. This is the PrimeFaces 14 standard for compact row padding and keeps more rows visible without scrolling. Any table that can grow beyond one screen also gets `stickyHeader="true"` — see [Data-Dense Page Patterns](data-dense-page-patterns.md) for the full scroll-management, lazy-loading, and action-reachability standards.
 
 ```xhtml
 <p:dataTable id="tbl"
              value="#{bean.items}"
              var="item"
+             stickyHeader="true"
              styleClass="p-datatable-sm">
 ```
 
@@ -462,7 +484,13 @@ the form reliably. The runtime counterpart is
 
 - **Never let Enter clear or wrongly submit the form.** A JSF form with no
   default command submits on Enter via the first command button, which on an
-  item-entry page silently wipes the in-progress bill. Guard it:
+  item-entry page silently wipes the in-progress bill. **First line of defence:
+  declare `<p:defaultCommand target="btnAdd"/>` pointing at the safe, repeatable
+  action** (Add on entry forms, Process/Search on filter forms — never
+  Settle/Finalize/Approve). See [Data-Dense Page Patterns § Keyboard-First Data
+  Entry](data-dense-page-patterns.md#3-keyboard-first-data-entry). Add the
+  per-field guards below only when individual fields need different Enter
+  behaviour:
   - On the item autocomplete, `onkeydown`: when the suggestion panel is open, let
     Enter select the highlighted item; otherwise `event.preventDefault()` so
     Enter does not submit.
@@ -484,6 +512,27 @@ the form reliably. The runtime counterpart is
   `settling` flag) so a rapid double-click cannot create duplicate bills/items.
   Do **not** rely on `this.disabled=true` in `onclick` — disabled fields are
   excluded from the POST, so the values they hold never reach the server.
+
+---
+
+## Validation and Feedback Patterns
+
+Consistent feedback stops users from double-clicking and re-submitting "silent" pages.
+
+### Messages: growl vs inline
+
+- **`p:growl` (template `id="growl"`) is for action outcomes**: saved, settled, failed-with-reason. Update it with `update="... :growl"` from every action button (see [AJAX guidelines](../jsf/ajax-update-guidelines.md) for the absolute-id rule).
+- **Inline `p:message for="fieldId"` is for field validation errors** — the error must appear next to the field the user has to fix, not only as a toast that disappears. On forms with server-side validation, place `p:message` beside each required input and a `p:messages showDetail="true"` at the top of the form for cross-field errors.
+- Never rely on growl alone for validation failures on long forms — the user cannot tell which of 20 fields is at fault.
+
+### Required fields
+
+- Mark required inputs with `required="true"` and `requiredMessage="..."` naming the field ("Quantity is required"), not the default cryptic message.
+- Visually indicate requiredness on the label (`p:outputLabel for="..."` renders the `*` automatically when the input is required).
+
+### Busy indicators
+
+Any action that can take longer than ~1 second must show progress — `p:ajaxStatus` (global) or `p:blockUI` (region). Patterns and code are in [Data-Dense Page Patterns § Feedback During Slow Operations](data-dense-page-patterns.md#6-feedback-during-slow-operations).
 
 ---
 
@@ -531,6 +580,7 @@ This applies to all entity-backed autocompletes: `Institution`, `Department`, `I
 ---
 
 ## Related Guides
+- `data-dense-page-patterns.md` – **scroll management, sticky action bars, keyboard-first entry, lazy loading, button-clutter budgets** for large-data pages.
 - `icon-management.md` – canonical icon library, terminology, and accessibility notes.
 - `page-break-implementation-guide.md` – printing guidance for token/bill flows.
 - Security and privilege patterns – see `developer_docs/security/privilege-system.md`.

--- a/developer_docs/ui/data-dense-page-patterns.md
+++ b/developer_docs/ui/data-dense-page-patterns.md
@@ -1,0 +1,261 @@
+# Data-Dense Page Patterns
+
+HMIS pages routinely show large datasets, many inputs, and many action buttons on one screen. End users work heads-down: they should be able to see the data, reach the actions, and enter rows **without scrolling back and forth**. This guide defines the standard patterns for achieving that. It complements the [UI Development Handbook](comprehensive-ui-guidelines.md) — read that first for page structure, button styling, and accessibility rules.
+
+Industry references these patterns align with: SAP Fiori (footer toolbar, dense responsive tables, keyboard shortcuts), IBM Carbon (sticky headers, condensed data tables), and PrimeFaces 14 DataTable documentation (sticky header, frozen columns, lazy loading).
+
+---
+
+## 1. Scroll Management for Tables
+
+The user must never lose the column headers or the row-identifying column while scrolling a large table.
+
+### Sticky header — default for every long table
+
+Add `stickyHeader="true"` to any `p:dataTable` that can grow beyond one screen. The header row stays pinned to the viewport top while the user scrolls.
+
+```xhtml
+<p:dataTable id="tblBillItem"
+             value="#{controller.items}"
+             var="item"
+             stickyHeader="true"
+             styleClass="p-datatable-sm">
+```
+
+Rules:
+- **Every data-entry and transaction table gets `stickyHeader="true"`.** There is no cost when the table is short.
+- Combine with `styleClass="p-datatable-sm"` (compact rows — mandatory per the handbook).
+- `stickyHeader` works on non-scrollable tables; do not add `scrollable="true"` just for this.
+
+### Fixed-height scroll region — when the page has content below the table
+
+When a table sits above other panels (e.g. bill items above payment details), give it its own scroll region so the content below stays reachable:
+
+```xhtml
+<p:dataTable ... scrollable="true" scrollHeight="400">
+```
+
+- Use a pixel `scrollHeight` (e.g. `400`) or a viewport-relative one (`scrollHeight="60vh"`).
+- Inside a scrollable table the header is automatically fixed — `stickyHeader` is not needed.
+
+### Frozen columns — wide tables only
+
+When a table needs horizontal scrolling (sum of column widths exceeds the container), freeze the identifying column(s) so rows stay recognizable:
+
+```xhtml
+<p:dataTable ... scrollable="true" scrollWidth="100%" frozenColumns="2">
+```
+
+- Freeze at most the row-index + item/name columns. Freezing more defeats the purpose.
+- Column `width` attributes are required for frozen layouts to compute correctly (see handbook § DataTable Compact Size for the width table).
+
+---
+
+## 2. Action Reachability — Sticky Action Areas
+
+**Rule: the page's primary actions (Save / Finalize / Approve / Settle / Add) must be reachable without scrolling, at any scroll position.**
+
+On long data-entry pages the three-zone panel header (with Save/Finalize/Approve) scrolls out of view as soon as the user works down the item list — then they scroll up to save, and scroll back down to continue. Two standard fixes, both backed by classes in `src/main/webapp/resources/css/ohmis.css`:
+
+### Option A — sticky panel header (preferred for pages using the three-zone header)
+
+Add `styleClass="sticky-panel-header"` to the main transaction `p:panel`. The panel's title bar — which contains the three-zone action layout — stays pinned to the viewport top while its content scrolls.
+
+```xhtml
+<p:panel styleClass="sticky-panel-header" rendered="...">
+    <f:facet name="header">
+        <!-- three-zone header with Save / Finalize / Approve -->
+    </f:facet>
+    <!-- long content -->
+</p:panel>
+```
+
+### Option B — sticky bottom action bar (for pages whose actions are below the form)
+
+Wrap the action buttons in a block `h:panelGroup` with `styleClass="sticky-action-bar"`. The bar pins to the bottom of the viewport until the user scrolls past its natural position.
+
+```xhtml
+<h:panelGroup layout="block" styleClass="sticky-action-bar d-flex gap-2 justify-content-end">
+    <p:commandButton id="btnCancel" value="Cancel" styleClass="ui-button-danger ui-button-outlined" .../>
+    <p:commandButton id="btnSettle" value="Settle" icon="pi pi-check-circle"
+                     styleClass="ui-button-stage-approve" style="min-width:120px" .../>
+</h:panelGroup>
+```
+
+Rules:
+- Pick **one** of the two per page — never both.
+- Button ordering inside a sticky bar follows the handbook rule: least important on the left, primary action rightmost.
+- The bar must contain **only buttons** (and a total/summary text at most). Inputs never go in a sticky bar.
+- Both classes degrade gracefully: if an ancestor container breaks `position: sticky`, the layout simply behaves as before.
+
+Reference implementation: `src/main/webapp/pharmacy/pharmacy_issue.xhtml` (sticky panel header + sticky table header).
+
+---
+
+## 3. Keyboard-First Data Entry
+
+Heads-down entry (pharmacy issue, GRN, billing) must be completable **without touching the mouse**: focus lands in the first field, Enter adds the row, focus returns for the next row.
+
+### `p:defaultCommand` — the standard for the Enter key
+
+`p:defaultCommand` declares which button the Enter key triggers within a form. This is the **canonical mechanism** — already used on 400+ pages — and is always preferred over per-field `onkeydown` JavaScript when the goal is simply "Enter = Add/Search":
+
+```xhtml
+<p:commandButton id="btnAdd" value="Add" action="#{controller.addBillItem}" ... />
+<p:defaultCommand target="btnAdd" />
+```
+
+Rules:
+- **Every data-entry form and every report-filter form gets a `p:defaultCommand`.** Without it, Enter submits via the first button in the form — on entry pages that silently wipes the in-progress bill (the failure mode described in the handbook § Data-entry components).
+- Point it at the *safe, repeatable* action: **Add** on item-entry forms, **Process/Search** on filter forms. Never point it at Settle/Finalize/Approve — irreversible actions must be a deliberate click (plus `confirm()`).
+- Only fall back to the `onkeydown`/`onkeyup` guard pattern (handbook § Data-entry components) when a single form needs *different* Enter behaviour per field (e.g. Enter in quantity commits the AJAX-bound value first). `p:defaultCommand` and the guard pattern can coexist: the guard suppresses Enter on specific fields; `defaultCommand` handles the rest.
+
+### `p:focus` — put the cursor where the work starts
+
+```xhtml
+<!-- Initial focus: first entry field on page load -->
+<p:focus id="focusItem" for="acStock" />
+```
+
+Rules:
+- Every data-entry page sets initial focus on the first input the user needs (usually the item autocomplete).
+- After an Add action, return focus to the first field by putting the relevant `p:focus` component id in the button's `update` list — that re-renders the focus component and re-applies it (see `pharmacy_issue.xhtml`: `btnAdd` updates `focusItem`).
+- After item selection, move focus forward to quantity the same way (`p:ajax event="itemSelect" update="... focusQty"`).
+
+### `accesskey` — shortcuts for the page's main actions
+
+Assign `accesskey` on the handful of buttons/fields a power user hits constantly. Project convention (from `pharmacy_issue.xhtml`):
+
+| Key | Action |
+|-----|--------|
+| `i` | Item / first entry field |
+| `q` | Quantity |
+| `a` | Add (row) |
+| `s` | Save draft |
+| `f` | Finalize |
+| `n` | New transaction |
+
+Keep these assignments consistent across modules — a pharmacist moving between issue/transfer/GRN pages should not relearn keys.
+
+### Tab order and field behaviour
+
+- Lay fields out in entry order (left→right, top→bottom) so the natural DOM tab order matches the workflow — do not use explicit `tabindex` values (they are unmaintainable across includes).
+- Read-only display fields (rates, computed values) must not trap tabbing: they are `readonly="true"`, which keeps them out of the way, and they should never sit *between* two fields the user types into.
+- On numeric fields add `onfocus="this.select();"` so tabbing in replaces the old value instead of appending.
+
+---
+
+## 4. Large Datasets — Lazy Loading and Pagination
+
+A page that loads thousands of rows into the DOM is the root cause of "the page is slow and scrolling is painful". Budget: **a table should render at most ~50–100 rows per request.**
+
+### Decision guide
+
+| Situation | Pattern |
+|---|---|
+| Transaction items being entered (10s of rows) | Plain table, `stickyHeader`, no paginator |
+| Search/list pages, report results (100s–1000s of rows) | `paginator="true" rows="25"` — and **lazy loading** when the full list is expensive |
+| Very large result sets (10,000+ rows), or lists users scan continuously | `LazyDataModel` + `virtualScroll="true" scrollRows="40"` |
+| Unbounded exports | Do not render in the browser — Excel export (`developer_docs/feature/excel-export-html-table.md`) |
+
+### Lazy loading with `LazyDataModel`
+
+A paginated table over a `List` still executes the full query and holds the whole list in the session bean; only rendering is paginated. For large tables bind a `org.primefaces.model.LazyDataModel` so **only the visible page is queried** (`load()` receives first/pageSize/sort/filter and issues a ranged JPQL query + a count query):
+
+```xhtml
+<p:dataTable value="#{controller.lazyBills}" var="b" lazy="true"
+             paginator="true" rows="25" stickyHeader="true"
+             styleClass="p-datatable-sm">
+```
+
+```java
+lazyBills = new LazyDataModel<Bill>() {
+    @Override
+    public int count(Map<String, FilterMeta> filterBy) {
+        return billFacade.countByJpql(countJpql, params).intValue();
+    }
+    @Override
+    public List<Bill> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
+        return billFacade.findByJpql(jpql, params, first, pageSize);
+    }
+};
+```
+
+Rules:
+- New search/list pages over unbounded tables (bills, patients, stock histories) should be lazy from day one.
+- Keep default `rows` at 25 (50 max). Offer `rowsPerPageTemplate="25,50,100"` rather than a big default.
+- Report pages that intentionally show a full day/period in one table must cap the range in the query (date filters are mandatory) and state the row count in the header.
+- Autocompletes are the same problem in miniature — `maxResults`, `minQueryLength`, `queryDelay` are mandatory per the handbook.
+
+---
+
+## 5. Reducing Button Clutter
+
+A page with 10+ visible buttons has no visual hierarchy — users scan longer and misclick more. Budget: **at most 5 always-visible buttons per action zone.**
+
+- **Primary + stage actions stay as buttons** (Save/Finalize/Approve, Add, Process, Print). These follow the three-stage classes and three-zone header layout in the handbook.
+- **Demote secondary/rare actions into a `p:splitButton`** — the common action is the button face, the variants live in the dropdown:
+
+```xhtml
+<p:splitButton id="btnPrint" value="Print" icon="pi pi-print" ajax="false"
+               action="#{controller.printA4()}" styleClass="ui-button-info">
+    <p:menuitem value="Print (Thermal)" icon="pi pi-print" action="#{controller.printPos()}" ajax="false"/>
+    <p:menuitem value="Export to Excel" icon="pi pi-file-excel" action="#{controller.exportExcel()}" ajax="false"/>
+</p:splitButton>
+```
+
+- **Group unrelated rare actions under a `p:menuButton`** labelled "More Actions" (e.g. reprint, audit trail, view log). Never bury a stage action (Save/Finalize/Approve) in a menu.
+- Row-level actions: maximum 3 icon buttons per row (each with the interpolated `title` required by the accessibility rules); further actions go in a row-level menu or the detail view.
+
+---
+
+## 6. Feedback During Slow Operations
+
+Users double-click and re-submit because nothing tells them the system is working. Every page with an action that can take >1 second needs a busy indicator.
+
+### Global AJAX indicator
+
+For AJAX actions, add one `p:ajaxStatus` per page (or rely on the template if present):
+
+```xhtml
+<p:ajaxStatus onstart="PF('statusDialog').show()" oncomplete="PF('statusDialog').hide()"/>
+<p:dialog widgetVar="statusDialog" modal="true" draggable="false" closable="false" resizable="false" showHeader="false">
+    <h:outputText value="Processing..." />
+</p:dialog>
+```
+
+### Blocking a region
+
+To block just a form/table during an AJAX action, pair the trigger with `p:blockUI`:
+
+```xhtml
+<p:commandButton id="btnProcess" value="Process" action="#{controller.process}" update="tblResults"/>
+<p:blockUI block="tblResults" trigger="btnProcess">
+    <h:outputText value="Loading..." />
+</p:blockUI>
+```
+
+### Non-AJAX submits
+
+`ajax="false"` buttons (report generation, downloads) cannot use `p:ajaxStatus`. Keep the `confirm()` + server-side re-entrancy guard from the handbook — and never `this.disabled=true` (breaks the POST; see [AJAX guidelines](../jsf/ajax-update-guidelines.md)).
+
+---
+
+## Checklist for a New Data-Dense Page
+
+- [ ] `stickyHeader="true"` + `styleClass="p-datatable-sm"` on every long table
+- [ ] Wide table? `scrollable` + `frozenColumns` on the identifying columns
+- [ ] Primary actions reachable at any scroll position (`sticky-panel-header` **or** `sticky-action-bar`)
+- [ ] `p:defaultCommand` targets the safe repeatable action; irreversible actions require a click + `confirm()`
+- [ ] `p:focus` on the first entry field; focus returned via `update` after Add
+- [ ] `accesskey` on the main entry/action controls, following the project key map
+- [ ] Large lists are lazy (`LazyDataModel`) or capped; default page size 25
+- [ ] ≤5 always-visible buttons per zone; secondary actions demoted to split/menu buttons
+- [ ] Busy indicator (`p:ajaxStatus` / `p:blockUI`) on actions that can take >1 s
+
+## Related Guides
+
+- [UI Development Handbook](comprehensive-ui-guidelines.md) — page structure, button standards, accessibility
+- [JSF AJAX Update Guidelines](../jsf/ajax-update-guidelines.md)
+- [PrimeFaces DataTable Selection](../jsf/primefaces-datatable-selection.md)
+- [Performance Optimization skill](../../.claude/skills/performance-optimization/SKILL.md)

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -70,7 +70,7 @@
                             </p:panel>
                         </h:panelGroup>
 
-                        <p:panel rendered="#{pharmacyIssueController.toDepartment ne null and pharmacyIssueController.toDepartment ne sessionController.loggedUser.department}">
+                        <p:panel styleClass="sticky-panel-header" rendered="#{pharmacyIssueController.toDepartment ne null and pharmacyIssueController.toDepartment ne sessionController.loggedUser.department}">
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between align-items-center w-100">
 
@@ -388,6 +388,8 @@
                                             var="bi"
                                             rowIndexVar="s"
                                             editable="true"
+                                            stickyHeader="true"
+                                            styleClass="p-datatable-sm"
                                             sortBy="#{bi.searialNo}" >
 
                                             <p:column headerText="Item" style="padding: 6px; width:300px;">

--- a/src/main/webapp/resources/css/ohmis.css
+++ b/src/main/webapp/resources/css/ohmis.css
@@ -898,6 +898,38 @@ th.align-right-header .ui-column-title {
 }
 
 
+/* ============================================================
+   Data-dense page patterns — sticky action areas
+   Standard classes for keeping page actions reachable while the
+   user scrolls long data-entry pages. Usage documented in
+   developer_docs/ui/data-dense-page-patterns.md:
+     .sticky-panel-header  → on the main transaction p:panel; keeps
+                             the three-zone header (Save/Finalize/
+                             Approve) pinned to the viewport top.
+     .sticky-action-bar    → on a block h:panelGroup wrapping the
+                             action buttons below a form; pins them
+                             to the viewport bottom.
+   Both degrade gracefully to normal flow if an ancestor container
+   prevents position:sticky from engaging.
+   ============================================================ */
+
+.sticky-panel-header > .ui-panel-titlebar {
+    position: sticky;
+    top: 0;
+    z-index: 900;
+}
+
+.sticky-action-bar {
+    position: sticky;
+    bottom: 0;
+    z-index: 900;
+    background-color: #ffffff;
+    border-top: 1px solid #dee2e6;
+    box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.08);
+    padding: 0.5rem 0.75rem;
+}
+
+
 /* Optimised menu item — subtle green tinge */
 a.ui-menuitem-link.menu-item-optimised,
 a.ui-menuitem-link.menu-item-optimised .ui-menuitem-text,


### PR DESCRIPTION
Closes #21850

## What this PR does

Improves the UI guidelines to address the project's core UX pain: data-dense pages where users struggle with scrolling and heads-down data entry. Based on a gap analysis of our docs vs actual codebase usage (3,860 XHTML pages) vs industry practice (SAP Fiori, IBM Carbon, PrimeFaces 14 docs, enterprise data-table UX research) — full analysis in #21850.

### New documentation
- **`developer_docs/ui/data-dense-page-patterns.md`** — the new standard for large-data pages:
  - Scroll management: `stickyHeader="true"` on every long table, `scrollHeight` regions, `frozenColumns` for wide tables (currently only 8/3,860 pages use any of these)
  - Action reachability: sticky panel header / sticky bottom action bar so Save/Finalize/Approve never scroll out of view
  - Keyboard-first entry: documents `p:defaultCommand` (already on 405 pages but previously undocumented) and `p:focus` (211 pages) as the standard, plus the project accesskey map
  - Large datasets: `LazyDataModel` / `virtualScroll` / pagination decision guide (only 3 pages currently use lazy loading)
  - Button-clutter budget: ≤5 visible buttons per zone, demotion to `p:splitButton`/`p:menuButton`
  - Busy indicators for slow operations

### Strengthened existing docs
- `comprehensive-ui-guidelines.md`: PrimeFaces-vs-Bootstrap decision matrix with an explicit forbidden list, new Validation & Feedback Patterns section, `p:defaultCommand` as first-line Enter handling, `stickyHeader` added to the dataTable standard.
- Linked from `CLAUDE.md` and the `ui-guidelines` skill.

### Code counterpart
- `ohmis.css`: new `.sticky-panel-header` and `.sticky-action-bar` classes (degrade gracefully to normal flow where `position:sticky` cannot engage).
- `pharmacy_issue.xhtml` retrofitted as the living reference implementation: sticky panel header + `stickyHeader` + `p-datatable-sm` on the bill-items table.

## Testing
- XHTML verified well-formed. Changes are JSF/CSS/docs only — no Java changes, no compilation required.
- The sticky CSS degrades gracefully; visual verification on local Payara recommended before wider rollout of the pattern to other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
