### PR TITLE
fix(inward): Room Vacancy Details shows only vacant rooms with correct 24hr charge

### DIFF
--- a/detect-maven.sh
+++ b/detect-maven.sh
@@ -30,6 +30,11 @@ case "$HOSTNAME" in
         /usr/lib/apache-netbeans/java/maven/bin/mvn "$@"
         exit $?
         ;;
+    "Damith"|"damith")
+        echo "Using NetBeans bundled Maven for Damith machine"
+        "/c/Program Files/NetBeans-16/netbeans/java/maven/bin/mvn.cmd" "$@"
+        exit $?
+        ;;
     # Add other machines here as they are documented
     # "OTHER-MACHINE"|"other-machine")
     #     echo "Using Maven for other machine"

--- a/src/main/java/com/divudi/bean/inward/RoomOccupancyController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomOccupancyController.java
@@ -135,8 +135,13 @@ public class RoomOccupancyController implements Serializable {
         Date toDate = null;
         String sql = "SELECT rf FROM RoomFacilityCharge rf "
                 + " where rf.retired=false "
-                + " and rf.room.filled=false"
+                + " and rf.room.filled!=true"
                 + " and rf.room.retired=false"
+                + " and rf.room.id NOT IN ("
+                + " SELECT pr.roomFacilityCharge.room.id"
+                + " FROM PatientRoom pr"
+                + " WHERE pr.retired=false"
+                + " AND pr.discharged=false)"
                 + " order by rf.name";
 
         roomFacilityCharges = getRoomFacilityChargeFacade().findByJpql(sql);

--- a/src/main/webapp/inward/inward_room_vacant.xhtml
+++ b/src/main/webapp/inward/inward_room_vacant.xhtml
@@ -16,51 +16,50 @@
             <h:form>
                 <div class="row">
                     <div class="col-md-3">
-                        <p:commandButton ajax="false" 
-                                         action="#{roomOccupancyController.createPatientRoomVacant()}"
-                                         value="Fill" class="w-50" />    
+                        <p:commandButton
+                            ajax="false"
+                            action="#{roomOccupancyController.createPatientRoomVacant()}"
+                            value="Fill"
+                            class="w-50" >
+                        </p:commandButton>
                     </div>
                 </div>
 
 
-                <p:dataTable 
-                    value="#{roomOccupancyController.roomFacilityCharges}" 
+                <p:dataTable
+                    value="#{roomOccupancyController.roomFacilityCharges}"
                     var="pr"
                     paginator="true"
                     paginatorPosition="bottom"
                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                    rowsPerPageTemplate="5,10,15" class="mt-3"
+                    rowsPerPageTemplate="5,10,15"
+                    class="mt-3"
                     >
 
 
                     <p:column headerText="Room">
-                        #{pr.room.name}                    
+                        #{pr.room.name}
                     </p:column>
 
                     <p:column headerText="Category">
-                        #{pr.roomCategory.name}                   
+                        #{pr.roomCategory.name}
                     </p:column>
 
                     <p:column headerText="Department">
-                        #{pr.department.name}                    
+                        #{pr.department.name}
                     </p:column>
 
-                    <!--                <p:column headerText="Chargers for 24">
-                    #{(pr.linenCharge)+
-                      ((pr.adminstrationCharge + pr.maintananceCharge
-                      + pr.medicalCareCharge + pr.roomCharge
-                      + pr.nursingCharge + pr.moCharge)*8)}                    
-                </p:column>-->
-
                     <p:column headerText="Room Chargers for 24">
-                        #{pr.roomCharge*8}                    
+                        <h:outputText value="#{pr.timedItemFee != null and pr.timedItemFee.durationHours > 0 ? pr.roomCharge * (24 / pr.timedItemFee.durationHours) : 0}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputText>
                     </p:column>
 
                 </p:dataTable>
 
 
 
-            </h:form> 
+            </h:form>
         </p:panel>
 
     </ui:define>

--- a/src/main/webapp/inward/inward_room_vacant.xhtml
+++ b/src/main/webapp/inward/inward_room_vacant.xhtml
@@ -1,67 +1,78 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-                template="/resources/template/template.xhtml"
-                xmlns:h="http://xmlns.jcp.org/jsf/html"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:p="http://primefaces.org/ui">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+<h:head>
+    <title>Room Vacancy Details</title>
+</h:head>
+<h:body>
+    <ui:composition template="/resources/template/template.xhtml">
+        <ui:define name="content">
+            <h:form id="frmRoomVacant">
+                <p:panel>
+                    <f:facet name="header">
+                        <div class="d-flex justify-content-between align-items-center w-100">
+                            <div class="d-flex align-items-center gap-2">
+                                <h:outputText styleClass="fas fa-bed"/>
+                                <h:outputText value="Room Vacancy Details"/>
+                            </div>
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:commandButton id="btnFill"
+                                                 ajax="false"
+                                                 action="#{roomOccupancyController.createPatientRoomVacant()}"
+                                                 value="Fill"
+                                                 icon="fas fa-sync-alt"
+                                                 style="min-width:120px"
+                                                 title="Load the list of currently vacant rooms"
+                                                 styleClass="ui-button-success"/>
+                            </div>
+                        </div>
+                    </f:facet>
 
