### PR TITLE
Add per-charge-type Comment column to inward final bill

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -457,6 +457,27 @@ test, try the token-based "Sale for Cashier" flow instead — its item-add/quant
 inputs worked fine in this session, only the retail-native page's Settle button was
 unreachable.
 
+## 20. A privilege-gated button that never renders may be a missing DB row, not a session issue
+
+If a `rendered="#{webUserController.hasPrivilege('SomePrivilege')}"` button never
+appears even after the §17 logout/relogin-and-reselect-department trick, the
+`webuserprivilege` row for that (user, department, privilege) triple may simply not
+exist in the local seed data — no amount of re-login fixes a privilege that was never
+granted for that department. Check first:
+
+```sql
+SELECT ID, PRIVILEGE, DEPARTMENT_ID, RETIRED
+FROM webuserprivilege
+WHERE WEBUSER_ID = <id> AND PRIVILEGE = 'SomePrivilege';
+```
+
+If the row for the target department is absent, insert it (`RETIRED = 0`) for that
+`WEBUSER_ID`/`DEPARTMENT_ID`, then follow §17 (logout → login → reselect department)
+to force `SessionController.fillUserPrivileges()` to re-read it — the privilege list is
+cached per session at login and won't pick up a new row otherwise. This came up testing
+`BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
+user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2494,6 +2494,7 @@ public class BhtSummeryController implements Serializable {
             temBi.setDiscount(cit.getDiscount());
             temBi.setNetValue(cit.getNetTotal());
             temBi.setAdjustedValue(cit.getAdjustedTotal());
+            temBi.setDescreption(cit.getComments());
             temBi.setCreatedAt(new Date());
             temBi.setCreater(getSessionController().getLoggedUser());
 
@@ -2541,6 +2542,7 @@ public class BhtSummeryController implements Serializable {
             temBi.setDiscount(cit.getDiscount());
             temBi.setNetValue(cit.getNetTotal());
             temBi.setAdjustedValue(cit.getAdjustedTotal());
+            temBi.setDescreption(cit.getComments());
             temBi.setCreatedAt(new Date());
             temBi.setCreater(getSessionController().getLoggedUser());
 
@@ -2578,6 +2580,7 @@ public class BhtSummeryController implements Serializable {
             temBi.setDiscount(cit.getDiscount());
             temBi.setNetValue(cit.getNetTotal());
             temBi.setAdjustedValue(cit.getAdjustedTotal());
+            temBi.setDescreption(cit.getComments());
             temBi.setCreatedAt(new Date());
             temBi.setCreater(getSessionController().getLoggedUser());
 
@@ -3449,6 +3452,25 @@ public class BhtSummeryController implements Serializable {
 
         setNetAdjustValue();
 
+        restoreChargeItemComments();
+
+    }
+
+    private void restoreChargeItemComments() {
+        if (getPatientEncounter() == null
+                || !getPatientEncounter().isPaymentFinalized()
+                || getPatientEncounter().getFinalBill() == null) {
+            return;
+        }
+
+        for (BillItem existing : getPatientEncounter().getFinalBill().getBillItems()) {
+            for (ChargeItemTotal cit : chargeItemTotals) {
+                if (existing.getInwardChargeType() == cit.getInwardChargeType()) {
+                    cit.setComments(existing.getDescreption());
+                    break;
+                }
+            }
+        }
     }
 
     private void setNetAdjustValue() {

--- a/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
@@ -21,6 +21,7 @@ public class ChargeItemTotal {
     private double discount = 0;
     private double netTotal = 0;
     private double adjustedTotal = 0.0;
+    private String comments;
     private List<PatientRoom> patientRooms;
     List<BillFee> billFees;
 
@@ -69,6 +70,14 @@ public class ChargeItemTotal {
 
     public void setAdjustedTotal(double adjustedTotal) {
         this.adjustedTotal = adjustedTotal;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
     }
 
     public List<PatientRoom> getPatientRooms() {

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -636,6 +636,18 @@
                                 </p:inputText>
                             </p:column>
 
+                            <p:column headerText="Comment" width="16em;">
+                                <p:inputText
+                                    autocomplete="off"
+                                    id="catComment"
+                                    class="w-100"
+                                    value="#{c.comments}">
+                                    <p:ajax process="@this" event="blur"
+                                            update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
+                                            listener="#{bhtSummeryController.changeIsMade()}"/>
+                                </p:inputText>
+                            </p:column>
+
                         </p:dataTable>
                     </p:panel>
 


### PR DESCRIPTION
## Summary
- Adds an editable **Comment** column as the last column of the Charge Types table (`dList`) on `inward/inward_bill_final.xhtml`, letting a user record a reason per charge type.
- Persists the comment on the existing per-charge-type summary `BillItem.descreption` field (no schema change) when the bill is settled (`saveBillItem`/`saveTempBillItem`/`saveOriginalBillItem`).
- Reloads previously-saved comments when `createChargeItemTotals()` rebuilds the transient row list for an already payment-finalized encounter (e.g. via Recalculate), so comments aren't silently lost.

Design agreed on and documented in #21939.

## Test plan
- [x] Rebuilt and redeployed locally.
- [x] Selected a real local-DB admission (`OPDCARD/42566`), typed a comment on the "Admission Fee" Charge Types row, settled the bill — "Bill Saved" confirmed.
- [x] Verified in the local DB that the summary `BillItem.DESCREPTION` for `AdmissionFee` on the new final bill holds the typed comment.
- [x] Re-triggered `createChargeItemTotals()` for the now-settled encounter (revisited via Settle Bill) and confirmed the Comment field reloads pre-filled from the DB.
- Screenshots and full verification notes posted on #21939.

Closes #21939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comment field for charge types in the final billing screen.
  * Comments entered for charges are now saved and restored when revisiting finalized billing details.

* **Bug Fixes**
  * Improved troubleshooting guidance for cases where a privilege-based action does not appear after re-logging in and reselecting a department.
  * Added a check-and-fix path for missing local access data that can block restricted buttons from rendering.

* **Documentation**
  * Expanded the Playwright end-to-end workflow guide with a new troubleshooting section and example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->