### PR TITLE
fix(pharmacy): F15 report adjustment values never reconciled (BillFinanceDetails never populated)

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/adjustment/BackfillRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/adjustment/BackfillRequestDTO.java
@@ -1,0 +1,17 @@
+package com.divudi.core.data.dto.adjustment;
+
+public class BackfillRequestDTO {
+    private Long departmentId;
+    private String fromDate;
+    private String toDate;
+    private boolean apply;
+
+    public Long getDepartmentId() { return departmentId; }
+    public void setDepartmentId(Long departmentId) { this.departmentId = departmentId; }
+    public String getFromDate() { return fromDate; }
+    public void setFromDate(String fromDate) { this.fromDate = fromDate; }
+    public String getToDate() { return toDate; }
+    public void setToDate(String toDate) { this.toDate = toDate; }
+    public boolean isApply() { return apply; }
+    public void setApply(boolean apply) { this.apply = apply; }
+}

--- a/src/main/java/com/divudi/core/data/dto/adjustment/BackfillResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/adjustment/BackfillResultDTO.java
@@ -1,0 +1,28 @@
+package com.divudi.core.data.dto.adjustment;
+
+public class BackfillResultDTO {
+    private Long billId;
+    private String billTypeAtomic;
+    private double computedNetTotal;
+    private double computedTotal;
+    private boolean applied;
+    private String note;
+
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+
+    public String getBillTypeAtomic() { return billTypeAtomic; }
+    public void setBillTypeAtomic(String billTypeAtomic) { this.billTypeAtomic = billTypeAtomic; }
+
+    public double getComputedNetTotal() { return computedNetTotal; }
+    public void setComputedNetTotal(double computedNetTotal) { this.computedNetTotal = computedNetTotal; }
+
+    public double getComputedTotal() { return computedTotal; }
+    public void setComputedTotal(double computedTotal) { this.computedTotal = computedTotal; }
+
+    public boolean isApplied() { return applied; }
+    public void setApplied(boolean applied) { this.applied = applied; }
+
+    public String getNote() { return note; }
+    public void setNote(String note) { this.note = note; }
+}

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -3065,6 +3065,16 @@ public class Bill implements Serializable, RetirableEntity {
         return billFinanceDetails;
     }
 
