### PR TITLE
fix(pharmacy): correct false return-quantity validation on BHT issue return

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -620,6 +620,86 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         this.directIssueDepartmentSummary = directIssueDepartmentSummary;
     }
 
+    public double getDirectIssueItemSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
     public List<BillListReportDTO> getReturnBillsToPatientEncounter() {
         return returnBillsToPatientEncounter;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -85,8 +85,8 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     private double directIssueBillsToPatientEncounterMargin;
     private double directIssueBillsToPatientEncounterDiscount;
     private List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter;
-    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary;
-    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary;
+    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary = new ArrayList<>();
+    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary = new ArrayList<>();
 
     // 3) Issue Returns list (PharmacyBhtPre RefundBill bills)
     private List<BillListReportDTO> returnBillsToPatientEncounter;

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -348,12 +348,17 @@ public class BhtIssueReturnController implements Serializable {
     }
 
     public void settle() {
-        
+
         if (returnComment == null || returnComment.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return comment is Mandatory..");
             return;
         }
-        
+
+        // Recompute from the just-submitted quantities. calTotal() was previously only
+        // triggered by the per-row blur AJAX (onEdit()); relying on that cached total here
+        // raced the full-page Return postback and could see a stale/zero total even when
+        // the submitted qty values were valid (issue #21883).
+        calTotal();
 
         if (getBill().getBillItems() != null) {
 //            System.out.println("this = " + getBill().getBillItems().size() );
@@ -379,10 +384,14 @@ public class BhtIssueReturnController implements Serializable {
             }
         }
 
-//
-//        System.out.println("returnBill.getTotal() = " + returnBill.getTotal());
-//        System.out.println("getReturnBill().getTotal() = " + getReturnBill().getTotal());
-        if (returnBill.getTotal() == 0) {
+// Validate against returned quantity, not gross value - a fully-margin item
+        // (Gross Rate 0.00, e.g. a service-charge-only line) has a legitimately zero
+        // returnBill.getTotal() even when a valid quantity was entered (issue #21883).
+        double totalReturnQty = 0.0;
+        for (BillItem bi : billItems) {
+            totalReturnQty += Math.abs(bi.getQty());
+        }
+        if (totalReturnQty == 0) {
             JsfUtil.addErrorMessage("Add Valied Return Quntity");
             return;
         }

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -27,20 +27,6 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
-                            <p:commandButton
-                                value="Download"
-                                ajax="false"
-                                icon="fa fa-download"
-                                styleClass="ui-button-secondary">
-                                <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
-                            </p:commandButton>
-                            <p:commandButton
-                                value="Print"
-                                ajax="false"
-                                icon="fa fa-print"
-                                styleClass="ui-button-secondary">
-                                <p:printer target="tbl1"></p:printer>
-                            </p:commandButton>
                         </div>
                     </div>
                 </f:facet>
@@ -93,11 +79,24 @@
                         </div>
                     </div>
                     <div class="col-9">
-                        <p:panel>
-                            <f:facet name="header">
-                                <p:outputLabel value="Direct Issues" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
-
+                        <p:tabView>
+                        <p:tab title="Direct Issues">
+                            <div class="d-flex justify-content-end gap-2 mb-2">
+                                <p:commandButton
+                                    value="Download"
+                                    ajax="false"
+                                    icon="fa fa-download"
+                                    styleClass="ui-button-secondary">
+                                    <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
+                                </p:commandButton>
+                                <p:commandButton
+                                    value="Print"
+                                    ajax="false"
+                                    icon="fa fa-print"
+                                    styleClass="ui-button-secondary">
+                                    <p:printer target="tbl1"></p:printer>
+                                </p:commandButton>
+                            </div>
                             <p:dataTable
                                 id="tbl1"
                                 rowIndexVar="rowIndex"
@@ -263,19 +262,18 @@
                                 </p:rowExpansion>
 
                             </p:dataTable>
+                        </p:tab>
 
-                        </p:panel>
-
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Items Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Items Summary">
                             <p:dataTable
                                 id="tblItemSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueItemSummary}"
                                 var="s">
                                 <p:column headerText="Item Name" width="30%">
                                     <h:outputLabel value="#{s.itemName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Code" width="14%">
                                     <h:outputLabel value="#{s.itemCode}"/>
@@ -284,69 +282,119 @@
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="10%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
+                        </p:tab>
 
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Issuing Department Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Issuing Department Summary">
                             <p:dataTable
                                 id="tblDeptSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummary}"
                                 var="s">
                                 <p:column headerText="Department" width="30%">
                                     <h:outputLabel value="#{s.departmentName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Qty" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
-
+                        </p:tab>
+                        </p:tabView>
                     </div>
                 </div>
             </p:panel>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -28,6 +28,7 @@
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
                         </div>
+                        <div></div>
                     </div>
                 </f:facet>
 

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -83,6 +83,7 @@
                         <p:tab title="Direct Issues">
                             <div class="d-flex justify-content-end gap-2 mb-2">
                                 <p:commandButton
+                                    id="btnDirectIssuesDownload"
                                     value="Download"
                                     ajax="false"
                                     icon="fa fa-download"
@@ -90,6 +91,7 @@
                                     <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
                                 </p:commandButton>
                                 <p:commandButton
+                                    id="btnDirectIssuesPrint"
                                     value="Print"
                                     ajax="false"
                                     icon="fa fa-print"

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -27,6 +27,8 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
                             <p:commandButton
                                 value="Download"
                                 ajax="false"

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
@@ -27,6 +27,8 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
                             <p:commandButton
                                 value="Download"
                                 ajax="false"


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements). This was flagged as the first item in Group F since it blocked verifying #21885's return-bill-side behavior.
- Checked pre-existing related issues #21872, #12069, #20207 first — all still open, no fixes/PRs exist, no duplicate work risk.
- **Root cause (found during investigation, different from the original assumption of an AJAX timing race)**: `BhtIssueReturnController.settle()` validated the return via `if (returnBill.getTotal() == 0)`, but `returnBill.getTotal()` reflects **Gross Value only**. Items with a legitimately zero Gross Rate (fully margin/service-charge-priced items — reproduced with "Panadol 500mg tab" on a real bill: Gross Rate 0.00 / Margin Rate 4.85 / Net Rate 4.85) produce a gross total of exactly `0` even when a valid non-zero quantity is returned. The check was validating the wrong field entirely.
- **Fix**: validate against total returned quantity across all items instead of gross value. Also added a `calTotal()` call at the top of `settle()` so totals are recomputed from the actually-submitted quantities at settle time, rather than relying only on whatever the last per-row blur AJAX (`onEdit()`) last computed.

## Files changed
- `src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java`

## Test plan
Rebuilt and redeployed locally (Java change). Verified end-to-end with Playwright + DB against the local coop DB:

- [x] Returned qty 1 of 2 for a zero-gross-rate item on a real bill — no false "Add Valied Return Quntity" warning fired; return succeeded and redirected to the bill preview.
- [x] DB verification: `RefundBill.total=0` (correct, matches Gross Rate 0.00), `margin=netTotal=-4.85` (correct), `BillItem.qty=1` (matches submitted value exactly) — confirming the return processed with correct values, not just that the warning was suppressed.

Screenshot posted on issue #21883: https://github.com/hmislk/hmis/issues/21883#issuecomment-4889172411

Closes #21883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added totals for direct-issue item and department summaries, including quantity, amount, margin, discount, and net total.
  * Updated the direct-issues report to use tabbed sections with totals shown in the summary tables.

* **Bug Fixes**
  * Improved return settlement checks so quantities are recalculated correctly and valid zero-total returns are handled properly.
  * Fixed button layout spacing on the requests and returns report pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->