### PR TITLE
fix(inward): inward service billing shows and charges site fees with base fallback

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemFeeManager.java
+++ b/src/main/java/com/divudi/bean/common/ItemFeeManager.java
@@ -973,6 +973,47 @@ public class ItemFeeManager implements Serializable {
         return fs;
     }
 
+    /**
+     * Sums the configured item-fee value per item for a batch of items, used to
+     * display the correct billing price in inward item lists. When
+     * {@code forInstitution} is not null, only site fees (fees scoped to that
+     * institution) are summed; when it is null, only base fees
+     * (fees with {@code forInstitution IS NULL}) are summed. The {@code foreigner}
+     * flag selects the foreigner fee column instead of the local fee.
+     *
+     * @return map of item id to summed fee value (items with no matching fee are absent)
+     */
+    public Map<Long, Double> fetchInwardFeeTotalsByItemIds(List<Long> itemIds, Institution forInstitution, boolean foreigner) {
+        Map<Long, Double> result = new HashMap<>();
+        if (itemIds == null || itemIds.isEmpty()) {
+            return result;
+        }
+        String feeColumn = foreigner ? "f.ffee" : "f.fee";
+        String jpql = "SELECT new com.divudi.core.data.ItemLight("
+                + "f.item.id, f.item.name, f.item.code, sum(" + feeColumn + ")) "
+                + "FROM ItemFee f "
+                + "WHERE f.retired=:ret "
+                + "AND f.item.id IN :ids "
+                + "AND f.forCategory IS NULL ";
+        Map<String, Object> m = new HashMap<>();
+        m.put("ret", false);
+        m.put("ids", itemIds);
+        if (forInstitution != null) {
+            jpql += "AND f.forInstitution=:ins ";
+            m.put("ins", forInstitution);
+        } else {
+            jpql += "AND f.forInstitution IS NULL ";
+        }
+        jpql += "GROUP BY f.item";
+        List<ItemLight> rows = (List<ItemLight>) itemFacade.findLightsByJpql(jpql, m);
+        if (rows != null) {
+            for (ItemLight il : rows) {
+                result.put(il.getId(), il.getTotal() != null ? il.getTotal() : 0.0);
+            }
+        }
+        return result;
+    }
+
     public List<ItemLight> fillItemLightsForDepartment(Department dept) {
         if (dept == null) {
             return new ArrayList<>();

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -978,15 +978,24 @@ public class BillBhtController implements Serializable {
         }
         addingEntry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
         bItem.setMarginValue(getBillBean().calBillItemMargin(addingEntry));
+
+        // Block items with no fee configured (neither site nor base fee) before adding
+        double feeGrossTotal = 0.0;
+        if (addingEntry.getLstBillFees() != null) {
+            for (BillFee bf : addingEntry.getLstBillFees()) {
+                feeGrossTotal += bf.getFeeGrossValue();
+            }
+        }
+        if (feeGrossTotal == 0.0) {
+            JsfUtil.addErrorMessage("This item has no fee configured and cannot be added.");
+            return;
+        }
+
         lstBillEntries.add(addingEntry);
 
         bItem.setRate(getBillBean().billItemRate(addingEntry));
 
         calTotals();
-        if (bItem.getNetValue() == 0.0) {
-            JsfUtil.addErrorMessage("Please enter the rate");
-            return;
-        }
 
         clearBillItemValues();
         //JsfUtil.addSuccessMessage("Item Added");
@@ -995,18 +1004,14 @@ public class BillBhtController implements Serializable {
     public List<BillFee> billFeeFromBillItemWithMatrix(BillItem billItem, PatientEncounter patientEncounter, Department matrixDepartment, PaymentMethod paymentMethod) {
 
         List<BillFee> billFeeList = new ArrayList<>();
-        boolean addAllBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are the same for all departments, institutions and sites.", true);
         boolean siteBasedBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site", false);
+        Institution site = sessionController.getDepartment() != null ? sessionController.getDepartment().getSite() : null;
         List<ItemFee> itemFee;
 
-        if (siteBasedBillFees && !addAllBillFees) {
-            if (sessionController.getDepartment() != null
-                    && sessionController.getDepartment().getSite() != null) {
-                itemFee = itemFeeManager.fillFees(
-                        billItem.getItem(),
-                        sessionController.getDepartment().getSite()
-                );
-            } else {
+        if (siteBasedBillFees && site != null) {
+            itemFee = itemFeeManager.fillFees(billItem.getItem(), site);
+            if (itemFee == null || itemFee.isEmpty()) {
+                // Fall back to base fees when the item has no site fee for this site
                 itemFee = itemFeeManager.fillFees(billItem.getItem());
             }
         } else {

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -72,8 +72,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.ejb.EJB;
@@ -1224,6 +1226,7 @@ public class BillBhtController implements Serializable {
                 temItems = itemApplicationController.getInvestigationsAndServices();
                 break;
         }
+        applyInwardFeeTotals(temItems);
         boolean listItemsByDepartment = configOptionApplicationController.getBooleanValueByKey("List Inward Items by Department", false);
         if (listItemsByDepartment) {
             fillInwardItemDepartments(temItems);
@@ -1235,6 +1238,51 @@ public class BillBhtController implements Serializable {
         }
 
         return temItems;
+    }
+
+    /**
+     * Overrides the displayed price of each inward item so the list reflects the
+     * fee that will actually be billed. When "Inward Bill Fees are based on the
+     * site" is ON and the logged department has a site, the site fee is shown;
+     * if the item has no site fee, the base fee is shown (matching the
+     * site&rarr;base fallback in {@link #billFeeFromBillItemWithMatrix}). When the
+     * config is OFF, the base fee is shown. Items with no fee show 0.00 and are
+     * blocked from being added in {@link #addToBill()}.
+     */
+    private void applyInwardFeeTotals(List<ItemLight> items) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+        boolean siteBasedBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site", false);
+        boolean foreigner = patientEncounter != null && patientEncounter.isForiegner();
+        Institution site = sessionController.getDepartment() != null ? sessionController.getDepartment().getSite() : null;
+
+        List<Long> itemIds = new ArrayList<>();
+        for (ItemLight il : items) {
+            if (il.getId() != null) {
+                itemIds.add(il.getId());
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        boolean useSiteFees = siteBasedBillFees && site != null;
+        Map<Long, Double> baseTotals = itemFeeManager.fetchInwardFeeTotalsByItemIds(itemIds, null, foreigner);
+        Map<Long, Double> siteTotals = useSiteFees
+                ? itemFeeManager.fetchInwardFeeTotalsByItemIds(itemIds, site, foreigner)
+                : new HashMap<>();
+
+        for (ItemLight il : items) {
+            Double value = null;
+            if (useSiteFees) {
+                Double s = siteTotals.get(il.getId());
+                value = (s != null && s != 0.0) ? s : baseTotals.get(il.getId());
+            } else {
+                value = baseTotals.get(il.getId());
+            }
+            il.setTotal(value != null ? value : 0.0);
+        }
     }
 
     private List<ItemLight> filterItemLightesByDepartment(List<ItemLight> ils, Department dept) {
@@ -1642,7 +1690,9 @@ public class BillBhtController implements Serializable {
     public void reloadItemLights() {
         itemApplicationController.reloadItems();
         itemController.reloadItems();
-        fillInwardItems();
+        // Force the inward item list (with its fee-based prices) to rebuild
+        inwardItem = null;
+        getInwardItem();
     }
 
     public void setInwardItems(List<ItemLight> inwardItems) {

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -1231,7 +1231,7 @@ public class BillBhtController implements Serializable {
                 temItems = itemApplicationController.getInvestigationsAndServices();
                 break;
         }
-        applyInwardFeeTotals(temItems);
+        temItems = applyInwardFeeTotals(temItems);
         boolean listItemsByDepartment = configOptionApplicationController.getBooleanValueByKey("List Inward Items by Department", false);
         if (listItemsByDepartment) {
             fillInwardItemDepartments(temItems);
@@ -1254,9 +1254,9 @@ public class BillBhtController implements Serializable {
      * config is OFF, the base fee is shown. Items with no fee show 0.00 and are
      * blocked from being added in {@link #addToBill()}.
      */
-    private void applyInwardFeeTotals(List<ItemLight> items) {
+    private List<ItemLight> applyInwardFeeTotals(List<ItemLight> items) {
         if (items == null || items.isEmpty()) {
-            return;
+            return items;
         }
         boolean siteBasedBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site", false);
         boolean foreigner = patientEncounter != null && patientEncounter.isForiegner();
@@ -1269,7 +1269,7 @@ public class BillBhtController implements Serializable {
             }
         }
         if (itemIds.isEmpty()) {
-            return;
+            return items;
         }
 
         boolean useSiteFees = siteBasedBillFees && site != null;
@@ -1278,8 +1278,13 @@ public class BillBhtController implements Serializable {
                 ? itemFeeManager.fetchInwardFeeTotalsByItemIds(itemIds, site, foreigner)
                 : new HashMap<>();
 
-        for (ItemLight il : items) {
-            Double value = null;
+        // Work on copies: the source lists can be application-scoped cached
+        // ItemLight instances shared across sessions, so mutating them in place
+        // would leak one session's price into another.
+        List<ItemLight> result = new ArrayList<>(items.size());
+        for (ItemLight src : items) {
+            ItemLight il = new ItemLight(src);
+            Double value;
             if (useSiteFees) {
                 Double s = siteTotals.get(il.getId());
                 value = (s != null && s != 0.0) ? s : baseTotals.get(il.getId());
@@ -1287,7 +1292,9 @@ public class BillBhtController implements Serializable {
                 value = baseTotals.get(il.getId());
             }
             il.setTotal(value != null ? value : 0.0);
+            result.add(il);
         }
+        return result;
     }
 
     private List<ItemLight> filterItemLightesByDepartment(List<ItemLight> ils, Department dept) {

--- a/src/main/java/com/divudi/core/data/ItemLight.java
+++ b/src/main/java/com/divudi/core/data/ItemLight.java
@@ -500,6 +500,40 @@ public class ItemLight {
 
     }
 
+    /**
+     * Copy constructor. Produces an independent instance so callers can safely
+     * mutate per-context fields (e.g. {@code total}) without corrupting shared,
+     * application-scoped cached {@code ItemLight} objects.
+     */
+    public ItemLight(ItemLight o) {
+        this.id = o.id;
+        this.orderNo = o.orderNo;
+        this.isMasterItem = o.isMasterItem;
+        this.hasReportFormat = o.hasReportFormat;
+        this.categoryName = o.categoryName;
+        this.categoryId = o.categoryId;
+        this.total = o.total;
+        this.totalForForeigner = o.totalForForeigner;
+        this.institutionName = o.institutionName;
+        this.institutionId = o.institutionId;
+        this.departmentName = o.departmentName;
+        this.departmentId = o.departmentId;
+        this.specialityName = o.specialityName;
+        this.specialityId = o.specialityId;
+        this.staffName = o.staffName;
+        this.staffId = o.staffId;
+        this.dtype = o.dtype;
+        this.name = o.name;
+        this.code = o.code;
+        this.barcode = o.barcode;
+        this.printName = o.printName;
+        this.shortName = o.shortName;
+        this.fullName = o.fullName;
+        this.feeName = o.feeName;
+        this.feeValue = o.feeValue;
+        this.feeValueForeign = o.feeValueForeign;
+    }
+
     @Override
     public int hashCode() {
         int hash = 0;


### PR DESCRIPTION
## Summary

On `inward/inward_bill_service.xhtml`, the "Investigation or Service" pick list showed each item's **base** price (`Item.total`) regardless of configured **site fees**, so the displayed guide price could disagree with what was actually billed. The add-to-bill logic also required a second, unintuitive config key and had no site→base fallback.

This PR makes the **displayed price** and the **billed fee** consistent, driven solely by the config key **"Inward Bill Fees are based on the site"**, independent of `ItemListingStrategy`.

Closes #21868

## Behavior

**When "Inward Bill Fees are based on the site" = ON (and the logged department has a site):**
- Item has a **Site Fee** → show / charge the **Site Fee**
- Item has **no Site Fee** but has a **Base Fee** → show / charge the **Base Fee** (fallback)
- Item has **no fee** → show **0.00** and **block** adding it

**When OFF:**
- Show / charge the **Base Fee** (zero-fee items blocked)

## Changes (commit by commit)

1. **`feat(inward): add batch item-fee totals query for site/base pricing`**
   New `ItemFeeManager.fetchInwardFeeTotalsByItemIds(itemIds, forInstitution, foreigner)` sums item-fee values per item in a single query (site fees when `forInstitution` is set, base fees when null). No per-item N+1.

2. **`feat(inward): show site/base fee price in inward item billing list`**
   `applyInwardFeeTotals` overrides each `ItemLight.total` to reflect the billable fee (site fee with base fallback, foreigner-aware, two batch queries). Reload now rebuilds the cached list so updated fees appear.

3. **`fix(inward): use site->base fee fallback when adding items; block zero-fee items`**
   `billFeeFromBillItemWithMatrix` now keys only on "Inward Bill Fees are based on the site" (dropped the separate "same for all departments…" gate) and falls back to base fees when there is no site fee, so the billed fee matches the list price. `addToBill` now rejects a 0.00-fee item **before** adding it instead of adding it and then erroring.

## Notes / trade-offs

- Displayed value is the **fee gross** (sum of item fees); the bill then applies the price-matrix margin/discount on top, so the final net can differ slightly from the list figure — the list is a guide price (unchanged behavior).
- The list is `@SessionScoped`-cached and rebuilt lazily / on Reload. Because the total is now patient-foreigner-aware, the displayed guide price for a *different* patient billed later in the same session may lag until Reload (the **actual billed fee is always computed fresh**, so charges are correct). Follow-up optional: rebuild the list on patient change.
- Scope: inward only; OPD / Collecting Centre paths untouched.

## Testing
- `mvn -o compile` passes on top of latest `development`.
- Manual: with the site config ON and a department that has a site, items with a site fee show/charge the site fee; items without fall back to base; fee-less items show 0.00 and cannot be added.

## Test plan

**Setup**
- A department that has a **Site** assigned, logged in under it.
- Config `Inward Bill Fees are based on the site` toggled per case below (Admin → Application Configuration).
- Three inward Service items:
  - **A** — has a **Site Fee** for that site (and a different Base Fee)
  - **B** — has **only a Base Fee** (no site fee for that site)
  - **C** — has **no fee** configured at all
- An active inpatient (BHT) to bill against.

**Cases — config ON (site-based)**
1. Open `inward/inward_bill_service.xhtml`, select the patient. Item **A** lists its **Site Fee**; Add → the settled fee equals the **Site Fee**.
2. Item **B** lists its **Base Fee** (fallback); Add → the settled fee equals the **Base Fee**.
3. Item **C** lists **0.00**; clicking **Add** is rejected with "This item has no fee configured and cannot be added." and no row is added.

**Cases — config OFF**
4. Items **A** and **B** both list their **Base Fee**; Add → settled fee equals the Base Fee. Item **C** still shows 0.00 and cannot be added.

**Additional**
5. **Foreigner patient**: with a foreigner BHT, the list price and billed fee use the foreigner fee (`ffee`) column.
6. **Reload**: change a site fee in Manage Site Fees, return to the page, click **Reload** → the list price updates to the new value.
7. **List independence**: verify the same fee behavior regardless of `Inward Item Listing Strategy` (ALL_ITEMS, ITEMS_MAPPED_TO_LOGGED_DEPARTMENT, etc.).

**Regression**
8. OPD and Collecting Centre billing item lists/prices are unchanged.
9. `mvn -o compile` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing now supports site-based fee selection when configured, with a fallback to standard fees if site-specific values are unavailable.
  * Item lists now show fee totals that better reflect the current billing setup, including site-aware totals where applicable.

* **Bug Fixes**
  * Prevented adding bill items when the calculated fee total is zero.
  * Improved item list refresh behavior so updated fee values appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->