### PR TITLE
feat(inward): redesign Inpatient Dashboard with encounter-scoped pharmacy pages

### DIFF
--- a/developer_docs/inward/2026-07-05-inpatient-dashboard-redesign-design.md
+++ b/developer_docs/inward/2026-07-05-inpatient-dashboard-redesign-design.md
@@ -1,0 +1,122 @@
+# Inpatient Dashboard Redesign — Design Spec
+
+Date: 2026-07-05
+Status: Approved by user, pending implementation plan
+
+## Problem Statement
+
+The Inpatient Dashboard (`/inward/admission_profile.xhtml`, `BhtSummeryController.navigateToInpatientProfile()`) is the central hub for a single patient encounter (BHT). Two independent problems exist today:
+
+1. **Wrong data scope on 6 pharmacy links.** Six buttons in the "Pharmaceuticals & Consumables" panel navigate to pages designed for the Nursing Workbench (`/nurse/index.xhtml`) — generic, all-patient, date-range-filtered search screens (`SearchController`-backed). When reached from the dashboard, a single `patientEncounter` is already known, but the target pages still force the user through From/To Date pickers and a Search click, and in most cases never actually filter by that encounter at all (confirmed by code investigation — the `patientEncounter` property set via `f:setPropertyActionListener` is dead data in 5 of the 6 query methods).
+2. **No visual distinction between actions and reports**, and patient identity (name/age/sex/BHT) is not prominent — it's one row among many in a small column-1 panel, competing visually with everything else.
+
+## Scope
+
+This spec covers exactly the items the user identified:
+- The 6 pharmacy-related dashboard links that wrongly reuse nurse-workbench search pages.
+- The visual/layout redesign of `admission_profile.xhtml` (patient banner + action/report panel separation).
+
+Out of scope (explicitly deferred by user decision during brainstorming): auditing non-pharmacy report links (Lab, Investigation, Professional Fee, Deposit searches) for the same date-filter problem. If the same issue exists there, it will be handled as a separate follow-up.
+
+All existing generic/nurse-workbench pages (`ward_pharmacy_bht_issue_request_list_for_issue.xhtml`, `ward_pharmacy_bht_issue_request_bill_search.xhtml`, `pharmacy_search_sale_bill_bht.xhtml`, `pharmacy_search_sale_bill_item_bht.xhtml`, `pharmacy_search_return_bill_bht.xhtml`) remain **unchanged** — they are still needed for their original multi-patient use case (Nursing Workbench and general pharmacy search menus).
+
+---
+
+## Part A — Encounter-Scoped Pharmacy Pages
+
+### Current State (investigated)
+
+| Dashboard button | Target page | Backing query | `patientEncounter` filter? |
+|---|---|---|---|
+| BHT Issue Requests | `ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml` | `SearchController.createInwardBHTForIssueTable()` | No — filters by `toDepartment` + date range only |
+| View Pharmacy Requests | `ward/ward_pharmacy_bht_issue_request_bill_search.xhtml` | `SearchController.createInwardBHTRequestTable()` | No — same gap |
+| Search Direct Issues by Bill | `inward/pharmacy_search_sale_bill_bht.xhtml` | `SearchController.createTableBht(PharmacyBhtPre)` | No — filters by institution/department + date range |
+| Search Direct Issues by Item | `inward/pharmacy_search_sale_bill_item_bht.xhtml` | `SearchController.createBillItemTableBht(PharmacyBhtPre)` | No — only `admissionType` used |
+| Search Issue Returns by Bill | `inward/pharmacy_search_return_bill_bht.xhtml` | `SearchController.createReturnBhtBills(PharmacyBhtPre)` | No |
+| Search Issue Returns by Item | `inward/pharmacy_search_return_bill_item_bht.xhtml` | **Page and query do not exist** — dead link today | N/A |
+
+These 6 collapse into 3 real data sets:
+- **Pharmacy Requests** (items 1+2): both query `Bill` where `billType=InwardPharmacyRequest`; item 1 adds an issued/not-issued split via `PharmacySaleBhtController.checkBillComponent()`.
+- **Direct Issues** (items 3+4): both query `PharmacyBhtPre` bills — bill-level vs. item-level rendering of the same data.
+- **Issue Returns** (items 5+6): item 5 queries `RefundBill` of type `PharmacyBhtPre`; item 6 has no existing implementation.
+
+### New Design
+
+**New controller**: `com.divudi.bean.inward.InwardPharmacyEncounterReportController` (`@Named`, `@ViewScoped`), following the established pattern in `InwardReportControllerBht` (`patientEncounter` field, guard-in-navigate methods, DTO-JPQL fetch methods, `navigateToAdmissionProfile()` "back" method).
+
+**New DTO**: reuse `com.divudi.core.data.dto.BillListReportDTO` (already has `billId`, `billNumber`, `billTypeAtomic`, `patientName`, `createdAt`, `createdUserName`, `retired/cancelled/refunded`, `total/discount/netTotal`, `bhtNo`, `deptId`) for all 3 bill-level lists — it already supports the "View" reprint navigation pattern used by the encounter-scoped Service Bill list (issue #21247 precedent). Use the enum-accepting constructor (avoids the documented `COALESCE`-on-enum EclipseLink binding gotcha).
+
+**New item-level DTO**: `com.divudi.core.data.dto.InpatientPharmacyBillItemDTO` (new) for the nested/expandable item rows within each bill — fields: `billId` (join key), `itemName`, `itemCode`, `qty`, `netValue`. Populated by a second JPQL query keyed by the list of bill IDs from the bill-level fetch, then grouped in Java by `billId` for the expandable row-toggle UI (PrimeFaces `p:dataTable` with `p:rowToggler` / expansion row).
+
+**Three new pages**, all under `src/main/webapp/inward/reports/`, all following the established shell from `inpatient_pharmacy_item_list_dto.xhtml` (growl → panel header with Download/Print/"Inpatient Dashboard" back button → `col-3` Patient Details + `common:admission_details` → `col-9` results table):
+
+1. **`inpatient_pharmacy_requests_list.xhtml`**
+   - Bill-level `p:dataTable`, one row per `InwardPharmacyRequest` bill for this `patientEncounter`.
+   - Columns: Bill No, Requested Department, Requested At, Requested By, Status (Issued / Not Issued, derived from whether any issued bill references it).
+   - Status filter dropdown (All / Not Issued / Issued Only) replaces the old 3 separate search buttons — client-side or re-query on change.
+   - Row expansion shows the nested "Issued" bills (Bill No, Date, Issued By, To Staff, Net Total).
+   - Row actions: "View Request" → existing `ward_pharmacy_reprint_bht_issue_request.xhtml` (unchanged). "Issue Medicines" → existing `PharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()` flow (unchanged), rendered only when not yet issued and user has `PharmacyBHTIssueAccept`. Nested "View Bill" → existing `ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml` (unchanged).
+
+2. **`inpatient_pharmacy_direct_issues_list.xhtml`**
+   - Bill-level `p:dataTable`, one row per `PharmacyBhtPre` sale bill for this `patientEncounter`.
+   - Columns: Bill No, Billed At, Billed By, Net Value.
+   - Row expansion shows item-level detail (Item Name, Code, Qty, Net Value) via the new `InpatientPharmacyBillItemDTO`.
+   - Row action: "View Bill" → existing `pharmacy_reprint_bill_sale_bht.xhtml` (unchanged).
+
+3. **`inpatient_pharmacy_returns_list.xhtml`**
+   - Bill-level `p:dataTable`, one row per `RefundBill` of type `PharmacyBhtPre` for this `patientEncounter`.
+   - Columns: Sale Bill No (via `billedBill`), Return Bill No, Returned At, Returned By, Net Value.
+   - Row expansion shows returned item-level detail.
+   - Row action: "View Bill" → existing `pharmacy_reprint_bill_return_bht.xhtml` (unchanged), disabled per existing `checkActiveReturnCashBill()`/`cancelled` guard logic.
+
+**Dashboard changes** (`admission_profile.xhtml`, "Pharmaceuticals & Consumables" panel, lines ~928-1028): the 6 search/report buttons ("BHT Issue Requests," "View Pharmacy Requests," "Search Direct Issues by Bill," "Search Direct Issues by Item," "Search Issue Returns by Bill," "Search Issue Returns by Item") are replaced by 3 buttons ("Pharmacy Requests," "Direct Issues," "Issue Returns"), each navigating straight to one of the new pages with `patientEncounter` set via `f:setPropertyActionListener` — no filters, no search click, data loads immediately. These 3 buttons move into the new "Pharmacy Reports & History" sub-panel (see Part B).
+
+The action-oriented pharmacy buttons ("Request from Pharmacy," "Direct Issue to BHTs," "Issue Discharge Medicines," "Direct Issue to Theatre Cases," "Receive Medicines from Pharmacy," "Return Medicines to Pharmacy") are unchanged and move into the new "Pharmacy Actions" sub-panel.
+
+---
+
+## Part B — Dashboard Visual Redesign
+
+### 1. Patient Identity Banner
+
+A new full-width strip inside the existing outer `p:panel`, placed directly below the current header row (title + Back to Search/Nursing WorkBench buttons) and above the 4-column row. Shows, in large/bold text: **Name — Age — Sex — BHT No**. The existing encounter-flag badges (`ON_ADMISSION_DEATH`, `RAPID_TEMP_AE`) move here from the header facet, so all patient-identifying/flagging information is in one glanceable strip.
+
+The existing "Patient Details" panel in column 1 remains, now scoped to secondary fields only (Mobile No, Phone No, NIC, Registration Source) — Name/Gender/Age are no longer duplicated there since they're now in the banner. (BHT No also drops from `common:admission_details` header duplication — it stays there too since that panel is reused elsewhere; no change needed to the composite component itself.)
+
+### 2. Action vs. Report Panel Split
+
+Three panels currently mix stateful actions with read-only reports/searches. Each is split into two sub-panels with visually distinct headers — **Actions** sub-panels use an accent color (e.g. `ui-button-success`/blue-green header background) with a bolt or plus-style icon; **Reports** sub-panels use a neutral/grey header with a list or chart-style icon.
+
+- **"Pharmaceuticals & Consumables"** →
+  - **"Pharmacy Actions"**: Request from Pharmacy, Direct Issue to BHTs, Issue Discharge Medicines, Direct Issue to Theatre Cases, Receive Medicines from Pharmacy, Return Medicines to Pharmacy.
+  - **"Pharmacy Reports & History"**: Pharmacy Requests, Direct Issues, Issue Returns (the 3 consolidated links from Part A).
+
+- **"Room Management"** →
+  - **"Room Status"**: current room assignment display (the `ui:repeat` over `activePatientRooms`), Room Details link.
+  - **"Room Actions"**: Add New Room, Add Guardian Room, Room Change, Guardian Room Change, Initiate Transfer, Accept Patients.
+
+- **"Clinical Data"** →
+  - **"Clinical Actions"**: Clinical Discharge, Nursing Discharge, Physical Discharge (stateful workflow transitions with color-coded complete/incomplete state — unchanged behavior).
+  - **"Clinical Reports & Records"**: Patient History, Clinical Notes, Ward Medications, Medicine Timeline, Discharge Medications, Investigations, Images, Diagnosis Card.
+
+Panels that are already single-purpose ("Admission," "Billing," "Documents," "Reports," "Operation Theatre") are unchanged.
+
+### 3. No Functional Regressions
+
+Part B is purely a rendering/layout change plus the button consolidation from Part A. No new privileges, no changed navigation targets other than the 3 pharmacy links, no changed business logic.
+
+---
+
+## Testing Plan
+
+- Playwright E2E: log in, navigate to an active admission's Inpatient Dashboard, verify the patient banner renders Name/Age/Sex/BHT prominently, verify the 3 new pharmacy links land directly on populated lists (no filter step), verify each list's row actions (View Request/View Bill/Issue Medicines) still navigate to the correct existing reprint pages, verify Action vs Report sub-panels render with distinct styling.
+- DB verification: confirm the new JPQL queries return the same bills as the old `SearchController` methods would for a given encounter (cross-check row counts against the legacy pages for a test BHT with pharmacy requests, direct issues, and returns).
+
+## Documentation
+
+- New wiki page(s) in `../hmis.wiki` covering the redesigned Inpatient Dashboard and the 3 new pharmacy history pages, per user's end-to-end requirement.
+- Update `developer_docs/navigation/inward_navigation.md` — replace the 6-row pharmacy table entries under "Pharmacy (privilege: `InwardPharmacyMenu`)" / "Ward Pharmacy" sections with the 3 new consolidated pages, and note the new controller in the Key Controllers table.
+
+## GitHub Issue
+
+No existing issue covers this (searched `hmislk/hmis` for dashboard/pharmacy-request/encounter-scoped terms — no match). A new issue will be created before implementation begins, following the `/start-issue` workflow.

--- a/developer_docs/jsf/navigation-patterns.md
+++ b/developer_docs/jsf/navigation-patterns.md
@@ -81,6 +81,27 @@ When a page is reached via an external URL with query parameters (lab result lin
 
 ---
 
+## 🚨 `@ViewScoped` + `f:setPropertyActionListener` + `faces-redirect=true` = lost state
+
+A common new-page pattern in this project: a button on page A sets a property on a target controller via `f:setPropertyActionListener`, then navigates (`ajax="false"`, `faces-redirect=true`) to page B, whose controller reads that property to fetch its data.
+
+```xhtml
+<!-- page A -->
+<p:commandButton value="View Report" action="#{reportController.navigateToReport()}" ajax="false">
+    <f:setPropertyActionListener value="#{admissionController.current}" target="#{reportController.patientEncounter}" />
+</p:commandButton>
+```
+
+**If `reportController` is `@ViewScoped`, this silently fails.** `faces-redirect=true` is a full browser redirect to a brand-new JSF view. A `@ViewScoped` bean's lifetime is tied to the *view* (`javax.faces.ViewState`) it was created for — navigating to a different view destroys the old instance and constructs a fresh one for the new view. The `patientEncounter` set moments earlier on page A's request is gone; `reportController.navigateToReport()` sees whatever field defaults to (usually `null`), and any query gated on `patientEncounter == null` either silently returns empty or bails with an error message that never renders (because the redirect already moved past that request).
+
+Symptoms are easy to misattribute to a data or JPQL bug: the query "looks right," the DB has matching rows, but the page shows nothing — because the bean holding the query's parameter isn't the same instance that had the parameter set.
+
+**Fix:** use `@SessionScoped` (or `@ApplicationScoped` for pure lookups) for any controller reached this way, matching `InwardReportControllerBht` and the majority pattern in this codebase. Reserve `@ViewScoped` for beans that are only ever populated by their own page's initial render (e.g. via `f:viewAction`/`f:viewParam`, case 1 above) and never receive state from a *different* page's button click.
+
+Found and fixed in issue #21852 (`InwardPharmacyEncounterReportController` — three new encounter-scoped report pages appeared to load with `patientEncounter` set from the dashboard, but returned zero rows and the "back to dashboard" button also failed, both traced to this same root cause).
+
+---
+
 ## `f:event type="preRenderView"` — same rules apply
 
 `f:event type="preRenderView"` fires on **every render**, including postbacks (form submissions), not just on initial GET. This makes it even more aggressive than `f:viewAction`. It is only legitimate in the same two cases above, and even then `f:viewAction` is preferred as it fires only on GET by default.

--- a/developer_docs/navigation/inward_navigation.md
+++ b/developer_docs/navigation/inward_navigation.md
@@ -104,6 +104,18 @@ The top-level menu entry is **Inpatient** (privilege: `Inward`).
 | Return Medicines to Pharmacy | `/ward/ward_pharmacy_return_to_pharmacy.xhtml` | `WardPharmacyReturnToPharmacyController` | Ward returns unused stock to pharmacy via porter |
 | Deduct from Ward Stock | `/ward/ward_medication_administration_settle.xhtml` | `MedicationAdministrationStockSettlementController` | Bulk-deduct administered medicines from ward stock |
 
+### Pharmacy Reports & History (dashboard-only, encounter-scoped — issue #21852)
+
+These 3 pages live under "Pharmacy Reports & History" in the admission profile's Pharmacy panel. Unlike the general Pharmacy menu items above, they take no date-range/department filter — each is pre-loaded for the current `patientEncounter` only, replacing 6 old dashboard buttons that wrongly pointed at the general, all-patient, date-filtered pages.
+
+| Menu Item | Page | Controller | Notes |
+|---|---|---|---|
+| Pharmacy Requests | `/inward/reports/inpatient_pharmacy_requests_list.xhtml` | `InwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()` | Replaces "BHT Issue Requests" + "View Pharmacy Requests"; entity-based (needs `Bill.isFullyIssued()`); expandable row shows fulfilling issue bill(s) |
+| Direct Issues | `/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml` | `InwardPharmacyEncounterReportController.navigateToInpatientPharmacyDirectIssuesList()` | Replaces "Search Direct Issues by Bill/Item"; `BillListReportDTO` bill-level rows + `InpatientPharmacyBillItemDTO` expandable item rows |
+| Issue Returns | `/inward/reports/inpatient_pharmacy_returns_list.xhtml` | `InwardPharmacyEncounterReportController.navigateToInpatientPharmacyReturnsList()` | Replaces "Search Issue Returns by Bill/Item" (the "by Item" variant never existed before this); same DTO pattern as Direct Issues, over `RefundBill` |
+
+`InwardPharmacyEncounterReportController` is `@SessionScoped` (not `@ViewScoped`) — see `developer_docs/jsf/navigation-patterns.md` for why this matters when a bean receives state via `f:setPropertyActionListener` from a different page.
+
 ### Clinical Data (privilege: varies)
 
 | Menu Item | Page | Controller | Notes |
@@ -283,6 +295,7 @@ Accessed via **Admin → Manage Inpatient Services** → `/inward/inward_adminis
 | `NursingWorkBenchController` | `com.divudi.bean.inward` | Nursing workbench (under development) |
 | `InwardReportController` | `com.divudi.bean.inward` | Inward reports |
 | `InwardReportControllerBht` | `com.divudi.bean.inward` | BHT-level reports |
+| `InwardPharmacyEncounterReportController` | `com.divudi.bean.inward` | Encounter-scoped pharmacy history (Requests/Direct Issues/Returns) for the dashboard's "Pharmacy Reports & History" panel (#21852) |
 | `AdmissionTypeController` | `com.divudi.bean.inward` | Admission type master data |
 | `InwardPriceAdjustmntController` | `com.divudi.bean.inward` | Price adjustments (note: typo in class name is intentional — DB compatibility) |
 | `WardPharmacyBhtIssueReceiveController` | `com.divudi.bean.pharmacy` | Ward-side confirmation of medicines received from porter (#21468) |

--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -1,0 +1,472 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.core.util.JsfUtil;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.BillListReportDTO;
+import com.divudi.core.data.dto.InpatientPharmacyBillItemDTO;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.PreBill;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.RefundBill;
+import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Encounter-scoped pharmacy history controller for the redesigned Inpatient
+ * Dashboard (issue #21852). Provides 3 filter-free, encounter-scoped lists
+ * (Pharmacy Requests, Direct Issues, Issue Returns) that replace 6 old
+ * dashboard buttons which wrongly pointed to generic date-filtered,
+ * multi-patient Nursing-Workbench search pages. Every list here queries
+ * strictly by patientEncounter - no date range, no department filter.
+ *
+ * Modeled on {@link InwardReportControllerBht}: patientEncounter field,
+ * guard-and-fetch-and-navigate methods, DTO-JPQL fetch methods using
+ * findLightsByJpqlWithoutCache, and navigateToAdmissionProfile() back-nav.
+ *
+ * SessionScoped (not ViewScoped): the dashboard button sets patientEncounter
+ * via f:setPropertyActionListener then navigates with faces-redirect=true to
+ * an entirely new view. A ViewScoped bean is destroyed and recreated for the
+ * new view, discarding patientEncounter (and the fetched lists) before the
+ * new page can read them - matches InwardReportControllerBht's scope for the
+ * same reason.
+ *
+ * @author Claude Code
+ */
+@Named
+@SessionScoped
+public class InwardPharmacyEncounterReportController implements Serializable {
+
+    @EJB
+    BillFacade billFacade;
+    @EJB
+    BillItemFacade billItemFacade;
+
+    @Inject
+    AdmissionController admissionController;
+
+    private PatientEncounter patientEncounter;
+
+    // 1) Pharmacy Requests list (InwardPharmacyRequest bills) - entity-based,
+    // since Bill.isFullyIssued() and the nested "issued" bill list are
+    // entity-only concerns (not expressible as pure DTO projections).
+    private List<Bill> pharmacyRequestBillsToPatientEncounter;
+    private double pharmacyRequestBillsToPatientEncounterNetTotal;
+
+    // 2) Direct Issues list (PharmacyBhtPre PreBill sale bills)
+    private List<BillListReportDTO> directIssueBillsToPatientEncounter;
+    private double directIssueBillsToPatientEncounterNetTotal;
+    private List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter;
+
+    // 3) Issue Returns list (PharmacyBhtPre RefundBill bills)
+    private List<BillListReportDTO> returnBillsToPatientEncounter;
+    private double returnBillsToPatientEncounterNetTotal;
+    private List<InpatientPharmacyBillItemDTO> returnBillItemsToPatientEncounter;
+
+    /**
+     * Replaces "BHT Issue Requests" + "View Pharmacy Requests". Lists all
+     * InwardPharmacyRequest bills for this patientEncounter, each carrying
+     * its own isFullyIssued() flag and a per-row "issued sub-bills" list
+     * fetched via getIssuedBillsForRequest(billId).
+     */
+    public String navigateToInpatientPharmacyRequestsList() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        pharmacyRequestBillsToPatientEncounter = new ArrayList<>();
+        pharmacyRequestBillsToPatientEncounterNetTotal = 0.0;
+        try {
+            pharmacyRequestBillsToPatientEncounter = fetchPharmacyRequestBills();
+            for (Bill b : pharmacyRequestBillsToPatientEncounter) {
+                pharmacyRequestBillsToPatientEncounterNetTotal += b.getNetTotal();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
+                    .log(Level.SEVERE, "Error loading pharmacy request bills", e);
+            JsfUtil.addErrorMessage("Error loading pharmacy request data");
+            return null;
+        }
+        return "/inward/reports/inpatient_pharmacy_requests_list?faces-redirect=true";
+    }
+
+    private List<Bill> fetchPharmacyRequestBills() {
+        String jpql = "SELECT b FROM Bill b "
+                + "WHERE b.billType = :billType "
+                + "AND b.retired = false "
+                + "AND b.patientEncounter = :pe "
+                + "ORDER BY b.createdAt DESC";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.InwardPharmacyRequest);
+        params.put("pe", patientEncounter);
+
+        List<Bill> result = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * Per-row expansion data for the Pharmacy Requests list: the "issued"
+     * sub-bills that reference a given request bill. Same data as
+     * InwardReportControllerBht.getBHTIssudBills(Bill) - duplicated here
+     * (simple 6-line JPQL) rather than injecting that controller.
+     */
+    public List<Bill> getIssuedBillsForRequest(Long requestBillId) {
+        if (requestBillId == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "SELECT b FROM Bill b "
+                + "WHERE b.retired = false "
+                + "AND b.billType = :billType "
+                + "AND b.referenceBill.id = :refId";
+        Map<String, Object> params = new HashMap<>();
+        params.put("refId", requestBillId);
+        params.put("billType", BillType.PharmacyBhtPre);
+        List<Bill> result = billFacade.findByJpql(jpql, params);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * Convenience wrapper so XHTML can bind directly against the request
+     * bill's own isFullyIssued() flag without an extra lookup.
+     */
+    public boolean isRequestFullyIssued(Long billId) {
+        if (billId == null) {
+            return false;
+        }
+        Bill b = billFacade.find(billId);
+        return b != null && b.isFullyIssued();
+    }
+
+    /**
+     * Replaces "Search Direct Issues by Bill" + "Search Direct Issues by
+     * Item". Lists all PharmacyBhtPre PreBill sale bills for this
+     * patientEncounter (bill-level DTO) plus their line items (item-level
+     * DTO), so a single page can render both the bill list and the
+     * expandable per-bill item rows.
+     */
+    public String navigateToInpatientPharmacyDirectIssuesList() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        directIssueBillsToPatientEncounter = new ArrayList<>();
+        directIssueBillsToPatientEncounterNetTotal = 0.0;
+        directIssueBillItemsToPatientEncounter = new ArrayList<>();
+        try {
+            directIssueBillsToPatientEncounter = fetchDirectIssueBills();
+            for (BillListReportDTO dto : directIssueBillsToPatientEncounter) {
+                if (dto.getNetTotal() != null) {
+                    directIssueBillsToPatientEncounterNetTotal += dto.getNetTotal().doubleValue();
+                }
+            }
+
+            List<Long> billIds = new ArrayList<>();
+            for (BillListReportDTO dto : directIssueBillsToPatientEncounter) {
+                billIds.add(dto.getBillId());
+            }
+            directIssueBillItemsToPatientEncounter = fetchDirectIssueBillItems(billIds);
+        } catch (Exception e) {
+            Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
+                    .log(Level.SEVERE, "Error loading direct issue bills", e);
+            JsfUtil.addErrorMessage("Error loading direct issue data");
+            return null;
+        }
+        return "/inward/reports/inpatient_pharmacy_direct_issues_list?faces-redirect=true";
+    }
+
+    private List<BillListReportDTO> fetchDirectIssueBills() {
+        // Bill.retired/cancelled/refunded are primitive boolean and
+        // total/discount/netTotal/margin are primitive double - project them
+        // directly (no COALESCE) to keep EclipseLink's reflective DTO
+        // constructor binding unambiguous. See BillListReportDTO comments.
+        String jpql = "SELECT new com.divudi.core.data.dto.BillListReportDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "b.billTypeAtomic, "
+                + "b.paymentMethod, "
+                + "COALESCE(b.patientEncounter.patient.person.name, ''), "
+                + "b.createdAt, "
+                + "COALESCE(b.creater.name, ''), "
+                + "b.retired, "
+                + "b.cancelled, "
+                + "b.refunded, "
+                + "b.total, "
+                + "b.discount, "
+                + "b.netTotal, "
+                + "COALESCE(b.patientEncounter.bhtNo, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.margin) "
+                + "FROM Bill b "
+                + "WHERE type(b) = PreBill "
+                + "AND b.billType = :billType "
+                + "AND b.retired = false "
+                + "AND b.patientEncounter = :pe "
+                + "ORDER BY b.createdAt DESC";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.PharmacyBhtPre);
+        params.put("pe", patientEncounter);
+
+        List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    private List<InpatientPharmacyBillItemDTO> fetchDirectIssueBillItems(List<Long> billIds) {
+        if (billIds == null || billIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+        String jpql = "SELECT new com.divudi.core.data.dto.InpatientPharmacyBillItemDTO("
+                + "bi.bill.id, "
+                + "bi.item.name, "
+                + "COALESCE(bi.item.code, ''), "
+                + "bi.qty, "
+                + "bi.netValue) "
+                + "FROM BillItem bi "
+                + "WHERE bi.bill.id IN :billIds "
+                + "AND bi.retired = false "
+                + "ORDER BY bi.bill.id, bi.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billIds", billIds);
+
+        List<InpatientPharmacyBillItemDTO> result = (List<InpatientPharmacyBillItemDTO>) billItemFacade
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * In-memory filter (no new query) for the per-row expansion on the
+     * Direct Issues list - the full item list was already fetched once for
+     * the whole encounter.
+     */
+    public List<InpatientPharmacyBillItemDTO> getItemsForDirectIssueBill(Long billId) {
+        if (billId == null || directIssueBillItemsToPatientEncounter == null) {
+            return new ArrayList<>();
+        }
+        List<InpatientPharmacyBillItemDTO> result = new ArrayList<>();
+        for (InpatientPharmacyBillItemDTO dto : directIssueBillItemsToPatientEncounter) {
+            if (billId.equals(dto.getBillId())) {
+                result.add(dto);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Replaces "Search Issue Returns by Bill" + "Search Issue Returns by
+     * Item" (the latter never existed before - built fresh here). Lists all
+     * PharmacyBhtPre RefundBill bills for this patientEncounter plus their
+     * returned line items.
+     */
+    public String navigateToInpatientPharmacyReturnsList() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        returnBillsToPatientEncounter = new ArrayList<>();
+        returnBillsToPatientEncounterNetTotal = 0.0;
+        returnBillItemsToPatientEncounter = new ArrayList<>();
+        try {
+            returnBillsToPatientEncounter = fetchReturnBills();
+            for (BillListReportDTO dto : returnBillsToPatientEncounter) {
+                if (dto.getNetTotal() != null) {
+                    returnBillsToPatientEncounterNetTotal += dto.getNetTotal().doubleValue();
+                }
+            }
+
+            List<Long> billIds = new ArrayList<>();
+            for (BillListReportDTO dto : returnBillsToPatientEncounter) {
+                billIds.add(dto.getBillId());
+            }
+            returnBillItemsToPatientEncounter = fetchReturnBillItems(billIds);
+        } catch (Exception e) {
+            Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
+                    .log(Level.SEVERE, "Error loading issue return bills", e);
+            JsfUtil.addErrorMessage("Error loading issue return data");
+            return null;
+        }
+        return "/inward/reports/inpatient_pharmacy_returns_list?faces-redirect=true";
+    }
+
+    private List<BillListReportDTO> fetchReturnBills() {
+        String jpql = "SELECT new com.divudi.core.data.dto.BillListReportDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "b.billTypeAtomic, "
+                + "b.paymentMethod, "
+                + "COALESCE(b.patientEncounter.patient.person.name, ''), "
+                + "b.createdAt, "
+                + "COALESCE(b.creater.name, ''), "
+                + "b.retired, "
+                + "b.cancelled, "
+                + "b.refunded, "
+                + "b.total, "
+                + "b.discount, "
+                + "b.netTotal, "
+                + "COALESCE(b.patientEncounter.bhtNo, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.margin, "
+                + "COALESCE(b.billedBill.deptId, '')) "
+                + "FROM RefundBill b "
+                + "WHERE b.billType = :billType "
+                + "AND b.retired = false "
+                + "AND b.patientEncounter = :pe "
+                + "ORDER BY b.createdAt DESC";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.PharmacyBhtPre);
+        params.put("pe", patientEncounter);
+
+        List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    private List<InpatientPharmacyBillItemDTO> fetchReturnBillItems(List<Long> billIds) {
+        if (billIds == null || billIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+        // Returned quantities/values are stored as negative on BillItem for
+        // return bills already (consistent with how
+        // InwardReportControllerBht.fetchPharmacyIssueDtos/isCancellationOrReturn
+        // treat *_RETURN types) - project as-is, no extra sign handling here.
+        String jpql = "SELECT new com.divudi.core.data.dto.InpatientPharmacyBillItemDTO("
+                + "bi.bill.id, "
+                + "bi.item.name, "
+                + "COALESCE(bi.item.code, ''), "
+                + "bi.qty, "
+                + "bi.netValue) "
+                + "FROM BillItem bi "
+                + "WHERE bi.bill.id IN :billIds "
+                + "AND bi.retired = false "
+                + "ORDER BY bi.bill.id, bi.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billIds", billIds);
+
+        List<InpatientPharmacyBillItemDTO> result = (List<InpatientPharmacyBillItemDTO>) billItemFacade
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * In-memory filter (no new query) for the per-row expansion on the Issue
+     * Returns list.
+     */
+    public List<InpatientPharmacyBillItemDTO> getItemsForReturnBill(Long billId) {
+        if (billId == null || returnBillItemsToPatientEncounter == null) {
+            return new ArrayList<>();
+        }
+        List<InpatientPharmacyBillItemDTO> result = new ArrayList<>();
+        for (InpatientPharmacyBillItemDTO dto : returnBillItemsToPatientEncounter) {
+            if (billId.equals(dto.getBillId())) {
+                result.add(dto);
+            }
+        }
+        return result;
+    }
+
+    public String navigateToAdmissionProfile() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter selected");
+            return null;
+        }
+        if (patientEncounter instanceof Admission) {
+            admissionController.setCurrent((Admission) patientEncounter);
+        }
+        return "/inward/admission_profile?faces-redirect=true";
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public List<Bill> getPharmacyRequestBillsToPatientEncounter() {
+        return pharmacyRequestBillsToPatientEncounter;
+    }
+
+    public void setPharmacyRequestBillsToPatientEncounter(List<Bill> pharmacyRequestBillsToPatientEncounter) {
+        this.pharmacyRequestBillsToPatientEncounter = pharmacyRequestBillsToPatientEncounter;
+    }
+
+    public double getPharmacyRequestBillsToPatientEncounterNetTotal() {
+        return pharmacyRequestBillsToPatientEncounterNetTotal;
+    }
+
+    public void setPharmacyRequestBillsToPatientEncounterNetTotal(double pharmacyRequestBillsToPatientEncounterNetTotal) {
+        this.pharmacyRequestBillsToPatientEncounterNetTotal = pharmacyRequestBillsToPatientEncounterNetTotal;
+    }
+
+    public List<BillListReportDTO> getDirectIssueBillsToPatientEncounter() {
+        return directIssueBillsToPatientEncounter;
+    }
+
+    public void setDirectIssueBillsToPatientEncounter(List<BillListReportDTO> directIssueBillsToPatientEncounter) {
+        this.directIssueBillsToPatientEncounter = directIssueBillsToPatientEncounter;
+    }
+
+    public double getDirectIssueBillsToPatientEncounterNetTotal() {
+        return directIssueBillsToPatientEncounterNetTotal;
+    }
+
+    public void setDirectIssueBillsToPatientEncounterNetTotal(double directIssueBillsToPatientEncounterNetTotal) {
+        this.directIssueBillsToPatientEncounterNetTotal = directIssueBillsToPatientEncounterNetTotal;
+    }
+
+    public List<InpatientPharmacyBillItemDTO> getDirectIssueBillItemsToPatientEncounter() {
+        return directIssueBillItemsToPatientEncounter;
+    }
+
+    public void setDirectIssueBillItemsToPatientEncounter(List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter) {
+        this.directIssueBillItemsToPatientEncounter = directIssueBillItemsToPatientEncounter;
+    }
+
+    public List<BillListReportDTO> getReturnBillsToPatientEncounter() {
+        return returnBillsToPatientEncounter;
+    }
+
+    public void setReturnBillsToPatientEncounter(List<BillListReportDTO> returnBillsToPatientEncounter) {
+        this.returnBillsToPatientEncounter = returnBillsToPatientEncounter;
+    }
+
+    public double getReturnBillsToPatientEncounterNetTotal() {
+        return returnBillsToPatientEncounterNetTotal;
+    }
+
+    public void setReturnBillsToPatientEncounterNetTotal(double returnBillsToPatientEncounterNetTotal) {
+        this.returnBillsToPatientEncounterNetTotal = returnBillsToPatientEncounterNetTotal;
+    }
+
+    public List<InpatientPharmacyBillItemDTO> getReturnBillItemsToPatientEncounter() {
+        return returnBillItemsToPatientEncounter;
+    }
+
+    public void setReturnBillItemsToPatientEncounter(List<InpatientPharmacyBillItemDTO> returnBillItemsToPatientEncounter) {
+        this.returnBillItemsToPatientEncounter = returnBillItemsToPatientEncounter;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/BillListReportDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BillListReportDTO.java
@@ -32,6 +32,7 @@ public class BillListReportDTO implements Serializable {
     private String bhtNo;
     private String deptId;
     private BigDecimal serviceCharge;
+    private String referenceBillNumber;
 
     // Default constructor
     public BillListReportDTO() {
@@ -120,6 +121,27 @@ public class BillListReportDTO implements Serializable {
         this.bhtNo = bhtNo;
         this.deptId = deptId;
         this.serviceCharge = serviceCharge != null ? BigDecimal.valueOf(serviceCharge) : null;
+    }
+
+    // Constructor for the encounter-scoped Inpatient Pharmacy Issue Returns list
+    // (issue #21852). Adds referenceBillNumber (the original sale bill's printed
+    // number, i.e. RefundBill.billedBill.deptId) on top of the #21247
+    // encounter-scoped constructor above, without touching that existing
+    // constructor's signature (per project rule: never modify existing
+    // constructors, only add new ones).
+    public BillListReportDTO(Long billId, String billNumber,
+                            BillTypeAtomic billTypeAtomicEnum, PaymentMethod paymentMethodEnum,
+                            String patientName, Date createdAt,
+                            String createdUserName, Boolean retired,
+                            Boolean cancelled, Boolean refunded,
+                            Double total, Double discount,
+                            Double netTotal,
+                            String bhtNo, String deptId, Double serviceCharge,
+                            String referenceBillNumber) {
+        this(billId, billNumber, billTypeAtomicEnum, paymentMethodEnum, patientName, createdAt,
+                createdUserName, retired, cancelled, refunded, total, discount, netTotal,
+                bhtNo, deptId, serviceCharge);
+        this.referenceBillNumber = referenceBillNumber;
     }
 
     // Getters and Setters
@@ -257,6 +279,14 @@ public class BillListReportDTO implements Serializable {
 
     public void setServiceCharge(BigDecimal serviceCharge) {
         this.serviceCharge = serviceCharge;
+    }
+
+    public String getReferenceBillNumber() {
+        return referenceBillNumber;
+    }
+
+    public void setReferenceBillNumber(String referenceBillNumber) {
+        this.referenceBillNumber = referenceBillNumber;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/data/dto/InpatientPharmacyBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InpatientPharmacyBillItemDTO.java
@@ -1,0 +1,71 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * Item-level DTO for the encounter-scoped inpatient pharmacy direct-issue and
+ * issue-return lists (Inpatient Dashboard redesign, issue #21852). Each row is
+ * one BillItem projected against its parent bill id, used to build the
+ * expandable per-bill item rows in the new pharmacy history pages.
+ *
+ * @author Claude Code
+ */
+public class InpatientPharmacyBillItemDTO implements Serializable {
+
+    private Long billId;
+    private String itemName;
+    private String itemCode;
+    private Double qty;
+    private Double netValue;
+
+    public InpatientPharmacyBillItemDTO() {
+    }
+
+    public InpatientPharmacyBillItemDTO(Long billId, String itemName, String itemCode, Double qty, Double netValue) {
+        this.billId = billId;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.netValue = netValue;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getNetValue() {
+        return netValue;
+    }
+
+    public void setNetValue(Double netValue) {
+        this.netValue = netValue;
+    }
+}

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -19,22 +19,6 @@
                         <div>
                             <h:outputText styleClass="fa fa-id-card"/>
                             <p:outputLabel value="Inpatient Dashboard" class="mt-2 mx-3"/>
-                            <!-- Encounter flag badge — hidden for the STANDARD default to keep
-                                 the dashboard clean for the vast majority of records. Styling
-                                 is flag-aware: dark for On Admission Death, amber for the
-                                 Rapid / Temp A&E pending-completion state. (Issues #21182, #21183) -->
-                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'ON_ADMISSION_DEATH'}">
-                                <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
-                                       icon="fas fa-cross"
-                                       styleClass="mx-2"
-                                       style="background-color:#455a64; color:#ffffff;"/>
-                            </ui:fragment>
-                            <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'RAPID_TEMP_AE'}">
-                                <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
-                                       icon="fas fa-truck-medical"
-                                       styleClass="mx-2"
-                                       style="background-color:#f0ad4e; color:#212529;"/>
-                            </ui:fragment>
                         </div>
                         <div><div class="d-flex gap-2">
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
@@ -59,6 +43,44 @@
                         </div>
                     </div>
                 </f:facet>
+
+                <!-- Patient Identity Banner: Name / Age / Sex / BHT No in one glanceable
+                     strip, plus the encounter-flag badges (moved here from the header
+                     facet so all patient-identifying/flag info lives in one place). -->
+                <div class="d-flex flex-wrap gap-4 align-items-center p-3 mb-2 rounded" style="background:#f0f4f8; border-left:6px solid #0d6efd;">
+                    <div>
+                        <div class="text-muted small">Name</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Age</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{admissionController.current.patient.person.ageAsString}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Sex</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{admissionController.current.patient.person.sex}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">BHT No</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{admissionController.current.bhtNo}"/></div>
+                    </div>
+                    <!-- Encounter flag badges — hidden for the STANDARD default to keep
+                         the dashboard clean for the vast majority of records. Styling
+                         is flag-aware: dark for On Admission Death, amber for the
+                         Rapid / Temp A&E pending-completion state. (Issues #21182, #21183) -->
+                    <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'ON_ADMISSION_DEATH'}">
+                        <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
+                               icon="fas fa-cross"
+                               styleClass="mx-2"
+                               style="background-color:#455a64; color:#ffffff;"/>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{admissionController.current.encounterRegistrationFlag eq 'RAPID_TEMP_AE'}">
+                        <p:tag value="#{admissionController.current.encounterRegistrationFlag.label}"
+                               icon="fas fa-truck-medical"
+                               styleClass="mx-2"
+                               style="background-color:#f0ad4e; color:#212529;"/>
+                    </ui:fragment>
+                </div>
 
                 <!-- Rapid / Temp A&E warning: demographics may be incomplete. Offers the
                      follow-up actions (complete details, change patient if duplicate, or
@@ -511,138 +533,149 @@
                         </p:panel>
 
                         <p:panel header="Room Management" class="m-1">
-                            <div class="row g-2">
-                                <!-- Current Room Assignments -->
-                                <div class="col-12">
-                                    <h:panelGroup rendered="#{empty admissionController.activePatientRooms}" layout="block">
-                                        <div class="text-center py-2 text-muted small">
-                                            <i class="fa-solid fa-info-circle me-1"/>
-                                            Not admitted to any room
-                                        </div>
-                                    </h:panelGroup>
-                                    <ui:repeat value="#{admissionController.activePatientRooms}" var="room">
-                                        <div class="d-flex align-items-center justify-content-between p-2 mb-1 border rounded" style="background: #f0f8ff;">
-                                            <div>
-                                                <div class="fw-semibold small">
-                                                    <i class="fa-solid fa-bed text-primary me-1"/>
-                                                    <h:outputText value="#{room.roomFacilityCharge.name}"/>
-                                                    <h:panelGroup rendered="#{room.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
-                                                        <span class="badge bg-success ms-1" style="font-size:0.65rem;">Guardian</span>
-                                                    </h:panelGroup>
-                                                </div>
-                                                <div class="text-muted" style="font-size:0.72rem;">
-                                                    <i class="fa-solid fa-clock me-1"/>
-                                                    Admitted:
-                                                    <h:outputText value="#{room.admittedAt}">
-                                                        <f:convertDateTime pattern="dd MMM yyyy HH:mm" timeZone="Asia/Colombo"/>
-                                                    </h:outputText>
-                                                </div>
+                            <div class="p-2 rounded mb-2" style="background-color:#eef1f4;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Status</div>
+                                <div class="row g-2">
+                                    <!-- Current Room Assignments -->
+                                    <div class="col-12">
+                                        <h:panelGroup rendered="#{empty admissionController.activePatientRooms}" layout="block">
+                                            <div class="text-center py-2 text-muted small">
+                                                <i class="fa-solid fa-info-circle me-1"/>
+                                                Not admitted to any room
                                             </div>
-                                            <p:commandButton
-                                                value="View"
-                                                ajax="false"
-                                                icon="fa-solid fa-arrow-right"
-                                                class="ui-button-sm ui-button-info"
-                                                action="#{admissionController.navigateToPatientRoomDetails()}">
-                                            </p:commandButton>
-                                        </div>
-                                    </ui:repeat>
-                                </div>
+                                        </h:panelGroup>
+                                        <ui:repeat value="#{admissionController.activePatientRooms}" var="room">
+                                            <div class="d-flex align-items-center justify-content-between p-2 mb-1 border rounded" style="background: #f0f8ff;">
+                                                <div>
+                                                    <div class="fw-semibold small">
+                                                        <i class="fa-solid fa-bed text-primary me-1"/>
+                                                        <h:outputText value="#{room.roomFacilityCharge.name}"/>
+                                                        <h:panelGroup rendered="#{room.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
+                                                            <span class="badge bg-success ms-1" style="font-size:0.65rem;">Guardian</span>
+                                                        </h:panelGroup>
+                                                    </div>
+                                                    <div class="text-muted" style="font-size:0.72rem;">
+                                                        <i class="fa-solid fa-clock me-1"/>
+                                                        Admitted:
+                                                        <h:outputText value="#{room.admittedAt}">
+                                                            <f:convertDateTime pattern="dd MMM yyyy HH:mm" timeZone="Asia/Colombo"/>
+                                                        </h:outputText>
+                                                    </div>
+                                                </div>
+                                                <p:commandButton
+                                                    value="View"
+                                                    ajax="false"
+                                                    icon="fa-solid fa-arrow-right"
+                                                    class="ui-button-sm ui-button-info"
+                                                    action="#{admissionController.navigateToPatientRoomDetails()}">
+                                                </p:commandButton>
+                                            </div>
+                                        </ui:repeat>
+                                    </div>
 
-                                <!-- Add New Room Buttons -->
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnAddNewRoom"
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
-                                        disabled="#{admissionController.current.discharged eq true}"
-                                        value="Add New Room"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToAddRoom}"
-                                        icon="fa fa-plus-circle"
-                                        class="w-100 ui-button-success">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{roomChangeController.current}" />
-                                    </p:commandButton>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnRoomDetails"
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomOccupency')}"
+                                            value="Room Details"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToPatientRoomDetails()}"
+                                            icon="fa-solid fa-bed"
+                                            class="w-100 ui-button-info">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnAddGuardianRoom"
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
-                                        value="Add Guardian Room"
-                                        ajax="false"
-                                        disabled="#{admissionController.current.discharged eq true}"
-                                        action="#{admissionController.navigateToAddGuardianRoom}"
-                                        icon="fa fa-user-plus"
-                                        class="w-100 ui-button-success">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{roomChangeController.current}" />
-                                    </p:commandButton>
-                                </div>
+                            </div>
 
-                                <div class="col-12">
-                                    <p:commandButton
-                                        id="btnRoomDetails"
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomRoomOccupency')}"
-                                        value="Room Details"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToPatientRoomDetails()}"
-                                        icon="fa-solid fa-bed"
-                                        class="w-100 ui-button-info">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnRoomChange"
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
-                                        disabled="#{admissionController.current.discharged eq true}"
-                                        value="Room Change"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToRoomChange}"
-                                        icon="fa fa-exchange-alt"
-                                        class="w-100">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{roomChangeController.current}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnGuardianRoomChange"
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
-                                        value="Guardian Room Change"
-                                        ajax="false"
-                                        disabled="#{admissionController.current.discharged eq true}"
-                                        action="#{admissionController.navigateToGuardianRoomChange}"
-                                        icon="fa fa-users"
-                                        class="w-100">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{roomChangeController.current}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomTransferInitiate')}"
-                                        value="Initiate Transfer"
-                                        ajax="false"
-                                        disabled="#{admissionController.current.discharged eq true}"
-                                        action="#{patientTransferController.navigateToInitiateTransferForAdmission(admissionController.current)}"
-                                        icon="fa fa-arrow-right"
-                                        class="w-100 ui-button-info">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        rendered="#{webUserController.hasPrivilege('InwardRoomPatientAccept')}"
-                                        value="Accept Patients"
-                                        ajax="false"
-                                        disabled="#{not patientTransferController.hasPendingRequestsForDepartment}"
-                                        action="#{patientTransferController.navigateToPatientAccept()}"
-                                        icon="fa fa-check-circle"
-                                        class="w-100 ui-button-success">
-                                    </p:commandButton>
+                            <hr class="my-2"/>
+
+                            <div class="p-2 rounded" style="background-color:#e8f5ee;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Actions</div>
+                                <div class="row g-2">
+                                    <!-- Add New Room Buttons -->
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnAddNewRoom"
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
+                                            disabled="#{admissionController.current.discharged eq true}"
+                                            value="Add New Room"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToAddRoom}"
+                                            icon="fa fa-plus-circle"
+                                            class="w-100 ui-button-success">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{roomChangeController.current}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnAddGuardianRoom"
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
+                                            value="Add Guardian Room"
+                                            ajax="false"
+                                            disabled="#{admissionController.current.discharged eq true}"
+                                            action="#{admissionController.navigateToAddGuardianRoom}"
+                                            icon="fa fa-user-plus"
+                                            class="w-100 ui-button-success">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{roomChangeController.current}" />
+                                        </p:commandButton>
+                                    </div>
+
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnRoomChange"
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
+                                            disabled="#{admissionController.current.discharged eq true}"
+                                            value="Room Change"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToRoomChange}"
+                                            icon="fa fa-exchange-alt"
+                                            class="w-100">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{roomChangeController.current}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnGuardianRoomChange"
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
+                                            value="Guardian Room Change"
+                                            ajax="false"
+                                            disabled="#{admissionController.current.discharged eq true}"
+                                            action="#{admissionController.navigateToGuardianRoomChange}"
+                                            icon="fa fa-users"
+                                            class="w-100">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{roomChangeController.current}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomTransferInitiate')}"
+                                            value="Initiate Transfer"
+                                            ajax="false"
+                                            disabled="#{admissionController.current.discharged eq true}"
+                                            action="#{patientTransferController.navigateToInitiateTransferForAdmission(admissionController.current)}"
+                                            icon="fa fa-arrow-right"
+                                            class="w-100 ui-button-info">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('InwardRoomPatientAccept')}"
+                                            value="Accept Patients"
+                                            ajax="false"
+                                            disabled="#{not patientTransferController.hasPendingRequestsForDepartment}"
+                                            action="#{patientTransferController.navigateToPatientAccept()}"
+                                            icon="fa fa-check-circle"
+                                            class="w-100 ui-button-success">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>
@@ -750,117 +783,128 @@
                         </p:panel>
 
                         <p:panel header="Clinical Data" class="m-1">
-                            <div class="row g-2">
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Patient History"
-                                        action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
-                                        ajax="false"
-                                        icon="fa fa-history"
-                                        class="w-100">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current.patient}"
-                                            target="#{patientController.current}" />
-                                    </p:commandButton>
+                            <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Actions</div>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Clinical Discharge"
+                                            ajax="false"
+                                            action="#{inpatientClinicalDataController.navigateToClinicalDischargeFromAdmission(admissionController.current)}"
+                                            icon="fa fa-sign-out-alt"
+                                            title="Navigate to Clinical Discharge"
+                                            rendered="#{webUserController.hasPrivilege('InpatientClinicalDischarge')}"
+                                            styleClass="w-100 #{admissionController.current.clinicallyDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnNursingDischarge"
+                                            value="Nursing Discharge"
+                                            ajax="false"
+                                            action="#{nursingDischargeController.navigateToNursingDischarge(admissionController.current)}"
+                                            icon="fa fa-user-nurse"
+                                            title="Navigate to Nursing Discharge"
+                                            rendered="#{webUserController.hasPrivilege('InwardNursingDischarge')}"
+                                            styleClass="w-100 #{admissionController.current.nursingDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnPhysicalDischarge"
+                                            value="Physical Discharge"
+                                            ajax="false"
+                                            action="#{nursingDischargeController.navigateToPhysicalDischarge(admissionController.current)}"
+                                            icon="fa fa-walking"
+                                            title="Navigate to Physical Discharge"
+                                            rendered="#{webUserController.hasPrivilege('InwardPhysicalDischarge')}"
+                                            styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Clinical Notes"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
-                                        icon="fa fa-file-medical-alt"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Ward Medications"
-                                        ajax="false"
-                                        action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
-                                        icon="fa fa-pills"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        rendered="#{webUserController.hasPrivilege('InpatientClinicalAssessment')}"
-                                        value="Medicine Timeline"
-                                        ajax="false"
-                                        action="#{inpatientClinicalDataController.navigateToWardMedicinesTimeline(admissionController.current)}"
-                                        icon="fa fa-project-diagram"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Discharge Medications"
-                                        ajax="false"
-                                        action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
-                                        icon="fa fa-prescription-bottle-alt"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Investigations"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToInpatientInvestigations()}"
-                                        icon="fa fa-search"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Images"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToInpatientImages}"
-                                        icon="fa fa-images"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Diagnosis Card"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToInpatientDiagnosisCard()}"
-                                        icon="fa fa-diagnoses"
-                                        class="w-100">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-12">
-                                    <p:commandButton
-                                        value="Clinical Discharge"
-                                        ajax="false"
-                                        action="#{inpatientClinicalDataController.navigateToClinicalDischargeFromAdmission(admissionController.current)}"
-                                        icon="fa fa-sign-out-alt"
-                                        title="Navigate to Clinical Discharge"
-                                        rendered="#{webUserController.hasPrivilege('InpatientClinicalDischarge')}"
-                                        styleClass="w-100 #{admissionController.current.clinicallyDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-12">
-                                    <p:commandButton
-                                        id="btnNursingDischarge"
-                                        value="Nursing Discharge"
-                                        ajax="false"
-                                        action="#{nursingDischargeController.navigateToNursingDischarge(admissionController.current)}"
-                                        icon="fa fa-user-nurse"
-                                        title="Navigate to Nursing Discharge"
-                                        rendered="#{webUserController.hasPrivilege('InwardNursingDischarge')}"
-                                        styleClass="w-100 #{admissionController.current.nursingDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-12">
-                                    <p:commandButton
-                                        id="btnPhysicalDischarge"
-                                        value="Physical Discharge"
-                                        ajax="false"
-                                        action="#{nursingDischargeController.navigateToPhysicalDischarge(admissionController.current)}"
-                                        icon="fa fa-walking"
-                                        title="Navigate to Physical Discharge"
-                                        rendered="#{webUserController.hasPrivilege('InwardPhysicalDischarge')}"
-                                        styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                    </p:commandButton>
+                            </div>
+
+                            <hr class="my-2"/>
+
+                            <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Reports &amp; Records</div>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Patient History"
+                                            action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
+                                            ajax="false"
+                                            icon="fa fa-history"
+                                            class="w-100">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current.patient}"
+                                                target="#{patientController.current}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Clinical Notes"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
+                                            icon="fa fa-file-medical-alt"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Ward Medications"
+                                            ajax="false"
+                                            action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
+                                            icon="fa fa-pills"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('InpatientClinicalAssessment')}"
+                                            value="Medicine Timeline"
+                                            ajax="false"
+                                            action="#{inpatientClinicalDataController.navigateToWardMedicinesTimeline(admissionController.current)}"
+                                            icon="fa fa-project-diagram"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Discharge Medications"
+                                            ajax="false"
+                                            action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
+                                            icon="fa fa-prescription-bottle-alt"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Investigations"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToInpatientInvestigations()}"
+                                            icon="fa fa-search"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Images"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToInpatientImages}"
+                                            icon="fa fa-images"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Diagnosis Card"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToInpatientDiagnosisCard()}"
+                                            icon="fa fa-diagnoses"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>
@@ -869,162 +913,132 @@
                     <!-- Column 4: Pharmaceuticals / Reports -->
                     <div class="col-3">
                         <p:panel header="Pharmaceuticals &amp; Consumables" class="m-1">
-                            <div class="row g-2">
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Request from Pharmacy"
-                                        ajax="false"
-                                        action="#{admissionController.navigateToPharmacyBhtRequest}"
-                                        icon="fa fa-prescription-bottle-alt"
-                                        class="w-100">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{pharmacyRequestForBhtController.patientEncounter}" />
-                                    </p:commandButton>
+                            <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Actions</div>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Request from Pharmacy"
+                                            ajax="false"
+                                            action="#{admissionController.navigateToPharmacyBhtRequest}"
+                                            icon="fa fa-prescription-bottle-alt"
+                                            class="w-100">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{pharmacyRequestForBhtController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Direct Issue to BHTs"
+                                            action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
+                                            actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                            icon="pi pi-check"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{inpatientDirectIssueNativeSqlController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="issueDischargeMedicinesBtn"
+                                            value="Issue Discharge Medicines"
+                                            action="/inward/pharmacy_discharge_medicine_issue?faces-redirect=true"
+                                            actionListener="#{pharmacySaleBhtController.resetAllForDischargeIssue()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
+                                            icon="fa fa-prescription-bottle-alt"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{pharmacySaleBhtController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Direct Issue to Theatre Cases"
+                                            action="/theater/inward_bill_surgery_issue?faces-redirect=true"
+                                            actionListener="#{pharmacySaleBhtController.resetAll()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                            icon="pi pi-check"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{pharmacySaleBhtController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnReceiveMedicinesFromPharmacyInpatient"
+                                            value="Receive Medicines from Pharmacy"
+                                            ajax="false"
+                                            action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
+                                            icon="fa fa-truck-medical"
+                                            class="w-100"/>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnReturnMedicinesToPharmacyInpatient"
+                                            value="Return Medicines to Pharmacy"
+                                            ajax="false"
+                                            action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"
+                                            icon="fa fa-truck-ramp-box"
+                                            class="w-100"/>
+                                    </div>
                                 </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Direct Issue to BHTs"
-                                        action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
-                                        actionListener="#{inpatientDirectIssueNativeSqlController.resetAll()}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{inpatientDirectIssueNativeSqlController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="issueDischargeMedicinesBtn"
-                                        value="Issue Discharge Medicines"
-                                        action="/inward/pharmacy_discharge_medicine_issue?faces-redirect=true"
-                                        actionListener="#{pharmacySaleBhtController.resetAllForDischargeIssue()}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
-                                        icon="fa fa-prescription-bottle-alt"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{pharmacySaleBhtController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Direct Issue to Theatre Cases"
-                                        action="/theater/inward_bill_surgery_issue?faces-redirect=true"
-                                        actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{pharmacySaleBhtController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="BHT Issue Requests"
-                                        action="/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true"
-                                        actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{pharmacySaleBhtController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnReceiveMedicinesFromPharmacyInpatient"
-                                        value="Receive Medicines from Pharmacy"
-                                        ajax="false"
-                                        action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
-                                        icon="fa fa-truck-medical"
-                                        class="w-100"/>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        id="btnReturnMedicinesToPharmacyInpatient"
-                                        value="Return Medicines to Pharmacy"
-                                        ajax="false"
-                                        action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"
-                                        icon="fa fa-truck-ramp-box"
-                                        class="w-100"/>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="View Pharmacy Requests"
-                                        action="#{admissionController.navigateToSearchInwardBills}"
-                                        rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{searchController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Search Direct Issues by Bill"
-                                        action="/inward/pharmacy_search_sale_bill_bht"
-                                        actionListener="#{searchController.makeListNull}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{searchController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Search Direct Issues by Item"
-                                        action="/inward/pharmacy_search_sale_bill_item_bht?faces-redirect=true"
-                                        actionListener="#{searchController.makeListNull}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{searchController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Search Issue Returns by Bill"
-                                        action="/inward/pharmacy_search_return_bill_bht?faces-redirect=true"
-                                        actionListener="#{searchController.makeListNull}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{searchController.patientEncounter}" />
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
-                                        value="Search Issue Returns by Item"
-                                        action="/inward/pharmacy_search_return_bill_item_bht?faces-redirect=true"
-                                        actionListener="#{searchController.makeListNull}"
-                                        rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                        icon="pi pi-check"
-                                        class="w-100"
-                                        ajax="false">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{searchController.patientEncounter}" />
-                                    </p:commandButton>
+                            </div>
+
+                            <hr class="my-2"/>
+
+                            <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                <div class="text-uppercase small fw-bold text-muted mb-2">Reports &amp; History</div>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnPharmacyRequestsHistory"
+                                            value="Pharmacy Requests"
+                                            action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
+                                            icon="fa fa-clipboard-list"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnDirectIssuesHistory"
+                                            value="Direct Issues"
+                                            action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyDirectIssuesList()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                            icon="fa fa-file-invoice"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnIssueReturnsHistory"
+                                            value="Issue Returns"
+                                            action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyReturnsList()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                            icon="fa fa-rotate-left"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -1,0 +1,210 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="inpatientPharmacyDirectIssuesGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fa fa-file-invoice"></h:outputText>
+                            <p:outputLabel value="Direct Issues"></p:outputLabel>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToProfile"
+                                value="Inpatient Dashboard"
+                                action="#{inwardPharmacyEncounterReportController.navigateToAdmissionProfile()}"
+                                ajax="false"
+                                icon="fa fa-arrow-circle-left"
+                                styleClass="ui-button-info ui-button-outlined">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Download"
+                                ajax="false"
+                                icon="fa fa-download"
+                                styleClass="ui-button-secondary">
+                                <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print"
+                                ajax="false"
+                                icon="fa fa-print"
+                                styleClass="ui-button-secondary">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Phone No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.phone}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Direct Issues" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                rowKey="#{dto.billId}"
+                                value="#{inwardPharmacyEncounterReportController.directIssueBillsToPatientEncounter}"
+                                var="dto">
+
+                                <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.billNumber}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Billed At" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Billed By" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.createdUserName}" />
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Net Value" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueBillsToPatientEncounterNetTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Status" />
+                                    </f:facet>
+                                    <h:outputLabel value="Cancelled" style="color: red;" rendered="#{dto.cancelled}" />
+                                    <h:outputLabel value="Refunded" style="color: red;" rendered="#{dto.refunded and not dto.cancelled}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" exportable="false">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Action" />
+                                    </f:facet>
+                                    <p:commandButton
+                                        id="btnViewBill"
+                                        value="View Bill"
+                                        icon="fa fa-eye"
+                                        ajax="false"
+                                        class="ui-button-info"
+                                        action="#{pharmacyBillSearch.navigateToViewPharmacyDirectIssueForInpatientBill()}">
+                                        <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
+                                    </p:commandButton>
+                                </p:column>
+
+                                <p:column style="width: 3em" exportable="false">
+                                    <p:rowToggler />
+                                </p:column>
+
+                                <p:rowExpansion>
+                                    <p:dataTable var="item" value="#{inwardPharmacyEncounterReportController.getItemsForDirectIssueBill(dto.billId)}">
+                                        <p:column headerText="Item Name" width="45%">
+                                            <h:outputLabel value="#{item.itemName}"/>
+                                        </p:column>
+                                        <p:column headerText="Code" width="20%">
+                                            <h:outputLabel value="#{item.itemCode}"/>
+                                        </p:column>
+                                        <p:column headerText="Qty" width="15%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.qty}">
+                                                <f:convertNumber pattern="#0.##" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Net Value" width="20%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:rowExpansion>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -1,0 +1,235 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="inpatientPharmacyRequestsGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fa fa-clipboard-list"></h:outputText>
+                            <p:outputLabel value="Pharmacy Requests"></p:outputLabel>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToProfile"
+                                value="Inpatient Dashboard"
+                                action="#{inwardPharmacyEncounterReportController.navigateToAdmissionProfile()}"
+                                ajax="false"
+                                icon="fa fa-arrow-circle-left"
+                                styleClass="ui-button-info ui-button-outlined">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Download"
+                                ajax="false"
+                                icon="fa fa-download"
+                                styleClass="ui-button-secondary">
+                                <p:dataExporter fileName="Inpatient Pharmacy Requests" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print"
+                                ajax="false"
+                                icon="fa fa-print"
+                                styleClass="ui-button-secondary">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Phone No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.phone}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Pharmacy Requests" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                rowKey="#{b.id}"
+                                value="#{inwardPharmacyEncounterReportController.pharmacyRequestBillsToPatientEncounter}"
+                                var="b">
+
+                                <p:column width="2em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.deptId}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Requested Department" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.department.name}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Requested At" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Requested By" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.creater.webUserPerson.name}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Status" />
+                                    </f:facet>
+                                    <p:tag
+                                        value="Issued"
+                                        severity="success"
+                                        rendered="#{inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                                    <p:tag
+                                        value="Not Issued"
+                                        severity="warning"
+                                        rendered="#{not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" exportable="false">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Actions" />
+                                    </f:facet>
+                                    <p:commandButton
+                                        id="btnViewRequest"
+                                        title="View Request"
+                                        class="ui-button-primary m-1"
+                                        ajax="false"
+                                        icon="fa fa-eye"
+                                        action="/ward/ward_pharmacy_reprint_bht_issue_request?faces-redirect=true">
+                                        <f:setPropertyActionListener value="#{b}" target="#{pharmacyBillSearch.bill}"/>
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnIssueMedicines"
+                                        title="Issue Medicines"
+                                        class="ui-button-success m-1"
+                                        ajax="false"
+                                        icon="fa fa-prescription-bottle-alt"
+                                        rendered="#{not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id) and webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
+                                        action="#{pharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()}">
+                                        <f:setPropertyActionListener value="#{b}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
+                                    </p:commandButton>
+                                </p:column>
+
+                                <p:column style="width: 3em" exportable="false">
+                                    <p:rowToggler />
+                                </p:column>
+
+                                <p:rowExpansion>
+                                    <p:dataTable var="ib" value="#{inwardPharmacyEncounterReportController.getIssuedBillsForRequest(b.id)}">
+                                        <p:column headerText="Bill No" width="15%">
+                                            <h:outputLabel value="#{ib.deptId}"/>
+                                        </p:column>
+                                        <p:column headerText="Date" width="20%">
+                                            <h:outputLabel value="#{ib.createdAt}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Issued By" width="20%">
+                                            <h:outputLabel value="#{ib.creater.webUserPerson.name}"/>
+                                        </p:column>
+                                        <p:column headerText="To Staff" width="20%">
+                                            <h:outputLabel value="#{ib.toStaff.person.nameWithTitle}"/>
+                                        </p:column>
+                                        <p:column headerText="Net Total" width="12%" style="text-align: right;">
+                                            <h:outputLabel value="#{ib.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Action" width="13%">
+                                            <p:commandButton ajax="false" value="View Bill" action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint?faces-redirect=true">
+                                                <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{ib}"/>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:rowExpansion>
+
+                            </p:dataTable>
+
+                            <div class="d-flex justify-content-end p-2">
+                                <h:outputLabel value="Total Net: " style="font-weight: bold;" />
+                                <h:outputLabel value="#{inwardPharmacyEncounterReportController.pharmacyRequestBillsToPatientEncounterNetTotal}" style="font-weight: bold; margin-left: 6px;">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </div>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
@@ -1,0 +1,210 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="inpatientPharmacyReturnsGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fa fa-rotate-left"></h:outputText>
+                            <p:outputLabel value="Issue Returns"></p:outputLabel>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToProfile"
+                                value="Inpatient Dashboard"
+                                action="#{inwardPharmacyEncounterReportController.navigateToAdmissionProfile()}"
+                                ajax="false"
+                                icon="fa fa-arrow-circle-left"
+                                styleClass="ui-button-info ui-button-outlined">
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Download"
+                                ajax="false"
+                                icon="fa fa-download"
+                                styleClass="ui-button-secondary">
+                                <p:dataExporter fileName="Inpatient Pharmacy Issue Returns" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+                            <p:commandButton
+                                value="Print"
+                                ajax="false"
+                                icon="fa fa-print"
+                                styleClass="ui-button-secondary">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Phone No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.phone}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Issue Returns" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                rowKey="#{dto.billId}"
+                                value="#{inwardPharmacyEncounterReportController.returnBillsToPatientEncounter}"
+                                var="dto">
+
+                                <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Sale Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.referenceBillNumber}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Return Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.billNumber}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Returned At" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Returned By" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.createdUserName}" />
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Net Value" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.returnBillsToPatientEncounterNetTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" exportable="false">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Action" />
+                                    </f:facet>
+                                    <p:commandButton
+                                        id="btnViewBill"
+                                        value="View Bill"
+                                        icon="fa fa-eye"
+                                        ajax="false"
+                                        class="ui-button-info"
+                                        disabled="#{dto.cancelled}"
+                                        action="/inward/pharmacy_reprint_bill_return_bht?faces-redirect=true">
+                                        <f:setPropertyActionListener value="#{dto.billId}" target="#{pharmacyBillSearch.billId}"/>
+                                    </p:commandButton>
+                                </p:column>
+
+                                <p:column style="width: 3em" exportable="false">
+                                    <p:rowToggler />
+                                </p:column>
+
+                                <p:rowExpansion>
+                                    <p:dataTable var="item" value="#{inwardPharmacyEncounterReportController.getItemsForReturnBill(dto.billId)}">
+                                        <p:column headerText="Item Name" width="45%">
+                                            <h:outputLabel value="#{item.itemName}"/>
+                                        </p:column>
+                                        <p:column headerText="Code" width="20%">
+                                            <h:outputLabel value="#{item.itemCode}"/>
+                                        </p:column>
+                                        <p:column headerText="Qty" width="15%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.qty}">
+                                                <f:convertNumber pattern="#0.##" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Net Value" width="20%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:rowExpansion>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Summary

Closes #21852.

- **Encounter-scoped pharmacy pages**: replaces 6 dashboard links that wrongly reused the date-filtered, all-patient Nursing Workbench search pages with 3 new pages — Pharmacy Requests, Direct Issues, Issue Returns — that load pre-filtered to the current BHT (no date range or department filter needed). New controller `InwardPharmacyEncounterReportController`, new DTO `InpatientPharmacyBillItemDTO`, and one additive constructor on `BillListReportDTO` (existing constructors untouched).
- **Dashboard visual redesign**: adds a prominent patient identity banner (Name/Age/Sex/BHT No + encounter flags), and splits the Pharmaceuticals, Room Management, and Clinical Data panels into color-coded Actions/Reports zones within a single panel per section (separated by a horizontal rule, not separate panels).
- All existing generic/Nursing-Workbench pharmacy search pages are unchanged — still used for their original all-patient use case.

## Bug found and fixed during verification

The new controller was initially `@ViewScoped`. Since the dashboard button does `f:setPropertyActionListener` + `faces-redirect=true` to a brand-new view, a `@ViewScoped` bean is destroyed and recreated for the new view — silently discarding the `patientEncounter` just set, and breaking both the new pages' data (empty lists) and the "Inpatient Dashboard" back-navigation button. Fixed to `@SessionScoped` (matching the existing `InwardReportControllerBht` pattern). Documented as a general JSF gotcha in `developer_docs/jsf/navigation-patterns.md`.

## Test plan

Verified with Playwright against the local `coop` demo DB (CareCode Model Hospital — training data, not real patients):
- [x] BHT/53354 (active) — Pharmacy Requests page shows both request bills with correct Issued/Not Issued status; Direct Issues page shows the direct-issue bill with expandable item breakdown; row totals cross-checked against the DB and match exactly
- [x] BHT/53212 (discharged) — Issue Returns page shows both return bills (Sale Bill No + Return Bill No + negative net values); cross-checked against the DB and matches exactly
- [x] "View Bill" / "View Request" row actions navigate to the correct existing reprint pages with the correct bill loaded
- [x] "Inpatient Dashboard" back-navigation from all 3 new pages works correctly
- [x] Merged single-panel layout (Actions/Reports separated by `<hr>`, tinted backgrounds, `col-6` buttons) verified visually after user feedback

Screenshots and full verification narrative posted on issue #21852.

## Docs
- Wiki: `Inpatient-Admission-Profile-Dashboard` updated with the new banner, panel layout, and pharmacy pages
- `developer_docs/navigation/inward_navigation.md` — new controller + pages documented
- `developer_docs/jsf/navigation-patterns.md` — new `@ViewScoped` gotcha section
- `developer_docs/inward/2026-07-05-inpatient-dashboard-redesign-design.md` — original design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)