### PR TITLE
feat(privilege): ShowServiceCharges and ShowTimeServiceCharges - hide fees on inward billing pages

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -930,6 +930,9 @@ public class UserPrivilageController implements Serializable {
         TreeNode nurseNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Work Bench"), allNode);
         TreeNode nursingWorkBench = new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBench, "Nursing Work Bench"), nurseNode);
         TreeNode showDrugCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowDrugCharges, "Show Drug Charges"), nurseNode);
+        TreeNode ShowServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowServiceCharges, "Show Service Charges"), nurseNode);
+        TreeNode ShowTimeServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowTimeServiceCharges, "Show Time Service Charges"), nurseNode);
+        
 
         // Admin Privileges
         TreeNode superAdminNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.SuperAdmin, "Super Admin"), allNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -137,6 +137,8 @@ public enum Privileges {
     //<editor-fold defaultstate="collapsed" desc="Nurse">
     NursingWorkBench("Nursing Work Bench"),
     ShowDrugCharges("Show Drug Charges"),
+    ShowServiceCharges("Show Service Charges"),
+    ShowTimeServiceCharges("Show Time Service Charges"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Finance">
@@ -1130,6 +1132,8 @@ public enum Privileges {
 
             case NursingWorkBench:
             case ShowDrugCharges:
+            case ShowServiceCharges:
+            case ShowTimeServiceCharges:
                 return "Nursing Work Bench";
                 
             case WatingRoomAdmitPatient:

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -424,7 +424,7 @@
                                                                 <p:column>
                                                                     <h:outputLabel value="#{t.departmentName}"/>
                                                                 </p:column>
-                                                                <p:column>
+                                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                                     <h:outputLabel value="#{t.total}" >
                                                                         <f:convertNumber pattern="#,##0.00" />
                                                                     </h:outputLabel>
@@ -585,7 +585,8 @@
                                                             <h:outputLabel value="#{bi.billItem.descreption}"/>
                                                         </p:column>
 
-                                                        <p:column width="7em" class="text-end">
+                                                        <p:column width="7em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Rate</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.rate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -599,28 +600,32 @@
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Gross Value</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.grossValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Discount</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.discount}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Service Charge</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.marginValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Net Value</f:facet>
                                                             <h:outputLabel value="#{bi.billItem.netValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -665,6 +670,7 @@
                                                         rowExpandMode="single"
                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
                                                                          or (webUserController.hasPrivilege('ShowInwardFee'))
+                                                                         or (webUserController.hasPrivilege('ShowServiceCharges'))
                                                                          ? '':'noDisplayRow'}">
                                                         <p:column width="2em">
                                                             <f:facet name="header"> </f:facet>
@@ -680,7 +686,8 @@
                                                             <h:outputLabel value="#{bif.billItem.item.name}"/>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Unit Rate</f:facet>
                                                             <h:outputLabel value="#{bif.feeUnitGrossValue}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -694,7 +701,8 @@
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="10em" class="text-end">
+                                                        <p:column width="10em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Total Gross</f:facet>
                                                             <p:inputText
                                                                 class="text-end w-100"
@@ -712,14 +720,16 @@
                                                             </p:inputText>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Discount</f:facet>
                                                             <h:outputLabel value="#{bif.feeDiscount}" class="text-end w-100">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Service Charge</f:facet>
                                                             <h:outputLabel
                                                                 id="matrix"
@@ -729,7 +739,8 @@
                                                             </h:outputLabel>
                                                         </p:column>
 
-                                                        <p:column width="8em" class="text-end">
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <f:facet name="header">Net Total</f:facet>
                                                             <h:outputLabel
                                                                 id="feeValue"
@@ -756,7 +767,7 @@
                                                             </p:selectOneMenu>
                                                         </p:column>
 
-                                                        <p:rowExpansion>
+                                                        <p:rowExpansion rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                             <div class="p-3 ms-4 border-start border-primary" style="background-color: #f0f4ff;">
                                                                 <div class="row g-3">
 
@@ -829,7 +840,8 @@
                                             </p:tabView>
                                         </p:panel>
                                     </div>
-                                    <div class="col-3">
+                                    <h:panelGroup layout="block" styleClass="col-3"
+                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <p:panel header="Bill Details" id="details"  >
                                             <div class="card">
                                                 <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
@@ -864,7 +876,7 @@
                                                 </div>
                                             </div>
                                         </p:panel>
-                                    </div>
+                                    </h:panelGroup>
                                 </div>
 
                             </h:panelGroup>
@@ -1014,21 +1026,24 @@
                                                 </p:column>
                                                 <p:column headerText="Gross Total"
                                                           styleClass="#{b.refunded ? 'row-warning' : b.cancelled ? 'row-danger' : ''}"
-                                                          class="text-end">
+                                                          class="text-end"
+                                                          rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                     <h:outputText value="#{b.total}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                     </h:outputText>
                                                 </p:column>
                                                 <p:column headerText="Discount"
                                                           styleClass="#{b.refunded ? 'row-warning' : b.cancelled ? 'row-danger' : ''}"
-                                                          class="text-end">
+                                                          class="text-end"
+                                                          rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                     <h:outputText value="#{b.discount}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                     </h:outputText>
                                                 </p:column>
                                                 <p:column headerText="Net Total"
                                                           styleClass="#{b.refunded ? 'row-warning' : b.cancelled ? 'row-danger' : ''}"
-                                                          class="text-end">
+                                                          class="text-end"
+                                                          rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                     <h:outputText value="#{b.netTotal}" >
                                                         <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                                     </h:outputText>

--- a/src/main/webapp/inward/inward_reprint_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_service.xhtml
@@ -115,8 +115,8 @@
                                             <in:bhtDetail admission="#{inwardSearch.bill.patientEncounter}"/>
                                         </p:panel>
                                     </div>
-                                    <div class="col-4 ">
-                                        <p:panelGrid columns="1" class="w-100">
+                                    <div class="col-4">
+                                        <p:panelGrid columns="1" class="w-100" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                             <f:facet name = "header">
                                                 <h:outputLabel value="Bill Details"/>
                                             </f:facet>
@@ -265,35 +265,40 @@
                                         </h:outputLabel>
                                     </p:column>
 
-                                    <p:column width="8em" class="text-end">
+                                    <p:column width="8em" class="text-end"
+                                              rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <f:facet name="header">Unit Rate</f:facet>
                                         <h:outputLabel value="#{bip.feeUnitGrossValue}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
                                     </p:column>
 
-                                    <p:column width="8em" class="text-end">
+                                    <p:column width="8em" class="text-end"
+                                              rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <f:facet name="header">Total Gross</f:facet>
                                         <h:outputLabel value="#{bip.feeGrossValue}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
                                     </p:column>
 
-                                    <p:column width="8em" class="text-end">
+                                    <p:column width="8em" class="text-end"
+                                              rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <f:facet name="header">Discount</f:facet>
                                         <h:outputLabel value="#{bip.feeDiscount}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
                                     </p:column>
 
-                                    <p:column width="8em" class="text-end">
+                                    <p:column width="8em" class="text-end"
+                                              rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <f:facet name="header">Service Charge</f:facet>
                                         <h:outputLabel value="#{bip.feeMargin}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
                                     </p:column>
 
-                                    <p:column width="8em" class="text-end">
+                                    <p:column width="8em" class="text-end"
+                                              rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <f:facet name="header">Net Total</f:facet>
                                         <h:outputLabel value="#{bip.feeValue}">
                                             <f:convertNumber pattern="#,##0.00"/>

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -282,7 +282,7 @@
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
                             </p:datePicker> 
                         </p:column>
-                        <p:column headerText="Total" styleClass="averageNumericColumn">
+                        <p:column headerText="Total" styleClass="averageNumericColumn" rendered="#{webUserController.hasPrivilege('ShowTimeServiceCharges')}">
                             <h:outputLabel  value="#{ti.serviceValue}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>

--- a/src/main/webapp/resources/bill/inwardBillPrintFiveFive.xhtml
+++ b/src/main/webapp/resources/bill/inwardBillPrintFiveFive.xhtml
@@ -152,20 +152,24 @@
                     <td styleClass="itemHeadingsFiveFive">
                         <h:outputText value="Item" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)" ></h:outputText>
                     </td>
