### PR TITLE
fix(inward): hide blank admission-detail rows in bhtDetail composite

### DIFF
--- a/src/main/webapp/resources/inward/bhtDetail.xhtml
+++ b/src/main/webapp/resources/inward/bhtDetail.xhtml
@@ -23,13 +23,15 @@
 
         <div class="row">
             <div class="col-md-12">
-                <div class="row">
-                    <div class="col-md-3"><p:outputLabel value="BHT No"/></div>
-                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
-                    <div class="col-md-8"><h:outputLabel  value="#{cc.attrs.admission.bhtNo}" /></div>
-                </div>
-              
-                <h:panelGroup rendered="#{cc.attrs.admission.referringConsultant ne null 
+                <h:panelGroup rendered="#{not empty cc.attrs.admission.bhtNo}">
+                    <div class="row">
+                        <div class="col-md-3"><p:outputLabel value="BHT No"/></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
+                        <div class="col-md-8"><h:outputLabel  value="#{cc.attrs.admission.bhtNo}" /></div>
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{cc.attrs.admission.referringConsultant ne null
                                          and cc.attrs.admission.referringConsultant.person ne null}">
                     <div class="row">
                         <div class="col-md-3"><p:outputLabel value="Consultant Name"/></div>
@@ -40,50 +42,62 @@
                     </div>
               </h:panelGroup>
 
-                <div class="row">
-                    <div class="col-md-3"><p:outputLabel value="Admission Type"  /></div>
-                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
-                    <div class="col-md-8"><h:outputLabel  value="#{cc.attrs.admission.admissionType.name}" /></div>
-                </div>
-
-                <div class="row">
-                    <div class="col-md-3"><p:outputLabel value="Payment Method"  /></div>
-                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
-                    <div class="col-md-8"> <h:outputLabel  value="#{cc.attrs.admission.paymentMethod}" /></div>
-                </div>
-
-                <div class="row">
-                    <div class="col-md-2"><p:outputLabel value="Room"  /></div>
-                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":"/></div>
-                    <div class="col-md-8">
-                        <h:outputLabel  value="#{cc.attrs.admission.currentPatientRoom.roomFacilityCharge.name}" />
+                <h:panelGroup rendered="#{not empty cc.attrs.admission.admissionType.name}">
+                    <div class="row">
+                        <div class="col-md-3"><p:outputLabel value="Admission Type"  /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
+                        <div class="col-md-8"><h:outputLabel  value="#{cc.attrs.admission.admissionType.name}" /></div>
                     </div>
-                </div>
+                </h:panelGroup>
 
-                <div class="row">
-                    <div class="col-md-2"><p:outputLabel value="Admission Date"  /></div>
-                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
-                    <div class="col-md-8">
-                        <h:outputLabel value="#{cc.attrs.admission.dateOfAdmission}">
-                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                        </h:outputLabel>
+                <h:panelGroup rendered="#{not empty cc.attrs.admission.paymentMethod}">
+                    <div class="row">
+                        <div class="col-md-3"><p:outputLabel value="Payment Method"  /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":"/></div>
+                        <div class="col-md-8"> <h:outputLabel  value="#{cc.attrs.admission.paymentMethod}" /></div>
                     </div>
-                </div>
+                </h:panelGroup>
 
