### PR TITLE
Register guardian mandatory-field config options for Patient Admission

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -268,6 +268,55 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Title is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's title (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Name is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's name (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian NIC is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's NIC/Passport (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Address is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's address (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Mobile Number is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's mobile number (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Home Phone Number is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's home phone number (default false)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Guardian Relationship is Required in Patient Admission",
+                "When Guardian Details are required, also require the guardian's relationship to the patient (default true)",
+                "inward/inward_admission",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
                 "Patient Admit - Enable Referred From in Patient Admission",
                 "Show the Referred From field during admission (default false)",
                 "inward/inward_admission",
@@ -2035,7 +2084,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Guardian Home Phone Number is Required in Patient Admission", true)) {
+            if (configOptionApplicationController.getBooleanValueByKey("Guardian Home Phone Number is Required in Patient Admission", false)) {
                 if (getCurrent().getGuardian().getPhone() == null || getCurrent().getGuardian().getPhone().isEmpty()) {
                     JsfUtil.addErrorMessage("Guardian Home Phone Number is Required");
                     return true;


### PR DESCRIPTION
## Summary
- Register the 7 existing per-field guardian mandatory toggles (Title, Name, NIC, Address, Mobile, Home Phone, Relationship) as `ConfigOptionInfo` entries in `AdmissionController.java` so admins can discover and adjust them from the Application Config admin page — previously only the master "Guardian Details Required in Patient Admission" switch was registered.
- Flip the default for "Guardian Home Phone Number is Required in Patient Admission" from `true` to `false`, so out of the box only Title, Name, NIC, Address, Mobile, and Relationship are mandatory (Home Phone is optional by default).

## Options added
| Config Option | Default |
|---|---|
| Guardian Details Required in Patient Admission (master toggle, pre-existing) | Not mandatory |
| Guardian Title is Required in Patient Admission | Mandatory |
| Guardian Name is Required in Patient Admission | Mandatory |
| Guardian NIC is Required in Patient Admission | Mandatory |
| Guardian Address is Required in Patient Admission | Mandatory |
| Guardian Mobile Number is Required in Patient Admission | Mandatory |
| Guardian Home Phone Number is Required in Patient Admission | Not mandatory |
| Guardian Relationship is Required in Patient Admission | Mandatory |

All options only take effect when the master "Guardian Details Required in Patient Admission" toggle is enabled.

## Test plan
- [ ] Confirm the 7 new options appear in the Application Config admin page under `inward/inward_admission`
- [ ] With "Guardian Details Required in Patient Admission" enabled and defaults unchanged, verify admission save is blocked when Title/Name/NIC/Address/Mobile/Relationship are missing
- [ ] Confirm admission save succeeds without a guardian Home Phone number (default no longer mandatory)
- [ ] Toggle a field's config option off/on and confirm the validation respects the change

Closes #21936

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more admission settings to control which guardian details are required, including title, name, ID/passport, address, mobile number, home phone number, and relationship.

* **Bug Fixes**
  * Updated the guardian home phone requirement to be optional by default during patient admission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->