-                    <td styleClass="itemHeadingsFiveFive" style="text-align:right; padding-right: 0.5cm;">
-                        <h:outputText value="Value" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)" ></h:outputText>
-                    </td>
+                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                        <td styleClass="itemHeadingsFiveFive" style="text-align:right; padding-right: 0.5cm;">
+                            <h:outputText value="Value" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)" ></h:outputText>
+                        </td>
+                    </h:panelGroup>
                 </tr>
                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                     <tr>
                         <td style="text-transform: capitalize!important;">
                             <h:outputLabel value="#{bip.searialNo+1} - #{bip.item.name}" style="font-weight: bold; font-size: var(--base-font-size); font-family: var(--font-family)"/>
                         </td>
-                        <td style="text-align:right; padding-right: 0.5cm;">
-                            <h:outputLabel value="#{bip.grossValue}" style="font-weight: bold; font-size: var(--base-font-size); font-family: var(--font-family)">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <td style="text-align:right; padding-right: 0.5cm;">
+                                <h:outputLabel value="#{bip.grossValue}" style="font-weight: bold; font-size: var(--base-font-size); font-family: var(--font-family)">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </h:panelGroup>
                     </tr>
                 </ui:repeat>
             </table>
@@ -174,25 +178,27 @@
             <br/>
 
             <!-- Bill Totals -->
