### PR TITLE
fix(inward): exclude investigation/service fees from professional payment due search

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -8138,6 +8138,7 @@ public class SearchController implements Serializable {
                 //Starting of newly added code
                 //                + " and b.bill.refunded=false "
                 //Ending of newly added code
+                + " and b.fee.feeType=:feeType"
                 + " and (b.feeValue - b.paidValue) > 0"
                 //                + " and  b.bill.billTime between :fromDate and :toDate ";
                 + " and  b.bill.createdAt between :fromDate and :toDate ";
@@ -8183,6 +8184,7 @@ public class SearchController implements Serializable {
         temMap.put("fromDate", getFromDate());
         temMap.put("btp", BillType.InwardBill);
         temMap.put("btp2", BillType.InwardProfessional);
+        temMap.put("feeType", FeeType.Staff);
 
         billFees = getBillFeeFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP, 50);
         List<BillFee> removeingBillFees = new ArrayList<>();
@@ -8215,6 +8217,7 @@ public class SearchController implements Serializable {
         temMap.put("billClass", BilledBill.class);
         temMap.put("btp", BillType.InwardBill);
         temMap.put("btp2", BillType.InwardProfessional);
+        temMap.put("feeType", FeeType.Staff);
 
         sql = "select b from BillFee b where "
                 + " b.retired=false "
@@ -8224,6 +8227,7 @@ public class SearchController implements Serializable {
                 //Starting of newly added code
                 //                + " and b.bill.refunded=false "
                 //Ending of newly added code
+                + " and b.fee.feeType=:feeType"
                 + " and (b.feeValue - b.paidValue) > 0"
                 //                + " and  b.bill.billTime between :fromDate and :toDate ";
                 + " and  b.bill.createdAt between :fromDate and :toDate ";
@@ -8294,6 +8298,7 @@ public class SearchController implements Serializable {
         sql = "select b from BillFee b where "
                 + " b.retired=false "
                 + " and (b.bill.billType=:btp or b.bill.billType=:btp2 )"
+                + " and b.fee.feeType=:feeType"
                 + " and (b.feeValue - b.paidValue) > 0"
                 + " and  b.bill.billDate between :fromDate and :toDate ";
 
@@ -8338,6 +8343,7 @@ public class SearchController implements Serializable {
         temMap.put("fromDate", getFromDate());
         temMap.put("btp", BillType.InwardBill);
         temMap.put("btp2", BillType.InwardProfessional);
+        temMap.put("feeType", FeeType.Staff);
 
         billFees = getBillFeeFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP);
         calTotal();


### PR DESCRIPTION
## Summary
- `SearchController.createDueFeeTableInward()`, `createDueFeeTableInwardAll()`, and `createDueFeeTableInwardAllWithCancelled()` (used by `/inward/inward_search_professional_payment_due.xhtml`) selected all due `BillFee` rows for inward bills regardless of fee type.
- This meant investigation and service charge fees (e.g. `FeeType.Service`, `FeeType.OwnInstitution`) appeared alongside actual doctor professional fees in the Inward Payments Due Search, even though the page is meant to show only professional payments.
- Added `and b.fee.feeType=:feeType` (bound to `FeeType.Staff`) to all three JPQL queries, matching the existing convention used elsewhere in the codebase (e.g. `ServiceSummery.java`) for isolating professional/staff fees.

Fixes #21802

## Test plan
- [ ] Deploy and open Inward Payments Due Search (`/inward/inward_search_professional_payment_due.xhtml`)
- [ ] Run Search / Search All for a date range with mixed inward bills containing both investigation/service charges and doctor professional fees
- [ ] Confirm only professional (staff) fee rows appear in the results, and the amounts/staff/speciality columns are unaffected for genuine professional fees

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined search and billing results to include only staff-related fee records in the affected queries.
  * Improved consistency of filtered results alongside existing status, payment, and date criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->