-                <div class="row">
-                    <div class="col-md-2"><p:outputLabel value="Nationality"  /></div>
-                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
-                    <div class="col-md-8"><h:outputLabel  value="Local" rendered="#{cc.attrs.admission.foriegner eq false}"/>
-                        <h:outputLabel  value="Foreigner" rendered="#{cc.attrs.admission.foriegner eq true}"/>
+                <h:panelGroup rendered="#{not empty cc.attrs.admission.currentPatientRoom.roomFacilityCharge.name}">
+                    <div class="row">
+                        <div class="col-md-2"><p:outputLabel value="Room"  /></div>
+                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":"/></div>
+                        <div class="col-md-8">
+                            <h:outputLabel  value="#{cc.attrs.admission.currentPatientRoom.roomFacilityCharge.name}" />
+                        </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-2"><p:outputLabel value="Claimability"  /></div>
-                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
-                    <div class="col-md-8"><h:outputLabel  value="Not Claimable" rendered="#{cc.attrs.admission.claimable eq false}"/>
-                        <h:outputLabel  value="Claimable" rendered="#{cc.attrs.admission.claimable eq true}"/>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{cc.attrs.admission.dateOfAdmission ne null}">
+                    <div class="row">
+                        <div class="col-md-2"><p:outputLabel value="Admission Date"  /></div>
+                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
+                        <div class="col-md-8">
+                            <h:outputLabel value="#{cc.attrs.admission.dateOfAdmission}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                            </h:outputLabel>
+                        </div>
                     </div>
-                </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{cc.attrs.admission.foriegner ne null}">
+                    <div class="row">
+                        <div class="col-md-2"><p:outputLabel value="Nationality"  /></div>
+                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
+                        <div class="col-md-8"><h:outputLabel  value="Local" rendered="#{cc.attrs.admission.foriegner eq false}"/>
+                            <h:outputLabel  value="Foreigner" rendered="#{cc.attrs.admission.foriegner eq true}"/>
+                        </div>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.admission.claimable ne null}">
+                    <div class="row">
+                        <div class="col-md-2"><p:outputLabel value="Claimability"  /></div>
+                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
+                        <div class="col-md-8"><h:outputLabel  value="Not Claimable" rendered="#{cc.attrs.admission.claimable eq false}"/>
+                            <h:outputLabel  value="Claimable" rendered="#{cc.attrs.admission.claimable eq true}"/>
+                        </div>
+                    </div>
+                </h:panelGroup>
                 <h:panelGroup rendered="#{cc.attrs.admission.creditCompany ne null}">
                     <div class="row">
                         <div class="col-md-2"><p:outputLabel value="Credit Company"  /></div>


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements)
- The "Patient Details" panel on `pharmacy_bill_issue_bht.xhtml` (and 5 other pages sharing the same composite) rendered field labels (e.g. "Room :") even when the underlying admission field was null/blank, leaving a dangling label with nothing after it.
- The nested `emr:patient` sub-composite already had the correct `rendered="#{not empty ...}"` guard on every row from an earlier fix. Only the admission-level rows defined directly in `bhtDetail.xhtml` were missing it: BHT No, Admission Type, Payment Method, Room, Admission Date, Nationality, Claimability.
- Applied the same existing guard pattern (already used for Consultant Name / Credit Company in this same file) to the remaining 7 rows, wrapping each in `h:panelGroup rendered="..."` so the whole row disappears as a unit when blank.

## Files changed
- `src/main/webapp/resources/inward/bhtDetail.xhtml` — composite-only fix, applies to all 6 pages that reuse it (`pharmacy_bill_issue_bht.xhtml`, `pharmacy_bill_issue_bht_old.xhtml`, `pharmacy_discharge_medicine_issue.xhtml`, `ward_pharmacy_bht_issue_request_edit.xhtml`, `ward_pharmacy_bht_issue_request_bill.xhtml`, `inward_bill_surgery_issue.xhtml`)

## Test plan
Verified end-to-end with Playwright against the local coop DB (no code rebuild needed — XHTML-only change):

- [x] **Case A — fully populated admission** (BHT/53358): all 7 admission-detail rows render normally, confirming no regression.
- [x] **Case B — admission with no room assigned** (OPDCARD/41098): the "Room" row is completely absent (previously showed "Room :" with nothing after it); every other populated field still renders correctly.

Screenshots (before/after) posted on issue #21877: https://github.com/hmislk/hmis/issues/21877#issuecomment-4888411729

Closes #21877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admission details now hide empty fields instead of showing blank labels.
  * The “BHT No” value only appears when a number is available.
  * Admission Type, Payment Method, Room, Admission Date, Nationality, and Claimability are now displayed only when populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->