-            <h:panelGrid columns="3" columnClasses="billLabel, billSeparator, billValue" style="width: 100%;">
-                <h:outputLabel value="Gross Total" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
-                <h:outputLabel value=":" />
-                <h:outputLabel value="#{cc.attrs.bill.total}" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)">
-                    <f:convertNumber pattern="#,##0.00" />
-                </h:outputLabel>
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                <h:panelGrid columns="3" columnClasses="billLabel, billSeparator, billValue" style="width: 100%;">
+                    <h:outputLabel value="Gross Total" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
+                    <h:outputLabel value=":" />
+                    <h:outputLabel value="#{cc.attrs.bill.total}" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputLabel>
 
-                <h:outputLabel value="Discount" style="font-weight: bolder!important; font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
-                <h:outputLabel value=":" />
-                <h:outputLabel value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important; font-size: var(--sub-header-font-size); font-family: var(--font-family)">
-                    <f:convertNumber pattern="#,##0.00" />
-                </h:outputLabel>
+                    <h:outputLabel value="Discount" style="font-weight: bolder!important; font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
+                    <h:outputLabel value=":" />
+                    <h:outputLabel value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important; font-size: var(--sub-header-font-size); font-family: var(--font-family)">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputLabel>
 
-                <h:outputLabel value="Net Total" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
-                <h:outputLabel value=":" />
-                <h:outputLabel value="#{cc.attrs.bill.netTotal}" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)">
-                    <f:convertNumber pattern="#,##0.00" />
-                </h:outputLabel>
-            </h:panelGrid>
+                    <h:outputLabel value="Net Total" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)"/>
+                    <h:outputLabel value=":" />
+                    <h:outputLabel value="#{cc.attrs.bill.netTotal}" style="font-size: var(--sub-header-font-size); font-family: var(--font-family)">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputLabel>
+                </h:panelGrid>
+            </h:panelGroup>
 
             <br/>
 
@@ -409,26 +415,28 @@
                                     <div>
                                         <table>
 
-                                            <tr>
-                                                <td>
-                                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"  value="Discount"/>
-                                                </td>
-                                                <td >
-                                                    <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{cc.attrs.bill.discount}" >
-                                                        <f:convertNumber pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>
-                                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
-                                                </td>
-                                                <td>
-                                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}"  >
-                                                        <f:convertNumber pattern="#,##0.00" />
-                                                    </h:outputLabel>
-                                                </td>
-                                            </tr>
+                                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <tr>
+                                                    <td>
+                                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"  value="Discount"/>
+                                                    </td>
+                                                    <td >
+                                                        <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{cc.attrs.bill.discount}" >
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
+                                                    </td>
+                                                    <td>
+                                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}"  >
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </td>
+                                                </tr>
+                                            </h:panelGroup>
 
                                             <tr>
                                                 <td colspan="2" >

