### PR TITLE
fix(sms): prevent Lab Report SMS timer freeze on transient DB failure (Southern Lanka hotfix)

### DIFF
--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -68,6 +68,24 @@ public class SmsManagerEjb {
     // Processes pending lab report approval SMS messages based on configurable delay strategies
     @Schedule(second = "0", minute = "*/1", hour = "*", persistent = false)
     public void processPendingLabReportApprovalSmsQueue() {
+        // Guard the automatic-timer callback. If a timeout method throws an
+        // exception out to the EJB container (e.g. a transient database
+        // connectivity failure while reading config options or running the
+        // query below), the non-persistent automatic timer can stop firing and
+        // never recover until the server is restarted. That was the root cause
+        // of the recurring "pending Lab Report SMS freeze" on Southern Lanka
+        // production: a brief DB outage killed this timer, and every restart
+        // only masked it. Swallow everything here so the timer always survives
+        // and resumes sending on its own once the underlying issue clears.
+        try {
+            processPendingLabReportApprovalSmsQueueInternal();
+        } catch (Throwable t) {
+            Logger.getLogger(SmsManagerEjb.class.getName()).log(Level.SEVERE,
+                    "processPendingLabReportApprovalSmsQueue failed; timer will retry next minute", t);
+        }
+    }
+
+    private void processPendingLabReportApprovalSmsQueueInternal() {
         if (configOptionApplicationController == null || smsFacade == null) {
             return;
         }


### PR DESCRIPTION
## Problem

Lab Report SMS are sent by an `@Schedule` automatic timer (`SmsManagerEjb.processPendingLabReportApprovalSmsQueue`) that runs every minute and delivers approved-report SMS after a configurable delay (10 min on SLH). Periodically — roughly every 3–4 days — the queue **freezes**: approved reports stay `pending`, no SMS is sent, and only a **server restart** clears it.

The Jun 25 fix (#21687, HTTP connect/read timeouts) removed one freeze mechanism (a socket hanging forever) but not this one.

## Root cause (investigated on SLH production, 2026-07-09)

- Sending stopped at **~15:00**; **52 SMS on fully-paid, eligible bills** sat undelivered for **5+ hours**.
- Trigger: a **transient database connectivity storm** — **1,109** `UndeclaredThrowableException` (broken pool connections) in the 15:00 hour, which also broke normal page renders. The DB **fully recovered by 17:00** (0 errors after).
- **But the timer never recovered** — dead for 5+ hours after the DB was healthy. A live thread dump showed no stuck threads (Jun 25 timeout fix working) and the timer thread alive but idle; a manual SMS send at 15:07 succeeded, proving gateway/DB/app were fine — only the scheduled timer was dead.

The timeout method read config options and ran its JPQL query **outside any `try/catch`**, inside the container transaction. When the DB blip made that throw, the timeout callback threw a **system exception to the EJB container**, and the non-persistent automatic timer stopped firing and did **not self-recover**. "Every 3–4 days" is simply "whenever the next DB blip happens."

## Fix

Wrap the whole timeout callback in `try/catch(Throwable)` (extracted the body into a private worker) so the timer callback never propagates an exception to the container. The timer keeps firing every minute and **resumes sending automatically** once the underlying issue clears. Errors are logged at SEVERE.

Minimal, low-risk change: 18 lines added, no behavioural change on the happy path.

## Testing

- `mvn -o compile` → BUILD SUCCESS.
- Verified against production data that this branch's query already filters `sentSuccessfully = false OR null`, so no duplicate-send risk on redeploy.

## Deployment note

Deploy via CI/CD only. After deploy the timer will resume automatically; no manual restart loop needed going forward.

## Follow-ups (not in this hotfix)

- Move gateway HTTP out of the container transaction; update each SMS status in its own `REQUIRES_NEW` transaction.
- Enable JDBC connection validation on the MySQL pools so the pool auto-recovers from DB blips faster.
