### PR TITLE
fix(pharmacy): Direct Purchase prints show retired items; expenses never persisted

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -959,6 +959,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
         currentExpense.setNetValue(currentExpense.getNetRate() * currentExpense.getQty());
         currentExpense.setGrossValue(currentExpense.getRate() * currentExpense.getQty());
 
+        // Owning-side FK: without this, Bill.billExpenses' cascade persists
+        // nothing back to this bill (issue #21856)
+        currentExpense.setExpenseBill(getBill());
+
         getCurrentExpense().setSearialNo(getBillExpenses().size());
         getBillExpenses().add(currentExpense);
 
@@ -993,6 +997,15 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
         if (getBill().getBillExpenses() != null) {
             getBill().getBillExpenses().remove(expense);
+        }
+
+        // Retire the persisted row - removing it from the in-memory list alone
+        // does not delete it (Bill.billExpenses has no orphanRemoval), so an
+        // "un-retired" removal would silently reappear on reload (issue #21856).
+        if (expense.getId() != null) {
+            expense.setRetired(true);
+            expense.setRetireComments("Removed during draft edit");
+            getBillItemFacade().edit(expense);
         }
 
         recalculateExpenseTotals();
@@ -1121,10 +1134,22 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
         //check and calculate expenses separately
         if (billExpenses != null && !billExpenses.isEmpty()) {
-            getBill().setBillExpenses(billExpenses);
-
+            // Persist each expense explicitly and set the owning-side expenseBill
+            // FK - relying on Bill.billExpenses' cascade alone leaves this FK
+            // NULL, since the mappedBy side (Bill.billExpenses) is not the
+            // owning side of the relationship (issue #21856).
+            int expenseSerial = 0;
             double totalForExpenses = 0;
-            for (BillItem expense : getBillExpenses()) {
+            for (BillItem expense : billExpenses) {
+                expense.setSearialNo(expenseSerial++);
+                expense.setExpenseBill(getBill());
+                expense.setCreatedAt(new Date());
+                expense.setCreater(getSessionController().getLoggedUser());
+                if (expense.getId() == null) {
+                    getBillItemFacade().create(expense);
+                } else {
+                    getBillItemFacade().edit(expense);
+                }
                 totalForExpenses += expense.getNetValue();
             }
 
@@ -1453,6 +1478,45 @@ public class PharmacyDirectPurchaseController implements Serializable {
                 getBillItemFacade().edit(bi);
             }
         }
+
+        // Retire any previously persisted expenses that were removed from the session list
+        java.util.Map<String, Object> retireExpenseParams = new java.util.HashMap<>();
+        retireExpenseParams.put("billId", getBill().getId());
+        List<BillItem> persistedExpenses = getBillItemFacade().findByJpql(
+            "SELECT be FROM BillItem be WHERE be.expenseBill.id = :billId AND be.retired = false",
+            retireExpenseParams);
+        java.util.Set<Long> sessionExpenseIds = new java.util.HashSet<>();
+        for (BillItem be : getBillExpenses()) {
+            if (be.getId() != null) {
+                sessionExpenseIds.add(be.getId());
+            }
+        }
+        for (BillItem persisted : persistedExpenses) {
+            if (!sessionExpenseIds.contains(persisted.getId())) {
+                persisted.setRetired(true);
+                persisted.setRetireComments("Removed during draft edit");
+                getBillItemFacade().edit(persisted);
+            }
+        }
+
+        // Save each bill expense explicitly - do not rely on Bill.billExpenses'
+        // cascade alone, since the owning-side expenseBill FK must be set on
+        // each child for the cascade-insert to actually link back to this bill
+        int expenseSerial = 0;
+        double totalForExpenses = 0.0;
+        for (BillItem expense : getBillExpenses()) {
+            expense.setSearialNo(expenseSerial++);
+            expense.setExpenseBill(getBill());
+            expense.setCreatedAt(new Date());
+            expense.setCreater(getSessionController().getLoggedUser());
+            if (expense.getId() == null) {
+                getBillItemFacade().create(expense);
+            } else {
+                getBillItemFacade().edit(expense);
+            }
+            totalForExpenses += expense.getNetValue();
+        }
+        getBill().setExpenseTotal(-Math.abs(totalForExpenses));
 
         getBillFacade().edit(getBill());
         draftMode = true;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -939,6 +939,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
     }
 
     public void addExpense() {
+        if (getBill().isCompleted()) {
+            JsfUtil.addErrorMessage("This bill is completed and cannot be edited.");
+            return;
+        }
         if (getBill().getId() == null) {
             getBillFacade().create(getBill());
             if (getBill().getBillFinanceDetails() == null) {
@@ -973,10 +977,14 @@ public class PharmacyDirectPurchaseController implements Serializable {
         recalculateExpenseTotals();
         recalculateProfitMarginsForAllItems();
 
-        // Persist the updated bill
-        if (getBill().getId() != null) {
-            getBillFacade().edit(getBill());
-        }
+        // Persist the expense directly so its generated id lands on this same
+        // in-memory object. Relying on getBillFacade().edit(getBill())'s cascade
+        // merges a copy of the bill graph - the id never comes back to
+        // currentExpense, so later save paths see getId()==null and either
+        // duplicate-create it or wrongly retire the row cascade already made
+        // (issue #21856 review).
+        getBillItemFacade().create(currentExpense);
+        getBillFacade().edit(getBill());
 
         currentExpense = null;
 
@@ -984,6 +992,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
     public void removeExpense(BillItem expense) {
         if (expense == null) {
+            return;
+        }
+        if (getBill().isCompleted()) {
+            JsfUtil.addErrorMessage("This bill is completed and cannot be edited.");
             return;
         }
 
@@ -1174,6 +1186,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
     }
 
     public void removeItem(BillItem bi) {
+        if (getBill().isCompleted()) {
+            JsfUtil.addErrorMessage("This bill is completed and cannot be edited.");
+            return;
+        }
         getBillItems().remove(bi);
 
         int i = 0;
@@ -1195,6 +1211,10 @@ public class PharmacyDirectPurchaseController implements Serializable {
     }
 
     public void updateBillItem() {
+        if (getBill().isCompleted()) {
+            JsfUtil.addErrorMessage("This bill is completed and cannot be edited.");
+            return;
+        }
         if (editingBillItem == null) {
             JsfUtil.addErrorMessage("No item selected for editing");
             return;

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -1393,6 +1393,22 @@ public class Bill implements Serializable, RetirableEntity {
         this.billItems = billItems;
     }
 
+    /**
+     * Bill items excluding retired ones. Bill print templates should use
+     * this instead of getBillItems() directly, so a line item removed
+     * during draft editing (retired = true) doesn't still appear on the
+     * printed bill (issue #21856).
+     */
+    public List<BillItem> getActiveBillItems() {
+        List<BillItem> active = new ArrayList<>();
+        for (BillItem bi : getBillItems()) {
+            if (!bi.isRetired()) {
+                active.add(bi);
+            }
+        }
+        return active;
+    }
+
     public Date getBillDate() {
         if (billDate == null) {
             billDate = createdAt;

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -590,11 +590,12 @@
                                         style="margin-right:10px"
                                         icon="fas fa-edit"
                                         title="Edit Item"
+                                        disabled="#{pharmacyDirectPurchaseController.bill.completed}"
                                         process="@this"
                                         update=":bill:dlgEditBillItem"
                                         oncomplete="PF('dlgEditBillItem').show()"
                                         action="#{pharmacyDirectPurchaseController.prepareEditBillItem(ph)}" />
-                                    <p:commandButton styleClass="ui-button-danger" icon="fas fa-trash" title="Delete Item" ajax="false" action="#{pharmacyDirectPurchaseController.removeItem(ph)}" />
+                                    <p:commandButton styleClass="ui-button-danger" icon="fas fa-trash" title="Delete Item" disabled="#{pharmacyDirectPurchaseController.bill.completed}" ajax="false" action="#{pharmacyDirectPurchaseController.removeItem(ph)}" />
                                 </p:column>
                             </p:dataTable>
 
@@ -777,6 +778,7 @@
                                                 value="Add"
                                                 icon="fas fa-plus"
                                                 class="ui-button-warning w-100"
+                                                disabled="#{pharmacyDirectPurchaseController.bill.completed}"
                                                 action="#{pharmacyDirectPurchaseController.addExpense()}"
                                                 ajax = "false"
                                                 process="billExpenseGrid btnAddExpense @this"
@@ -814,6 +816,7 @@
                                             title="Delete expense"
                                             styleClass="ui-button-danger"
                                             icon="pi pi-trash"
+                                            disabled="#{pharmacyDirectPurchaseController.bill.completed}"
                                             action="#{pharmacyDirectPurchaseController.removeExpense(be)}"
                                             process="@this"
                                             update="tblExpenses :#{p:resolveFirstComponentWithId('billExpenseGrid',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails',view).clientId}" />

--- a/src/main/webapp/pharmacy/direct_purchase.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase.xhtml
@@ -586,6 +586,7 @@
 
                                 <p:column>
                                     <p:commandButton
+                                        id="btnEditItem"
                                         styleClass="ui-button-warning"
                                         style="margin-right:10px"
                                         icon="fas fa-edit"
@@ -595,7 +596,7 @@
                                         update=":bill:dlgEditBillItem"
                                         oncomplete="PF('dlgEditBillItem').show()"
                                         action="#{pharmacyDirectPurchaseController.prepareEditBillItem(ph)}" />
-                                    <p:commandButton styleClass="ui-button-danger" icon="fas fa-trash" title="Delete Item" disabled="#{pharmacyDirectPurchaseController.bill.completed}" ajax="false" action="#{pharmacyDirectPurchaseController.removeItem(ph)}" />
+                                    <p:commandButton id="btnDeleteItem" styleClass="ui-button-danger" icon="fas fa-trash" title="Delete Item" disabled="#{pharmacyDirectPurchaseController.bill.completed}" ajax="false" action="#{pharmacyDirectPurchaseController.removeItem(ph)}" />
                                 </p:column>
                             </p:dataTable>
 

--- a/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase.xhtml
@@ -77,7 +77,7 @@
             <div>
                 <p:dataTable 
                     rowIndexVar="rowIndex"
-                    value="#{cc.attrs.bill.billItems}" 
+                    value="#{cc.attrs.bill.activeBillItems}" 
                     var="bip"
                     style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
                     <p:column style="padding: 4px;">

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing.xhtml
@@ -77,7 +77,7 @@
             <div>
                 <p:dataTable 
                     rowIndexVar="rowIndex"
-                    value="#{cc.attrs.bill.billItems}" 
+                    value="#{cc.attrs.bill.activeBillItems}" 
                     var="bip"
                     style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
                     <p:column style="padding: 4px;">

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_1.xhtml
@@ -77,7 +77,7 @@
             <div>
                 <p:dataTable 
                     rowIndexVar="rowIndex"
-                    value="#{cc.attrs.bill.billItems}" 
+                    value="#{cc.attrs.bill.activeBillItems}" 
                     var="bip"
                     style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
                     <p:column style="padding: 4px;">

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_2.xhtml
@@ -92,7 +92,7 @@
             <div>
                 <p:dataTable
                     rowIndexVar="rowIndex"
-                    value="#{cc.attrs.bill.billItems}"
+                    value="#{cc.attrs.bill.activeBillItems}"
                     var="bip"
                     style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
                     <p:column style="padding: 4px;">

--- a/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purhcase_with_costing_custom_letter.xhtml
@@ -109,7 +109,7 @@
 
             <div>
                 
-                <h:panelGroup rendered="#{not empty cc.attrs.bill.billItems}">
+                <h:panelGroup rendered="#{not empty cc.attrs.bill.activeBillItems}">
                     <table style="width: 94%; margin: 0 auto; border-collapse: collapse; font-size: 15px;" >
                         <thead >
                             <tr>
@@ -136,7 +136,7 @@
                         </thead>
 
                         <tbody>
-                            <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                            <ui:repeat value="#{cc.attrs.bill.activeBillItems}" var="bip">
                                 <tr>
                                     <td style="padding: 4px; border: 1px solid black;">
                                         <h:outputText value="#{bip.item.name}" />

--- a/src/main/webapp/resources/pharmacy/purhcase.xhtml
+++ b/src/main/webapp/resources/pharmacy/purhcase.xhtml
@@ -102,7 +102,7 @@
                 <div>
                     <p:dataTable
                         rowIndexVar="rowIndex"
-                        value="#{cc.attrs.bill.billItems}"
+                        value="#{cc.attrs.bill.activeBillItems}"
                         var="bip"
                         style="font-size: 15px; margin-left: 3%; margin-right: 3%;">
                         <p:column style="padding: 4px;width: 6em;">
@@ -330,7 +330,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                <ui:repeat value="#{cc.attrs.bill.activeBillItems}" var="bip">
                                     <tr>
                                         <td style="border: 1px solid #000; padding: 8px;">
                                             <h:outputText value="#{bip.item.name}"/>

--- a/src/main/webapp/resources/pharmacy/purhcase_ws.xhtml
+++ b/src/main/webapp/resources/pharmacy/purhcase_ws.xhtml
@@ -61,7 +61,7 @@
 
             <div >
                 <p:spacer height="15px"/>
-                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont" value="#{cc.attrs.bill.billItems}" var="bip" >
+                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont" value="#{cc.attrs.bill.activeBillItems}" var="bip" >
 
                     <p:column>
                         <f:facet name="header">Item</f:facet>


### PR DESCRIPTION
## Summary

Two data-integrity bugs found while validating the Save/Finalize/Approve workflow shipped in #21855.

- **Retired items still print.** `Bill.billItems` is a plain `@OneToMany` with no `retired` filter, and every Direct Purchase print template (`pharmacy:purhcase` and its variants: `direct_purhcase`, `direct_purhcase_with_costing*`, `purhcase_ws`) bound directly to it. An item removed during draft editing — correctly retired in the database by `persistDraftDirectPurchase()` — still appeared on the printed bill, value included in the total. Added `Bill.getActiveBillItems()` (filters `retired = false`) and switched every Direct Purchase print template to use it.
- **Bill Expenses were never persisted as itemized records**, in either the old single-step Settle flow or the new draft workflow. `Bill.billExpenses` is `@OneToMany(mappedBy = "expenseBill", cascade = ALL)`, but nothing ever set the owning-side `expenseBill` FK on the child `BillItem` — only the parent's in-memory collection got the item appended. Merging the bill with that FK unset never creates a linked row, so the expense value only survived as a stray in-memory carry-over on `bill.expenseTotal` (itself correct only by accident, from `addExpense()`'s own immediate save). Reopening a saved/finalized draft — via search **or** the "Approve Direct Purchase" list — always showed an empty Bill Expenses grid.

  Fixed by setting `BillItem.expenseBill` explicitly wherever an expense is created (`addExpense()`, `persistDraftDirectPurchase()`, `settleDirectPurchaseBillFinally()`), and by having `persistDraftDirectPurchase()` explicitly create/edit each expense and retire ones removed from the session list — mirroring how bill items are already handled, instead of depending on cascade alone.

- Also gated **Delete Item / Edit Item / Add Expense / Delete Expense** behind `!bill.completed` in `direct_purchase.xhtml`, since none of those controls had any way to actually save an edit made after Finalize.

Closes #21856

## Test plan

Verified end-to-end via Playwright against local Payara (Main Pharmacy department, `coop` database):

- [x] Save Draft with 2 items + 1 expense → reopen via "Approve Direct Purchase" list → expense now visible (previously always empty)
- [x] Remove an item after Save Draft, then Finalize → item correctly retired in DB, does **not** reappear on reopen or on Approve
- [x] Approve the bill → Purchase Bill print shows only the active item and the correct Expense Total; the retired item is excluded (previously it printed anyway)
- [x] Edit Item / Delete Item / Add Expense / Delete Expense are disabled once `bill.completed` is true
- [x] `mvn compile` clean

Screenshots (before/after) documented in issue #21856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct Purchase views and print templates now display only active (non-retired) bill items.
  * When a bill is completed, item and expense actions are disabled, preventing further edits.
* **Bug Fixes**
  * Expense changes are now persisted more reliably in both draft and final handling.
  * Removed expenses are now properly retired in persistence (not just removed from memory).
  * Profit percentage display now avoids divide-by-zero issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->