### PR TITLE
fix(pharmacy): Direct Purchase Finalize data-loss and missing Approve action

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1384,14 +1384,22 @@ public class PharmacyDirectPurchaseController implements Serializable {
     
     // <editor-fold defaultstate="collapsed" desc="Draft Workflow Methods">
 
-    public void saveDraftDirectPurchase() {
+    /**
+     * Persists the current bill and items as a draft (PRE type, not completed).
+     * Shared by the explicit Save Draft action and by Finalize, which
+     * transparently saves first when no draft has been saved yet.
+     *
+     * @return true if the draft was persisted, false if validation failed (an
+     * error message has already been added to the growl in that case)
+     */
+    private boolean persistDraftDirectPurchase() {
         if (getBillItems() == null || getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Please add items before saving");
-            return;
+            return false;
         }
         if (getBill().getFromInstitution() == null) {
             JsfUtil.addErrorMessage("Please select a Supplier");
-            return;
+            return false;
         }
 
         // Save bill header as PRE type — no bill number yet, no stock
@@ -1447,13 +1455,22 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
 
         getBillFacade().edit(getBill());
-        JsfUtil.addSuccessMessage("Direct Purchase draft saved successfully.");
         draftMode = true;
+        return true;
+    }
+
+    public void saveDraftDirectPurchase() {
+        if (persistDraftDirectPurchase()) {
+            JsfUtil.addSuccessMessage("Direct Purchase draft saved successfully.");
+        }
     }
 
     public void finalizeDraftDirectPurchase() {
-        if (bill == null || bill.getId() == null) {
-            JsfUtil.addErrorMessage("No draft loaded. Please save the draft first.");
+        // Always (re)persist first: addItem() may have already created a bare
+        // bill row (to get an id for the item FK) before department/supplier
+        // were set, so bill.getId() != null does not mean the draft is fully
+        // saved. persistDraftDirectPurchase() handles both create and edit.
+        if (!persistDraftDirectPurchase()) {
             return;
         }
 

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -53,7 +53,7 @@
                                     style="margin-right: 8px;">
                                 </p:commandButton>
 
-                                <!-- Finalize: shown when draft is saved but not yet finalized -->
+                                <!-- Finalize: also shown before any draft save — finalizing saves the draft first if needed -->
                                 <p:commandButton
                                     id="btnFinalize"
                                     value="Finalize"
@@ -62,7 +62,20 @@
                                     styleClass="ui-button-warning"
                                     ajax="false"
                                     icon="pi pi-check"
-                                    rendered="#{pharmacyDirectPurchaseController.draftMode and pharmacyDirectPurchaseController.bill.id ne null and !pharmacyDirectPurchaseController.bill.completed and webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false) and !pharmacyDirectPurchaseController.bill.completed and webUserController.hasPrivilege('PharmacyDirectPurchaseFinalize')}"
+                                    style="margin-right: 8px;">
+                                </p:commandButton>
+
+                                <!-- Approve: shown once finalized (completed) but not yet approved (checked) -->
+                                <p:commandButton
+                                    id="btnApprove"
+                                    value="Approve"
+                                    onclick="if (!confirm('Approve this finalized Direct Purchase? Stock will be updated.')) return false"
+                                    action="#{pharmacyDirectPurchaseController.approveDirectPurchaseDraft}"
+                                    styleClass="ui-button-success"
+                                    ajax="false"
+                                    icon="pi pi-verified"
+                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Direct Purchase', false) and pharmacyDirectPurchaseController.bill.completed and !pharmacyDirectPurchaseController.bill.checked and webUserController.hasPrivilege('PharmacyDirectPurchaseApprove')}"
                                     style="margin-right: 8px;">
                                 </p:commandButton>
 


### PR DESCRIPTION
## Summary
- `finalizeDraftDirectPurchase()` used `bill.getId() == null` as its signal that a draft still needed the full `persistDraftDirectPurchase()` save (department, institution, supplier, creator, items). But `addItem()` (the "+ Add" item handler) already creates a bare `Bill` row the moment the first item is added, just to get an id for the item's FK — before the supplier is necessarily picked. So `bill.getId()` was already non-null by the time Finalize ran, and the real save was skipped entirely. Clicking **Finalize** without first clicking **Save Draft** finalized a bill with `FROMINSTITUTION_ID`, `DEPARTMENT_ID`, `CREATER_ID` all `NULL` and zero bill items.
- `finalizeDraftDirectPurchase()` now unconditionally calls `persistDraftDirectPurchase()` first, which already correctly handles both the create and edit cases.
- The inline **Approve** button was intentionally removed from `direct_purchase.xhtml` in #21838 in favor of approving from the "Direct Purchase List - To Approve" page, matching the Purchase Order pattern. But that list's Approve button only calls `navigateToEditSavedDirectPurchase()` → `loadDraftForEditing()`, which reopens the draft for editing — it never calls `approveDirectPurchaseDraft()`. There was no UI path left to actually approve a finalized Direct Purchase. Added the button back, gated on the bill being `completed` and not yet `checked`, so it doubles as a review step before the stock-impacting approve action.

Closes #21853

## Test plan
Verified end-to-end via Playwright against local Payara (Main Pharmacy department, `coop` database):
- [x] Save Draft → Finalize → Approve: department/supplier/items persist correctly, bill number generated, stock + batch created
- [x] Finalize directly on a brand-new bill (skipping Save Draft): department/supplier/items now persist correctly (previously all NULL/empty)
- [x] Approve button appears only once a draft is finalized and not yet checked, and only for users with `PharmacyDirectPurchaseApprove`
- [x] `mvn compile` clean

Screenshots and workflow write-up published to the wiki: [Direct Purchase Save/Finalize/Approve Workflow](https://github.com/hmislk/hmis/wiki/Direct-Purchase-Save-Finalize-Approve-Workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Finalizing a direct purchase now saves any unsaved draft data first, helping prevent missing items or incomplete records.
  * Improved validation so drafts can’t be saved or finalized without required details like items and supplier selection.

* **Refactor**
  * Streamlined the draft save/finalize flow for direct purchases.
  * Updated the finalize action to appear under the revised workflow and privilege settings, with clearer behavior before draft saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->