### PR TITLE
fix(inward): restructure Reprint BHT Issue page header, add print config button

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -19,6 +19,7 @@ import com.divudi.bean.store.StoreBillSearch;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.PaperType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.CashTransactionBean;
@@ -766,6 +767,36 @@ public class PharmacyBillSearch implements Serializable {
         JsfUtil.addSuccessMessage("Mark As Un Check");
 
     }
+
+    // <editor-fold defaultstate="collapsed" desc="Reprint BHT Issue - Print Format Settings (Issue #21880)">
+    public boolean isReprintBhtIssuePosPaper() {
+        return PaperType.PosPaper == getSessionController().getDepartmentPreference().getPharmacyBillPaperType();
+    }
+
+    public void setReprintBhtIssuePosPaper(boolean value) {
+        if (value) {
+            getSessionController().getDepartmentPreference().setPharmacyBillPaperType(PaperType.PosPaper);
+        } else if (isReprintBhtIssuePosPaper()) {
+            getSessionController().getDepartmentPreference().setPharmacyBillPaperType(null);
+        }
+    }
+
+    public boolean isReprintBhtIssueFiveFivePaper() {
+        return PaperType.FiveFivePaper == getSessionController().getDepartmentPreference().getPharmacyBillPaperType();
+    }
+
+    public void setReprintBhtIssueFiveFivePaper(boolean value) {
+        if (value) {
+            getSessionController().getDepartmentPreference().setPharmacyBillPaperType(PaperType.FiveFivePaper);
+        } else if (isReprintBhtIssueFiveFivePaper()) {
+            getSessionController().getDepartmentPreference().setPharmacyBillPaperType(null);
+        }
+    }
+
+    public void saveReprintBhtIssuePaperConfig() {
+        JsfUtil.addSuccessMessage("Print format settings saved");
+    }
+    // </editor-fold>
 
     public void unitCancell() {
 

--- a/src/main/webapp/inward/pharmacy_reprint_bill_sale_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_reprint_bill_sale_bht.xhtml
@@ -17,83 +17,96 @@
                 <h:form>
                     <p:panel header="Reprint" >
                         <f:facet name="header" >
-                            <div class=" d-flex justify-content-between ">
-                                <div><h:outputLabel value="Reprint BHT Issue" class="mt-2"></h:outputLabel></div>
+                            <div class="d-flex justify-content-between align-items-center w-100">
+
+                                <!-- LEFT: title + print config -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <h:outputLabel value="Reprint BHT Issue"></h:outputLabel>
+                                    <p:commandButton
+                                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                        icon="fas fa-cog"
+                                        styleClass="ui-button-secondary ui-button-outlined"
+                                        type="button"
+                                        title="Print Format Settings"
+                                        onclick="PF('reprintBhtIssuePaperConfigDialog').show();" />
+                                </div>
+
+                                <!-- CENTER: Back to Interim -->
                                 <div class="d-flex gap-2">
-                                    <p:commandButton 
-                                        value="Reprint" 
-                                        class="ui-button-info"
-                                        ajax="false" 
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Back to Interim"
+                                        icon="fa fa-backward"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="/inward/inward_bill_intrim" />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Inpatient Dashboard"
+                                        icon="fas fa-id-card"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="#{admissionController.navigateToAdmissionProfilePage}"
+                                        rendered="#{pharmacyBillSearch.bill.patientEncounter ne null}">
+                                        <f:setPropertyActionListener
+                                            value="#{pharmacyBillSearch.bill.patientEncounter}"
+                                            target="#{admissionController.current}" />
+                                    </p:commandButton>
+                                </div>
+
+                                <!-- RIGHT: actions, left=least important -> right=primary -->
+                                <div class="d-flex gap-2 align-items-center">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Mark As Checked"
+                                        action="#{pharmacyBillSearch.markAsChecked()}"
+                                        icon="fa fa-check-square"
+                                        styleClass="ui-button-success"
+                                        rendered="#{webUserController.hasPrivilege('InwardCheck')}"  />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Mark As Un Check"
+                                        icon="fa fa-square"
+                                        styleClass="ui-button-warning"
+                                        action="#{pharmacyBillSearch.markAsUnChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="To Return Item"
+                                        action="#{bhtIssueReturnController.navigateToReturnPharmacyDirectIssueToInpatients()}"
+                                        icon="fa fa-undo"
+                                        styleClass="ui-button-warning"
+                                        disabled="#{pharmacyBillSearch.bill.cancelled eq true or pharmacyBillSearch.bill.patientEncounter.discharged eq true}"  >
+                                        <f:setPropertyActionListener
+                                            value="#{pharmacyBillSearch.bill}"
+                                            target="#{bhtIssueReturnController.bill}"  />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="To Cancel"
+                                        rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}"
+                                        disabled="#{pharmacyBillSearch.bill.cancelled eq true or pharmacyBillSearch.bill.patientEncounter.discharged eq true}"
+                                        styleClass="ui-button-danger"
+                                        icon="fa fa-ban"
+                                        action="#{pharmacyBillSearch.navigateToCancelPharmacyDirectIssueToInpatients}" >
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Excel"
+                                        styleClass="noPrintButton ui-button-secondary"
+                                        icon="fa-solid fa-file-excel">
+                                        <p:dataExporter type="xlsx" target="tbl" fileName="Inward_Payment_Bill"  />
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        value="Reprint"
+                                        styleClass="ui-button-success"
+                                        style="min-width:120px"
+                                        ajax="false"
                                         icon="fa-solid fa-print">
                                         <p:printer target="gpBillPreview" ></p:printer>
                                     </p:commandButton>
