### PR TITLE
fix(inward): remove dead boolean-null rendered guards (CodeRabbit follow-up)

### DIFF
--- a/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
@@ -41,22 +41,18 @@
                         </div>
                     </h:panelGroup>
 
-                    <h:panelGroup rendered="#{cc.attrs.admission.foriegner ne null}">
-                        <div class="row">
-                            <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
-                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                            <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
-                        </div>
-                    </h:panelGroup>
+                    <div class="row">
+                        <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                        <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
+                    </div>
 
-                    <h:panelGroup rendered="#{cc.attrs.admission.claimable ne null}">
-                        <div class="row">
-                            <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
-                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
-                            </div>
+                    <div class="row">
+                        <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
                         </div>
-                    </h:panelGroup>
+                    </div>
 
                     <h:panelGroup rendered="#{cc.attrs.admission.referringDoctor ne null or cc.attrs.admission.referringConsultant ne null}">
                         <div class="row">

--- a/src/main/webapp/resources/inward/bhtDetail.xhtml
+++ b/src/main/webapp/resources/inward/bhtDetail.xhtml
@@ -80,24 +80,20 @@
                     </div>
                 </h:panelGroup>
 
-                <h:panelGroup rendered="#{cc.attrs.admission.foriegner ne null}">
-                    <div class="row">
-                        <div class="col-md-2"><p:outputLabel value="Nationality"  /></div>
-                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
-                        <div class="col-md-8"><h:outputLabel  value="Local" rendered="#{cc.attrs.admission.foriegner eq false}"/>
-                            <h:outputLabel  value="Foreigner" rendered="#{cc.attrs.admission.foriegner eq true}"/>
-                        </div>
+                <div class="row">
+                    <div class="col-md-2"><p:outputLabel value="Nationality"  /></div>
+                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
+                    <div class="col-md-8"><h:outputLabel  value="Local" rendered="#{cc.attrs.admission.foriegner eq false}"/>
+                        <h:outputLabel  value="Foreigner" rendered="#{cc.attrs.admission.foriegner eq true}"/>
                     </div>
-                </h:panelGroup>
-                <h:panelGroup rendered="#{cc.attrs.admission.claimable ne null}">
-                    <div class="row">
-                        <div class="col-md-2"><p:outputLabel value="Claimability"  /></div>
-                        <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
-                        <div class="col-md-8"><h:outputLabel  value="Not Claimable" rendered="#{cc.attrs.admission.claimable eq false}"/>
-                            <h:outputLabel  value="Claimable" rendered="#{cc.attrs.admission.claimable eq true}"/>
-                        </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-2"><p:outputLabel value="Claimability"  /></div>
+                    <div class="col-md-2 justify-content-end d-flex"><p:outputLabel value=":" /></div>
+                    <div class="col-md-8"><h:outputLabel  value="Not Claimable" rendered="#{cc.attrs.admission.claimable eq false}"/>
+                        <h:outputLabel  value="Claimable" rendered="#{cc.attrs.admission.claimable eq true}"/>
                     </div>
-                </h:panelGroup>
+                </div>
                 <h:panelGroup rendered="#{cc.attrs.admission.creditCompany ne null}">
                     <div class="row">
                         <div class="col-md-2"><p:outputLabel value="Credit Company"  /></div>


### PR DESCRIPTION
## Summary
CodeRabbit correctly flagged on PR #21892 (merged just before the review comment posted) that `Admission.foriegner` and `Admission.claimable` are primitive `boolean` fields (default `false`, never `null`). The `rendered="#{... ne null}"` guards added for the Citizenship/Claimable rows in #21878's fix were dead code — always evaluating true, never actually hiding anything.

This PR:
- Removes the dead guards from `admission_details.xhtml` (already merged via #21892, before the fix landed — timing race with the review)
- Applies the same correction to `bhtDetail.xhtml` (merged earlier via #21889 for #21877), which had the identical pattern for its Nationality/Claimability rows

A primitive boolean has no meaningful "unrecorded" state, so these rows should simply always render — matching the original (correct) pre-fix behavior for those two specific fields only. All other blank-field guards in both files (which check `not empty` on strings/objects) are unaffected and continue to work correctly.

## Files changed
- `src/main/webapp/resources/ezcomp/common/admission_details.xhtml`
- `src/main/webapp/resources/inward/bhtDetail.xhtml`

## Test plan
- [x] Confirmed via Playwright (BHT/53352, BHT/53358) that Citizenship/Claimable/Nationality/Claimability rows continue to render correctly after removing the dead guards — no visual change, since the guards never actually hid anything.

Related: #21877, #21878, #21876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how nationality/citizenship and claimability details are shown in admission and BHT views.
  * These fields now display more consistently, including clearer Foreigner/Local and Claimable/Non-Claimable labels.
  * Visibility behavior was adjusted so the information appears in a more predictable way when values are present or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->