+    /**
+     * Null-check for billFinanceDetails that does NOT auto-vivify a new instance
+     * (unlike getBillFinanceDetails(), which lazily creates one on first call).
+     * Use this when the presence/absence of BillFinanceDetails is itself meaningful,
+     * e.g. as the fingerprint of "bill created before BFD population existed".
+     */
+    public boolean hasBillFinanceDetails() {
+        return billFinanceDetails != null;
+    }
+
     public void setBillFinanceDetails(BillFinanceDetails billFinanceDetails) {
         this.billFinanceDetails = billFinanceDetails;
         if (billFinanceDetails != null && billFinanceDetails.getBill() != this) {

--- a/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
+++ b/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
@@ -59,12 +59,14 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
             return calculateStockValueAtRetailRateOptimized(date, departmentId);
         }
         try {
-            String src     = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED") + " sh";
+            // See calculateStockValueAtRetailRateOptimized(Date, Long) for why sh.RETAILRATE
+            // must be preferred over the item batch's current rate.
+            String src     = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED, RETAILRATE") + " sh";
             String srcSmall = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, RETIRED, CREATEDAT") + " combined";
             String sql =
                 "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.retail_rate), 0.0) AS total_value " +
                 "FROM ( " +
-                "    SELECT sh.STOCKQTY, COALESCE(ib.RETAILSALERATE, 0.0) AS retail_rate " +
+                "    SELECT sh.STOCKQTY, COALESCE(NULLIF(sh.RETAILRATE, 0), ib.RETAILSALERATE, 0.0) AS retail_rate " +
                 "    FROM " + src + " " +
                 "    INNER JOIN ( " +
                 "        SELECT DEPARTMENT_ID, ITEMBATCH_ID, MAX(ID) AS max_id " +
@@ -98,12 +100,20 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
             // Use native SQL for better performance
             // This query finds the latest stock history record for each item batch before the given date
             // and calculates the total retail value
+            // Prefer the retail rate snapshot recorded on the StockHistory row itself
+            // (sh.RETAILRATE, written by PharmacyBean.addToStockHistory at the time of
+            // that stock movement) over the item batch's CURRENT retail rate. Without this,
+            // a mid-period PHARMACY_RETAIL_RATE_ADJUSTMENT is invisible to this calculation
+            // (both "opening" and "closing" would use the same current rate), which double-
+            // counts the adjustment bill's own delta when the F15 report reconciles
+            // Opening + Sales + Purchases + Transfers + Adjustments = Closing. This mirrors
+            // the already-correct pattern in calculateStockValueAtPurchaseRateOptimized.
             String sql =
                 "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.retail_rate), 0.0) AS total_value " +
                 "FROM ( " +
                 "    SELECT  " +
                 "        sh.STOCKQTY, " +
-                "        COALESCE(ib.RETAILSALERATE, 0.0) AS retail_rate " +
+                "        COALESCE(NULLIF(sh.RETAILRATE, 0), ib.RETAILSALERATE, 0.0) AS retail_rate " +
                 "    FROM STOCKHISTORY sh " +
                 "    INNER JOIN ( " +
                 "        SELECT  " +
@@ -237,13 +247,16 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
             return calculateStockValueAtCostRateOptimized(date, departmentId);
         }
         try {
-            String src      = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED") + " sh";
+            // See calculateStockValueAtCostRateOptimized(Date, Long) for why sh.COSTRATE
+            // must be preferred over the item batch's current rate.
+            String src      = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, STOCKQTY, RETIRED, COSTRATE") + " sh";
             String srcSmall = shUnionSrc("ID, DEPARTMENT_ID, ITEMBATCH_ID, RETIRED, CREATEDAT") + " combined";
             String sql =
                 "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.cost_rate), 0.0) AS total_value " +
                 "FROM ( " +
                 "    SELECT sh.STOCKQTY, " +
-                "        CASE WHEN ib.COSTRATE IS NOT NULL AND ib.COSTRATE != 0 THEN ib.COSTRATE " +
+                "        CASE WHEN sh.COSTRATE IS NOT NULL AND sh.COSTRATE != 0 THEN sh.COSTRATE " +
+                "             WHEN ib.COSTRATE IS NOT NULL AND ib.COSTRATE != 0 THEN ib.COSTRATE " +
                 "             WHEN ib.PURCAHSERATE IS NOT NULL AND ib.PURCAHSERATE != 0 THEN ib.PURCAHSERATE " +
                 "             ELSE 0.0 END AS cost_rate " +
                 "    FROM " + src + " " +
@@ -277,13 +290,16 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
         try {
             // Use native SQL for better performance
             // This query finds the latest stock history record for each item batch before the given date
-            // and calculates the total cost value using the cost rate fallback logic
+            // and calculates the total cost value using the cost rate fallback logic.
+            // Prefer sh.COSTRATE (the snapshot recorded at that stock movement) over the item
+            // batch's CURRENT cost rate - see calculateStockValueAtRetailRateOptimized for why.
             String sql =
                 "SELECT COALESCE(SUM(latest_stock.STOCKQTY * latest_stock.cost_rate), 0.0) AS total_value " +
                 "FROM ( " +
                 "    SELECT  " +
                 "        sh.STOCKQTY, " +
                 "        CASE " +
+                "            WHEN sh.COSTRATE IS NOT NULL AND sh.COSTRATE != 0 THEN sh.COSTRATE " +
                 "            WHEN ib.COSTRATE IS NOT NULL AND ib.COSTRATE != 0 THEN ib.COSTRATE " +
                 "            WHEN ib.PURCAHSERATE IS NOT NULL AND ib.PURCAHSERATE != 0 THEN ib.PURCAHSERATE " +
                 "            ELSE 0.0 " +

--- a/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
+++ b/src/main/java/com/divudi/core/facade/StockHistoryFacade.java
@@ -38,6 +38,24 @@ public class StockHistoryFacade extends AbstractFacade<StockHistory> {
     }
 
     /**
+     * Finds the StockHistory row written at the time of a given stock movement
+     * (e.g. a stock-quantity adjustment), so its cost/purchase/retail rate
+     * snapshot - captured by PharmacyBean.addToStockHistory at that exact
+     * moment - can be used instead of the item batch's CURRENT rate, which may
+     * have since changed via a later rate adjustment.
+     */
+    public StockHistory findByPharmaceuticalBillItem(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem pbItem) {
+        if (pbItem == null || pbItem.getId() == null) {
+            return null;
+        }
+        String jpql = "select sh from StockHistory sh where sh.pbItem=:pbItem order by sh.id desc";
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("pbItem", pbItem);
+        List<StockHistory> results = findByJpql(jpql, params);
+        return (results == null || results.isEmpty()) ? null : results.get(0);
+    }
+
+    /**
      * Calculates the stock value at retail rate for a given date and department.
      * This method uses a simplified native SQL query for better performance.
      *

--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -724,6 +724,7 @@ public class PharmacyService {
                 BillTypeAtomic.PHARMACY_WHOLESALE_RATE_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT_BILL,
+                BillTypeAtomic.PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT,
                 BillTypeAtomic.PHARMACY_ADJUSTMENT,
                 BillTypeAtomic.PHARMACY_ADJUSTMENT_CANCELLED
         );

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -4978,7 +4978,8 @@ public class AnthropicApiService implements Serializable {
                     {"POST", "/pharmacy_adjustments/stock_quantity", "Adjust quantity of a stock batch"},
                     {"POST", "/pharmacy_adjustments/retail_rate",    "Adjust retail sale rate of a stock batch"},
                     {"POST", "/pharmacy_adjustments/purchase_rate",  "Adjust purchase rate of a stock batch"},
-                    {"POST", "/pharmacy_adjustments/expiry_date",    "Adjust expiry date of a stock batch"}
+                    {"POST", "/pharmacy_adjustments/expiry_date",    "Adjust expiry date of a stock batch"},
+                    {"POST", "/pharmacy_adjustments/backfill_finance_details", "Admin-only: backfill BillFinanceDetails for pre-fix adjustment bills (dry-run by default)"}
                 });
 
         appendModule(sb, "Pharmacy - Search", "/pharmacy_adjustments/search",

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -266,6 +266,9 @@ public class PharmacyAdjustmentApiService implements Serializable {
         double deltaCostValue = 0.0;
         double deltaPurchaseValue = 0.0;
         double deltaQty = 0.0;
+        double totalBeforeValue = 0.0;
+        double totalAfterValue = 0.0;
+        boolean costValueApproximatedFromCurrentRate = false;
 
         for (BillItem item : bill.getBillItems()) {
             PharmaceuticalBillItem ph = item.getPharmaceuticalBillItem();
@@ -280,18 +283,32 @@ public class PharmacyAdjustmentApiService implements Serializable {
                 // captured at adjustment time.
                 double qtyDelta = after - before;
                 deltaRetailValue += qtyDelta * item.getNetRate();
+                // NOTE: no historical cost-rate snapshot exists on PharmaceuticalBillItem for
+                // this bill type (costRate is never set by the adjustment-creation code), so
+                // we fall back to the item batch's CURRENT cost/purchase rate. This is an
+                // approximation, not the rate in effect at the time of the original adjustment.
+                // Disclosed to the caller via result.note below.
                 Double costRateObj = ph.getItemBatch() != null ? ph.getItemBatch().getCostRate() : null;
                 double costRate = costRateObj != null ? costRateObj
                         : (ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate());
                 deltaCostValue += qtyDelta * costRate;
                 deltaQty += Math.abs(qtyDelta);
+                costValueApproximatedFromCurrentRate = true;
+                // before/after are quantities here; convert to values using the retail rate
+                // captured at adjustment time (item.getNetRate()), matching createStockAdjustmentBillItem.
+                totalBeforeValue += before * item.getNetRate();
+                totalAfterValue += after * item.getNetRate();
             } else if (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_RETAIL_RATE_ADJUSTMENT) {
                 // before/after are total values (qty * rate) already, per createRetailRateAdjustmentBillItem
                 deltaRetailValue += (after - before);
                 deltaQty += item.getQty();
+                totalBeforeValue += before;
+                totalAfterValue += after;
             } else if (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_PURCHASE_RATE_ADJUSTMENT) {
                 deltaPurchaseValue += (after - before);
                 deltaQty += item.getQty();
+                totalBeforeValue += before;
+                totalAfterValue += after;
             }
         }
 
@@ -313,6 +330,8 @@ public class PharmacyAdjustmentApiService implements Serializable {
         bfd.setGrossTotal(BigDecimal.valueOf(Math.abs(netTotal)));
         bfd.setNetTotal(BigDecimal.valueOf(netTotal));
         bfd.setTotalQuantity(BigDecimal.valueOf(deltaQty));
+        bfd.setTotalBeforeAdjustmentValue(BigDecimal.valueOf(totalBeforeValue));
+        bfd.setTotalAfterAdjustmentValue(BigDecimal.valueOf(totalAfterValue));
         bill.setBillFinanceDetails(bfd);
         bill.setTotal(Math.abs(netTotal));
         bill.setNetTotal(netTotal);
@@ -320,7 +339,12 @@ public class PharmacyAdjustmentApiService implements Serializable {
         billFacade.edit(bill);
 
         result.setApplied(true);
-        result.setNote("Backfilled from stored before/after audit values");
+        String note = "Backfilled from stored before/after audit values";
+        if (costValueApproximatedFromCurrentRate) {
+            note += ". Cost value approximated using current item batch cost rate "
+                    + "(no historical cost-rate snapshot exists for this bill type)";
+        }
+        result.setNote(note);
         return result;
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -11,6 +11,7 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.dto.adjustment.*;
 import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.WebUser;
@@ -31,6 +32,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -439,12 +441,19 @@ public class PharmacyAdjustmentApiService implements Serializable {
 
     private PharmaceuticalBillItem createStockAdjustmentBillItem(Bill bill, Stock stock, double quantityChange,
                                                                double beforeQty, double afterQty, WebUser user) {
+        double retailsaleRate = stock.getItemBatch().getRetailsaleRate();
+        Double costRateObj = stock.getItemBatch().getCostRate();
+        double costRate = (costRateObj != null) ? costRateObj : stock.getItemBatch().getPurcahseRate();
+
+        double deltaRetailValue = quantityChange * retailsaleRate;
+        double deltaCostValue = quantityChange * costRate;
+
         BillItem billItem = new BillItem();
         billItem.setItem(stock.getItemBatch().getItem());
         billItem.setQty(quantityChange);
-        billItem.setGrossValue(stock.getItemBatch().getRetailsaleRate() * afterQty);
-        billItem.setNetRate(stock.getItemBatch().getRetailsaleRate());
-        billItem.setNetValue(afterQty * billItem.getNetRate());
+        billItem.setGrossValue(Math.abs(deltaRetailValue));
+        billItem.setNetRate(retailsaleRate);
+        billItem.setNetValue(deltaRetailValue);
         billItem.setDiscount(billItem.getGrossValue() - billItem.getNetValue());
         billItem.setInwardChargeType(InwardChargeType.Medicine);
         billItem.setBill(bill);
@@ -465,6 +474,28 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setBillItem(billItem);
 
         billItemFacade.create(billItem);
+
+        // Populate BillFinanceDetails + bill totals so the F15 report's Adjustment
+        // Transactions section reconciles Opening + ... + Adjustments = Closing.
+        BillFinanceDetails bfd = bill.getBillFinanceDetails();
+        if (bfd == null) {
+            bfd = new BillFinanceDetails(bill);
+            bill.setBillFinanceDetails(bfd);
+        }
+        bfd.setTotalRetailSaleValue(BigDecimal.valueOf(deltaRetailValue));
+        bfd.setTotalCostValue(BigDecimal.valueOf(deltaCostValue));
+        bfd.setGrossTotal(BigDecimal.valueOf(Math.abs(deltaRetailValue)));
+        bfd.setNetTotal(BigDecimal.valueOf(deltaRetailValue));
+        bfd.setTotalQuantity(BigDecimal.valueOf(Math.abs(quantityChange)));
+        bfd.setTotalBeforeAdjustmentValue(BigDecimal.valueOf(beforeQty * retailsaleRate));
+        bfd.setTotalAfterAdjustmentValue(BigDecimal.valueOf(afterQty * retailsaleRate));
+        bfd.setTotalPurchaseValue(BigDecimal.ZERO);
+        bfd.setTotalWholesaleValue(BigDecimal.ZERO);
+
+        bill.setTotal(Math.abs(deltaRetailValue));
+        bill.setNetTotal(deltaRetailValue);
+        billFacade.edit(bill);
+
         return pharmaceuticalBillItem;
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -292,6 +292,10 @@ public class PharmacyAdjustmentApiService implements Serializable {
                 double costRate = costRateObj != null ? costRateObj
                         : (ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate());
                 deltaCostValue += qtyDelta * costRate;
+                // Same approximation caveat as cost: no historical purchase-rate snapshot
+                // exists for this bill type, so fall back to the item batch's current rate.
+                double purchaseRate = ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate();
+                deltaPurchaseValue += qtyDelta * purchaseRate;
                 deltaQty += Math.abs(qtyDelta);
                 costValueApproximatedFromCurrentRate = true;
                 // before/after are quantities here; convert to values using the retail rate
@@ -312,15 +316,22 @@ public class PharmacyAdjustmentApiService implements Serializable {
             }
         }
 
-        double netTotal = deltaRetailValue + deltaPurchaseValue;
+        // Purchase-rate-adjustment bills carry their value in deltaPurchaseValue only;
+        // stock-quantity and retail-rate adjustments carry it in deltaRetailValue. A
+        // stock-quantity bill now also populates deltaPurchaseValue (see above) so the
+        // BFD's totalPurchaseValue reconciles, but that must not double-count into the
+        // bill's own total/netTotal - only one dimension is ever the bill's "primary" value.
+        double netTotal = (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_PURCHASE_RATE_ADJUSTMENT)
+                ? deltaPurchaseValue
+                : deltaRetailValue;
         result.setComputedNetTotal(netTotal);
         result.setComputedTotal(Math.abs(netTotal));
 
         // Build disclosure text (applies to both dry-run and apply paths)
         String disclosureSuffix = "";
         if (costValueApproximatedFromCurrentRate) {
-            disclosureSuffix = ". Cost value approximated using current item batch cost rate "
-                    + "(no historical cost-rate snapshot exists for this bill type)";
+            disclosureSuffix = ". Cost and purchase values approximated using current item batch rates "
+                    + "(no historical rate snapshot exists for this bill type)";
         }
 
         if (!apply) {
@@ -375,7 +386,16 @@ public class PharmacyAdjustmentApiService implements Serializable {
         params.put("to", toDate);
         params.put("ret", false);
 
-        java.util.List<Bill> bills = billFacade.findByJpql(jpql, params);
+        // Bill.createdAt is @Temporal(TIMESTAMP). The 2-arg findByJpql(jpql, params)
+        // overload binds every Date parameter as TemporalType.DATE, which silently
+        // truncates the time-of-day - toDate's end-of-day precision (23:59:59.999)
+        // would be dropped and the query would compare against midnight instead,
+        // silently excluding same-day bills. Bind from/to explicitly as TIMESTAMP.
+        java.util.Map<String, javax.persistence.TemporalType> temporalTypes = new java.util.HashMap<>();
+        temporalTypes.put("from", javax.persistence.TemporalType.TIMESTAMP);
+        temporalTypes.put("to", javax.persistence.TemporalType.TIMESTAMP);
+
+        java.util.List<Bill> bills = billFacade.findByJpql(jpql, params, temporalTypes);
 
         java.util.List<BackfillResultDTO> results = new java.util.ArrayList<>();
         for (Bill bill : bills) {
@@ -615,9 +635,11 @@ public class PharmacyAdjustmentApiService implements Serializable {
         double retailsaleRate = stock.getItemBatch().getRetailsaleRate();
         Double costRateObj = stock.getItemBatch().getCostRate();
         double costRate = (costRateObj != null) ? costRateObj : stock.getItemBatch().getPurcahseRate();
+        double purchaseRate = stock.getItemBatch().getPurcahseRate();
 
         double deltaRetailValue = quantityChange * retailsaleRate;
         double deltaCostValue = quantityChange * costRate;
+        double deltaPurchaseValue = quantityChange * purchaseRate;
 
         BillItem billItem = new BillItem();
         billItem.setItem(stock.getItemBatch().getItem());
@@ -660,7 +682,9 @@ public class PharmacyAdjustmentApiService implements Serializable {
         bfd.setTotalQuantity(BigDecimal.valueOf(Math.abs(quantityChange)));
         bfd.setTotalBeforeAdjustmentValue(BigDecimal.valueOf(beforeQty * retailsaleRate));
         bfd.setTotalAfterAdjustmentValue(BigDecimal.valueOf(afterQty * retailsaleRate));
-        bfd.setTotalPurchaseValue(BigDecimal.ZERO);
+        // A quantity change moves stock value at cost, purchase, AND retail rates
+        // simultaneously - populate all three so each F15 report column reconciles.
+        bfd.setTotalPurchaseValue(BigDecimal.valueOf(deltaPurchaseValue));
         bfd.setTotalWholesaleValue(BigDecimal.ZERO);
 
         bill.setTotal(Math.abs(deltaRetailValue));

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -597,8 +597,8 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setItemBatch(stock.getItemBatch());
         pharmaceuticalBillItem.setQty(stock.getStock());
         pharmaceuticalBillItem.setPurchaseRate(oldPurchaseRate);
-        pharmaceuticalBillItem.setLastPurchaseRate(newPurchaseRate); // Store new rate
-        pharmaceuticalBillItem.setFreeQty((float) rateChange); // Store rate change
+        pharmaceuticalBillItem.setLastPurchaseRate(newPurchaseRate);
+        pharmaceuticalBillItem.setFreeQty((float) rateChange);
         pharmaceuticalBillItem.setBeforeAdjustmentValue(stock.getStock() * oldPurchaseRate);
         pharmaceuticalBillItem.setAfterAdjustmentValue(stock.getStock() * newPurchaseRate);
 
@@ -606,6 +606,26 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setBillItem(billItem);
 
         billItemFacade.create(billItem);
+
+        BillFinanceDetails bfd = bill.getBillFinanceDetails();
+        if (bfd == null) {
+            bfd = new BillFinanceDetails(bill);
+            bill.setBillFinanceDetails(bfd);
+        }
+        bfd.setTotalPurchaseValue(BigDecimal.valueOf(changeValue));
+        bfd.setGrossTotal(BigDecimal.valueOf(Math.abs(changeValue)));
+        bfd.setNetTotal(BigDecimal.valueOf(changeValue));
+        bfd.setTotalQuantity(BigDecimal.valueOf(stock.getStock()));
+        bfd.setTotalBeforeAdjustmentValue(BigDecimal.valueOf(stock.getStock() * oldPurchaseRate));
+        bfd.setTotalAfterAdjustmentValue(BigDecimal.valueOf(stock.getStock() * newPurchaseRate));
+        bfd.setTotalCostValue(BigDecimal.ZERO);
+        bfd.setTotalRetailSaleValue(BigDecimal.ZERO);
+        bfd.setTotalWholesaleValue(BigDecimal.ZERO);
+
+        bill.setTotal(Math.abs(changeValue));
+        bill.setNetTotal(changeValue);
+        billFacade.edit(bill);
+
         return pharmaceuticalBillItem;
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -518,8 +518,8 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setItemBatch(stock.getItemBatch());
         pharmaceuticalBillItem.setQty(stock.getStock());
         pharmaceuticalBillItem.setRetailRate(oldRetailRate);
-        pharmaceuticalBillItem.setLastPurchaseRate(newRetailRate); // Store new rate in this field
-        pharmaceuticalBillItem.setFreeQty((float) rateChange); // Store rate change in this field
+        pharmaceuticalBillItem.setLastPurchaseRate(newRetailRate);
+        pharmaceuticalBillItem.setFreeQty((float) rateChange);
         pharmaceuticalBillItem.setBeforeAdjustmentValue(stock.getStock() * oldRetailRate);
         pharmaceuticalBillItem.setAfterAdjustmentValue(stock.getStock() * newRetailRate);
 
@@ -527,6 +527,26 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setBillItem(billItem);
 
         billItemFacade.create(billItem);
+
+        BillFinanceDetails bfd = bill.getBillFinanceDetails();
+        if (bfd == null) {
+            bfd = new BillFinanceDetails(bill);
+            bill.setBillFinanceDetails(bfd);
+        }
+        bfd.setTotalRetailSaleValue(BigDecimal.valueOf(changeValue));
+        bfd.setGrossTotal(BigDecimal.valueOf(Math.abs(changeValue)));
+        bfd.setNetTotal(BigDecimal.valueOf(changeValue));
+        bfd.setTotalQuantity(BigDecimal.valueOf(stock.getStock()));
+        bfd.setTotalBeforeAdjustmentValue(BigDecimal.valueOf(stock.getStock() * oldRetailRate));
+        bfd.setTotalAfterAdjustmentValue(BigDecimal.valueOf(stock.getStock() * newRetailRate));
+        bfd.setTotalCostValue(BigDecimal.ZERO);
+        bfd.setTotalPurchaseValue(BigDecimal.ZERO);
+        bfd.setTotalWholesaleValue(BigDecimal.ZERO);
+
+        bill.setTotal(Math.abs(changeValue));
+        bill.setNetTotal(changeValue);
+        billFacade.edit(bill);
+
         return pharmaceuticalBillItem;
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -554,7 +554,7 @@ public class PharmacyAdjustmentApiService implements Serializable {
                                                                     Date newExpiryDate, WebUser user) {
         BillItem billItem = new BillItem();
         billItem.setItem(stock.getItemBatch().getItem());
-        billItem.setQty(0.0); // No quantity change for expiry adjustment
+        billItem.setQty(0.0);
         billItem.setGrossValue(0.0);
         billItem.setNetValue(0.0);
         billItem.setInwardChargeType(InwardChargeType.Medicine);
@@ -575,6 +575,26 @@ public class PharmacyAdjustmentApiService implements Serializable {
         pharmaceuticalBillItem.setBillItem(billItem);
 
         billItemFacade.create(billItem);
+
+        BillFinanceDetails bfd = bill.getBillFinanceDetails();
+        if (bfd == null) {
+            bfd = new BillFinanceDetails(bill);
+            bill.setBillFinanceDetails(bfd);
+        }
+        bfd.setTotalRetailSaleValue(BigDecimal.ZERO);
+        bfd.setTotalCostValue(BigDecimal.ZERO);
+        bfd.setTotalPurchaseValue(BigDecimal.ZERO);
+        bfd.setTotalWholesaleValue(BigDecimal.ZERO);
+        bfd.setGrossTotal(BigDecimal.ZERO);
+        bfd.setNetTotal(BigDecimal.ZERO);
+        bfd.setTotalQuantity(BigDecimal.ZERO);
+        bfd.setTotalBeforeAdjustmentValue(BigDecimal.ZERO);
+        bfd.setTotalAfterAdjustmentValue(BigDecimal.ZERO);
+
+        bill.setTotal(0.0);
+        bill.setNetTotal(0.0);
+        billFacade.edit(bill);
+
         return pharmaceuticalBillItem;
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -64,6 +64,9 @@ public class PharmacyAdjustmentApiService implements Serializable {
     private DepartmentFacade departmentFacade;
 
     @EJB
+    private com.divudi.core.facade.StockHistoryFacade stockHistoryFacade;
+
+    @EJB
     private PharmacyBean pharmacyBean;
 
     @EJB
@@ -283,21 +286,40 @@ public class PharmacyAdjustmentApiService implements Serializable {
                 // captured at adjustment time.
                 double qtyDelta = after - before;
                 deltaRetailValue += qtyDelta * item.getNetRate();
-                // NOTE: no historical cost-rate snapshot exists on PharmaceuticalBillItem for
-                // this bill type (costRate is never set by the adjustment-creation code), so
-                // we fall back to the item batch's CURRENT cost/purchase rate. This is an
-                // approximation, not the rate in effect at the time of the original adjustment.
-                // Disclosed to the caller via result.note below.
-                Double costRateObj = ph.getItemBatch() != null ? ph.getItemBatch().getCostRate() : null;
-                double costRate = costRateObj != null ? costRateObj
-                        : (ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate());
+                // PharmacyBean.addToStockHistory records a cost/purchase rate snapshot on the
+                // StockHistory row it writes at the exact time of this adjustment (same row
+                // resetStock() creates). Prefer that historical snapshot over the item batch's
+                // CURRENT rate, which may have since changed via a later rate adjustment -
+                // using the current rate for a bill from days/weeks ago silently produces a
+                // wrong delta if the rate has moved since. Fall back to current rate only when
+                // no snapshot exists at all (disclosed to the caller via result.note below).
+                com.divudi.core.entity.pharmacy.StockHistory historicalSnapshot =
+                        stockHistoryFacade.findByPharmaceuticalBillItem(ph);
+
+                Double historicalCostRate = (historicalSnapshot != null && historicalSnapshot.getCostRate() != 0.0)
+                        ? historicalSnapshot.getCostRate() : null;
+                double costRate;
+                if (historicalCostRate != null) {
+                    costRate = historicalCostRate;
+                } else {
+                    Double costRateObj = ph.getItemBatch() != null ? ph.getItemBatch().getCostRate() : null;
+                    costRate = costRateObj != null ? costRateObj
+                            : (ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate());
+                    costValueApproximatedFromCurrentRate = true;
+                }
                 deltaCostValue += qtyDelta * costRate;
-                // Same approximation caveat as cost: no historical purchase-rate snapshot
-                // exists for this bill type, so fall back to the item batch's current rate.
-                double purchaseRate = ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate();
+
+                Double historicalPurchaseRate = (historicalSnapshot != null && historicalSnapshot.getPurchaseRate() != 0.0)
+                        ? historicalSnapshot.getPurchaseRate() : null;
+                double purchaseRate;
+                if (historicalPurchaseRate != null) {
+                    purchaseRate = historicalPurchaseRate;
+                } else {
+                    purchaseRate = ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate();
+                    costValueApproximatedFromCurrentRate = true;
+                }
                 deltaPurchaseValue += qtyDelta * purchaseRate;
                 deltaQty += Math.abs(qtyDelta);
-                costValueApproximatedFromCurrentRate = true;
                 // before/after are quantities here; convert to values using the retail rate
                 // captured at adjustment time (item.getNetRate()), matching createStockAdjustmentBillItem.
                 totalBeforeValue += before * item.getNetRate();

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -244,6 +244,131 @@ public class PharmacyAdjustmentApiService implements Serializable {
         return response;
     }
 
+    /**
+     * Recomputes BillFinanceDetails + bill totals for a single pre-fix adjustment
+     * bill, using the before/after audit values already stored on its bill items.
+     * Skips (no-op) any bill that already has BillFinanceDetails, so this is safe
+     * to re-run over the same set of bills repeatedly.
+     */
+    @Transactional
+    public BackfillResultDTO backfillFinanceDetails(Bill bill, boolean apply) {
+        BackfillResultDTO result = new BackfillResultDTO();
+        result.setBillId(bill.getId());
+        result.setBillTypeAtomic(bill.getBillTypeAtomic() != null ? bill.getBillTypeAtomic().name() : null);
+
+        if (bill.hasBillFinanceDetails()) {
+            result.setApplied(false);
+            result.setNote("Skipped: BillFinanceDetails already present");
+            return result;
+        }
+
+        double deltaRetailValue = 0.0;
+        double deltaCostValue = 0.0;
+        double deltaPurchaseValue = 0.0;
+        double deltaQty = 0.0;
+
+        for (BillItem item : bill.getBillItems()) {
+            PharmaceuticalBillItem ph = item.getPharmaceuticalBillItem();
+            if (ph == null) {
+                continue;
+            }
+            double before = ph.getBeforeAdjustmentValue();
+            double after = ph.getAfterAdjustmentValue();
+
+            if (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT) {
+                // before/after are quantities; item.getNetRate() is the retail rate
+                // captured at adjustment time.
+                double qtyDelta = after - before;
+                deltaRetailValue += qtyDelta * item.getNetRate();
+                Double costRateObj = ph.getItemBatch() != null ? ph.getItemBatch().getCostRate() : null;
+                double costRate = costRateObj != null ? costRateObj
+                        : (ph.getItemBatch() != null ? ph.getItemBatch().getPurcahseRate() : item.getNetRate());
+                deltaCostValue += qtyDelta * costRate;
+                deltaQty += Math.abs(qtyDelta);
+            } else if (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_RETAIL_RATE_ADJUSTMENT) {
+                // before/after are total values (qty * rate) already, per createRetailRateAdjustmentBillItem
+                deltaRetailValue += (after - before);
+                deltaQty += item.getQty();
+            } else if (bill.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_PURCHASE_RATE_ADJUSTMENT) {
+                deltaPurchaseValue += (after - before);
+                deltaQty += item.getQty();
+            }
+        }
+
+        double netTotal = deltaRetailValue + deltaPurchaseValue;
+        result.setComputedNetTotal(netTotal);
+        result.setComputedTotal(Math.abs(netTotal));
+
+        if (!apply) {
+            result.setApplied(false);
+            result.setNote("Dry run: not persisted");
+            return result;
+        }
+
+        BillFinanceDetails bfd = new BillFinanceDetails(bill);
+        bfd.setTotalRetailSaleValue(BigDecimal.valueOf(deltaRetailValue));
+        bfd.setTotalCostValue(BigDecimal.valueOf(deltaCostValue));
+        bfd.setTotalPurchaseValue(BigDecimal.valueOf(deltaPurchaseValue));
+        bfd.setTotalWholesaleValue(BigDecimal.ZERO);
+        bfd.setGrossTotal(BigDecimal.valueOf(Math.abs(netTotal)));
+        bfd.setNetTotal(BigDecimal.valueOf(netTotal));
+        bfd.setTotalQuantity(BigDecimal.valueOf(deltaQty));
+        bill.setBillFinanceDetails(bfd);
+        bill.setTotal(Math.abs(netTotal));
+        bill.setNetTotal(netTotal);
+
+        billFacade.edit(bill);
+
+        result.setApplied(true);
+        result.setNote("Backfilled from stored before/after audit values");
+        return result;
+    }
+
+    /**
+     * Finds pre-fix adjustment bills for a department in a date range (BillFinanceDetails
+     * IS NULL is the fingerprint of "created before this fix went live") and runs the
+     * backfill over each, in dry-run or apply mode.
+     */
+    public java.util.List<BackfillResultDTO> backfillFinanceDetailsForDepartment(
+            Department department, java.util.Date fromDate, java.util.Date toDate, boolean apply) {
+        java.util.List<BillTypeAtomic> types = java.util.Arrays.asList(
+                BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_RETAIL_RATE_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_PURCHASE_RATE_ADJUSTMENT);
+
+        String jpql = "select b from Bill b where b.department=:dep "
+                + "and b.billTypeAtomic in :types and b.createdAt between :from and :to "
+                + "and b.billFinanceDetails is null and b.retired=:ret order by b.createdAt asc";
+
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("dep", department);
+        params.put("types", types);
+        params.put("from", fromDate);
+        params.put("to", toDate);
+        params.put("ret", false);
+
+        java.util.List<Bill> bills = billFacade.findByJpql(jpql, params);
+
+        java.util.List<BackfillResultDTO> results = new java.util.ArrayList<>();
+        for (Bill bill : bills) {
+            results.add(backfillFinanceDetails(bill, apply));
+        }
+        return results;
+    }
+
+    /**
+     * REST-facing overload: resolves departmentId -> Department and parses
+     * yyyy-MM-dd date strings before delegating to
+     * {@link #backfillFinanceDetailsForDepartment(Department, Date, Date, boolean)}.
+     */
+    public java.util.List<BackfillResultDTO> backfillFinanceDetailsForDepartment(
+            Long departmentId, String fromDateStr, String toDateStr, boolean apply) throws Exception {
+        Department department = loadAndValidateDepartment(departmentId);
+        Date fromDate = parseDate(fromDateStr);
+        Date toDate = parseDate(toDateStr);
+        return backfillFinanceDetailsForDepartment(department, fromDate, toDate, apply);
+    }
+
     // Private helper methods
 
     private void validateStockQuantityRequest(StockQuantityAdjustmentDTO request) throws Exception {

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -356,6 +356,7 @@ public class PharmacyAdjustmentApiService implements Serializable {
      * IS NULL is the fingerprint of "created before this fix went live") and runs the
      * backfill over each, in dry-run or apply mode.
      */
+    @Transactional
     public java.util.List<BackfillResultDTO> backfillFinanceDetailsForDepartment(
             Department department, java.util.Date fromDate, java.util.Date toDate, boolean apply) {
         java.util.List<BillTypeAtomic> types = java.util.Arrays.asList(
@@ -392,7 +393,10 @@ public class PharmacyAdjustmentApiService implements Serializable {
             Long departmentId, String fromDateStr, String toDateStr, boolean apply) throws Exception {
         Department department = loadAndValidateDepartment(departmentId);
         Date fromDate = parseDate(fromDateStr);
-        Date toDate = parseDate(toDateStr);
+        // toDate is parsed to midnight (00:00:00) by parseDate; advance it to the end
+        // of that day so bills created later on the same calendar day are not silently
+        // excluded from the JPQL "between :from and :to" range below.
+        Date toDate = endOfDay(parseDate(toDateStr));
         return backfillFinanceDetailsForDepartment(department, fromDate, toDate, apply);
     }
 
@@ -496,6 +500,21 @@ public class PharmacyAdjustmentApiService implements Serializable {
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.DAY_OF_MONTH, cal.getActualMaximum(Calendar.DAY_OF_MONTH));
+        return cal.getTime();
+    }
+
+    /**
+     * Advances the given date to the last instant of that calendar day
+     * (23:59:59.999), so it can be used as an inclusive upper bound in a
+     * "between" range query without excluding bills created later that day.
+     */
+    Date endOfDay(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        cal.set(Calendar.MINUTE, 59);
+        cal.set(Calendar.SECOND, 59);
+        cal.set(Calendar.MILLISECOND, 999);
         return cal.getTime();
     }
 

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiService.java
@@ -316,9 +316,16 @@ public class PharmacyAdjustmentApiService implements Serializable {
         result.setComputedNetTotal(netTotal);
         result.setComputedTotal(Math.abs(netTotal));
 
+        // Build disclosure text (applies to both dry-run and apply paths)
+        String disclosureSuffix = "";
+        if (costValueApproximatedFromCurrentRate) {
+            disclosureSuffix = ". Cost value approximated using current item batch cost rate "
+                    + "(no historical cost-rate snapshot exists for this bill type)";
+        }
+
         if (!apply) {
             result.setApplied(false);
-            result.setNote("Dry run: not persisted");
+            result.setNote("Dry run: not persisted" + disclosureSuffix);
             return result;
         }
 
@@ -339,11 +346,7 @@ public class PharmacyAdjustmentApiService implements Serializable {
         billFacade.edit(bill);
 
         result.setApplied(true);
-        String note = "Backfilled from stored before/after audit values";
-        if (costValueApproximatedFromCurrentRate) {
-            note += ". Cost value approximated using current item batch cost rate "
-                    + "(no historical cost-rate snapshot exists for this bill type)";
-        }
+        String note = "Backfilled from stored before/after audit values" + disclosureSuffix;
         result.setNote(note);
         return result;
     }

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -278,7 +278,12 @@ public class CapabilityStatementResource {
                         "API Key (Finance header)",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Pharmacy Adjustments", "/api/pharmacy_adjustments",
-                        "Pharmacy stock and adjustment operations",
+                        "Pharmacy stock and adjustment operations. "
+                        + "POST /backfill_finance_details is an admin-only, idempotent backfill: recomputes "
+                        + "BillFinanceDetails + bill totals for adjustment bills created before this fix existed, "
+                        + "using each bill's own stored before/after audit values. Bills that already have "
+                        + "BillFinanceDetails are skipped, not overwritten. Body: departmentId, fromDate, toDate "
+                        + "(yyyy-MM-dd), apply (false = dry run).",
                         "API Key",
                         "GET", "POST"))
                 .add(resource("Pharmacy Discounts", "/api/pharmacy/discounts",

--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
@@ -232,6 +232,49 @@ public class PharmacyAdjustmentApi {
     }
 
     /**
+     * Backfill BillFinanceDetails + bill totals for adjustment bills created before
+     * this fix existed, so historical F15 reports reconcile. Idempotent: bills that
+     * already have BillFinanceDetails are skipped.
+     * Endpoint: POST /api/pharmacy_adjustments/backfill_finance_details
+     * Body: {"departmentId": 90094, "fromDate": "2026-07-01", "toDate": "2026-07-04", "apply": false}
+     */
+    @POST
+    @Path("/backfill_finance_details")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response backfillFinanceDetails(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            BackfillRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, BackfillRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null || request.getDepartmentId() == null) {
+                return errorResponse("departmentId is required", 400);
+            }
+
+            String privilege = "PharmacyAdjustmentDepartmentStockQTY";
+            if (!webUserService.hasPrivilege(privilege, user, request.getDepartmentId())) {
+                return errorResponse("Not authorized", 403);
+            }
+
+            Object response = adjustmentService.backfillFinanceDetailsForDepartment(
+                    request.getDepartmentId(), request.getFromDate(), request.getToDate(), request.isApply());
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
      * Validate API key and return associated user
      */
     private WebUser validateApiKey(String key) {

--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyAdjustmentApi.java
@@ -260,8 +260,15 @@ public class PharmacyAdjustmentApi {
                 return errorResponse("departmentId is required", 400);
             }
 
-            String privilege = "PharmacyAdjustmentDepartmentStockQTY";
-            if (!webUserService.hasPrivilege(privilege, user, request.getDepartmentId())) {
+            // This backfill's JPQL query (backfillFinanceDetailsForDepartment) touches bills of
+            // THREE distinct types - PHARMACY_STOCK_ADJUSTMENT, PHARMACY_RETAIL_RATE_ADJUSTMENT,
+            // and PHARMACY_PURCHASE_RATE_ADJUSTMENT - each normally gated by its own privilege on
+            // the regular (non-backfill) endpoints. Require all three here so a user privileged
+            // for only one adjustment type cannot use this endpoint to write to bill types they
+            // hold no direct privilege over.
+            if (!webUserService.hasPrivilege("PharmacyAdjustmentDepartmentStockQTY", user, request.getDepartmentId())
+                    || !webUserService.hasPrivilege("PharmacyAdjustmentSaleRate", user, request.getDepartmentId())
+                    || !webUserService.hasPrivilege("PharmacyAdjustmentPurchaseRate", user, request.getDepartmentId())) {
                 return errorResponse("Not authorized", 403);
             }
 

--- a/src/test/java/com/divudi/ejb/PharmacyServiceAdjustmentBillTypesTest.java
+++ b/src/test/java/com/divudi/ejb/PharmacyServiceAdjustmentBillTypesTest.java
@@ -1,0 +1,17 @@
+package com.divudi.ejb;
+
+import com.divudi.core.data.BillTypeAtomic;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PharmacyServiceAdjustmentBillTypesTest {
+
+    @Test
+    public void adjustmentBillTypesIncludeExpiryDateAdjustment() {
+        PharmacyService service = new PharmacyService();
+        assertTrue(service.getPharmacyAdjustmentBillTypes()
+                .contains(BillTypeAtomic.PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT),
+                "Expiry-date adjustment bills must appear in the F15 Adjustment Transactions section");
+    }
+}

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -54,6 +54,7 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         itemBatch.setItem(new Item());
         itemBatch.setRetailsaleRate(netRate);
         itemBatch.setCostRate(netRate * 0.6);
+        itemBatch.setPurcahseRate(netRate * 0.7);
 
         Stock stock = new Stock();
         stock.setItemBatch(itemBatch);
@@ -98,8 +99,8 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
 
         // Finding 1: cost-value approximation must be disclosed via the note field for this bill type.
         assertNotNull(result.getNote());
-        assertTrue(result.getNote().contains("Cost value approximated using current item batch cost rate"),
-                "Expected note to disclose cost-value approximation, got: " + result.getNote());
+        assertTrue(result.getNote().contains("Cost and purchase values approximated using current item batch rates"),
+                "Expected note to disclose cost/purchase-value approximation, got: " + result.getNote());
     }
 
     @Test
@@ -139,10 +140,27 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         assertEquals(0, java.math.BigDecimal.valueOf(500.0).compareTo(bill.getBillFinanceDetails().getTotalBeforeAdjustmentValue()));
         assertEquals(0, java.math.BigDecimal.valueOf(600.0).compareTo(bill.getBillFinanceDetails().getTotalAfterAdjustmentValue()));
 
-        // Cost-value approximation disclosure only applies to PHARMACY_STOCK_ADJUSTMENT bills.
+        // Cost/purchase-value approximation disclosure only applies to PHARMACY_STOCK_ADJUSTMENT bills.
         assertNotNull(result.getNote());
-        assertFalse(result.getNote().contains("Cost value approximated"),
-                "Retail-rate adjustment backfill should not carry the cost-approximation note, got: " + result.getNote());
+        assertFalse(result.getNote().contains("approximated using current item batch rates"),
+                "Retail-rate adjustment backfill should not carry the cost/purchase-approximation note, got: " + result.getNote());
+    }
+
+    @Test
+    @DisplayName("Backfill for a stock-quantity bill also populates totalPurchaseValue, "
+            + "without double-counting it into the bill's netTotal")
+    public void testBackfillStockAdjustmentPopulatesPurchaseValueWithoutDoubleCountingNetTotal() {
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0); // delta qty = 15, purcahseRate = 70.0
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, true /* apply */);
+
+        assertTrue(result.isApplied());
+        // totalPurchaseValue = 15 * 70.0 = 1050.0 (F15 report's "Stock Value (Purchase)" column)
+        assertEquals(0, java.math.BigDecimal.valueOf(1050.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()));
+        // netTotal/computedNetTotal stay scoped to the retail dimension (1500.0) - must NOT
+        // become 1500.0 + 1050.0, which would double-count the same quantity change twice.
+        assertEquals(1500.0, bill.getNetTotal(), 0.001);
+        assertEquals(1500.0, result.getComputedNetTotal(), 0.001);
     }
 
     @Test
@@ -186,8 +204,8 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         assertNotNull(result.getNote());
         assertTrue(result.getNote().contains("Dry run: not persisted"),
                 "Expected dry-run base message, got: " + result.getNote());
-        assertTrue(result.getNote().contains("Cost value approximated using current item batch cost rate"),
-                "Expected dry-run note to disclose cost-value approximation, got: " + result.getNote());
+        assertTrue(result.getNote().contains("Cost and purchase values approximated using current item batch rates"),
+                "Expected dry-run note to disclose cost/purchase-value approximation, got: " + result.getNote());
     }
 
     @Test

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -17,8 +17,10 @@ import org.junit.jupiter.api.Test;
 
 import javax.persistence.EntityManager;
 import java.lang.reflect.Field;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -186,5 +188,36 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
                 "Expected dry-run base message, got: " + result.getNote());
         assertTrue(result.getNote().contains("Cost value approximated using current item batch cost rate"),
                 "Expected dry-run note to disclose cost-value approximation, got: " + result.getNote());
+    }
+
+    @Test
+    @DisplayName("endOfDay normalizes a date to 23:59:59.999 of the same calendar day, "
+            + "so a bill created later that day falls within a between(from, endOfDay(toDate)) range")
+    public void testEndOfDayIncludesSameDayBillsInBackfillRange() throws Exception {
+        SimpleDateFormat dayFormat = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat dayTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        Date parsedToDate = dayFormat.parse("2026-07-04"); // midnight, as parseDate() produces
+        Date normalizedToDate = service.endOfDay(parsedToDate);
+
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(normalizedToDate);
+        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(59, cal.get(Calendar.MINUTE));
+        assertEquals(59, cal.get(Calendar.SECOND));
+        assertEquals(999, cal.get(Calendar.MILLISECOND));
+        // Still the same calendar day - only the time-of-day component changed.
+        Calendar original = Calendar.getInstance();
+        original.setTime(parsedToDate);
+        assertEquals(original.get(Calendar.YEAR), cal.get(Calendar.YEAR));
+        assertEquals(original.get(Calendar.DAY_OF_YEAR), cal.get(Calendar.DAY_OF_YEAR));
+
+        // A bill created at 14:30:00 on the same day must fall within [from, normalizedToDate],
+        // whereas it would have been excluded by the un-normalized midnight bound.
+        Date billCreatedAt = dayTimeFormat.parse("2026-07-04 14:30:00");
+        assertTrue(billCreatedAt.after(parsedToDate),
+                "Sanity check: bill timestamp is after the un-normalized midnight bound");
+        assertFalse(billCreatedAt.after(normalizedToDate),
+                "Bill created at 14:30:00 on toDate must be included once toDate is normalized to end-of-day");
     }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -86,6 +86,61 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         assertNotNull(bill.getBillFinanceDetails());
         assertEquals(0, java.math.BigDecimal.valueOf(1500.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
         assertEquals(1, billFacade.edited.size());
+
+        // Finding 2: totalBeforeAdjustmentValue/totalAfterAdjustmentValue must be populated,
+        // computed as quantity * netRate (before=10*100=1000, after=25*100=2500).
+        assertNotNull(bill.getBillFinanceDetails().getTotalBeforeAdjustmentValue());
+        assertNotNull(bill.getBillFinanceDetails().getTotalAfterAdjustmentValue());
+        assertEquals(0, java.math.BigDecimal.valueOf(1000.0).compareTo(bill.getBillFinanceDetails().getTotalBeforeAdjustmentValue()));
+        assertEquals(0, java.math.BigDecimal.valueOf(2500.0).compareTo(bill.getBillFinanceDetails().getTotalAfterAdjustmentValue()));
+
+        // Finding 1: cost-value approximation must be disclosed via the note field for this bill type.
+        assertNotNull(result.getNote());
+        assertTrue(result.getNote().contains("Cost value approximated using current item batch cost rate"),
+                "Expected note to disclose cost-value approximation, got: " + result.getNote());
+    }
+
+    @Test
+    @DisplayName("Backfill for retail-rate adjustment bills uses stored before/after values directly and does not add the cost-approximation note")
+    public void testBackfillRetailRateAdjustmentPopulatesBeforeAfterTotalsWithoutApproximationNote() {
+        Bill bill = new Bill();
+        bill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_RATE_ADJUSTMENT);
+        bill.setBillFinanceDetails(null);
+
+        ItemBatch itemBatch = new ItemBatch();
+        itemBatch.setItem(new Item());
+
+        Stock stock = new Stock();
+        stock.setItemBatch(itemBatch);
+
+        BillItem billItem = new BillItem();
+        billItem.setBill(bill);
+        billItem.setInwardChargeType(InwardChargeType.Medicine);
+        billItem.setCreatedAt(Calendar.getInstance().getTime());
+        billItem.setQty(50.0);
+
+        PharmaceuticalBillItem phItem = new PharmaceuticalBillItem();
+        phItem.setStock(stock);
+        phItem.setItemBatch(itemBatch);
+        // before/after are already total values (qty * rate) for this bill type.
+        phItem.setBeforeAdjustmentValue(50.0 * 10.0); // 500
+        phItem.setAfterAdjustmentValue(50.0 * 12.0);  // 600
+        billItem.setPharmaceuticalBillItem(phItem);
+        phItem.setBillItem(billItem);
+
+        bill.getBillItems().add(billItem);
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, true /* apply */);
+
+        assertTrue(result.isApplied());
+        assertNotNull(bill.getBillFinanceDetails());
+        assertEquals(0, java.math.BigDecimal.valueOf(500.0).compareTo(bill.getBillFinanceDetails().getTotalBeforeAdjustmentValue()));
+        assertEquals(0, java.math.BigDecimal.valueOf(600.0).compareTo(bill.getBillFinanceDetails().getTotalAfterAdjustmentValue()));
+
+        // Cost-value approximation disclosure only applies to PHARMACY_STOCK_ADJUSTMENT bills.
+        assertNotNull(result.getNote());
+        assertFalse(result.getNote().contains("Cost value approximated"),
+                "Retail-rate adjustment backfill should not carry the cost-approximation note, got: " + result.getNote());
     }
 
     @Test

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -168,4 +168,23 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         assertEquals(999.0, bill.getNetTotal(), 0.001, "Existing BFD must not be recomputed/overwritten");
         assertTrue(billFacade.edited.isEmpty());
     }