-                                    <p:commandButton 
-                                        ajax="false" 
-                                        value="To Cancel" 
-                                        rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}"
-                                        disabled="#{pharmacyBillSearch.bill.cancelled eq true or pharmacyBillSearch.bill.patientEncounter.discharged eq true}" 
-                                        class="ui-button-danger"
-                                        icon="fa fa-ban"
-                                        action="#{pharmacyBillSearch.navigateToCancelPharmacyDirectIssueToInpatients}" >                           
-                                    </p:commandButton>
-                                    <p:commandButton 
-                                        ajax="false" 
-                                        value="To Return Item" 
-                                        action="#{bhtIssueReturnController.navigateToReturnPharmacyDirectIssueToInpatients()}"   
-                                        icon="fa fa-undo"
-                                        disabled="#{pharmacyBillSearch.bill.cancelled eq true or pharmacyBillSearch.bill.patientEncounter.discharged eq true}"  >                                
-                                        <f:setPropertyActionListener 
-                                            value="#{pharmacyBillSearch.bill}" 
-                                            target="#{bhtIssueReturnController.bill}"  />
-                                    </p:commandButton>
-
-<!--                                    <p:commandButton 
-                                        ajax="false" 
-                                        value="Reverse Bill" 
-                                        class="ui-button-warning"
-                                        icon="fa fa-exchange-alt"
-                                        action="#{pharmacyBillSearch.navigateToReversePharmacyDirectIssueToInpatients}"
-                                        disabled="#{pharmacyBillSearch.bill.cancelled}"
-                                        title="Create a reverse bill with negative quantities"  >                           
-                                    </p:commandButton>-->
-
-                                    <p:commandButton 
-                                        ajax="false" 
-                                        value="Excel" 
-                                        styleClass="noPrintButton" 
-                                        icon="fa-solid fa-file-excel" 
-                                        class="ui-button-success">
-                                        <p:dataExporter type="xlsx" target="tbl" fileName="Inward_Payment_Bill"  />
-                                    </p:commandButton> 
                                 </div>
                             </div>
 
                         </f:facet>
-
-                        <div class=" d-flex justify-content-end">
-                            <div class="d-flex gap-2">
-                                <p:commandButton 
-                                    ajax="false" 
-                                    value="Mark As Checked"
-                                    action="#{pharmacyBillSearch.markAsChecked()}"
-                                    icon="fa fa-check-square"
-                                    class="ui-button-success"
-                                    rendered="#{webUserController.hasPrivilege('InwardCheck')}"  />
-                                <p:commandButton 
-                                    ajax="false" 
-                                    value="Mark As Un Check"
-                                    icon="fa fa-square"
-                                    class="ui-button-warning"
-                                    action="#{pharmacyBillSearch.markAsUnChecked()}"
-                                    rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  />
-                                <p:commandButton 
-                                    ajax="false" 
-                                    value="Back To Interim"
-                                    icon="fa fa-backward"
-                                    class=""
-                                    action="/inward/inward_bill_intrim"  />
-                            </div>
-                        </div>
 
                         <div class="row mt-3">
                             <div class="col-md-4">
@@ -212,16 +225,7 @@
                                         </div>
                                     </f:facet>
 
