### PR TITLE
Fix nursing discharge blocked ('room discharge has not been completed') after multi-room discharge (#21935)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -7,6 +7,7 @@ import com.divudi.core.data.dto.PendingPharmacyItemDTO;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -36,6 +37,9 @@ public class NursingDischargeController implements Serializable {
 
     @EJB
     private BillFacade billFacade;
+
+    @EJB
+    private PatientRoomFacade patientRoomFacade;
 
     @Inject
     private SessionController sessionController;
@@ -149,6 +153,28 @@ public class NursingDischargeController implements Serializable {
     // Nursing Discharge
     // -------------------------------------------------------------------------
 
+    /**
+     * Returns true when the encounter still has at least one active (non-retired,
+     * non-discharged) room stay.
+     * <p>
+     * This is the source of truth for "room discharge completed" instead of the
+     * cached {@code PatientEncounter.roomDischargeDateTime} field, which is only
+     * stamped by {@code RoomChangeController} when the discharged room happens to
+     * be the tail of the room-stay linked list ({@code nextRoom == null}). In
+     * multi-room-change scenarios that field can stay {@code null} even though
+     * every room stay has been discharged, permanently blocking nursing
+     * discharge (issue #21935).
+     */
+    private boolean hasActiveRoom() {
+        String jpql = "SELECT COUNT(pr) FROM PatientRoom pr"
+                + " WHERE pr.patientEncounter = :pe"
+                + " AND pr.retired = false"
+                + " AND pr.discharged = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", currentEncounter);
+        return patientRoomFacade.findLongByJpql(jpql, params) > 0;
+    }
+
     public void confirmNursingDischarge() {
         if (currentEncounter == null) {
             JsfUtil.addErrorMessage("No patient encounter loaded.");
@@ -158,7 +184,7 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Nursing discharge already confirmed.");
             return;
         }
-        if (currentEncounter.getRoomDischargeDateTime() == null) {
+        if (hasActiveRoom()) {
             JsfUtil.addErrorMessage("Cannot confirm nursing discharge: room discharge has not been completed.");
             return;
         }


### PR DESCRIPTION
## Problem

Nursing discharge was permanently blocked with **"Cannot confirm nursing discharge: room discharge has not been completed."** even when the patient had already been discharged from *every* room (all room stays showing "Left" on the Patient Room Details page).

## Root cause

`NursingDischargeController.confirmNursingDischarge()` guarded on the cached encounter field `PatientEncounter.roomDischargeDateTime`. That field is only stamped in `RoomChangeController.discharge()` / `dischargeWithCurrentTime()`, and only when the discharged room is the tail of the room-stay linked list (`nextRoom == null`, an inverse `@OneToOne(mappedBy = "previousRoom")` relation). In multi-room-change scenarios the field can stay `null` even though every room stay is discharged — permanently blocking nursing discharge.

## Fix

Replace the cached-field check with `hasActiveRoom()`, a `COUNT` query for any non-retired, non-discharged `PatientRoom` on the encounter. This reflects the real room-stay state regardless of how/where each room was discharged, and does not depend on the fragile `nextRoom == null` sync. Uses `findLongByJpql` per the COUNT-query convention.

## Verification (Playwright + DB, local Payara, `coop` DB)

Tested against **BHT/53352** (encounter 9596606) — 4 room stays, all `DISCHARGED = 1`, `ROOMDISCHARGEDATETIME` still NULL (the exact scenario the old guard mishandled):

- **Before:** clicking Confirm → red growl "room discharge has not been completed"; `NURSINGDISCHARGEDATETIME` stays NULL.
- **After (this fix):** clicking Confirm → green banner *"Nursing discharge confirmed by buddhika on 08 Jul 2026 14:57:29"*; button flips to "Cancel Nursing Discharge".
- **DB confirmed:** `NURSINGDISCHARGEDATETIME = 2026-07-08 14:57:30`, `NURSINGDISCHARGEDBY_ID = 60103`, while `ROOMDISCHARGEDATETIME` remained NULL — proving the new guard succeeds where the cached-field guard failed.

## Scope

Single-file change to `NursingDischargeController.java`. No schema change. `persistence.xml` shown in the diff carries the CI/CD placeholders; restored to local JNDI post-push.

Closes #21935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nursing discharge confirmation to check the patient’s current room-stay status directly, reducing cases where discharge could be blocked or allowed incorrectly.
  * Discharge readiness now reflects the latest active room record instead of relying on an outdated stored value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->