--- a/src/main/webapp/resources/bill/inwardBillPrintPos.xhtml
+++ b/src/main/webapp/resources/bill/inwardBillPrintPos.xhtml
@@ -280,11 +280,13 @@
                             <h:outputLabel value="#{bip.item.printName}" style="text-transform: capitalize!important;">
                             </h:outputLabel>
                         </td>
-                        <td   style="padding-left: 40px;">
-                            <h:outputLabel    value="#{bip.grossValue}"    >
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <td   style="padding-left: 40px;">
+                                <h:outputLabel    value="#{bip.grossValue}"    >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </h:panelGroup>
 
                     </tr>
 
@@ -309,7 +311,7 @@
                             <hr/>                       
                         </td>
                     </tr>
-                        <h:panelGroup rendered="#{(webUserController.hasPrivilege('ShowInwardFee'))}">
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowInwardFee') or webUserController.hasPrivilege('ShowServiceCharges')}">
                             <tr >
                                 <td class="totalsBlock" >
                                     <h:outputLabel value="Actual Total"  style="padding-right: 170px"/>

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
@@ -274,9 +274,11 @@
                         <td style="width:55%!important;">
                             <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
                         </td>
-                        <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
-                        </td>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                            </td>
+                        </h:panelGroup>
                     </tr>
                     <tr>
                         <td colspan="2" style="text-align: center;" class="billline">
@@ -291,11 +293,13 @@
                                     <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.item.name}"  style="text-transform: capitalize!important;"  >
                                     </h:outputLabel>
                                 </td>
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
                             </tr>
 
                         </ui:repeat>
@@ -313,17 +317,19 @@
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputLabel>
                                 </td>
-                                <td    style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td    style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
 
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
 
                             </tr>
                         </ui:repeat>
@@ -340,6 +346,7 @@
 
             </div>
 
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
             <div  >
 
                 <table style="width: 100%;">
@@ -408,6 +415,7 @@
                 </table>
 
             </div>
+            </h:panelGroup>
 
             <h:panelGroup rendered="#{cc.attrs.duplicate and configOptionApplicationController.getBooleanValueByKey('OPD View Duplicate Bill Printing Details',false)}">
                 <div class="d-flex gap-2 justify-content-center" style="font-size: 12px;">

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
@@ -239,9 +239,11 @@
                         <td style="width:55%!important;">
                             <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
                         </td>
-                        <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
-                        </td>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" />
+                            </td>
+                        </h:panelGroup>
                     </tr>
                     <tr>
                         <td colspan="2" style="text-align: center;" class="billline">
@@ -256,11 +258,13 @@
                                     <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.item.name}"  style="text-transform: capitalize!important;"  >
                                     </h:outputLabel>
                                 </td>
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
                             </tr>
 
                         </ui:repeat>
@@ -278,17 +282,19 @@
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputLabel>
                                 </td>
-                                <td    style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td    style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
 
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
 
                             </tr>
                         </ui:repeat>
@@ -305,6 +311,7 @@
 
             </div>
 
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
             <div  >
 
                 <table style="width: 100%;">
@@ -373,6 +380,7 @@
                 </table>
 
             </div>
+            </h:panelGroup>
 
             <div style="text-decoration: overline; margin-top: 20px;">
                 <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.webUserPerson.name}"/>

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
@@ -173,8 +173,10 @@
                     <thead>
                         <tr>
                             <th>No</th>
-                            <th>Particular</th>
-                            <th style="text-align: right">Amount</th>
+                            <th style="text-align: left">Particular</th>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <th style="text-align: right">Amount</th>
+                            </h:panelGroup>
                         </tr>
                     </thead>
 
@@ -197,11 +199,13 @@
                                             rendered="#{!item.priority.shortName.blank and item.item.allowedForBillingPriority}"/>
                                     </h:panelGroup>
                                 </td>
-                                <td style="text-align: right">
-                                    <h:outputLabel value="#{item.netValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td style="text-align: right">
+                                        <h:outputLabel value="#{item.netValue}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
                             </tr>
                         </ui:repeat>
                     </tbody>
@@ -241,33 +245,35 @@
                     </div>
                     <div class="w-100">
                         <table class="total-table" style="line-height: 1.0;">
