### PR TITLE
Fix 30s Direct Issue settle: replace em.refresh(bill) with detach + L2 evict

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -181,11 +181,7 @@ public class InpatientDirectIssueNativeSqlService {
         LOGGER.log(Level.INFO, "[NativeSettle] Starting finance details ms={0}", System.currentTimeMillis() - t0);
         double[] billTotals = insertFinanceDetails(billId, biIds, pbIds, items);
 
-        // Step 5: Update bill-level totals natively, then refresh the managed entity.
-        // em.refresh(bill) reloads both the updated totals and the natively-written
-        // BILLFINANCEDETAILS_ID FK (set by insertFinanceDetails) into L1. Without the
-        // refresh, L1 retains billFinanceDetails=null and that stale null FK would be
-        // merged into L2 at commit, causing subsequent EAGER loads to return null. (#20435)
+        // Step 5: Update bill-level totals natively.
         em.createNativeQuery(
                 "UPDATE " + billTable() + " SET total=?, netTotal=?, grantTotal=? WHERE ID=?")
                 .setParameter(1, billTotals[0])   // grossTotal
@@ -193,17 +189,35 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(3, billTotals[0])   // grantTotal = grossTotal (intentional naming per Bill entity)
                 .setParameter(4, billId)
                 .executeUpdate();
-        em.refresh(bill);
 
-        // Evict natively-written entity classes from the EclipseLink L2 cache.
-        // Bill is intentionally NOT evicted — em.refresh(bill) loaded the correct full
-        // state (totals + BILLFINANCEDETAILS_ID FK) and the commit merges it into L2.
+        // Reconcile the JPA caches with the natively-written state WITHOUT the
+        // catastrophic full-graph reload that em.refresh(bill) triggers.
+        //
+        // Previously this used em.refresh(bill) to pull the natively-written
+        // BILLFINANCEDETAILS_ID FK + totals back into L1 so a stale null FK would
+        // not be merged into L2 at commit (#20435). But em.refresh reloads the
+        // Bill's entire EAGER graph, and Bill.stockBill (EAGER) ↔ StockBill.bill
+        // (EAGER) form a circular EAGER reference; every Bill pulled in drags its
+        // own EAGER one-to-ones (pharmacyBill/stockBill/billFinanceDetails/
+        // currentRequest). For a batch whose related bill-graph is not yet in the
+        // L2 cache this fanned out into a ~30s recursive load — the "first issue of
+        // a batch is slow, later issues of the same batch are fast" symptom (#21888).
+        //
+        // Instead: detach the managed Bill so its stale (billFinanceDetails=null)
+        // state is NOT merged into L2 at commit, and evict Bill from L2 so the next
+        // read reloads the correct FK straight from the database. Same correctness
+        // guarantee as the refresh, none of the EAGER-graph cost.
+        long tReconcile = System.currentTimeMillis();
+        em.detach(bill);
         javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(Bill.class, billId);
         cache.evict(StockHistory.class);
         cache.evict(Stock.class);
         cache.evict(BillItem.class);
         cache.evict(BillFinanceDetails.class);
         cache.evict(BillItemFinanceDetails.class);
+        LOGGER.log(Level.INFO, "[NativeSettle] cache reconcile done ms={0} reconcileMs={1}",
+                new Object[]{System.currentTimeMillis() - t0, System.currentTimeMillis() - tReconcile});
 
         LOGGER.log(Level.INFO, "[NativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});


### PR DESCRIPTION
## Problem (#21888)

Settling an inpatient Direct Issue (BHT Issue) bill took **~30 seconds** on the first issue of a batch, and was fast for subsequent issues of the same batch.

## Root cause

Split timing instrumentation in `InpatientDirectIssueNativeSqlService.settle()` isolated the cost to a single line — `em.refresh(bill)`:

| Step | Time |
|---|---|
| Bill persist → native inserts → finance details → bill-totals UPDATE | 257 ms |
| **`em.refresh(bill)`** | **30,120 ms** |
| L2 cache evictions | 0 ms |
| **Total** | **30,377 ms** |

`Bill.stockBill` is `FetchType.EAGER` and `StockBill.bill` is *also* `EAGER` — a **circular EAGER reference**. `em.refresh(bill)` reloads the Bill's entire EAGER graph, and every `Bill` pulled in drags its own EAGER one-to-ones (`pharmacyBill` / `stockBill` / `billFinanceDetails` / `currentRequest`), fanning recursively across the batch's related bill graph. When that graph isn't yet in the EclipseLink L2 cache (first issue of a batch) it takes ~30s; once warm (later issues of the same batch) it's fast — exactly the reported symptom.

## Fix

The refresh existed only to keep the JPA caches consistent with the natively-written `BILLFINANCEDETAILS_ID` FK (issue #20435). Replaced it with the same pattern **every sibling native-settle service already uses** (RetailSale, TransferIssue/Receive, Wholesale, GRN) — none of which had this problem:

- `em.detach(bill)` — the stale null FK is not merged into L2 at commit
- `cache.evict(Bill.class, billId)` — the next read reloads the correct FK from the DB

Same #20435 correctness guarantee, none of the EAGER-graph cost.

## Verification (Playwright, local deployment)

- Settle time: **30,377 ms → 210 ms (~145×)**
- DB linkage correct: `BILLFINANCEDETAILS_ID` + `BillItemFinanceDetails` rows written, totals match
- Bill preview renders correctly; "Bill settled successfully"

Part of umbrella #21876.

Closes #21888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement consistency for inpatient direct issue bills, so updated totals are more reliably reflected after finance reconciliation.
  * Reduced the chance of stale billing information appearing after totals are recalculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->