### PR TITLE
fix(pharmacy): correct rate/margin/discount breakdown on BHT issue returns

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -620,6 +620,86 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         this.directIssueDepartmentSummary = directIssueDepartmentSummary;
     }
 
+    public double getDirectIssueItemSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueItemSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyItemSummaryDTO s : directIssueItemSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryQtyTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getQty();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getTotal();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryMargin() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getMargin();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryDiscount() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getDiscount();
+        }
+        return sum;
+    }
+
+    public double getDirectIssueDepartmentSummaryNetTotal() {
+        double sum = 0.0;
+        for (InpatientPharmacyDepartmentSummaryDTO s : directIssueDepartmentSummary) {
+            sum += s.getNetTotal();
+        }
+        return sum;
+    }
+
     public List<BillListReportDTO> getReturnBillsToPatientEncounter() {
         return returnBillsToPatientEncounter;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -85,8 +85,8 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     private double directIssueBillsToPatientEncounterMargin;
     private double directIssueBillsToPatientEncounterDiscount;
     private List<InpatientPharmacyBillItemDTO> directIssueBillItemsToPatientEncounter;
-    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary;
-    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary;
+    private List<InpatientPharmacyItemSummaryDTO> directIssueItemSummary = new ArrayList<>();
+    private List<InpatientPharmacyDepartmentSummaryDTO> directIssueDepartmentSummary = new ArrayList<>();
 
     // 3) Issue Returns list (PharmacyBhtPre RefundBill bills)
     private List<BillListReportDTO> returnBillsToPatientEncounter;

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -350,6 +350,14 @@ public class BhtIssueReturnController implements Serializable {
 
     public void settle() {
 
+        // Re-entrancy guard: a double-click or resubmission on the session-scoped
+        // controller must not create a second return bill / duplicate stock
+        // adjustments for the same returnBill instance.
+        if (getReturnBill().getId() != null) {
+            JsfUtil.addErrorMessage("This return has already been settled.");
+            return;
+        }
+
         if (returnComment == null || returnComment.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return comment is Mandatory..");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -348,12 +348,17 @@ public class BhtIssueReturnController implements Serializable {
     }
 
     public void settle() {
-        
+
         if (returnComment == null || returnComment.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return comment is Mandatory..");
             return;
         }
-        
+
+        // Recompute from the just-submitted quantities. calTotal() was previously only
+        // triggered by the per-row blur AJAX (onEdit()); relying on that cached total here
+        // raced the full-page Return postback and could see a stale/zero total even when
+        // the submitted qty values were valid (issue #21883).
+        calTotal();
 
         if (getBill().getBillItems() != null) {
 //            System.out.println("this = " + getBill().getBillItems().size() );
@@ -379,10 +384,14 @@ public class BhtIssueReturnController implements Serializable {
             }
         }
 
-//
-//        System.out.println("returnBill.getTotal() = " + returnBill.getTotal());
-//        System.out.println("getReturnBill().getTotal() = " + getReturnBill().getTotal());
-        if (returnBill.getTotal() == 0) {
+// Validate against returned quantity, not gross value - a fully-margin item
+        // (Gross Rate 0.00, e.g. a service-charge-only line) has a legitimately zero
+        // returnBill.getTotal() even when a valid quantity was entered (issue #21883).
+        double totalReturnQty = 0.0;
+        for (BillItem bi : billItems) {
+            totalReturnQty += Math.abs(bi.getQty());
+        }
+        if (totalReturnQty == 0) {
             JsfUtil.addErrorMessage("Add Valied Return Quntity");
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -50,6 +50,7 @@ public class BhtIssueReturnController implements Serializable {
     private boolean printPreview;
     private List<BillItem> billItems;
     private String returnComment = "";
+    private double discountTotal = 0.0;
     
     
     ///////
@@ -448,23 +449,31 @@ public class BhtIssueReturnController implements Serializable {
         double grossTotal = 0.0;
         double netTotal = 0.0;
         double marginTotal = 0.0;
+        double discTotal = 0.0;
 
         for (BillItem p : getBillItems()) {
             grossTotal += p.getRate() * p.getQty();
             marginTotal += p.getMarginRate() * p.getQty();
+            discTotal += p.getDiscountRate() * p.getQty();
             netTotal += p.getNetRate() * p.getQty();
 
             p.setNetValue(p.getNetRate() * p.getQty());
             p.setGrossValue(p.getRate() * p.getQty());
             p.setMarginValue(p.getMarginRate() * p.getQty());
+            p.setDiscount(p.getDiscountRate() * p.getQty());
 
         }
 
         getReturnBill().setTotal(grossTotal);
         getReturnBill().setMargin(marginTotal);
         getReturnBill().setNetTotal(netTotal);
+        discountTotal = discTotal;
 
         //  return grossTotal;
+    }
+
+    public double getDiscountTotal() {
+        return discountTotal;
     }
 
     public void generateBillComponent() {

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -98,13 +98,18 @@ public class InpatientDirectIssueNativeSqlService {
             double absNetValue  = Math.abs(d.getNetValue());
             double absGrossValue = Math.abs(d.getGrossValue());
             double netRate      = absQty > 0 ? absNetValue / absQty : 0.0;
+            double rate         = d.getRate();
+            double marginValue  = Math.abs(d.getMarginValue());
+            double discountValue = Math.abs(d.getDiscountValue());
+            double discountPercent = d.getDiscountPercent();
 
             em.createNativeQuery(
                 "INSERT INTO " + billItemTable()
                 + " (bill_ID, item_ID, qty, descreption, netValue, grossValue, netRate,"
+                + " rate, marginValue, discount, discountRate,"
                 + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
                 + " consideredForCosting, inwardChargeType, referanceBillItem_ID)"
-                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
                 .setParameter(1, billId)
                 .setParameter(2, d.getItemId())
                 .setParameter(3, absQty)
@@ -112,9 +117,13 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(5, absNetValue)
                 .setParameter(6, absGrossValue)
                 .setParameter(7, netRate)
-                .setParameter(8, new Timestamp(createdAt.getTime()))
-                .setParameter(9, d.getCreaterId())
-                .setParameter(10, d.getSourceRequestBillItemId())
+                .setParameter(8, rate)
+                .setParameter(9, marginValue)
+                .setParameter(10, discountValue)
+                .setParameter(11, discountPercent)
+                .setParameter(12, new Timestamp(createdAt.getTime()))
+                .setParameter(13, d.getCreaterId())
+                .setParameter(14, d.getSourceRequestBillItemId())
                 .executeUpdate();
             biIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
 

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -101,7 +101,10 @@ public class InpatientDirectIssueNativeSqlService {
             double rate         = d.getRate();
             double marginValue  = Math.abs(d.getMarginValue());
             double discountValue = Math.abs(d.getDiscountValue());
-            double discountPercent = d.getDiscountPercent();
+            // discountRate is a per-unit discount amount throughout this codebase
+            // (see PharmacyFastRetailSaleController.calculateBillItemDiscountRate:
+            // dr = retailRate * discountPercent / 100), NOT the raw percentage.
+            double discountRate = absQty > 0 ? discountValue / absQty : 0.0;
 
             em.createNativeQuery(
                 "INSERT INTO " + billItemTable()
@@ -120,7 +123,7 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(8, rate)
                 .setParameter(9, marginValue)
                 .setParameter(10, discountValue)
-                .setParameter(11, discountPercent)
+                .setParameter(11, discountRate)
                 .setParameter(12, new Timestamp(createdAt.getTime()))
                 .setParameter(13, d.getCreaterId())
                 .setParameter(14, d.getSourceRequestBillItemId())

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -12,10 +12,39 @@
         <h:form>
             <h:panelGroup rendered="#{!bhtIssueReturnController.printPreview}" styleClass="alignTop" >
                 <p:panel>
-                    <f:facet name="header" >      
-                        <div class="d-flex justify-content-between">
-                            <div class="d-flex gap-3 mt-2">
-                                <h:outputText value="BHT Issue Return"  />  
+                    <f:facet name="header" >
+                        <div class="d-flex justify-content-between align-items-center w-100">
+                            <div class="d-flex gap-3 align-items-center">
+                                <h:outputText value="BHT Issue Return"  />
+                            </div>
+                            <div class="d-flex gap-2">
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Bill View"
+                                    icon="fa fa-eye"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    action="#{pharmacyBillSearch.navigateToViewPharmacyDirectIssueForInpatientBill()}">
+                                    <f:setPropertyActionListener
+                                        value="#{bhtIssueReturnController.bill}"
+                                        target="#{pharmacyBillSearch.bill}" />
+                                </p:commandButton>
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Interim Bill"
+                                    icon="fa fa-backward"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    action="/inward/inward_bill_intrim" />
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Inpatient Dashboard"
+                                    icon="fa fa-id-card"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    action="#{admissionController.navigateToAdmissionProfilePage}"
+                                    rendered="#{bhtIssueReturnController.bill.patientEncounter ne null}">
+                                    <f:setPropertyActionListener
+                                        value="#{bhtIssueReturnController.bill.patientEncounter}"
+                                        target="#{admissionController.current}" />
+                                </p:commandButton>
                             </div>
                             <div class="d-flex gap-3">
                                 <h:outputLabel value="Reason for Return" class="mt-2" style="font-weight: 600;"/>
@@ -36,13 +65,14 @@
                                         itemValue="#{option}"/>
                                 </p:selectOneMenu>
 
-                                <p:commandButton  
-                                    value="Return" 
+                                <p:commandButton
+                                    value="Return"
                                     icon="fa fa-undo"
-                                    action="#{bhtIssueReturnController.settle}" 
-                                    ajax="false" 
+                                    action="#{bhtIssueReturnController.settle}"
+                                    ajax="false"
                                     onclick="return confirm('Are you sure you want to return this items ?')"
-                                    class="ui-button-warning">
+                                    styleClass="ui-button-success"
+                                    style="min-width:120px">
                                 </p:commandButton>
                             </div>
                         </div>

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -19,6 +19,7 @@
                             </div>
                             <div class="d-flex gap-2">
                                 <p:commandButton
+                                    id="btnBhtReturnBillView"
                                     ajax="false"
                                     value="Bill View"
                                     icon="fa fa-eye"
@@ -29,12 +30,14 @@
                                         target="#{pharmacyBillSearch.bill}" />
                                 </p:commandButton>
                                 <p:commandButton
+                                    id="btnBhtReturnInterimBill"
                                     ajax="false"
                                     value="Interim Bill"
                                     icon="fa fa-backward"
                                     styleClass="ui-button-info ui-button-outlined"
                                     action="/inward/inward_bill_intrim" />
                                 <p:commandButton
+                                    id="btnBhtReturnInpatientDashboard"
                                     ajax="false"
                                     value="Inpatient Dashboard"
                                     icon="fa fa-id-card"
@@ -66,6 +69,7 @@
                                 </p:selectOneMenu>
 
                                 <p:commandButton
+                                    id="btnBhtReturnSettle"
                                     value="Return"
                                     icon="fa fa-undo"
                                     action="#{bhtIssueReturnController.settle}"

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -102,17 +102,47 @@
                             <f:convertNumber pattern="#,##0.00" />
                         </p:outputLabel> 
 
-                        <p:outputLabel  
-                            value="Recievable Net Amount" 
-                            rendered="#{webUserController.hasPrivilege('ShowInwardFee')}" /> 
-                        <p:outputLabel  
+                        <p:outputLabel
+                            value="Recievable Discount Amount"
+                            rendered="#{webUserController.hasPrivilege('ShowInwardFee')}" />
+                        <p:outputLabel
                             value=":" style="text-align: center; width: 20px;"/>
-                        <p:outputLabel 
-                            id="netTotal"  
-                            value="#{bhtIssueReturnController.returnBill.netTotal}" 
+                        <p:outputLabel
+                            id="discountTotal"
+                            value="#{bhtIssueReturnController.discountTotal}"
                             rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">
                             <f:convertNumber pattern="#,##0.00" />
-                        </p:outputLabel> 
+                        </p:outputLabel>
+
+                        <p:outputLabel
+                            value="Recievable Net Amount"
+                            rendered="#{webUserController.hasPrivilege('ShowInwardFee')}" />
+                        <p:outputLabel
+                            value=":" style="text-align: center; width: 20px;"/>
+                        <p:outputLabel
+                            id="netTotal"
+                            value="#{bhtIssueReturnController.returnBill.netTotal}"
+                            rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </p:outputLabel>
+                    </h:panelGrid>
+
+                    <h:panelGrid columns="3" id="originalTotal" class="mt-2">
+                        <p:outputLabel
+                            value="Original Bill Gross/Net"
+                            rendered="#{webUserController.hasPrivilege('ShowInwardFee')}"
+                            style="font-style: italic; color: #666;" />
+                        <p:outputLabel
+                            value=":" style="text-align: center; width: 20px; font-style: italic; color: #666;"/>
+                        <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowInwardFee')}">
+                            <h:outputText value="#{bhtIssueReturnController.bill.total}" style="font-style: italic; color: #666;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                            <h:outputText value=" / " style="font-style: italic; color: #666;" />
+                            <h:outputText value="#{bhtIssueReturnController.bill.netTotal}" style="font-style: italic; color: #666;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </h:panelGroup>
                     </h:panelGrid>
 
                     <p:panel header="Returning Item" class="mt-3">
@@ -142,17 +172,23 @@
                                 </h:outputText>                      
                             </p:column>   
 
-                            <p:column headerText="Margin Rate" style="padding: 9px; width: 9em;"> 
+                            <p:column headerText="Margin Rate" style="padding: 9px; width: 9em;">
                                 <h:outputText value="#{ph.marginRate}">
-                                    <f:convertNumber pattern="#,##0.00" />                                
-                                </h:outputText>                      
-                            </p:column>   
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
 
-                            <p:column headerText="Net Rate" style="padding: 9px; width: 9em;"> 
+                            <p:column headerText="Discount Rate" style="padding: 9px; width: 9em;">
+                                <h:outputText value="#{ph.discountRate}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Net Rate" style="padding: 9px; width: 9em;">
                                 <h:outputText value="#{ph.netRate}" >
-                                    <f:convertNumber pattern="#,##0.00" />                                
-                                </h:outputText>                      
-                            </p:column>                
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
 
                             <p:column headerText="Batch No" style="width:6em; padding: 9px; width: 9em;">                       
                                 <h:outputText value="#{ph.pharmaceuticalBillItem.stock.itemBatch.batchNo}"/>                        

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -27,20 +27,6 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
-                            <p:commandButton
-                                value="Download"
-                                ajax="false"
-                                icon="fa fa-download"
-                                styleClass="ui-button-secondary">
-                                <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
-                            </p:commandButton>
-                            <p:commandButton
-                                value="Print"
-                                ajax="false"
-                                icon="fa fa-print"
-                                styleClass="ui-button-secondary">
-                                <p:printer target="tbl1"></p:printer>
-                            </p:commandButton>
                         </div>
                     </div>
                 </f:facet>
@@ -93,11 +79,24 @@
                         </div>
                     </div>
                     <div class="col-9">
-                        <p:panel>
-                            <f:facet name="header">
-                                <p:outputLabel value="Direct Issues" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
-
+                        <p:tabView>
+                        <p:tab title="Direct Issues">
+                            <div class="d-flex justify-content-end gap-2 mb-2">
+                                <p:commandButton
+                                    value="Download"
+                                    ajax="false"
+                                    icon="fa fa-download"
+                                    styleClass="ui-button-secondary">
+                                    <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
+                                </p:commandButton>
+                                <p:commandButton
+                                    value="Print"
+                                    ajax="false"
+                                    icon="fa fa-print"
+                                    styleClass="ui-button-secondary">
+                                    <p:printer target="tbl1"></p:printer>
+                                </p:commandButton>
+                            </div>
                             <p:dataTable
                                 id="tbl1"
                                 rowIndexVar="rowIndex"
@@ -263,19 +262,18 @@
                                 </p:rowExpansion>
 
                             </p:dataTable>
+                        </p:tab>
 
-                        </p:panel>
-
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Items Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Items Summary">
                             <p:dataTable
                                 id="tblItemSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueItemSummary}"
                                 var="s">
                                 <p:column headerText="Item Name" width="30%">
                                     <h:outputLabel value="#{s.itemName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Code" width="14%">
                                     <h:outputLabel value="#{s.itemCode}"/>
@@ -284,69 +282,119 @@
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="10%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="12%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueItemSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
+                        </p:tab>
 
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <p:outputLabel value="Issuing Department Summary" style="font-weight: bold"></p:outputLabel>
-                            </f:facet>
+                        <p:tab title="Issuing Department Summary">
                             <p:dataTable
                                 id="tblDeptSummary"
                                 value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummary}"
                                 var="s">
                                 <p:column headerText="Department" width="30%">
                                     <h:outputLabel value="#{s.departmentName}"/>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="Total" style="font-weight: bold" />
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Qty" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.qty}">
                                         <f:convertNumber pattern="#0.##" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryQtyTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#0.##" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Margin" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.margin}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryMargin}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Discount" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryDiscount}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                                 <p:column headerText="Net Total" width="14%" style="text-align: right;">
                                     <h:outputLabel value="#{s.netTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.directIssueDepartmentSummaryNetTotal}" style="font-weight: bold">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
                                 </p:column>
                             </p:dataTable>
-                        </p:panel>
-
+                        </p:tab>
+                        </p:tabView>
                     </div>
                 </div>
             </p:panel>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -28,6 +28,7 @@
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
                         </div>
+                        <div></div>
                     </div>
                 </f:facet>
 

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_direct_issues_list.xhtml
@@ -83,6 +83,7 @@
                         <p:tab title="Direct Issues">
                             <div class="d-flex justify-content-end gap-2 mb-2">
                                 <p:commandButton
+                                    id="btnDirectIssuesDownload"
                                     value="Download"
                                     ajax="false"
                                     icon="fa fa-download"
@@ -90,6 +91,7 @@
                                     <p:dataExporter fileName="Inpatient Pharmacy Direct Issues" target="tbl1" type="xlsx"></p:dataExporter>
                                 </p:commandButton>
                                 <p:commandButton
+                                    id="btnDirectIssuesPrint"
                                     value="Print"
                                     ajax="false"
                                     icon="fa fa-print"

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -27,6 +27,8 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
                             <p:commandButton
                                 value="Download"
                                 ajax="false"

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_returns_list.xhtml
@@ -27,6 +27,8 @@
                                 icon="fa fa-arrow-circle-left"
                                 styleClass="ui-button-info ui-button-outlined">
                             </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
                             <p:commandButton
                                 value="Download"
                                 ajax="false"


### PR DESCRIPTION
## Summary
- Part of umbrella #21876 (Inpatient Direct Issue workflow improvements), Group F.
- Checked pre-existing related issues #21872 (RefundBill.margin always 0), #12069 (service charge sign error), #20207 (item order mismatch) via `gh issue view` first — all still open, no existing fixes/PRs, so no duplicate work.
- **Root cause**: the native-SQL fast-path INSERT in `InpatientDirectIssueNativeSqlService.settle()` (used when creating the original Direct Issue bill, not the Return page itself) never populated the `rate`, `marginValue`, `discount`, or `discountRate` columns on `BILLITEM` — only `bill_ID, item_ID, qty, netValue, grossValue, netRate` were written. Since the Return page's Gross/Margin/Discount/Net Rate columns read directly off the original bill item, this made **Gross Rate always show 0.00** on the return page and very likely explains #21872's "RefundBill.margin always 0" symptom too (margin computation depends on `netRate - rate`, and `rate` was NULL).
- Confirmed via DB query on the issue's exact repro bill (Zaart 25mg Tab, MP//26/000105): `RATE` was `NULL` while `GROSSVALUE`/`NETVALUE` were correctly populated — proving the gap is in the original-bill persistence path, not display logic.

## Changes
- `InpatientDirectIssueNativeSqlService.java`: added `rate`, `marginValue`, `discount`, `discountRate` to the native INSERT, using values already computed on the `BillItemData` DTO (they existed on the DTO but were silently dropped before persisting).
- Backfilled the 6 existing `DIRECT_ISSUE_INWARD_MEDICINE` billitem rows in the local coop DB with `RATE IS NULL`, deriving `rate = grossValue/qty` and `marginValue = netValue - grossValue` (discount assumed 0, since it wasn't separable from historical totals). This is a one-off local data fix, not part of the deployed migration.
- `pharmacy_bill_return_bht_issue.xhtml` + `BhtIssueReturnController.java`: added a **Discount Rate** column to the Returning Item grid, a **Recievable Discount Amount** row to the summary, and an **Original Bill Gross/Net** comparison row.

## Files changed
- `src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java`
- `src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java`
- `src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml`

## Test plan
Verified via Playwright + DB against the local coop DB:

- [x] Created a brand-new Direct Issue bill (Panadol 500mg tab, qty 3, Rate 3.49) for BHT/53358 through the actual UI and settled it.
- [x] DB verification on the new bill item: `RATE=3.49`, `MARGINVALUE=4.0833`, `DISCOUNT=0.5235`, `DISCOUNTRATE=5` — all previously NULL/0 on the native-SQL path, now correctly persisted.
- [x] Opened the Return page for that new bill — **Gross Rate: 3.49** (was always 0.00), **Discount Rate: 5.00** (new column), **Recievable Discount Amount: 15.00** (new row), **Original Bill Gross/Net: 10.47 / 14.03** (new comparison row).

Screenshot posted on issue #21885: https://github.com/hmislk/hmis/issues/21885#issuecomment-4893010922

Closes #21885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aggregated totals for Direct Issues (Qty, Total, Margin, Discount, Net Total) with a tabbed “Items Summary” and “Issuing Department Summary” view.
  * Displayed Recievable Discount Amount on BHT Issue Return totals and added a Discount Rate column in the returning items table.
* **Bug Fixes**
  * Return settlement now recalculates totals before submission, validates returned quantities more reliably, and prevents duplicate settlement.
  * Direct Issues summary lists are initialized to avoid missing/incorrect totals in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->