-                            <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null}">
-                                <tr>
-                                    <td >Total Amount</td>
-                                    <td  style="text-align: right;">
-                                        <h:outputLabel value="#{cc.attrs.bill.total}" >
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </tr>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null}">
+                                    <tr>
+                                        <td >Total Amount</td>
+                                        <td  style="text-align: right;">
+                                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
 
+                                    <tr>
+                                        <td >Discount</td>
+                                        <td  style="text-align: right;">
+                                            <h:outputLabel  value="#{- cc.attrs.bill.discount}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
                                 <tr>
-                                    <td >Discount</td>
-                                    <td  style="text-align: right;">
-                                        <h:outputLabel  value="#{- cc.attrs.bill.discount}">
+                                    <td >Net Amount</td>
+                                    <td style="text-align: right;">
+                                        <h:outputLabel value="#{cc.attrs.bill.netTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
                                 </tr>
                             </h:panelGroup>
-                            <tr>
-                                <td >Net Amount</td>
-                                <td style="text-align: right;">
-                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
                             <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null 
                                                       and cc.attrs.billCount eq 1 
                                                       and cc.attrs.bill.paymentMethod eq 'Cash'}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
@@ -211,7 +211,9 @@
                         <tr>
                             <th>No</th>
                             <th>Item Name</th>
-                            <th style="text-align: right">Value</th>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <th style="text-align: right">Value</th>
+                            </h:panelGroup>
                         </tr>
                     </thead>
                     <tbody>
@@ -221,11 +223,13 @@
                                     <!-- Display the item number across all items -->
                                     <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
                                     <td>#{item.item.name}</td>
-                                    <td style="text-align: right">
-                                        <h:outputLabel value="#{item.netValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
+                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                        <td style="text-align: right">
+                                            <h:outputLabel value="#{item.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </tr>
                             </ui:repeat>
                         </h:panelGroup>
@@ -235,11 +239,13 @@
                                     <!-- Display the item number across all items -->
                                     <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
                                     <td>#{item.item.name}</td>
-                                    <td style="text-align: right">
-                                        <h:outputLabel value="#{item.netValue}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
+                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                        <td style="text-align: right">
+                                            <h:outputLabel value="#{item.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </tr>
                             </ui:repeat>
                         </h:panelGroup>
@@ -251,34 +257,35 @@
 
                 <!-- Totals Table -->
                 <table class="total-table">
-                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}" >
-                        <tr>
-                            <td >Total:</td>
-                            <td  style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.total}" >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td >Discount:</td>
-                            <td  style="text-align: right;">
-                                <h:outputLabel  value="#{-cc.attrs.bill.discount}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                        </tr>
+                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                        <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}" >
+                            <tr>
+                                <td >Total:</td>
+                                <td  style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td >Discount:</td>
+                                <td  style="text-align: right;">
+                                    <h:outputLabel  value="#{-cc.attrs.bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
 
+                        <tr>
+                            <td >Net Total:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
                     </h:panelGroup>
-
-                    <tr>
-                        <td >Net Total:</td>
-                        <td style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
 
                     <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Inward Service Bill - Group Bill Item By Name',false)}">
                         <tr>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
@@ -288,11 +288,13 @@
                                     <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.item.printName}"  style="text-transform: capitalize!important;"  >
                                     </h:outputLabel>
                                 </td>
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
                             </tr>
 
                         </ui:repeat>
@@ -310,17 +312,19 @@
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputLabel>
                                 </td>
-                                <td    style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                    <td    style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
 
-                                <td style="text-align: right;" >
-                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
+                                    <td style="text-align: right;" >
+                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
 
                             </tr>
                         </ui:repeat>
@@ -334,6 +338,7 @@
                 <hr/>
             </div>
 
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
             <div  >
 
                 <table style="width: 100%;">
@@ -354,6 +359,7 @@
                 </table>
 
             </div>
+            </h:panelGroup>
 
             <div style="text-decoration: overline; margin-top: 20px;">
                 <h:outputLabel value="Cashier : #{cc.attrs.bill.creater.webUserPerson.name}"/>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
@@ -327,7 +327,7 @@
                          top: 45%;
                          font-size:12px!important;" >
                         <h:dataTable value="#{cc.attrs.bill.billItems}" var="bip1"  >
