### PR TITLE
fix(inward): restructure BHT Issue page header to three-zone layout

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -155,50 +155,64 @@
 
                 <p:panel rendered="#{!inpatientDirectIssueNativeSqlController.billPreview}">
                     <f:facet name="header">
-                        <div class="d-flex justify-content-between">
-                            <div>
+                        <div class="d-flex justify-content-between align-items-center w-100">
+
+                            <!-- LEFT: title -->
+                            <div class="d-flex align-items-center gap-2">
                                 <h:outputText styleClass="fa-solid fa-pills fa-lg" />
                                 <p:outputLabel value="Direct Issue of Medicines to Inpatients (Native SQL)" class="mx-4" />
                             </div>
+
+                            <!-- CENTER: entity-level navigation -->
                             <div class="d-flex gap-2">
                                 <p:commandButton
-                                    value="New Bill"
+                                    value="Inpatient Dashboard"
                                     ajax="false"
-                                    class="ui-button-warning"
-                                    icon="fa-solid fa-plus"
-                                    action="pharmacy_bill_issue_bht"
-                                    actionListener="#{inpatientDirectIssueNativeSqlController.resetAll}">
+                                    icon="fas fa-id-card"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    action="#{admissionController.navigateToAdmissionProfilePage}"
+                                    rendered="#{inpatientDirectIssueNativeSqlController.patientEncounter ne null}">
+                                    <f:setPropertyActionListener
+                                        value="#{inpatientDirectIssueNativeSqlController.patientEncounter}"
+                                        target="#{admissionController.current}" />
                                 </p:commandButton>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                     <p:commandButton
                                         value="Nursing WorkBench"
                                         action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                         ajax="false"
-                                        class="ui-button-operating-theatre"
-                                        icon="fa fa-arrow-left">
+                                        icon="fa fa-arrow-left"
+                                        styleClass="ui-button-info ui-button-outlined">
                                     </p:commandButton>
                                 </h:panelGroup>
                             </div>
+
+                            <!-- RIGHT: actions, left=least important -> right=primary -->
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:commandButton
+                                    value="New Bill"
+                                    ajax="false"
+                                    styleClass="ui-button-warning"
+                                    icon="fa-solid fa-plus"
+                                    action="pharmacy_bill_issue_bht"
+                                    actionListener="#{inpatientDirectIssueNativeSqlController.resetAll}">
+                                </p:commandButton>
+                                <p:commandButton
+                                    id="btnSettleNative"
+                                    value="Settle"
+                                    ajax="true"
+                                    onclick="if(!confirm('Are you sure you want to settle this pharmacy bill issue?')){return false;} var o=document.getElementById('settlingOverlay'); o.style.display='flex'; o.style.pointerEvents='all';"
+                                    oncomplete="document.getElementById('settlingOverlay').style.display='none';"
+                                    ondblclick="return false;"
+                                    action="#{inpatientDirectIssueNativeSqlController.settleInpatientDirectIssue()}"
+                                    update="gpPatientPanel panelErrorMsg"
+                                    styleClass="ui-button-success"
+                                    style="min-width:120px"
+                                    icon="fa-solid fa-check-circle">
+                                </p:commandButton>
+                            </div>
                         </div>
                     </f:facet>
-
-                    <!-- Settle button row -->
-                    <div class="row mb-3">
-                        <div class="d-flex justify-content-end align-items-center">
-                            <p:commandButton
-                                id="btnSettleNative"
-                                value="Settle"
-                                ajax="true"
-                                onclick="if(!confirm('Are you sure you want to settle this pharmacy bill issue?')){return false;} var o=document.getElementById('settlingOverlay'); o.style.display='flex'; o.style.pointerEvents='all';"
-                                oncomplete="document.getElementById('settlingOverlay').style.display='none';"
-                                ondblclick="return false;"
-                                action="#{inpatientDirectIssueNativeSqlController.settleInpatientDirectIssue()}"
-                                update="gpPatientPanel panelErrorMsg"
-                                class="ui-button-success mx-2"
-                                icon="fa-solid fa-check">
-                            </p:commandButton>
-                        </div>
-                    </div>
 
                     <div class="row">
                         <!-- Patient detail panel -->


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements)
- `inward/pharmacy_bill_issue_bht.xhtml` had two issues: button arrangement didn't follow the standard three-zone panel-header pattern, and there was no "Inpatient Dashboard" navigation button.
- Restructured the panel header per `developer_docs/ui/comprehensive-ui-guidelines.md` § Panel Header — Three-Zone Layout:
  - **Left**: title
  - **Center**: navigation — added **Inpatient Dashboard** button (reuses the existing `admissionController.navigateToAdmissionProfilePage` + `f:setPropertyActionListener` pattern already used on `pharmacy_discharge_medicine_issue.xhtml`) alongside the existing Nursing WorkBench button
  - **Right**: actions ordered by ascending importance — New Bill (`ui-button-warning`) → Settle (`ui-button-success`, rightmost, primary, `min-width:120px`, `icon="fa-solid fa-check-circle"`)
- Settle was previously a separate button row below the header; folded into the header's right zone per the guideline.

## Files changed
- `src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml`

## Test plan
Verified end-to-end with Playwright against the local coop DB (no rebuild needed — XHTML-only change):

- [x] Header renders in the three-zone layout: title left, Inpatient Dashboard + Nursing WorkBench center, New Bill + Settle right (Settle rightmost).
- [x] Clicked "Inpatient Dashboard" from a BHT Issue page with patient OPDCARD/41098 loaded — correctly navigated to `admission_profile.xhtml` showing the same patient, confirming the nav button carries the right admission context.
- [x] Settle button retains its existing double-submit guard (`confirm()` + `ondblclick="return false;"`) and blocking overlay — unchanged, only relocated.

Screenshot posted on issue #21879: https://github.com/hmislk/hmis/issues/21879#issuecomment-4888710104

Closes #21879