### PR TITLE
Direct Issues report: Total/Margin/Discount breakdown, item/department summaries, merged returns

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -11,6 +11,8 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dto.BillListReportDTO;
 import com.divudi.core.data.dto.InpatientPharmacyBillItemDTO;
+import com.divudi.core.data.dto.InpatientPharmacyDepartmentSummaryDTO;
+import com.divudi.core.data.dto.InpatientPharmacyItemSummaryDTO;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.PatientEncounter;
@@ -20,7 +22,10 @@ import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -72,10 +77,16 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     private List<Bill> pharmacyRequestBillsToPatientEncounter;
     private double pharmacyRequestBillsToPatientEncounterNetTotal;
 
-    // 2) Direct Issues list (PharmacyBhtPre PreBill sale bills)
+    // 2) Direct Issues list (PharmacyBhtPre PreBill sale bills, merged with their
+    // RefundBill returns so the whole picture is visible on one page)
     private List<BillListReportDTO> directIssueBillsToPatientEncounter;
     private double directIssueBillsToPatientEncounterNetTotal;
+    private double directIssueBillsToPatientEncounterTotal;
+    private double directIssueBillsToPatientEncounterMargin;
+    private double directIssueBillsToPatientEncounterDiscount;
     private List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter;
+    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary;
+    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary;
 
     // 3) Issue Returns list (PharmacyBhtPre RefundBill bills)
     private List<BillListReportDTO> returnBillsToPatientEncounter;
@@ -171,12 +182,26 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         }
         directIssueBillsToPatientEncounter = new ArrayList<>();
         directIssueBillsToPatientEncounterNetTotal = 0.0;
+        directIssueBillsToPatientEncounterTotal = 0.0;
+        directIssueBillsToPatientEncounterMargin = 0.0;
+        directIssueBillsToPatientEncounterDiscount = 0.0;
         directIssueBillItemsToPatientEncounter = new ArrayList<>();
+        directIssueItemSummary = new ArrayList<>();
+        directIssueDepartmentSummary = new ArrayList<>();
         try {
             directIssueBillsToPatientEncounter = fetchDirectIssueBills();
             for (BillListReportDTO dto : directIssueBillsToPatientEncounter) {
                 if (dto.getNetTotal() != null) {
                     directIssueBillsToPatientEncounterNetTotal += dto.getNetTotal().doubleValue();
+                }
+                if (dto.getTotal() != null) {
+                    directIssueBillsToPatientEncounterTotal += dto.getTotal().doubleValue();
+                }
+                if (dto.getServiceCharge() != null) {
+                    directIssueBillsToPatientEncounterMargin += dto.getServiceCharge().doubleValue();
+                }
+                if (dto.getDiscount() != null) {
+                    directIssueBillsToPatientEncounterDiscount += dto.getDiscount().doubleValue();
                 }
             }
 
@@ -185,6 +210,8 @@ public class InwardPharmacyEncounterReportController implements Serializable {
                 billIds.add(dto.getBillId());
             }
             directIssueBillItemsToPatientEncounter = fetchDirectIssueBillItems(billIds);
+            directIssueItemSummary = buildItemSummary(directIssueBillItemsToPatientEncounter);
+            directIssueDepartmentSummary = buildDepartmentSummary(directIssueBillItemsToPatientEncounter);
         } catch (Exception e) {
             Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
                     .log(Level.SEVERE, "Error loading direct issue bills", e);
@@ -229,6 +256,58 @@ public class InwardPharmacyEncounterReportController implements Serializable {
 
         List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade
                 .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
+        List<BillListReportDTO> issues = result != null ? result : new ArrayList<>();
+
+        // Merge in returns of these direct issues (RefundBill rows created by
+        // BhtIssueReturnController.settle()) so the whole picture - issues and
+        // their returns - is visible on one list, per issue #21871.
+        List<BillListReportDTO> returns = fetchDirectIssueReturnBills();
+        List<BillListReportDTO> merged = new ArrayList<>(issues.size() + returns.size());
+        merged.addAll(issues);
+        merged.addAll(returns);
+        merged.sort(Comparator.comparing(BillListReportDTO::getCreatedAt).reversed());
+        return merged;
+    }
+
+    private List<BillListReportDTO> fetchDirectIssueReturnBills() {
+        // Same DTO shape as fetchReturnBills() (17-arg constructor incl.
+        // referenceBillNumber = the original issue bill's printed number), but
+        // scoped only to the two direct-issue return atomics so ward
+        // issue-on-request returns are not pulled into this report.
+        String jpql = "SELECT new com.divudi.core.data.dto.BillListReportDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "b.billTypeAtomic, "
+                + "b.paymentMethod, "
+                + "COALESCE(b.patientEncounter.patient.person.name, ''), "
+                + "b.createdAt, "
+                + "COALESCE(b.creater.name, ''), "
+                + "b.retired, "
+                + "b.cancelled, "
+                + "b.refunded, "
+                + "b.total, "
+                + "b.discount, "
+                + "b.netTotal, "
+                + "COALESCE(b.patientEncounter.bhtNo, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.margin, "
+                + "COALESCE(b.billedBill.deptId, '')) "
+                + "FROM RefundBill b "
+                + "WHERE b.billType = :billType "
+                + "AND b.billTypeAtomic IN :returnAtomics "
+                + "AND b.retired = false "
+                + "AND b.patientEncounter = :pe "
+                + "ORDER BY b.createdAt DESC";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.PharmacyBhtPre);
+        params.put("returnAtomics", Arrays.asList(
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_RETURN));
+        params.put("pe", patientEncounter);
+
+        List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade
+                .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
         return result != null ? result : new ArrayList<>();
     }
 
