### PR TITLE
fix(inward): Direct Issues report summaries as tabs + footer totals

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -620,6 +620,86 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         this.directIssueDepartmentSummary = directIssueDepartmentSummary;
     }
 
+    public double getDirectIssueItemSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
     public List<BillListReportDTO> getReturnBillsToPatientEncounter() {
         return returnBillsToPatientEncounter;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -85,8 +85,8 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     private double directIssueBillsToPatientEncounterMargin;
     private double directIssueBillsToPatientEncounterDiscount;
     private List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter;
-    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary;
-    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary;
+    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary = new ArrayList<>();
+    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary = new ArrayList<>();
 
     // 3) Issue Returns list (PharmacyBhtPre RefundBill bills)
     private List<BillListReportDTO> returnBillsToPatientEncounter;

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -27,20 +27,6 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
-                            <p:commandButton
-                                value="Download"
-                                ajax="false"
-                                icon="fa fa-download"
-                                styleClass="ui-button-secondary">
-                                <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
-                            </p:commandButton>
-                            <p:commandButton
-                                value="Print"
-                                ajax="false"
-                                icon="fa fa-print"
-                                styleClass="ui-button-secondary">
-                                <p:printer target="tbl1"></p:printer>
-                            </p:commandButton>
                         </div>
                     </div>
                 </f:facet>
@@ -93,11 +79,24 @@
                         </div>
                     </div>
                     <div class="col-9">
-                        <p:panel>
-                            <f:facet name="header">
-                                <p:outputLabel value="Direct Issues" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
-
+                        <p:tabView>
+                        <p:tab title="Direct Issues">
+                            <div class="d-flex justify-content-end gap-2 mb-2">
+                                <p:commandButton
+                                    value="Download"
+                                    ajax="false"
+                                    icon="fa fa-download"
+                                    styleClass="ui-button-secondary">
+                                    <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
+                                </p:commandButton>
+                                <p:commandButton
+                                    value="Print"
+                                    ajax="false"
+                                    icon="fa fa-print"
+                                    styleClass="ui-button-secondary">
+                                    <p:printer target="tbl1"></p:printer>
+                                </p:commandButton>
+                            </div>
                             <p:dataTable
                                 id="tbl1"
                                 rowIndexVar="rowIndex"
@@ -263,19 +262,18 @@
                                 </p:rowExpansion>
 
                             </p:dataTable>
+                        </p:tab>
 
-                        </p:panel>
-
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Items Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Items Summary">
                             <p:dataTable
                                 id="tblItemSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueItemSummary}"
                                 var="s">
                                 <p:column headerText="Item Name" width="30%">
                                     <h:outputLabel value="#{s.itemName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Code" width="14%">
                                     <h:outputLabel value="#{s.itemCode}"/>
@@ -284,69 +282,119 @@
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="10%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
+                        </p:tab>
 
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Issuing Department Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Issuing Department Summary">
                             <p:dataTable
                                 id="tblDeptSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummary}"
                                 var="s">
                                 <p:column headerText="Department" width="30%">
                                     <h:outputLabel value="#{s.departmentName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Qty" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
-
+                        </p:tab>
+                        </p:tabView>
                     </div>
                 </div>
             </p:panel>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -83,6 +83,7 @@
                         <p:tab title="Direct Issues">
                             <div class="d-flex justify-content-end gap-2 mb-2">
                                 <p:commandButton
+                                    id="btnDirectIssuesDownload"
                                     value="Download"
                                     ajax="false"
                                     icon="fa fa-download"
@@ -90,6 +91,7 @@
                                     <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
                                 </p:commandButton>
                                 <p:commandButton
+                                    id="btnDirectIssuesPrint"
                                     value="Print"
                                     ajax="false"
                                     icon="fa fa-print"


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements); layout-only follow-up on top of #21871/#21873 (which added the Total/Margin/Discount data)
- The Bills / Items Summary / Issuing Department Summary panels on `inward/reports/inpatient_pharmacy_direct_issues_list.xhtml` were stacked vertically; converted to tabs inside a `p:tabView`.
- Items Summary and Issuing Department Summary tables were missing footer total rows — added, using 10 new computed getters on `InwardPharmacyEncounterReportController` that sum the existing pre-built summary lists.
- **Bug found during verification and fixed in the same PR**: moving the Bills table into `p:tabView` broke the header's Download/Print buttons (`ComponentNotFoundException` — non-active tab content isn't part of the component tree at button-render time in this PrimeFaces version). Fixed by relocating Download/Print into the "Direct Issues" tab itself, next to its table.

## Files changed
- `src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml`
- `src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java`

## Test plan
Rebuilt and redeployed locally (Java change). Verified end-to-end with Playwright against the local coop DB (BHT/53358):

- [x] All three tabs (Direct Issues, Items Summary, Issuing Department Summary) render and are switchable.
- [x] Items Summary and Department Summary footer totals (106.98 / 0.00 / 0.00 / 143.70) match the Direct Issues tab's own footer totals — cross-checked for correctness.
- [x] Download/Print buttons work correctly from inside the Direct Issues tab (previously threw a 500 error after the tab conversion, before the relocation fix).

Screenshots posted on issue #21881: https://github.com/hmislk/hmis/issues/21881#issuecomment-4888902383

Closes #21881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added computed summary totals for direct-issues, including quantity, amount, margin, discount, and net total for both item and issuing department views.
  * Updated the direct-issues reporting screen to use a tabbed layout for the main list, item summary, and issuing department summary.
  * Relocated print/download controls into the Direct Issues tab for faster access.
* **Bug Fixes**
  * Improved reliability of direct-issue summaries by ensuring summary lists are properly initialized.
  * Updated table footer totals so column totals display consistently across summary tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->