+
+    @Test
+    @DisplayName("Dry run for stock adjustment includes cost-approximation disclosure in the note")
+    public void testDryRunStockAdjustmentIncludesCostApproximationDisclosure() {
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0);
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, false /* dry run */);
+
+        assertFalse(result.isApplied());
+        assertEquals(1500.0, result.getComputedNetTotal(), 0.001);
+        assertTrue(billFacade.edited.isEmpty(), "Dry run must not persist changes");
+
+        // Verify that dry-run note includes the same cost-approximation disclosure as apply path.
+        assertNotNull(result.getNote());
+        assertTrue(result.getNote().contains("Dry run: not persisted"),
+                "Expected dry-run base message, got: " + result.getNote());
+        assertTrue(result.getNote().contains("Cost value approximated using current item batch cost rate"),
+                "Expected dry-run note to disclose cost-value approximation, got: " + result.getNote());
+    }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -33,6 +33,13 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         @Override public void edit(Bill entity) { edited.add(entity); }
     }
 
+    private static class DummyStockHistoryFacade extends com.divudi.core.facade.StockHistoryFacade {
+        @Override public com.divudi.core.entity.pharmacy.StockHistory findByPharmaceuticalBillItem(
+                com.divudi.core.entity.pharmacy.PharmaceuticalBillItem pbItem) {
+            return null;
+        }
+    }
+
     private PharmacyAdjustmentApiService service;
     private DummyBillFacade billFacade;
 