-                            <h:column>
+                            <h:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                 <f:facet name="header">
                                     <h:outputText value=" Amount" />
                                 </f:facet>
@@ -365,16 +365,18 @@
                                     <br/>
                                 </td>
                             </tr>
-                            <tr>
-                                <td style="text-align: left; min-width: 3cm;">
-                                    <h:outputLabel value="TOTAL" style="font-weight: bold ; text-align: right!important; font-size: 15px!important;"/>
-                                </td>
-                                <td style="text-align: right!important; ">
-                                    <h:outputLabel value="#{cc.attrs.bill.total+cc.attrs.bill.vat}" style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <tr>
+                                    <td style="text-align: left; min-width: 3cm;">
+                                        <h:outputLabel value="TOTAL" style="font-weight: bold ; text-align: right!important; font-size: 15px!important;"/>
+                                    </td>
+                                    <td style="text-align: right!important; ">
+                                        <h:outputLabel value="#{cc.attrs.bill.total+cc.attrs.bill.vat}" style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
 
                             <!--                             <tr>
                                                             <td style="text-align: left; min-width: 3cm;">
@@ -397,16 +399,18 @@
                                                             </td>
                                                         </tr>-->
 
-                            <tr>
-                                <td style="text-align: left;">
-                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" style="font-weight: bold ; text-align: right!important;  font-size: 15px!important;   "  value="Discount"/>
-                                </td>
-                                <td style="text-align: right!important; ">
-                                    <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discount}"  style="font-weight: bold ; text-align: right!important;  font-size: 15px!important;   ">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                            </tr>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <tr>
+                                    <td style="text-align: left;">
+                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" style="font-weight: bold ; text-align: right!important;  font-size: 15px!important;   "  value="Discount"/>
+                                    </td>
+                                    <td style="text-align: right!important; ">
+                                        <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discount}"  style="font-weight: bold ; text-align: right!important;  font-size: 15px!important;   ">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
                             <!--                            <tr>
                                                             <td style="text-align: left; min-width: 3cm;">
                                                                 <h:outputLabel value="VAT (15%)" style="text-align: right!important; font-size: 12px!important;" rendered="#{cc.attrs.bill.vat ne 0.0}"/>
@@ -417,20 +421,22 @@
                                                                 </h:outputLabel>
                                                             </td>
                                                         </tr>-->
-                            <tr>
-                                <td style="text-align: left;">
-                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>
-                                    <!--<h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>-->
-                                </td>
-                                <td style="text-align: right!important; ">
-                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <tr>
+                                    <td style="text-align: left;">
+                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>
+                                        <!--<h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>-->
+                                    </td>
+                                    <td style="text-align: right!important; ">
+                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
 <!--                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0}"    value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>-->
                                 </td>
-                            </tr>
+                                </tr>
+                            </h:panelGroup>
 
 
 

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
@@ -331,9 +331,11 @@
                             <h:outputLabel value="ITEM" styleClass="itemHeadings" ></h:outputLabel>
                         </td>
 
-                        <td  style="width:100%;text-align: right; ">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadings" ></h:outputLabel>
-                        </td>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <td  style="width:100%;text-align: right; ">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadings" ></h:outputLabel>
+                            </td>
+                        </h:panelGroup>
                     </tr>
 
                     <tr>
@@ -352,11 +354,13 @@
                                 <h:outputLabel value="#{bip.item.printName}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
                                 </h:outputLabel>
                             </td>
-                            <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 30px;" >
-                                <h:outputLabel    value="#{bip.grossValue}"    >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 30px;" >
+                                    <h:outputLabel    value="#{bip.grossValue}"    >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </h:panelGroup>
 
                         </tr>
 
@@ -374,6 +378,7 @@
 
                 <table style="width: 100%; margin-left:0.5cm; ">
 
+                    <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                     <h:panelGroup rendered="#{cc.attrs.bill.balance gt 4.0 }" >
 
                         <tr>
@@ -470,6 +475,7 @@
                             </td>
                         </tr>
 
+                    </h:panelGroup>
                     </h:panelGroup>
 
                 </table>