+                    <p:dataTable id="tblRoomVacant"
+                                 widgetVar="wgtRoomVacant"
+                                 value="#{roomOccupancyController.roomFacilityCharges}"
+                                 var="pr"
+                                 rowKey="#{pr.id}"
+                                 rowIndexVar="rowIndex"
+                                 summary="Vacant rooms available for admission"
+                                 paginator="true"
+                                 paginatorPosition="bottom"
+                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                 rowsPerPageTemplate="5,10,15"
+                                 stickyHeader="true"
+                                 styleClass="p-datatable-sm mt-3"
+                                 emptyMessage="No vacant rooms found. Click Fill to load the list.">
 
-    <ui:define name="content">
-        <p:panel>
-            <f:facet name="header">
-                Room Vacancy Details
-            </f:facet>
-            <h:form>
-                <div class="row">
-                    <div class="col-md-3">
-                        <p:commandButton
-                            ajax="false"
-                            action="#{roomOccupancyController.createPatientRoomVacant()}"
-                            value="Fill"
-                            class="w-50" >
-                        </p:commandButton>
-                    </div>
-                </div>
+                        <p:column headerText="#" width="2em" styleClass="text-center">
+                            <h:outputText value="#{rowIndex + 1}"/>
+                        </p:column>
 
+                        <p:column headerText="Room" width="10em">
+                            <h:outputText value="#{pr.room.name}"/>
+                        </p:column>
 
-                <p:dataTable
-                    value="#{roomOccupancyController.roomFacilityCharges}"
-                    var="pr"
-                    paginator="true"
-                    paginatorPosition="bottom"
-                    paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                    rowsPerPageTemplate="5,10,15"
-                    class="mt-3"
-                    >
+                        <p:column headerText="Category" width="10em">
+                            <h:outputText value="#{pr.roomCategory.name}"/>
+                        </p:column>
 
+                        <p:column headerText="Department" width="12em">
+                            <h:outputText value="#{pr.department.name}"/>
+                        </p:column>
 
-                    <p:column headerText="Room">
-                        #{pr.room.name}
-                    </p:column>
+                        <p:column headerText="Room Charges for 24 Hrs" width="10em" styleClass="text-end">
+                            <h:outputText value="#{pr.timedItemFee != null and pr.timedItemFee.durationHours > 0 ? pr.roomCharge * (24 / pr.timedItemFee.durationHours) : 0}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputText>
+                        </p:column>
 
-                    <p:column headerText="Category">
-                        #{pr.roomCategory.name}
-                    </p:column>
-
-                    <p:column headerText="Department">
-                        #{pr.department.name}
-                    </p:column>
-
-                    <p:column headerText="Room Chargers for 24">
-                        <h:outputText value="#{pr.timedItemFee != null and pr.timedItemFee.durationHours > 0 ? pr.roomCharge * (24 / pr.timedItemFee.durationHours) : 0}">
-                            <f:convertNumber pattern="#,##0.00"/>
-                        </h:outputText>
-                    </p:column>
-
-                </p:dataTable>
-
-
-
+                    </p:dataTable>
+                </p:panel>
             </h:form>
-        </p:panel>
-
-    </ui:define>
-
-</ui:composition>
+        </ui:define>
+    </ui:composition>
+</h:body>
+</html>


### PR DESCRIPTION
## Summary
- Fixes the vacant-room filter so occupied rooms no longer appear as vacant (previously relied solely on the stale `Room.filled` flag, which is only set by the external `InwardRoomApi`, never by the normal admission/discharge workflow).
- Corrects the "Room Charges for 24" column: was hardcoded `roomCharge * 8` (assumes fixed 3-hour billing blocks); now uses each room's actual `timedItemFee.durationHours` and formats as currency.
- Modernizes the page UI to match current project standards (three-zone panel header, accessible/dense datatable, sticky header, sized columns).

Fixes #21902

## Test plan
- [ ] Admit a patient to a room via the normal admission flow, click "Fill" on Room Vacancy Details, confirm that room no longer appears
- [ ] Discharge the patient and confirm the room reappears as vacant
- [ ] Confirm the "Room Charges for 24 Hrs" column shows a correctly formatted (#,##0.00) value based on the room's actual billing duration
- [ ] Visual check of the redesigned page (header, table, pagination)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Room Vacancy Details page with a refreshed table layout, improved pagination, sticky headers, row numbers, and clearer empty-state messaging.
  * Enhanced the Fill action button with better styling and a more polished appearance.

* **Bug Fixes**
  * Improved vacant room selection so occupied rooms are excluded more reliably.
  * Adjusted 24-hour room charge calculation to use duration-based pricing, with safer handling when timing details are missing.

* **Chores**
  * Added support for an additional machine-specific Maven setup during local builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->