@@ -241,7 +320,11 @@ public class InwardPharmacyEncounterReportController implements Serializable {
                 + "bi.item.name, "
                 + "COALESCE(bi.item.code, ''), "
                 + "bi.qty, "
-                + "bi.netValue) "
+                + "bi.grossValue, "
+                + "bi.marginValue, "
+                + "bi.discount, "
+                + "bi.netValue, "
+                + "COALESCE(bi.bill.department.name, '')) "
                 + "FROM BillItem bi "
                 + "WHERE bi.bill.id IN :billIds "
                 + "AND bi.retired = false "
@@ -253,6 +336,57 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         List<InpatientPharmacyBillItemDTO> result = (List<InpatientPharmacyBillItemDTO>) billItemFacade
                 .findLightsByJpqlWithoutCache(jpql, params, TemporalType.TIMESTAMP);
         return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * In-memory aggregation (no new query) grouping the already-fetched
+     * encounter item list by item name+code, for the Items Summary panel
+     * (issue #21871). Includes both direct-issue and return line items, so
+     * the totals reflect net consumption.
+     */
+    private List<InpatientPharmacyItemSummaryDTO> buildItemSummary(List<InpatientPharmacyBillItemDTO> items) {
+        Map<String, InpatientPharmacyItemSummaryDTO> byItem = new LinkedHashMap<>();
+        for (InpatientPharmacyBillItemDTO item : items) {
+            String key = item.getItemName() + "|" + item.getItemCode();
+            InpatientPharmacyItemSummaryDTO summary = byItem.get(key);
+            if (summary == null) {
+                summary = new InpatientPharmacyItemSummaryDTO(item.getItemName(), item.getItemCode());
+                byItem.put(key, summary);
+            }
+            summary.setQty(summary.getQty() + nz(item.getQty()));
+            summary.setTotal(summary.getTotal() + nz(item.getTotal()));
+            summary.setMargin(summary.getMargin() + nz(item.getMargin()));
+            summary.setDiscount(summary.getDiscount() + nz(item.getDiscount()));
+            summary.setNetTotal(summary.getNetTotal() + nz(item.getNetValue()));
+        }
+        return new ArrayList<>(byItem.values());
+    }
+
+    /**
+     * In-memory aggregation (no new query) grouping the already-fetched
+     * encounter item list by issuing department, for the Issuing Department
+     * Summary panel (issue #21871).
+     */
+    private List<InpatientPharmacyDepartmentSummaryDTO> buildDepartmentSummary(List<InpatientPharmacyBillItemDTO> items) {
+        Map<String, InpatientPharmacyDepartmentSummaryDTO> byDept = new LinkedHashMap<>();
+        for (InpatientPharmacyBillItemDTO item : items) {
+            String key = item.getDepartmentName();
+            InpatientPharmacyDepartmentSummaryDTO summary = byDept.get(key);
+            if (summary == null) {
+                summary = new InpatientPharmacyDepartmentSummaryDTO(key);
+                byDept.put(key, summary);
+            }
+            summary.setQty(summary.getQty() + nz(item.getQty()));
+            summary.setTotal(summary.getTotal() + nz(item.getTotal()));
+            summary.setMargin(summary.getMargin() + nz(item.getMargin()));
+            summary.setDiscount(summary.getDiscount() + nz(item.getDiscount()));
+            summary.setNetTotal(summary.getNetTotal() + nz(item.getNetValue()));
+        }
+        return new ArrayList<>(byDept.values());
+    }
+
+    private double nz(Double value) {
+        return value != null ? value : 0.0;
     }
 
     /**
@@ -438,12 +572,52 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         this.directIssueBillsToPatientEncounterNetTotal = directIssueBillsToPatientEncounterNetTotal;
     }
 
+    public double getDirectIssueBillsToPatientEncounterTotal() {
+        return directIssueBillsToPatientEncounterTotal;
+    }
+
+    public void setDirectIssueBillsToPatientEncounterTotal(double directIssueBillsToPatientEncounterTotal) {
+        this.directIssueBillsToPatientEncounterTotal = directIssueBillsToPatientEncounterTotal;
+    }
+
+    public double getDirectIssueBillsToPatientEncounterMargin() {
+        return directIssueBillsToPatientEncounterMargin;
+    }
+
+    public void setDirectIssueBillsToPatientEncounterMargin(double directIssueBillsToPatientEncounterMargin) {
+        this.directIssueBillsToPatientEncounterMargin = directIssueBillsToPatientEncounterMargin;
+    }
+
+    public double getDirectIssueBillsToPatientEncounterDiscount() {
+        return directIssueBillsToPatientEncounterDiscount;
+    }
+
+    public void setDirectIssueBillsToPatientEncounterDiscount(double directIssueBillsToPatientEncounterDiscount) {
+        this.directIssueBillsToPatientEncounterDiscount = directIssueBillsToPatientEncounterDiscount;
+    }
+
     public List<InpatientPharmacyBillItemDTO> getDirectIssueBillItemsToPatientEncounter() {
         return directIssueBillItemsToPatientEncounter;
     }
 
     public void setDirectIssueBillItemsToPatientEncounter(List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter) {
         this.directIssueBillItemsToPatientEncounter = directIssueBillItemsToPatientEncounter;
+    }
+
+    public List<InpatientPharmacyItemSummaryDTO> getDirectIssueItemSummary() {
+        return directIssueItemSummary;
+    }
+
+    public void setDirectIssueItemSummary(List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary) {
+        this.directIssueItemSummary = directIssueItemSummary;
+    }
+
+    public List<InpatientPharmacyDepartmentSummaryDTO> getDirectIssueDepartmentSummary() {
+        return directIssueDepartmentSummary;
+    }
+
+    public void setDirectIssueDepartmentSummary(List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary) {
+        this.directIssueDepartmentSummary = directIssueDepartmentSummary;
     }
 
     public List<BillListReportDTO> getReturnBillsToPatientEncounter() {

--- a/src/main/java/com/divudi/core/data/dto/InpatientPharmacyBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InpatientPharmacyBillItemDTO.java
@@ -17,6 +17,10 @@ public class InpatientPharmacyBillItemDTO implements Serializable {
     private String itemCode;
     private Double qty;
     private Double netValue;
+    private Double total;
+    private Double margin;
+    private Double discount;
+    private String departmentName;
 
     public InpatientPharmacyBillItemDTO() {
     }
@@ -27,6 +31,24 @@ public class InpatientPharmacyBillItemDTO implements Serializable {
         this.itemCode = itemCode;
         this.qty = qty;
         this.netValue = netValue;
+    }
+
+    // Constructor adding the Total/Margin/Discount breakdown and issuing department
+    // (Inpatient Dashboard Direct Issues report enhancement, issue #21871). Added
+    // rather than modifying the original constructor per project rule (never change
+    // existing constructor signatures).
+    public InpatientPharmacyBillItemDTO(Long billId, String itemName, String itemCode,
+            Double qty, Double total, Double margin, Double discount, Double netValue,
+            String departmentName) {
+        this.billId = billId;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.total = total;
+        this.margin = margin;
+        this.discount = discount;
+        this.netValue = netValue;
+        this.departmentName = departmentName;
     }
 
     public Long getBillId() {
@@ -67,5 +89,37 @@ public class InpatientPharmacyBillItemDTO implements Serializable {
 
     public void setNetValue(Double netValue) {
         this.netValue = netValue;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+
+    public Double getMargin() {
+        return margin;
+    }
+
+    public void setMargin(Double margin) {
+        this.margin = margin;
+    }
+
+    public Double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(Double discount) {
+        this.discount = discount;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/InpatientPharmacyDepartmentSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InpatientPharmacyDepartmentSummaryDTO.java
@@ -1,0 +1,76 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * Per-issuing-department aggregate across all direct-issue and issue-return
+ * bills in one patient encounter (Inpatient Dashboard Direct Issues report,
+ * issue #21871). Built by in-memory accumulation over
+ * InpatientPharmacyBillItemDTO rows, not a JPQL projection.
+ *
+ * @author Claude Code
+ */
+public class InpatientPharmacyDepartmentSummaryDTO implements Serializable {
+
+    private String departmentName;
+    private double qty;
+    private double total;
+    private double margin;
+    private double discount;
+    private double netTotal;
+
+    public InpatientPharmacyDepartmentSummaryDTO() {
+    }
+
+    public InpatientPharmacyDepartmentSummaryDTO(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public double getQty() {
+        return qty;
+    }
+
+    public void setQty(double qty) {
+        this.qty = qty;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public void setTotal(double total) {
+        this.total = total;
+    }
+
+    public double getMargin() {
+        return margin;
+    }
+
+    public void setMargin(double margin) {
+        this.margin = margin;
+    }
+
+    public double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(double discount) {
+        this.discount = discount;
+    }
+
+    public double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(double netTotal) {
+        this.netTotal = netTotal;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/InpatientPharmacyItemSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InpatientPharmacyItemSummaryDTO.java
@@ -1,0 +1,86 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * Per-item aggregate across all direct-issue and issue-return bills in one
+ * patient encounter (Inpatient Dashboard Direct Issues report, issue #21871).
+ * Built by in-memory accumulation over InpatientPharmacyBillItemDTO rows, not
+ * a JPQL projection.
+ *
+ * @author Claude Code
+ */
+public class InpatientPharmacyItemSummaryDTO implements Serializable {
+
+    private String itemName;
+    private String itemCode;
+    private double qty;
+    private double total;
+    private double margin;
+    private double discount;
+    private double netTotal;
+
+    public InpatientPharmacyItemSummaryDTO() {
+    }
+
+    public InpatientPharmacyItemSummaryDTO(String itemName, String itemCode) {
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public double getQty() {
+        return qty;
+    }
+
+    public void setQty(double qty) {
+        this.qty = qty;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public void setTotal(double total) {
+        this.total = total;
+    }
+
+    public double getMargin() {
+        return margin;
+    }
+
+    public void setMargin(double margin) {
+        this.margin = margin;
+    }
+
+    public double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(double discount) {
+        this.discount = discount;
+    }
+
+    public double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(double netTotal) {
+        this.netTotal = netTotal;
+    }
+}

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -119,6 +119,14 @@
                                     <h:outputLabel value="#{dto.billNumber}" />
                                 </p:column>
 
+                                <p:column width="7em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : (dto.billTypeAtomic.contains('RETURN') ? 'ui-messages-warn' : '')}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Type" />
+                                    </f:facet>
+                                    <h:outputLabel value="Return" style="color: #b45f06; font-weight: bold;" rendered="#{dto.billTypeAtomic.contains('RETURN')}" />
+                                    <h:outputLabel value="Issue" rendered="#{!dto.billTypeAtomic.contains('RETURN')}" />
+                                </p:column>
+
                                 <p:column width="12em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Billed At" />
@@ -133,6 +141,48 @@
                                         <h:outputLabel value="Billed By" />
                                     </f:facet>
                                     <h:outputLabel value="#{dto.createdUserName}" />
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Total" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueBillsToPatientEncounterTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Margin" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.serviceCharge}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueBillsToPatientEncounterMargin}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Discount" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueBillsToPatientEncounterDiscount}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
 
                                 <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
@@ -178,18 +228,33 @@
 
                                 <p:rowExpansion>
                                     <p:dataTable var="item" value="#{inwardPharmacyEncounterReportController.getItemsForDirectIssueBill(dto.billId)}">
-                                        <p:column headerText="Item Name" width="45%">
+                                        <p:column headerText="Item Name" width="30%">
                                             <h:outputLabel value="#{item.itemName}"/>
                                         </p:column>
-                                        <p:column headerText="Code" width="20%">
+                                        <p:column headerText="Code" width="14%">
                                             <h:outputLabel value="#{item.itemCode}"/>
                                         </p:column>
-                                        <p:column headerText="Qty" width="15%" style="text-align: right;">
+                                        <p:column headerText="Qty" width="10%" style="text-align: right;">
                                             <h:outputLabel value="#{item.qty}">
                                                 <f:convertNumber pattern="#0.##" />
                                             </h:outputLabel>
                                         </p:column>
-                                        <p:column headerText="Net Value" width="20%" style="text-align: right;">
+                                        <p:column headerText="Total" width="12%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.total}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Margin" width="12%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.margin}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Discount" width="10%" style="text-align: right;">
+                                            <h:outputLabel value="#{item.discount}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Net Total" width="12%" style="text-align: right;">
                                             <h:outputLabel value="#{item.netValue}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
@@ -199,6 +264,87 @@
 
                             </p:dataTable>
 
+                        </p:panel>
+
+                        <p:panel class="mt-3">
+                            <f:facet name="header">
+                                <p:outputLabel value="Items Summary" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+                            <p:dataTable
+                                id="tblItemSummary"
+                                value="#{inwardPharmacyEncounterReportController.directIssueItemSummary}"
+                                var="s">
+                                <p:column headerText="Item Name" width="30%">
+                                    <h:outputLabel value="#{s.itemName}"/>
+                                </p:column>
+                                <p:column headerText="Code" width="14%">
+                                    <h:outputLabel value="#{s.itemCode}"/>
+                                </p:column>
+                                <p:column headerText="Qty" width="10%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.qty}">
+                                        <f:convertNumber pattern="#0.##" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Total" width="12%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Margin" width="12%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.margin}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Discount" width="10%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Net Total" width="12%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+
+                        <p:panel class="mt-3">
+                            <f:facet name="header">
+                                <p:outputLabel value="Issuing Department Summary" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+                            <p:dataTable
+                                id="tblDeptSummary"
+                                value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummary}"
+                                var="s">
+                                <p:column headerText="Department" width="30%">
+                                    <h:outputLabel value="#{s.departmentName}"/>
+                                </p:column>
+                                <p:column headerText="Qty" width="14%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.qty}">
+                                        <f:convertNumber pattern="#0.##" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Total" width="14%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Margin" width="14%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.margin}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Discount" width="14%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Net Total" width="14%" style="text-align: right;">
+                                    <h:outputLabel value="#{s.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                            </p:dataTable>
                         </p:panel>
 
                     </div>


### PR DESCRIPTION
## Summary
- Adds Total, Margin, Discount, Net Total columns at both the bill level (with footer totals) and item level (row expansion) on the Inpatient Dashboard's Direct Issues report.
- Adds an **Items Summary** panel: totals aggregated per item across the whole patient encounter.
- Adds an **Issuing Department Summary** panel: totals aggregated per issuing department.
- Merges direct-issue **returns** (`RefundBill` rows created by `BhtIssueReturnController`) into the same bill-level list, flagged with a "Type" column (Issue/Return), sorted by date alongside issues — previously returns were entirely invisible on this report.

Closes #21871

## Implementation notes
- `InpatientPharmacyBillItemDTO` gets a new constructor (existing one untouched) carrying total/margin/discount/departmentName.
- Two new lightweight summary DTOs (`InpatientPharmacyItemSummaryDTO`, `InpatientPharmacyDepartmentSummaryDTO`) built via in-memory aggregation over the already-fetched item list — no new heavy queries.
- `fetchDirectIssueBills()` now merges a second query (`fetchDirectIssueReturnBills()`) scoped to the two direct-issue return atomics, sorted together by `createdAt`.
- Returned qty/value are already negative on `RefundBill`'s `BillItem`s, so summaries net correctly with no extra sign handling.

## Testing performed
Verified end-to-end against the local `coop` DB (admission BHT/47186, patient encounter 616173 — direct issues from ETU, Main Pharmacy, THEATRE, plus 9 returns from Main Pharmacy):
- Row expansion for return bill `MPPHISSRET/154` (Lasix 20mg (spc) Injection): Qty 5, Total -244.50, Margin -95.36, Discount 0.00, Net Total -339.86 — matches DB `billitem` values exactly.
- Items Summary for "Lasix 20mg (spc) Injection": Qty 27, Total 831.30, Margin 324.21, Net Total 1,155.51 — matches DB aggregate across all issue+return bills for that item.
- Issuing Department Summary (ETU/Main Pharmacy/THEATRE) matches direct DB aggregation grouped by `bill.department`.
- Bill-level footer totals (Total 115,146.17, Margin 49,867.19, Discount 0.00, Net Value 160,039.02) match `SUM(bill.total/margin/discount/netTotal)` across all issue+return bills in the encounter exactly.
- Build: `mvn clean package -DskipTests` → BUILD SUCCESS. Deployed to local Payara and driven via Playwright (login → department selection → BHT search → Inpatient Dashboard → Direct Issues).

Screenshots: https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21871_direct_issues_list_full.png and https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21871_direct_issues_row_expanded.png

## Follow-up (separate issue)
While verifying, found that `RefundBill.margin` is always persisted as `0` for direct-issue returns (`BhtIssueReturnController`) — a pre-existing data bug unrelated to this report (which faithfully displays whatever is in `bill.margin`). Filed separately as #21872.

## Test plan
- [x] Build succeeds
- [x] Verified against local DB
- [x] Playwright end-to-end walkthrough of the report page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer inpatient pharmacy “Direct Issues” reporting with new totals for margin and discount.
  * Introduced item-level and department-level summary panels for easier review of encounter activity.
  * Added a clear “Issue/Return” type indicator in the main report list.

* **Bug Fixes**
  * Improved handling of return entries so they appear together with related issue records in the report.
  * Enhanced detail rows to show complete financial breakdowns, including total, margin, discount, and net total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->