--- a/src/main/webapp/theater/inward_bill_surgery_service.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_service.xhtml
@@ -199,10 +199,10 @@
                                             <p:column>
                                                 <h:outputLabel value="#{ix.department.name}"/>
                                             </p:column>  
-                                            <p:column>
-                                                <h:outputLabel value="#{ix.total}" 
+                                            <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ix.total}"
                                                                rendered="#{ix.chargesVisibleForInward}"/>
-                                            </p:column>  
+                                            </p:column>
                                             <p:ajax event="itemSelect" process="acIx" update="@all" />
                                         </p:autoComplete>
 
@@ -283,9 +283,10 @@
                                             </p:dataTable>
                                         </p:tab>
                                         <p:tab id="tabBillFee" title="Fees" >
-                                            <p:dataTable rowIndexVar="rowIndex" value="#{billBhtController.lstBillFees}" var="bif" 
-                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward) 
+                                            <p:dataTable rowIndexVar="rowIndex" value="#{billBhtController.lstBillFees}" var="bif"
+                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
                                                                           or (webUserController.hasPrivilege('ShowInwardFee'))
+                                                                          or (webUserController.hasPrivilege('ShowServiceCharges'))
                                                                           ? '':'noDisplayRow'}">
                                                 <p:column>
                                                     <f:facet name="header">No</f:facet>
@@ -297,9 +298,9 @@
                                                     <h:outputLabel value="#{bif.billItem.item.name}"/>
                                                 </p:column>
 
-                                                <p:column >
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                     <f:facet name="header">Fee Gross Value</f:facet>
-                                                    <h:inputText autocomplete="off" value="#{bif.feeGrossValue}" 
+                                                    <h:inputText autocomplete="off" value="#{bif.feeGrossValue}"
                                                                  disabled="#{!bif.billItem.item.userChangable
                                                                              or(!webUserController.hasPrivilege('ShowInwardFee'))}" >
                                                         <f:convertNumber pattern="#,##0.00" />
@@ -310,14 +311,14 @@
                                                     </h:inputText>
                                                 </p:column>
 
-                                                <p:column>
-                                                    <f:facet name="header">Matrix Value</f:facet>  
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">Matrix Value</f:facet>
                                                     <h:outputLabel id="matrix" value="#{bif.feeMargin}">
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputLabel>
                                                 </p:column>
 
-                                                <p:column >
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                                     <f:facet name="header">Fee Value</f:facet>
                                                     <h:outputLabel id="feeValue"  value="#{bif.feeValue}"  >
                                                         <f:convertNumber pattern="#,##0.00" />
@@ -459,7 +460,7 @@
                                                             </h:outputLabel>
                                                         </h:panelGroup>
                                                     </h:column>
-                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">
+                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee') or webUserController.hasPrivilege('ShowServiceCharges')}">
 
                                                         <h:outputLabel  value="#{bip.billItem.grossValue}"
                                                                         rendered="#{bip.billItem.item.department.id eq bill.toDepartment.id}"
@@ -467,14 +468,14 @@
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputLabel>
                                                     </h:column>
-                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">                                                       
+                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee') or webUserController.hasPrivilege('ShowServiceCharges')}">                                                       
                                                         <h:outputLabel  value="#{bip.billItem.marginValue}" 
                                                                         rendered="#{bip.billItem.item.department.id eq bill.toDepartment.id}"
                                                                         style="margin: 4px; font-size: 11px!important;" >
                                                             <f:convertNumber pattern="#,##0.00" />
                                                         </h:outputLabel>
                                                     </h:column>
-                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">                                                     
+                                                    <h:column   rendered="#{webUserController.hasPrivilege('ShowInwardFee') or webUserController.hasPrivilege('ShowServiceCharges')}">                                                     
                                                         <h:outputLabel  value="#{bip.billItem.netValue}"  
                                                                         rendered="#{bip.billItem.item.department.id eq bill.toDepartment.id}"
                                                                         style="margin: 4px; font-size: 11px!important;" >

--- a/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
+++ b/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
@@ -192,7 +192,7 @@
                                             <p:column headerText="Service">
                                                 <h:outputLabel value="#{ix.name}"/>
                                             </p:column>
