### PR TITLE
Exclude retired BillItem lines from Transfer Receive bill print (#21913)

### DIFF
--- a/src/main/webapp/resources/pharmacy/pharmacy_transfer_receive_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_transfer_receive_receipt.xhtml
@@ -224,7 +224,7 @@
                         <tr>
                             <td class="summary-label">Number of Items</td>
                             <td class="summary-value">
-                                <h:outputLabel value="#{cc.attrs.bill.billItems.size()}">
+                                <h:outputLabel value="#{cc.attrs.bill.activeBillItems.size()}">
                                     <f:convertNumber pattern="#,##0" />
                                 </h:outputLabel>
                             </td>

--- a/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfeRecieve_detailed.xhtml
@@ -90,7 +90,7 @@
 
             <div >
 
-                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont compact-table" value="#{cc.attrs.bill.billItems}" sortBy="#{bip.searialNo}" var="bip"
+                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont compact-table" value="#{cc.attrs.bill.activeBillItems}" sortBy="#{bip.searialNo}" var="bip"
                              style="line-height: 1.1;">
 
                     <p:column style="text-align: left;">

--- a/src/main/webapp/resources/pharmacy/transferReceive.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferReceive.xhtml
@@ -113,7 +113,7 @@
                     rowIndexVar="rowIndex"
                     styleClass="no-border-table compact-table"
                     style=" border: none !important; font-size: #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Item List in Pharmacy Disbursement Reports', '10pt')}!Important; line-height: 1.1 !important;"
-                    value="#{cc.attrs.bill.billItems}" sortBy="#{bip.searialNo}" var="bip">
+                    value="#{cc.attrs.bill.activeBillItems}" sortBy="#{bip.searialNo}" var="bip">
 
                     <p:column
                         width="2em"

--- a/src/main/webapp/resources/pharmacy/transferReceive_custom_1_letter.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferReceive_custom_1_letter.xhtml
@@ -97,7 +97,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" varStatus="rowIndex">
+                        <ui:repeat value="#{cc.attrs.bill.activeBillItems}" var="bip" varStatus="rowIndex">
                             <tr>
                                 <!-- No -->
                                 <td class="left-col">#{rowIndex.index + 1}</td>

--- a/src/main/webapp/resources/pharmacy/transfer_receive_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfer_receive_custom_1.xhtml
@@ -117,7 +117,7 @@
                     rowIndexVar="rowIndex"
                     styleClass="no-border-table compact-table"
                     style="border: none !important; font-size: #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Item List in Pharmacy Disbursement Reports', '10pt')}!Important; line-height: 1.1 !important;"
-                    value="#{cc.attrs.bill.billItems}" sortBy="#{bip.searialNo}" var="bip">
+                    value="#{cc.attrs.bill.activeBillItems}" sortBy="#{bip.searialNo}" var="bip">
 
                     <p:column
                         width="2em"

--- a/src/main/webapp/resources/pharmacy/transfer_receive_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/transfer_receive_custom_2.xhtml
@@ -90,7 +90,7 @@
 
             <div >
 
-                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont compact-table" value="#{cc.attrs.bill.billItems}" sortBy="#{bip.searialNo}" var="bip"
+                <p:dataTable rowIndexVar="rowIndex" styleClass="noBorder normalFont compact-table" value="#{cc.attrs.bill.activeBillItems}" sortBy="#{bip.searialNo}" var="bip"
                              style="line-height: 1.1;">
 
                     <p:column style="text-align: left;">


### PR DESCRIPTION
## Summary

Fixes #21913 — the Pharmacy Transfer Receive print/reprint page rendered **retired** `BillItem` lines (e.g. duplicate lines retired by the 2026-06-01 mass-duplicate cleanup still showed twice on the printed bill).

## Root cause

All six transfer-receive print composites bound their item tables to `cc.attrs.bill.billItems`. `Bill.billItems` is an unfiltered `@OneToMany`, so JPA lazy-loads **every** `BillItem` for the bill regardless of `retired` status. `BillBeanController.fillBillItems()` does filter `retired=false`, but `fetchBillWithItemsAndFees()` only uses that list to attach fees — it never assigns it back via `setBillItems()`, so the print template sees the raw collection.

## Fix

Switched all six composites from `bill.billItems` → `bill.activeBillItems`, the in-memory retired-item filter (`Bill.getActiveBillItems()`) that was added for the **same problem class** in issue #21856. This mirrors the established codebase precedent rather than introducing a new one, and is scoped precisely to the transfer-receive print path (no controller/behavior change to the other 8 reprint pages that share `fetchBillWithItemsAndFees`).

Files changed (view-only, no Java compiled):

- `transferReceive.xhtml`
- `pharmacy_transfer_receive_receipt.xhtml` (also the "Number of Items" count)
- `transferReceive_custom_1_letter.xhtml`
- `transfeRecieve_detailed.xhtml`
- `transfer_receive_custom_1.xhtml`
- `transfer_receive_custom_2.xhtml`

## Verification

This is a JSF-only change (CLAUDE.md rule #12 — XHTML-only, no Java), so no compile/redeploy was required. Verified by inspection that:

- `Bill.getActiveBillItems()` (`Bill.java:1402`) filters `!bi.isRetired()` in memory over `getBillItems()`.
- All six composites now bind to `activeBillItems`; no stray `bill.billItems` references remain in the transfer-receive print path.
- The reprint page `pharmacy_reprint_transfer_receive.xhtml` routes through exactly these six config-toggled composites, so every print variant is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer receive screens and printed receipts now display the active item list, ensuring the shown items and item counts match the current transfer.
  * Updated related tables and letter/receipt layouts so line items, totals, and summaries stay consistent across transfer receive views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->