-                                    <div class="d-flex  justify-content-end">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
-                                    </div>
-
-                                    <h:panelGroup   id="gpBillPreview" class="mt-2"> 
+                                    <h:panelGroup   id="gpBillPreview" class="mt-2">
 
                                         <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                             <ph:issueBill bill="#{pharmacyBillSearch.bill}" duplicate="true" />
@@ -246,6 +250,46 @@
 
                     </p:panel>
                 </h:form>
+
+                <p:dialog id="reprintBhtIssuePaperConfigDialog"
+                          header="Reprint BHT Issue - Print Format Settings"
+                          widgetVar="reprintBhtIssuePaperConfigDialog"
+                          modal="true"
+                          width="500"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <h:form id="reprintBhtIssuePaperConfigForm">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox
+                                id="cbPosPaper"
+                                value="#{pharmacyBillSearch.reprintBhtIssuePosPaper}" />
+                            <h:outputLabel for="cbPosPaper" value="POS Paper" class="ms-2" />
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox
+                                id="cbFiveFivePaper"
+                                value="#{pharmacyBillSearch.reprintBhtIssueFiveFivePaper}" />
+                            <h:outputLabel for="cbFiveFivePaper" value="5 x 5 Paper" class="ms-2" />
+                        </div>
+                        <p:messages showDetail="true" closable="true" />
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex gap-2">
+                                <p:commandButton
+                                    value="Apply &amp; Close"
+                                    icon="fas fa-save"
+                                    styleClass="ui-button-success"
+                                    ajax="false"
+                                    action="#{pharmacyBillSearch.saveReprintBhtIssuePaperConfig}" />
+                                <p:commandButton
+                                    value="Cancel"
+                                    icon="fas fa-times"
+                                    styleClass="ui-button-secondary"
+                                    onclick="PF('reprintBhtIssuePaperConfigDialog').hide(); return false;"
+                                    type="button" />
+                            </div>
+                        </div>
+                    </h:form>
+                </p:dialog>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements)
- `inward/pharmacy_reprint_bill_sale_bht.xhtml` had 4 issues per #21880:
  1. Action buttons scattered across two rows, not right-aligned as one group.
  2. "Back to Interim" wasn't visually separated/centered.
  3. No "Inpatient Dashboard" navigation button.
  4. Legacy `p:selectOneMenu` paper-type dropdown instead of the standard print-config gear button pattern.
- Restructured the header into the standard three-zone layout per `developer_docs/ui/comprehensive-ui-guidelines.md`:
  - **Left**: title + print-config gear button (`ChangeReceiptPrintingPaperTypes` privilege-gated)
  - **Center**: Back to Interim + new Inpatient Dashboard button (reuses the `admissionController.navigateToAdmissionProfilePage` + `f:setPropertyActionListener` pattern from #21879)
  - **Right**: Mark As Checked/Un Check, To Return Item, To Cancel, Excel, Reprint — ordered by ascending importance, Reprint rightmost/primary
- Converted the legacy dropdown to a gear button → `p:dialog` with `h:selectBooleanCheckbox` options (POS Paper, 5 x 5 Paper), per `developer_docs/configuration/printer-configuration-system.md`. Added `isReprintBhtIssuePosPaper`/`isReprintBhtIssueFiveFivePaper` (+ setters) and `saveReprintBhtIssuePaperConfig()` to `PharmacyBillSearch`, which translate the checkbox state to/from the existing `sessionController.departmentPreference.pharmacyBillPaperType` enum — no change to the underlying storage mechanism or to the two config-key-driven preview panels (kept as-is, scoped app-wide via `configOptionApplicationController`, per discussion — full department-scoped migration is a separate concern, tracked in #20259).

## Files changed
- `src/main/webapp/inward/pharmacy_reprint_bill_sale_bht.xhtml`
- `src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java`

## Test plan
Rebuilt and redeployed locally (Java change). Verified end-to-end with Playwright against the local coop DB:

- [x] Header renders in the three-zone layout; all buttons present and correctly ordered.
- [x] Gear button opens the print-config dialog; checking "POS Paper" + Apply & Close correctly toggles on the POS-format preview panel (confirmed via accessibility snapshot); reopening shows the checkbox state persisted; unchecking restores default.
- [x] "Inpatient Dashboard" button navigates to `admission_profile.xhtml` showing the same patient (BHT/53358) as the reprint page.

Screenshot posted on issue #21880: https://github.com/hmislk/hmis/issues/21880#issuecomment-4888815901

Closes #21880