-                                            <p:column headerText="Rate">
+                                            <p:column headerText="Rate" rendered="#{webUserController.hasPrivilege('ShowServiceCharges') or webUserController.hasPrivilege('ShowTimeServiceCharges')}">
                                                 <h:outputLabel value="#{ix.total}"/>
                                             </p:column>
                                         </p:autoComplete>
@@ -265,7 +265,7 @@
                                     value="#{ti.billFee.patientItem.toTime}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                             </p:column>
-                            <p:column headerText="Total" styleClass="averageNumericColumn">
+                            <p:column headerText="Total" styleClass="averageNumericColumn" rendered="#{webUserController.hasPrivilege('ShowTimeServiceCharges')}">
                                 <h:outputLabel value="#{ti.billFee.patientItem.serviceValue}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>


### PR DESCRIPTION
## Summary

Implements issue #16608. Privilege-based visibility control for service charge and fee information across all inward billing interfaces.

### New Privileges Added

- `ShowServiceCharges` (Nursing Work Bench) - hides service fee columns on billing pages and all print templates
- `ShowTimeServiceCharges` (Nursing Work Bench) - hides Total column on timed service consumption pages

Both privileges are registered in `UserPrivilageController` and appear in the admin privilege assignment UI tree.

## Pages Changed

### Inward Service Billing
- `inward/inward_bill_service.xhtml` - item listbox Total column, Bill Items tab (Rate, Gross Value, Discount, Service Charge, Net Value), Fees tab (Unit Rate, Total Gross, Discount, Service Charge, Net Total, row expansion), Bill Details panel, post-settle table
- `inward/inward_reprint_bill_service.xhtml` - fees datatable columns, Bill Details panel
- `inward/inward_timed_service_consume.xhtml` - Total column (ShowTimeServiceCharges)

### Theater / Surgery
- `theater/inward_bill_surgery_service.xhtml` - autoComplete Total column, Fees tab (Fee Gross Value, Matrix Value, Fee Value), row visibility filter, post-settle print view item amounts
- `theater/inward_timed_service_consume_surgery.xhtml` - Rate column in autoComplete, Total column

### 9 Print Templates (guarded with ShowServiceCharges)

- `resources/bill/inwardBillPrintPos.xhtml` - totals section, per-item grossValue
- `resources/bill/inwardBillPrintFiveFive.xhtml` - totals panelGrid, per-item grossValue, Value header
- `resources/ezcomp/prints/posOpdBill_inward_service.xhtml` - totals table, per-item grossValue, VALUE header
- `resources/ezcomp/prints/five_five_custom_3_inward.xhtml` - totals, per-item netValue (grouped + ungrouped), Value header
- `resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml` - per-item grossValue/rate, totals div
- `resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml` - TOTAL/Discount/Net Total rows, Amount column header + per-item
- `resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml` - totals section, per-item netValue, Amount header; fixed Particular header left-alignment
- `resources/ezcomp/prints/A4_paper_with_headings.xhtml` - totals div, per-item grossValue/rate, VALUE header
- `resources/ezcomp/prints/A4_paper_without_headings.xhtml` - same as A4 with headings

## Visibility Rules

- Qty and item name always visible to all users
- All monetary fields hidden unless ShowServiceCharges is granted
- Timed service totals hidden unless ShowTimeServiceCharges is granted
- Pharmacy pages (`pharmacy_bill_issue_bht.xhtml`, `inward_bill_surgery_issue.xhtml`) already guarded with existing `ShowDrugCharges` privilege - no changes needed

## Test Plan

- [ ] User without ShowServiceCharges: no fee columns visible on any inward or surgery billing page or print preview
- [ ] User with ShowServiceCharges: all fee columns appear correctly
- [ ] ShowTimeServiceCharges hides/shows Total on timed service pages (inward + surgery)
- [ ] Both new privileges visible in admin privilege tree under Nursing Work Bench
- [ ] All 9 print templates hide amounts and column headers correctly

Closes #16608

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new permission-based visibility for service charge and timed service amount fields across billing, print, and surgery screens.
  * Introduced separate controls for service charge details and timed service totals.

* **Bug Fixes**
  * Hid rate, gross value, discount, and net total fields for users without the relevant access.
  * Updated bill previews and printouts so totals and charge breakdowns appear only when permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->