### PR TITLE
fix(sms): prevent Lab Report SMS timer freeze on transient DB failure

### DIFF
--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -75,6 +75,24 @@ public class SmsManagerEjb {
     // Processes pending lab report approval SMS messages based on configurable delay strategies
     @Schedule(second = "0", minute = "*/1", hour = "*", persistent = false)
     public void processPendingLabReportApprovalSmsQueue() {
+        // Guard the automatic-timer callback. If a timeout method throws an
+        // exception out to the EJB container (e.g. a transient database
+        // connectivity failure while reading config options or running the
+        // query below), the non-persistent automatic timer can stop firing and
+        // never recover until the server is restarted. That was the root cause
+        // of the recurring "pending Lab Report SMS freeze" on Southern Lanka
+        // production: a brief DB outage killed this timer, and every restart
+        // only masked it. Swallow everything here so the timer always survives
+        // and resumes sending on its own once the underlying issue clears.
+        try {
+            processPendingLabReportApprovalSmsQueueInternal();
+        } catch (Throwable t) {
+            Logger.getLogger(SmsManagerEjb.class.getName()).log(Level.SEVERE,
+                    "processPendingLabReportApprovalSmsQueue failed; timer will retry next minute", t);
+        }
+    }
+
+    private void processPendingLabReportApprovalSmsQueueInternal() {
         if (configOptionApplicationController == null || smsFacade == null) {
             return;
         }


### PR DESCRIPTION
## Problem

Lab Report SMS are delivered by an `@Schedule` automatic timer (`SmsManagerEjb.processPendingLabReportApprovalSmsQueue`, every minute). Periodically — roughly every 3–4 days on Southern Lanka production — the queue **freezes**: approved reports stay `pending`, no SMS goes out, and only a **server restart** clears it. The Jun 25 fix (#21687, HTTP timeouts) removed one freeze cause but not this one.

## Root cause (investigated on SLH production, 2026-07-09)

- Sending stopped at ~15:00; **52 SMS on fully-paid, eligible bills** sat undelivered 5+ hours.
- Trigger: a **transient DB connectivity storm** — **1,109** `UndeclaredThrowableException` (broken pool connections) in the 15:00 hour, fully recovered by 17:00.
- **The timer never recovered** — dead 5+ hours after the DB was healthy. Thread dump showed no stuck threads and the timer thread idle; a manual SMS at 15:07 succeeded, proving only the scheduled timer was dead.

The timeout method read config options and ran its JPQL query **outside any `try/catch`**, inside the container transaction. When the DB blip made that throw, the timeout callback threw a **system exception to the EJB container**, and the non-persistent automatic timer stopped firing and did not self-recover.

## Fix

Wrap the whole timeout callback in `try/catch(Throwable)` (body extracted into a private worker) so the callback never propagates to the container. The timer keeps firing and resumes sending automatically once the underlying issue clears. Errors logged at SEVERE.

Minimal change; no happy-path behaviour change.

## Related

Same fix shipped as Southern Lanka hotfix #21972 (targeting `southernlanka-prod`). This PR lands it in `development` so it propagates to all deployments.

## Testing

`mvn -o compile` → BUILD SUCCESS.

## Follow-ups (not in this PR)

- Move gateway HTTP out of the container transaction; update each SMS status in its own `REQUIRES_NEW` transaction.
- Enable JDBC connection validation on the MySQL pools for faster pool recovery from DB blips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS queue processing reliability by preventing unexpected errors from stopping the scheduled job.
  * Errors during processing are now logged and safely handled so the task can continue running on future schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->