@@ -43,6 +50,10 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
         Field f = PharmacyAdjustmentApiService.class.getDeclaredField("billFacade");
         f.setAccessible(true);
         f.set(service, billFacade);
+
+        Field shf = PharmacyAdjustmentApiService.class.getDeclaredField("stockHistoryFacade");
+        shf.setAccessible(true);
+        shf.set(service, new DummyStockHistoryFacade());
     }
 
     private Bill buildHistoricalQuantityAdjustmentBill(double beforeQty, double afterQty, double netRate) {
@@ -75,6 +86,44 @@ public class PharmacyAdjustmentApiServiceBackfillTest {
 
         bill.getBillItems().add(billItem);
         return bill;
+    }
+
+    @Test
+    @DisplayName("Backfill prefers the StockHistory rate snapshot at adjustment time over the item batch's "
+            + "current rate, and does not disclose an approximation when a snapshot is found")
+    public void testBackfillUsesHistoricalStockHistoryRateNotCurrentRate() throws Exception {
+        // Item batch's CURRENT rates (e.g. changed by a later rate adjustment, after this bill was created).
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0); // delta qty = 15
+        PharmaceuticalBillItem ph = bill.getBillItems().get(0).getPharmaceuticalBillItem();
+        // Current cost/purchase rates from buildHistoricalQuantityAdjustmentBill: 60.0 / 70.0.
+        // Historical snapshot at adjustment time was actually 55.0 / 65.0 - simulating a rate
+        // change that happened AFTER this bill was created but BEFORE the backfill runs.
+        com.divudi.core.entity.pharmacy.StockHistory snapshot = new com.divudi.core.entity.pharmacy.StockHistory();
+        snapshot.setCostRate(55.0);
+        snapshot.setPurchaseRate(65.0);
+
+        Field shf = PharmacyAdjustmentApiService.class.getDeclaredField("stockHistoryFacade");
+        shf.setAccessible(true);
+        shf.set(service, new com.divudi.core.facade.StockHistoryFacade() {
+            @Override public com.divudi.core.entity.pharmacy.StockHistory findByPharmaceuticalBillItem(
+                    com.divudi.core.entity.pharmacy.PharmaceuticalBillItem pbItem) {
+                return pbItem == ph ? snapshot : null;
+            }
+        });
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, true /* apply */);
+
+        assertTrue(result.isApplied());
+        // Historical: 15 * 55.0 = 825.0 (NOT 15 * 60.0 = 900.0, the current rate)
+        assertEquals(0, java.math.BigDecimal.valueOf(825.0).compareTo(bill.getBillFinanceDetails().getTotalCostValue()),
+                "Expected cost value computed from the historical StockHistory snapshot (55.0), not the current item batch rate (60.0)");
+        // Historical: 15 * 65.0 = 975.0 (NOT 15 * 70.0 = 1050.0, the current rate)
+        assertEquals(0, java.math.BigDecimal.valueOf(975.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()),
+                "Expected purchase value computed from the historical StockHistory snapshot (65.0), not the current item batch rate (70.0)");
+
+        assertNotNull(result.getNote());
+        assertFalse(result.getNote().contains("approximated using current item batch rates"),
+                "A real historical snapshot was found, so no approximation disclosure should be added, got: " + result.getNote());
     }
 
     @Test

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceBackfillTest.java
@@ -1,0 +1,116 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.dto.adjustment.BackfillResultDTO;
+import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.pharmacy.ItemBatch;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.facade.BillFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.persistence.EntityManager;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PharmacyAdjustmentApiServiceBackfillTest {
+
+    private static class DummyBillFacade extends BillFacade {
+        List<Bill> edited = new ArrayList<>();
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public void edit(Bill entity) { edited.add(entity); }
+    }
+
+    private PharmacyAdjustmentApiService service;
+    private DummyBillFacade billFacade;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        service = new PharmacyAdjustmentApiService();
+        billFacade = new DummyBillFacade();
+        Field f = PharmacyAdjustmentApiService.class.getDeclaredField("billFacade");
+        f.setAccessible(true);
+        f.set(service, billFacade);
+    }
+
+    private Bill buildHistoricalQuantityAdjustmentBill(double beforeQty, double afterQty, double netRate) {
+        Bill bill = new Bill();
+        bill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT);
+        bill.setBillFinanceDetails(null); // fingerprint of a pre-fix bill
+
+        ItemBatch itemBatch = new ItemBatch();
+        itemBatch.setItem(new Item());
+        itemBatch.setRetailsaleRate(netRate);
+        itemBatch.setCostRate(netRate * 0.6);
+
+        Stock stock = new Stock();
+        stock.setItemBatch(itemBatch);
+
+        BillItem billItem = new BillItem();
+        billItem.setNetRate(netRate);
+        billItem.setBill(bill);
+        billItem.setInwardChargeType(InwardChargeType.Medicine);
+        billItem.setCreatedAt(Calendar.getInstance().getTime());
+
+        PharmaceuticalBillItem phItem = new PharmaceuticalBillItem();
+        phItem.setStock(stock);
+        phItem.setItemBatch(itemBatch);
+        phItem.setBeforeAdjustmentValue(beforeQty);
+        phItem.setAfterAdjustmentValue(afterQty);
+        billItem.setPharmaceuticalBillItem(phItem);
+        phItem.setBillItem(billItem);
+
+        bill.getBillItems().add(billItem);
+        return bill;
+    }
+
+    @Test
+    @DisplayName("Backfill computes delta value from stored before/after quantities and writes BFD + bill totals")
+    public void testBackfillPopulatesFinanceDetailsFromStoredAuditFields() {
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0); // delta = 15 * 100 = 1500
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, true /* apply */);
+
+        assertTrue(result.isApplied());
+        assertEquals(1500.0, bill.getNetTotal(), 0.001);
+        assertNotNull(bill.getBillFinanceDetails());
+        assertEquals(0, java.math.BigDecimal.valueOf(1500.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
+        assertEquals(1, billFacade.edited.size());
+    }
+
+    @Test
+    @DisplayName("Dry run computes the result but does not call billFacade.edit")
+    public void testDryRunDoesNotPersist() {
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0);
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, false /* dry run */);
+
+        assertFalse(result.isApplied());
+        assertEquals(1500.0, result.getComputedNetTotal(), 0.001);
+        assertTrue(billFacade.edited.isEmpty(), "Dry run must not persist changes");
+    }
+
+    @Test
+    @DisplayName("Bills that already have BillFinanceDetails are skipped, not overwritten")
+    public void testAlreadyBackfilledBillIsSkipped() {
+        Bill bill = buildHistoricalQuantityAdjustmentBill(10.0, 25.0, 100.0);
+        bill.setBillFinanceDetails(new com.divudi.core.entity.BillFinanceDetails(bill));
+        bill.setNetTotal(999.0); // pretend it was already correctly fixed once
+
+        BackfillResultDTO result = service.backfillFinanceDetails(bill, true);
+
+        assertFalse(result.isApplied());
+        assertEquals(999.0, bill.getNetTotal(), 0.001, "Existing BFD must not be recomputed/overwritten");
+        assertTrue(billFacade.edited.isEmpty());
+    }
+}

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
@@ -155,6 +155,9 @@ public class PharmacyAdjustmentApiServiceTest {
         assertNotNull(bill.getBillFinanceDetails(), "BillFinanceDetails must be created so the F15 report can read it");
         assertEquals(0, java.math.BigDecimal.valueOf(1500.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
         assertEquals(0, java.math.BigDecimal.valueOf(15.0 * 55.0).compareTo(bill.getBillFinanceDetails().getTotalCostValue()));
+        // A quantity change moves stock value at the purchase rate too (F15 report's
+        // "Stock Value (Purchase)" column), not just cost/retail.
+        assertEquals(0, java.math.BigDecimal.valueOf(15.0 * 60.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()));
     }
 
     @Test
@@ -171,6 +174,8 @@ public class PharmacyAdjustmentApiServiceTest {
         Bill bill = billFacade.saved.get(0);
         assertEquals(-600.0, bill.getNetTotal(), 0.001);
         assertEquals(600.0, bill.getTotal(), 0.001, "Bill.total (gross) should be the absolute value of the change");
+        assertEquals(0, java.math.BigDecimal.valueOf(-6.0 * 60.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()),
+                "A quantity decrease must record a negative purchase-value delta too");
     }
 
     @Test

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
@@ -186,4 +186,25 @@ public class PharmacyAdjustmentApiServiceTest {
         assertEquals(0, java.math.BigDecimal.valueOf(200.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
         assertEquals(0, java.math.BigDecimal.ZERO.compareTo(bill.getBillFinanceDetails().getTotalCostValue()));
     }
+
+    @Test
+    @DisplayName("Purchase rate adjustment records the rate-change value in totalPurchaseValue")
+    public void testPurchaseRateAdjustmentPopulatesFinanceDetails() throws Exception {
+        com.divudi.core.data.dto.adjustment.PurchaseRateAdjustmentDTO request =
+                new com.divudi.core.data.dto.adjustment.PurchaseRateAdjustmentDTO();
+        request.setStockId(1L);
+        request.setNewPurchaseRate(70.0); // was 60.0, stock qty = 10 -> change = 10 * 10 = 100.0
+        request.setComment("purchase rate correction");
+        request.setDepartmentId(1L);
+
+        service.adjustPurchaseRate(request, user);
+
+        assertEquals(1, billFacade.saved.size());
+        Bill bill = billFacade.saved.get(0);
+        assertEquals(100.0, bill.getNetTotal(), 0.001);
+        assertEquals(100.0, bill.getTotal(), 0.001);
+        assertNotNull(bill.getBillFinanceDetails());
+        assertEquals(0, java.math.BigDecimal.valueOf(100.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()));
+        assertEquals(0, java.math.BigDecimal.ZERO.compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
+    }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
@@ -165,4 +165,25 @@ public class PharmacyAdjustmentApiServiceTest {
         assertEquals(-600.0, bill.getNetTotal(), 0.001);
         assertEquals(600.0, bill.getTotal(), 0.001, "Bill.total (gross) should be the absolute value of the change");
     }
+
+    @Test
+    @DisplayName("Retail rate adjustment records the rate-change value across current stock qty")
+    public void testRetailRateAdjustmentPopulatesFinanceDetails() throws Exception {
+        com.divudi.core.data.dto.adjustment.RetailRateAdjustmentDTO request =
+                new com.divudi.core.data.dto.adjustment.RetailRateAdjustmentDTO();
+        request.setStockId(1L);
+        request.setNewRetailRate(120.0); // was 100.0, stock qty = 10 -> change = 10 * 20 = 200.0
+        request.setComment("rate correction");
+        request.setDepartmentId(1L);
+
+        service.adjustRetailRate(request, user);
+
+        assertEquals(1, billFacade.saved.size());
+        Bill bill = billFacade.saved.get(0);
+        assertEquals(200.0, bill.getNetTotal(), 0.001);
+        assertEquals(200.0, bill.getTotal(), 0.001);
+        assertNotNull(bill.getBillFinanceDetails());
+        assertEquals(0, java.math.BigDecimal.valueOf(200.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
+        assertEquals(0, java.math.BigDecimal.ZERO.compareTo(bill.getBillFinanceDetails().getTotalCostValue()));
+    }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
@@ -1,0 +1,168 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.dto.adjustment.StockQuantityAdjustmentDTO;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.pharmacy.ItemBatch;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.ItemBatchFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.PharmacyBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.persistence.EntityManager;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PharmacyAdjustmentApiServiceTest {
+
+    private static class DummyBillFacade extends BillFacade {
+        List<Bill> saved = new ArrayList<>();
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public void create(Bill entity) { saved.add(entity); }
+        @Override public void edit(Bill entity) { /* no-op: entity already mutated in-memory */ }
+    }
+
+    private static class DummyBillItemFacade extends BillItemFacade {
+        List<BillItem> saved = new ArrayList<>();
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public void create(BillItem entity) { saved.add(entity); }
+    }
+
+    private static class DummyStockFacade extends StockFacade {
+        Stock stock;
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public Stock find(Object id) { return stock; }
+    }
+
+    private static class DummyDepartmentFacade extends DepartmentFacade {
+        Department department;
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public Department find(Object id) { return department; }
+    }
+
+    private static class DummyItemBatchFacade extends ItemBatchFacade {
+        @Override protected EntityManager getEntityManager() { return null; }
+        @Override public void edit(ItemBatch entity) { /* no-op */ }
+    }
+
+    private static class DummyBillNumberGenerator extends BillNumberGenerator {
+        @Override
+        public String departmentBillNumberGeneratorYearly(Department dep, com.divudi.core.data.BillTypeAtomic billType) {
+            return "TEST/ADJ/0001";
+        }
+    }
+
+    private static class DummyPharmacyBean extends PharmacyBean {
+        @Override
+        public boolean resetStock(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem ph, Stock stock, double qty, Department department) {
+            stock.setStock(qty);
+            return true;
+        }
+        @Override
+        public void addToStockHistory(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem phItem, Stock stock, Department d) {
+            /* no-op */
+        }
+    }
+
+    private PharmacyAdjustmentApiService service;
+    private DummyBillFacade billFacade;
+    private DummyBillItemFacade billItemFacade;
+    private DummyStockFacade stockFacade;
+    private DummyDepartmentFacade departmentFacade;
+    private Stock stock;
+    private WebUser user;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        service = new PharmacyAdjustmentApiService();
+
+        billFacade = new DummyBillFacade();
+        billItemFacade = new DummyBillItemFacade();
+        stockFacade = new DummyStockFacade();
+        departmentFacade = new DummyDepartmentFacade();
+
+        ItemBatch itemBatch = new ItemBatch();
+        itemBatch.setItem(new Item());
+        itemBatch.setRetailsaleRate(100.0);
+        itemBatch.setPurcahseRate(60.0);
+        itemBatch.setCostRate(55.0);
+
+        stock = new Stock();
+        stock.setItemBatch(itemBatch);
+        stock.setStock(10.0);
+        stockFacade.stock = stock;
+
+        Department department = new Department();
+        department.setInstitution(new com.divudi.core.entity.Institution());
+        departmentFacade.department = department;
+
+        user = new WebUser();
+
+        setField("billFacade", billFacade);
+        setField("billItemFacade", billItemFacade);
+        setField("stockFacade", stockFacade);
+        setField("departmentFacade", departmentFacade);
+        setField("itemBatchFacade", new DummyItemBatchFacade());
+        setField("billNumberGenerator", new DummyBillNumberGenerator());
+        setField("pharmacyBean", new DummyPharmacyBean());
+        setField("configOptionApplicationController", new com.divudi.bean.common.ConfigOptionApplicationController());
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field f = PharmacyAdjustmentApiService.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(service, value);
+    }
+
+    @Test
+    @DisplayName("Stock quantity adjustment records the delta value, not the ending value, on the bill")
+    public void testQuantityAdjustmentUsesDeltaValue() throws Exception {
+        StockQuantityAdjustmentDTO request = new StockQuantityAdjustmentDTO();
+        request.setStockId(1L);
+        request.setNewQuantity(25.0); // was 10 -> +15 units
+        request.setComment("test correction");
+        request.setDepartmentId(1L);
+
+        service.adjustStockQuantity(request, user);
+
+        assertEquals(1, billFacade.saved.size());
+        Bill bill = billFacade.saved.get(0);
+
+        // delta = 15 units * 100.0 retail rate = 1500.0, NOT 25 * 100.0 = 2500.0
+        assertEquals(1500.0, bill.getNetTotal(), 0.001, "Bill.netTotal must reflect the quantity delta, not the ending balance");
+        assertEquals(1500.0, bill.getTotal(), 0.001);
+
+        assertNotNull(bill.getBillFinanceDetails(), "BillFinanceDetails must be created so the F15 report can read it");
+        assertEquals(0, java.math.BigDecimal.valueOf(1500.0).compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
+        assertEquals(0, java.math.BigDecimal.valueOf(15.0 * 55.0).compareTo(bill.getBillFinanceDetails().getTotalCostValue()));
+    }
+
+    @Test
+    @DisplayName("Stock quantity decrease produces a negative delta value")
+    public void testQuantityDecreaseIsNegative() throws Exception {
+        StockQuantityAdjustmentDTO request = new StockQuantityAdjustmentDTO();
+        request.setStockId(1L);
+        request.setNewQuantity(4.0); // was 10 -> -6 units
+        request.setComment("shrinkage correction");
+        request.setDepartmentId(1L);
+
+        service.adjustStockQuantity(request, user);
+
+        Bill bill = billFacade.saved.get(0);
+        assertEquals(-600.0, bill.getNetTotal(), 0.001);
+        assertEquals(600.0, bill.getTotal(), 0.001, "Bill.total (gross) should be the absolute value of the change");
+    }
+}

--- a/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PharmacyAdjustmentApiServiceTest.java
@@ -77,6 +77,13 @@ public class PharmacyAdjustmentApiServiceTest {
         }
     }
 
+    private static class DummyConfigOptionApplicationController extends com.divudi.bean.common.ConfigOptionApplicationController {
+        @Override
+        public Boolean getBooleanValueByKey(String key, boolean defaultValue) {
+            return defaultValue;
+        }
+    }
+
     private PharmacyAdjustmentApiService service;
     private DummyBillFacade billFacade;
     private DummyBillItemFacade billItemFacade;
@@ -118,7 +125,7 @@ public class PharmacyAdjustmentApiServiceTest {
         setField("itemBatchFacade", new DummyItemBatchFacade());
         setField("billNumberGenerator", new DummyBillNumberGenerator());
         setField("pharmacyBean", new DummyPharmacyBean());
-        setField("configOptionApplicationController", new com.divudi.bean.common.ConfigOptionApplicationController());
+        setField("configOptionApplicationController", new DummyConfigOptionApplicationController());
     }
 
     private void setField(String name, Object value) throws Exception {
@@ -205,6 +212,25 @@ public class PharmacyAdjustmentApiServiceTest {
         assertEquals(100.0, bill.getTotal(), 0.001);
         assertNotNull(bill.getBillFinanceDetails());
         assertEquals(0, java.math.BigDecimal.valueOf(100.0).compareTo(bill.getBillFinanceDetails().getTotalPurchaseValue()));
+        assertEquals(0, java.math.BigDecimal.ZERO.compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
+    }
+
+    @Test
+    @DisplayName("Expiry date adjustment creates a zero-valued BillFinanceDetails, not a null one")
+    public void testExpiryDateAdjustmentCreatesZeroValueFinanceDetails() throws Exception {
+        com.divudi.core.data.dto.adjustment.ExpiryDateAdjustmentDTO request =
+                new com.divudi.core.data.dto.adjustment.ExpiryDateAdjustmentDTO();
+        request.setStockId(1L);
+        request.setNewExpiryDate("2027-12-31");
+        request.setComment("expiry correction");
+        request.setDepartmentId(1L);
+
+        service.adjustExpiryDate(request, user);
+
+        assertEquals(1, billFacade.saved.size());
+        Bill bill = billFacade.saved.get(0);
+        assertEquals(0.0, bill.getNetTotal(), 0.001);
+        assertNotNull(bill.getBillFinanceDetails(), "Even a zero-value adjustment should have an explicit BFD row");
         assertEquals(0, java.math.BigDecimal.ZERO.compareTo(bill.getBillFinanceDetails().getTotalRetailSaleValue()));
     }
 }


### PR DESCRIPTION
## Summary

The F15 "Daily Stock Values" pharmacy report's Adjustment Transactions section always showed 0.00, even on days with real pharmacy adjustment activity — breaking the reconciliation identity `Opening + Sales + Purchases + Transfers + Adjustments = Closing`. Root cause: the `/api/pharmacy_adjustments/*` REST endpoints create audit-trail bills but never populate `BillFinanceDetails` or `Bill.total`/`netTotal`, which is exactly what the F15 report's adjustment query reads. Reproduced live against COOP production (OPD Pharmacy, 03 July 2026) via Playwright before starting the fix.

- Added the missing `PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT` bill type to the report's adjustment query list
- Fixed stock-quantity adjustments to record the delta value `(afterQty − beforeQty) × rate`, not the full ending value, and populate `BillFinanceDetails` + bill totals
- Fixed retail-rate and purchase-rate adjustments to populate `BillFinanceDetails` + bill totals (their delta formula was already correct)
- Fixed expiry-date adjustments to create an explicit zero-valued `BillFinanceDetails` for consistency
- Added an idempotent, privilege-gated admin backfill endpoint (`POST /pharmacy_adjustments/backfill_finance_details`, dry-run by default) to retroactively populate `BillFinanceDetails` for adjustment bills created before this fix existed, using only each bill's own stored audit fields — never inventing data

Full design/implementation plan: `docs/superpowers/plans/2026-07-04-f15-adjustment-value-fix.md`

## Test plan
- [x] `mvn test` — full suite passes
- [x] Each task implemented via TDD with dedicated unit tests (dummy-facade convention, no Mockito)
- [x] Task-level and final whole-branch code review completed; all Critical/Important findings fixed (delta-vs-ending-value semantics, cost-value approximation disclosure, before/after totals, privilege scope widened to cover all 3 adjustment bill types the backfill touches, backfill `toDate` end-of-day normalization, missing `@Transactional` boundary)
- [ ] Run the admin backfill in dry-run mode against COOP OPD Pharmacy production data, verify output, then apply and confirm F15 reconciles for 2026-07-03 and 2026-07-04 (tracked separately — requires a `-hotfix` branch to `coop-prod` per repo convention, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only endpoint to backfill missing pharmacy historical finance details and bill totals, with dry-run support (`apply=false`) and department/date-range targeting.
  * Pharmacy adjustment capabilities now include expiry-date adjustments.
* **Bug Fixes**
  * Pharmacy adjustment bills now immediately populate finance details and update bill totals correctly when created.
  * Backfill operation now skips bills that already have finance details and improves historical valuation accuracy by preferring stored snapshots for retail and cost rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->