### PR TITLE
fix(pharmacy): keep Bill.billItems synced to prevent orphan-delete on retried Finalize

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1488,6 +1488,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
         if (getBill().getId() == null) {
             getBillFacade().create(getBill());
         } else {
+            syncBillItemsCollectionFromDatabase();
             getBillFacade().edit(getBill());
         }
 
@@ -1566,9 +1567,32 @@ public class PharmacyDirectPurchaseController implements Serializable {
         }
         getBill().setExpenseTotal(-Math.abs(totalForExpenses));
 
+        syncBillItemsCollectionFromDatabase();
         getBillFacade().edit(getBill());
         draftMode = true;
         return true;
+    }
+
+    /**
+     * Bill.billItems has orphanRemoval=true, but this method persists each BillItem
+     * directly via BillItemFacade rather than through that collection, so the in-memory
+     * bill's billItems field is otherwise left null/stale across repeated calls. If
+     * something has since refreshed this bill's shared cache entry (e.g. a Finalize
+     * attempt blocked by validation, which reloads the bill before returning), a later
+     * edit(bill) can treat that stale/empty collection as authoritative and orphan-delete
+     * the BillItem rows this method just persisted (issue #21900). Re-fetching the
+     * collection immediately before each edit(bill) keeps it accurate.
+     */
+    private void syncBillItemsCollectionFromDatabase() {
+        if (getBill().getId() == null) {
+            return;
+        }
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("billId", getBill().getId());
+        List<BillItem> currentlyPersistedItems = getBillItemFacade().findByJpql(
+            "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId", params);
+        getBill().getBillItems().clear();
+        getBill().getBillItems().addAll(currentlyPersistedItems);
     }
 
     public void saveDraftDirectPurchase() {


### PR DESCRIPTION
## Summary
- Fixes #21900: retrying **Finalize** on a Direct Purchase after it was blocked by the "Select Payment Method" validation throws a 500 error (`SQLIntegrityConstraintViolationException` FK violation on `pharmaceuticalbillitem`), permanently stranding the draft bill.
- Root cause: `Bill.billItems` is mapped `orphanRemoval=true`, but `persistDraftDirectPurchase()` persists each `BillItem` directly via `BillItemFacade` rather than through that collection, leaving the in-memory `bill.billItems` field `null`/stale. A blocked Finalize attempt calls `billService.reloadBill(bill)` first, which refreshes this bill's shared EclipseLink cache entry. The retried `persistDraftDirectPurchase()` call's subsequent `edit(bill)` then treats the stale/empty collection as authoritative and orphan-deletes the `BillItem` row already persisted in the DB.
- Fix: re-fetch and sync `Bill.billItems` from the database immediately before each `edit(bill)` call in `persistDraftDirectPurchase()`, so the collection always accurately reflects what's actually persisted and orphanRemoval has nothing incorrectly-perceived-as-orphaned to delete.

## Test plan
- [x] Reproduced the crash pre-fix: New Direct Purchase → add item → Finalize with no Payment Method (blocked) → set Payment Method → Finalize again → 500 error, item hard-deleted from DB, bill permanently stuck.
- [x] Captured EclipseLink SQL logs confirming the exact sequence: lazy-load of `Bill.billItems` → `UPDATE BILL ... PAYMENTMETHOD = ?` → `DELETE FROM BILLITEM`.
- [x] Applied fix, rebuilt, redeployed, re-ran the identical repro: Finalize now succeeds, item remains intact, bill transitions to `COMPLETED=1` with the correct `PAYMENTMETHOD`.
- [x] Re-verified the unaffected happy paths still work: Save Draft → navigate away → Finalize via list; Save Draft → Finalize same page session (both approved cleanly, correct cost-rate distribution, no duplicate `BillItem` rows).
- [x] Verified COGS report variance remains 0.00 after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)