### PR TITLE
fix(inward): hide blank rows in admission_details composite

### DIFF
--- a/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
@@ -23,87 +23,113 @@
             </f:facet>
             <div class="row">
                 <div class="col-md-12">
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Date of Admission" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.dateOfAdmission}" >
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
-                            </h:outputText></div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="BHT No" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputLabel  value="#{cc.attrs.admission.bhtNo}" /></div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
+                    <h:panelGroup rendered="#{cc.attrs.admission.dateOfAdmission ne null}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Date of Admission" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.dateOfAdmission}" >
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
+                                </h:outputText></div>
                         </div>
-                    </div><!-- comment -->
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Referring Doctor"/></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.referringDoctor ne null ? cc.attrs.admission.referringDoctor.person.name : cc.attrs.admission.referringConsultant.person.name}" /></div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-5"><h:outputLabel value="OPD Doctor" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.opdDoctor.person.nameWithTitle}" />
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.bhtNo}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="BHT No" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputLabel  value="#{cc.attrs.admission.bhtNo}" /></div>
                         </div>
-                    </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Admission Type"/></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.admissionType.name}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{cc.attrs.admission.foriegner ne null}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><h:outputLabel value="Payment Method"/></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.paymentMethod}" /></div>
-                    </div><!-- comment -->
+                    <h:panelGroup rendered="#{cc.attrs.admission.claimable ne null}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
+                            </div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Guardian Name" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.name}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{cc.attrs.admission.referringDoctor ne null or cc.attrs.admission.referringConsultant ne null}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Referring Doctor"/></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.referringDoctor ne null ? cc.attrs.admission.referringDoctor.person.name : cc.attrs.admission.referringConsultant.person.name}" /></div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Guardian NIC / Passport"/></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"> <h:outputText value="#{cc.attrs.admission.guardian.nic}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{cc.attrs.admission.opdDoctor ne null}">
+                        <div class="row">
+                            <div class="col-md-5"><h:outputLabel value="OPD Doctor" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.opdDoctor.person.nameWithTitle}" />
+                            </div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Guardian Mobile No" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.mobile}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.admissionType.name}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Admission Type"/></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.admissionType.name}" /></div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Guardian Home Phone No" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.phone}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.paymentMethod}">
+                        <div class="row">
+                            <div class="col-md-5"><h:outputLabel value="Payment Method"/></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.paymentMethod}" /></div>
+                        </div>
+                    </h:panelGroup>
 
-                    <div class="row">
-                        <div class="col-md-5"><p:outputLabel value="Guardian Address" /></div>
-                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.address}" /></div>
-                    </div>
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.guardian.name}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Guardian Name" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.name}" /></div>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.guardian.nic}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Guardian NIC / Passport"/></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"> <h:outputText value="#{cc.attrs.admission.guardian.nic}" /></div>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.guardian.mobile}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Guardian Mobile No" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.mobile}" /></div>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.guardian.phone}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Guardian Home Phone No" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.phone}" /></div>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.admission.guardian.address}">
+                        <div class="row">
+                            <div class="col-md-5"><p:outputLabel value="Guardian Address" /></div>
+                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.guardian.address}" /></div>
+                        </div>
+                    </h:panelGroup>
                 </div></div>
 
 


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements), sibling fix to #21877 (merged: #21889)
- The "Admission Details" panel (`resources/ezcomp/common/admission_details.xhtml`) rendered every row's label even when the underlying admission field was null/blank — e.g. "Guardian Home Phone No :" with nothing after it.
- Applied the same `rendered="#{not empty ...}"` / `rendered="#{... ne null}"` guard pattern used in #21877's fix to `bhtDetail.xhtml`, wrapping all 13 rows (Date of Admission, BHT No, Citizenship, Claimable/Non-Claimable, Referring Doctor, OPD Doctor, Admission Type, Payment Method, Guardian Name, Guardian NIC/Passport, Guardian Mobile No, Guardian Home Phone No, Guardian Address) in `h:panelGroup rendered="..."`.

## Files changed
- `src/main/webapp/resources/ezcomp/common/admission_details.xhtml` — composite-only fix, applies to all 22 pages that reuse it (`admission_profile.xhtml`, surgery pages, pharmacy report pages, `pharmacy_cancel_bill_retail_bht.xhtml`, etc.)

## Test plan
Verified end-to-end with Playwright against the local coop DB (no code rebuild needed — XHTML-only change):

- [x] Admission BHT/53352 (every field populated except Guardian Home Phone No): "Guardian Home Phone No" row is completely absent; every other populated row (Date of Admission, BHT No, Citizenship, Claimable/Non-Claimable, Referring Doctor, OPD Doctor, Admission Type, Payment Method, Guardian Name/NIC/Mobile/Address) renders correctly — no regression.

Screenshot posted on issue #21878: https://github.com/hmislk/hmis/issues/21878#issuecomment-4888646209

Closes #21878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Admission Details page so fields only appear when data is available, reducing blank or empty rows.
  * Updated several admission fields, including date, BHT number, doctor details, payment method, and guardian information, to display more cleanly based on available information.
  * Refined the display of citizenship and claim status labels for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->