### PR TITLE
feat(inward): room-facility-category-aware service margin matrix

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -478,6 +478,21 @@ cached per session at login and won't pick up a new row otherwise. This came up 
 `BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
 user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
 
+## 21. Inward "Add Services" item picker — the Filter box does not load other departments' items
+
+On `inward/inward_bill_service.xhtml` (and the surgery equivalent) the item selector shows
+a **department button row** (OPD, ETU, Inward, MRI, …) above an "Investigation or Service"
+list. That list is scoped to the **currently selected department button**, defaulting to the
+first (usually OPD). The "Filter" textbox only narrows the *already-loaded* department's list —
+typing an item name that belongs to another department returns nothing. To bill a service
+that lives in a different department (e.g. `CT SCANNING CHARGES` / `SUTURING & DRESSING
+CHARGES` under **ETU**), first click that department's button to load its items, *then* pick
+from the list. Symptom if you skip this: the filter shows "no match" even though the item
+exists and the DB confirms it. Refs churn after the department-button AJAX, so re-`snapshot`
+before clicking the option, and click the visible listbox row (the hidden native `<option>`
+with the same text is not clickable). Verified while testing room-category service margins
+(issue #21977).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -220,6 +220,33 @@ public class PriceMatrixController implements Serializable {
         return result;
     }
 
+    // =========================================================================
+    // Room-category-aware fetchInwardMargin overloads (issue #21977)
+    //
+    // Thread the patient's current room category through to the room-category-
+    // aware getInwardPriceAdjustment lookup. A null roomCategory restricts the
+    // lookup to wildcard (NULL) rows, so callers with no room context behave
+    // exactly as before. The category cascade (item category then parent
+    // category) and the config-gated payment-method dimension are preserved.
+    // =========================================================================
+
+    public PriceMatrix fetchInwardMargin(BillItem billItem, double serviceValue, Department department,
+            PaymentMethod paymentMethod, Institution creditCompany, AdmissionType admissionType, RoomCategory roomCategory) {
+        return fetchInwardMargin(billItem.getItem(), serviceValue, department, paymentMethod, creditCompany, admissionType, roomCategory);
+    }
+
+    public PriceMatrix fetchInwardMargin(Item item, double serviceValue, Department department,
+            PaymentMethod paymentMethod, Institution creditCompany, AdmissionType admissionType, RoomCategory roomCategory) {
+        boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
+        Category category = resolveInwardMatrixCategory(item);
+        PaymentMethod pm = isPaymentMethodAllowedInInwardMatrix ? paymentMethod : null;
+        PriceMatrix result = getInwardPriceAdjustment(department, serviceValue, category, pm, creditCompany, admissionType, roomCategory);
+        if (result == null && category != null) {
+            result = getInwardPriceAdjustment(department, serviceValue, category.getParentCategory(), pm, creditCompany, admissionType, roomCategory);
+        }
+        return result;
+    }
+
     public double getItemWithInwardMargin(Item item) {
         if (item == null) {
             return 0.0;
@@ -464,6 +491,125 @@ public class PriceMatrixController implements Serializable {
             hm.put("at", admissionType);
         }
         return firstInwardPriceAdjustment(findInwardPriceAdjustments(sql, hm));
+    }
+
+    // =========================================================================
+    // Room-category-aware inward price-adjustment lookup (issue #21977)
+    //
+    // Adds the patient's current room category as an optional matrix dimension,
+    // additive on top of the existing paymentMethod / creditCompany /
+    // admissionType dimensions. Semantics mirror admissionType (issue #21551):
+    //
+    //   - A row created WITH a roomCategory applies only to that room category.
+    //   - A row created WITHOUT a roomCategory (NULL) is a wildcard and applies
+    //     to every room category — this preserves the behaviour of all existing
+    //     matrices, which have no room category set.
+    //   - When both a matching room-category-specific row and a wildcard row
+    //     exist for the same dept/category/price-range (and payment method /
+    //     credit company / admission type), the specific row wins.
+    //   - When roomCategory is null at the call site (patient not in a room yet),
+    //     the lookup restricts to wildcard (NULL) rows only, identical to the
+    //     legacy behaviour.
+    //
+    // Rather than doubling every existing overload, all of them are consolidated
+    // to delegate to one predicate-builder that appends a WHERE fragment per
+    // supplied dimension and orders wildcards last. The tie-break between
+    // admission-type specificity and room-category specificity is controlled by
+    // the config option below so deployments can choose which dimension is the
+    // dominant sort key.
+    // =========================================================================
+
+    private static final String CONFIG_ROOM_CATEGORY_OVER_ADMISSION_TYPE =
+            "Inward Matrix - Room Category takes priority over Admission Type";
+
+    /**
+     * Builds the ORDER BY that ranks the most specific matrix row first and the
+     * full wildcard row last, across the admissionType and roomCategory
+     * dimensions. Each dimension contributes 0 when specific and 1 when wildcard
+     * (NULL). The config flag decides which dimension is the primary sort key;
+     * a row that is specific on both always outranks any partially-specific row,
+     * which in turn outranks the full wildcard.
+     */
+    private String inwardMatrixOrderBy(boolean admissionTypeSupplied, boolean roomCategorySupplied) {
+        if (!admissionTypeSupplied && !roomCategorySupplied) {
+            return "";
+        }
+        String roomRank = roomCategorySupplied
+                ? "case when a.roomCategory is null then 1 else 0 end" : null;
+        String admRank = admissionTypeSupplied
+                ? "case when a.admissionType is null then 1 else 0 end" : null;
+        boolean roomFirst = configOptionApplicationController
+                .getBooleanValueByKey(CONFIG_ROOM_CATEGORY_OVER_ADMISSION_TYPE, false);
+        StringBuilder order = new StringBuilder(" order by ");
+        if (roomRank != null && admRank != null) {
+            order.append(roomFirst ? roomRank + ", " + admRank : admRank + ", " + roomRank);
+        } else {
+            order.append(roomRank != null ? roomRank : admRank);
+        }
+        return order.toString();
+    }
+
+    /**
+     * Appends the "(a.roomCategory = :rc or a.roomCategory is null)" fragment
+     * when a room category is supplied, else restricts to wildcard rows only —
+     * so a caller with no room context never picks up a room-specific row.
+     */
+    private String roomCategoryPredicate(RoomCategory roomCategory) {
+        if (roomCategory == null) {
+            return " and a.roomCategory is null";
+        }
+        return " and (a.roomCategory=:rc or a.roomCategory is null)";
+    }
+
+    /**
+     * Full inward price-adjustment lookup with every optional dimension threaded
+     * through. paymentMethod / creditCompany / admissionType / roomCategory are
+     * each optional (null = not filtered / wildcard-only, per the semantics
+     * documented above). This is the single method all the public overloads
+     * ultimately delegate to.
+     */
+    public InwardPriceAdjustment getInwardPriceAdjustment(Department department, double dbl, Category category,
+            PaymentMethod paymentMethod, Institution creditCompany, AdmissionType admissionType, RoomCategory roomCategory) {
+        StringBuilder sql = new StringBuilder("select a from InwardPriceAdjustment a "
+                + " where a.retired=false"
+                + " and a.category=:cat "
+                + " and a.department=:dep"
+                + " and (a.fromPrice< :frPrice and a.toPrice >:tPrice)");
+        HashMap hm = new HashMap();
+        hm.put("dep", department);
+        hm.put("frPrice", dbl);
+        hm.put("tPrice", dbl);
+        hm.put("cat", category);
+
+        if (paymentMethod == null) {
+            // No payment-method filter: match rows regardless of payment method.
+        } else {
+            sql.append(" and a.paymentMethod=:pm");
+            hm.put("pm", paymentMethod);
+        }
+
+        if (creditCompany == null) {
+            sql.append(" and a.creditCompany is null");
+        } else {
+            sql.append(" and a.creditCompany=:cc");
+            hm.put("cc", creditCompany);
+        }
+
+        if (admissionType == null) {
+            sql.append(" and a.admissionType is null");
+        } else {
+            sql.append(" and (a.admissionType=:at or a.admissionType is null)");
+            hm.put("at", admissionType);
+        }
+
+        sql.append(roomCategoryPredicate(roomCategory));
+        if (roomCategory != null) {
+            hm.put("rc", roomCategory);
+        }
+
+        sql.append(inwardMatrixOrderBy(admissionType != null, roomCategory != null));
+
+        return firstInwardPriceAdjustment(findInwardPriceAdjustments(sql.toString(), hm));
     }
 
     public InwardMemberShipDiscount getInwardMemberDisCount(PaymentMethod paymentMethod, MembershipScheme membershipScheme, Institution ins, InwardChargeType inwardChargeType, AdmissionType admissionType) {

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -42,6 +42,7 @@ import com.divudi.core.entity.Fee;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.ItemFee;
 import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.WebUser;
@@ -544,6 +545,21 @@ public class BillBhtController implements Serializable {
         this.priceMatrixController = priceMatrixController;
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not yet in a room (or the room has no facility charge / category). Used
+     * as the room-category dimension of the inward service-margin matrix lookup
+     * (issue #21977); null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public List<BillItem> saveBillItems(Bill bill, List<BillEntry> billEntries, WebUser webUser, Department matrixDepartment, PaymentMethod paymentMethod) {
         List<BillItem> list = new ArrayList<>();
         for (BillEntry e : billEntries) {
@@ -558,7 +574,7 @@ public class BillBhtController implements Serializable {
             billItem.setSearialNo(list.size());
 
             for (BillFee bf : billItem.getBillFees()) {
-                PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, bf.getFeeUnitGrossValue() != null ? bf.getFeeUnitGrossValue() : bf.getFeeGrossValue(), matrixDepartment, paymentMethod, bill.getPatientEncounter() != null ? bill.getPatientEncounter().getAdmissionType() : null);
+                PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, bf.getFeeUnitGrossValue() != null ? bf.getFeeUnitGrossValue() : bf.getFeeGrossValue(), matrixDepartment, paymentMethod, null, bill.getPatientEncounter() != null ? bill.getPatientEncounter().getAdmissionType() : null, resolveCurrentRoomCategory(bill.getPatientEncounter()));
                 getInwardBean().setBillFeeMargin(bf, bf.getBillItem().getItem(), priceMatrix, bill.getPatientEncounter());
                 getBillFeeFacade().edit(bf);
 
@@ -1021,7 +1037,7 @@ public class BillBhtController implements Serializable {
         for (Fee i : itemFee) {
             BillFee billFee = getBillBean().createBillFee(billItem, i, patientEncounter);
 
-            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, billFee.getFeeGrossValue(), matrixDepartment, paymentMethod, patientEncounter != null ? patientEncounter.getAdmissionType() : null);
+            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, billFee.getFeeGrossValue(), matrixDepartment, paymentMethod, null, patientEncounter != null ? patientEncounter.getAdmissionType() : null, resolveCurrentRoomCategory(patientEncounter));
 
             getInwardBean().setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
 
@@ -1131,7 +1147,7 @@ public class BillBhtController implements Serializable {
                 ? bf.getBillItem().getQty() : 1.0;
         bf.setFeeUnitGrossValue(bf.getFeeGrossValue() / qty);
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod(), getPatientEncounter().getAdmissionType());
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod(), null, getPatientEncounter().getAdmissionType(), resolveCurrentRoomCategory(getPatientEncounter()));
 
         getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), priceMatrix);
 
@@ -1154,7 +1170,7 @@ public class BillBhtController implements Serializable {
         lstBillItems = null;
         getLstBillItems();
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeGrossValue(), getBatchBill().getFromDepartment(), getPatientEncounter().getPaymentMethod(), getPatientEncounter().getAdmissionType());
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeGrossValue(), getBatchBill().getFromDepartment(), getPatientEncounter().getPaymentMethod(), null, getPatientEncounter().getAdmissionType(), resolveCurrentRoomCategory(getPatientEncounter()));
 
         getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getBatchBill().getFromDepartment(), priceMatrix);
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2590,7 +2590,7 @@ public class InwardBeanController implements Serializable {
                 Department dept = item.getDepartment() != null ? item.getDepartment()
                         : (bi.getBill() != null ? bi.getBill().getDepartment() : null);
                 PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(bi, svcValue, dept,
-                        patientEncounter.getPaymentMethod(), cc, patientEncounter.getAdmissionType());
+                        patientEncounter.getPaymentMethod(), cc, patientEncounter.getAdmissionType(), resolveCurrentRoomCategory(patientEncounter));
                 if (ccMatrix != null) {
                     effectivePriceMatrix = ccMatrix;
                 }
@@ -2634,6 +2634,21 @@ public class InwardBeanController implements Serializable {
             return list.get(0).getInstitution();
         }
         return null;
+    }
+
+    /**
+     * Room category of the encounter's current room, or null when the patient is
+     * not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward margin matrix (issue #21977); null
+     * means "wildcard row only", preserving legacy behaviour.
+     */
+    private com.divudi.core.entity.inward.RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
     }
 
     /**
@@ -2688,7 +2703,7 @@ public class InwardBeanController implements Serializable {
             com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(patientEncounter);
             if (creditCompany != null) {
                 PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(billItem, serviceValue, matrixDepartment,
-                        patientEncounter.getPaymentMethod(), creditCompany, patientEncounter.getAdmissionType());
+                        patientEncounter.getPaymentMethod(), creditCompany, patientEncounter.getAdmissionType(), resolveCurrentRoomCategory(patientEncounter));
                 if (ccMatrix != null) {
                     effectivePriceMatrix = ccMatrix;
                 }
@@ -2717,7 +2732,7 @@ public class InwardBeanController implements Serializable {
             com.divudi.core.entity.Institution creditCompany = resolveSingleCreditCompany(patientEncounter);
             if (creditCompany != null) {
                 PriceMatrix ccMatrix = priceMatrixController.fetchInwardMargin(billFee.getBillItem(), serviceValue,
-                        matrixDepartment, patientEncounter.getPaymentMethod(), creditCompany, patientEncounter.getAdmissionType());
+                        matrixDepartment, patientEncounter.getPaymentMethod(), creditCompany, patientEncounter.getAdmissionType(), resolveCurrentRoomCategory(patientEncounter));
                 if (ccMatrix != null) {
                     effectivePriceMatrix = ccMatrix;
                 }

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -73,6 +73,7 @@ public class InwardPriceAdjustmntController implements Serializable {
     private Category roomLocation;
     private Institution creditCompany;
     private AdmissionType admissionType;
+    private Category roomCategory;
 
     private void recreateModel() {
         fromPrice = toPrice + 1;
@@ -80,6 +81,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         margin = 0;
         creditCompany = null;
         admissionType = null;
+        roomCategory = null;
         items = null;
     }
 
@@ -89,6 +91,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         margin = 0;
         creditCompany = null;
         admissionType = null;
+        roomCategory = null;
         items = null;
     }
 
@@ -157,6 +160,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setMargin(margin);
         a.setCreditCompany(creditCompany);
         a.setAdmissionType(admissionType);
+        a.setRoomCategory(roomCategory);
         a.setCreatedAt(new Date());
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
@@ -195,6 +199,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             a.setMargin(margin);
             a.setCreditCompany(creditCompany);
             a.setAdmissionType(admissionType);
+            a.setRoomCategory(roomCategory);
             a.setCreatedAt(new Date());
             a.setCreater(getSessionController().getLoggedUser());
             if (a.getId() == null) {
@@ -488,6 +493,14 @@ public class InwardPriceAdjustmntController implements Serializable {
 
     public void setAdmissionType(AdmissionType admissionType) {
         this.admissionType = admissionType;
+    }
+
+    public Category getRoomCategory() {
+        return roomCategory;
+    }
+
+    public void setRoomCategory(Category roomCategory) {
+        this.roomCategory = roomCategory;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/ServiceFeeEdit.java
+++ b/src/main/java/com/divudi/bean/inward/ServiceFeeEdit.java
@@ -13,7 +13,9 @@ import com.divudi.core.data.FeeType;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PriceMatrix;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -153,9 +155,17 @@ public class ServiceFeeEdit implements Serializable {
 
         getBillFeeFacade().edit(billFee);
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, billFee.getFeeGrossValue(), billItem.getBill().getFromDepartment(),billItem.getBill().getPatientEncounter().getPaymentMethod(), billItem.getBill().getPatientEncounter().getAdmissionType());
+        PatientEncounter encounter = billItem.getBill().getPatientEncounter();
+        // Room category of the patient's current room drives the room-category
+        // dimension of the inward margin matrix (issue #21977); null = wildcard.
+        RoomCategory roomCategory = (encounter != null
+                && encounter.getCurrentPatientRoom() != null
+                && encounter.getCurrentPatientRoom().getRoomFacilityCharge() != null)
+                ? encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory()
+                : null;
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, billFee.getFeeGrossValue(), billItem.getBill().getFromDepartment(), encounter.getPaymentMethod(), null, encounter.getAdmissionType(), roomCategory);
 
-        getInwardBean().updateBillItemMargin(billItem, billFee.getFeeGrossValue(), billItem.getBill().getPatientEncounter(), billItem.getBill().getFromDepartment(), priceMatrix);
+        getInwardBean().updateBillItemMargin(billItem, billFee.getFeeGrossValue(), encounter, billItem.getBill().getFromDepartment(), priceMatrix);
 
         getBillBean().updateBillItemByBillFee(billItem);
         getBillBean().updateBillByBillFee(billItem.getBill());

--- a/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardPriceAdjustmentApi.java
@@ -25,6 +25,7 @@ import com.divudi.core.entity.ServiceSubCategory;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.InwardPriceAdjustment;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.lab.Investigation;
 import com.divudi.core.entity.lab.InvestigationCategory;
 import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
@@ -148,6 +149,7 @@ public class InwardPriceAdjustmentApi {
             Long departmentId    = longParam("departmentId");
             Long categoryId      = longParam("categoryId");
             Long creditCompanyId = longParam("creditCompanyId");
+            Long roomCategoryId  = longParam("roomCategoryId");
             String paymentMethodStr = param("paymentMethod");
             int limit = intParam("limit", 200, 1, 1000);
 
@@ -194,6 +196,10 @@ public class InwardPriceAdjustmentApi {
             if (creditCompanyId != null) {
                 jpql.append(" and a.creditCompany.id = :ccid");
                 params.put("ccid", creditCompanyId);
+            }
+            if (roomCategoryId != null) {
+                jpql.append(" and a.roomCategory.id = :rcid");
+                params.put("rcid", roomCategoryId);
             }
 
             jpql.append(" order by a.department.name, a.category.name, a.fromPrice");
@@ -326,8 +332,21 @@ public class InwardPriceAdjustmentApi {
                 }
             }
 
+            RoomCategory roomCategory = null;
+            Long roomCategoryId = asLong(body.get("roomCategoryId"));
+            if (roomCategoryId != null) {
+                Category rc = categoryFacade.find(roomCategoryId);
+                if (rc == null || rc.isRetired()) {
+                    return errorResponse("Room category not found: " + roomCategoryId, 400);
+                }
+                if (!(rc instanceof RoomCategory)) {
+                    return errorResponse("Category " + roomCategoryId + " is not a RoomCategory", 400);
+                }
+                roomCategory = (RoomCategory) rc;
+            }
+
             InwardPriceAdjustment existing = findDuplicate(
-                    department, category, paymentMethod, fromPrice, toPrice, creditCompany);
+                    department, category, paymentMethod, fromPrice, toPrice, creditCompany, roomCategory);
             if (existing != null) {
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("status", "already_exists");
@@ -346,6 +365,7 @@ public class InwardPriceAdjustmentApi {
             entry.setToPrice(toPrice);
             entry.setMargin(margin);
             entry.setCreditCompany(creditCompany);
+            entry.setRoomCategory(roomCategory);
             if (department != null) {
                 entry.setInstitution(department.getInstitution());
             }
@@ -483,9 +503,26 @@ public class InwardPriceAdjustmentApi {
                 }
             }
 
+            if (body.containsKey("roomCategoryId")) {
+                Long rcId = asLong(body.get("roomCategoryId"));
+                if (rcId == null) {
+                    entry.setRoomCategory(null);
+                } else {
+                    Category rc = categoryFacade.find(rcId);
+                    if (rc == null || rc.isRetired()) {
+                        return errorResponse("Room category not found: " + rcId, 400);
+                    }
+                    if (!(rc instanceof RoomCategory)) {
+                        return errorResponse("Category " + rcId + " is not a RoomCategory", 400);
+                    }
+                    entry.setRoomCategory((RoomCategory) rc);
+                }
+            }
+
             InwardPriceAdjustment dup = findDuplicate(
                     entry.getDepartment(), entry.getCategory(), entry.getPaymentMethod(),
-                    entry.getFromPrice(), entry.getToPrice(), entry.getCreditCompany());
+                    entry.getFromPrice(), entry.getToPrice(), entry.getCreditCompany(),
+                    entry.getRoomCategory());
             if (dup != null && !dup.getId().equals(entry.getId())) {
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("status", "already_exists");
@@ -720,12 +757,52 @@ public class InwardPriceAdjustmentApi {
         }
     }
 
+    /**
+     * Search room categories by name.
+     * GET /api/inward-price-adjustment/room-categories/search?query=&limit=
+     */
+    @GET
+    @Path("/room-categories/search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response searchRoomCategories() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            String query = param("query");
+            int limit = intParam("limit", 30, 1, 200);
+            StringBuilder jpql = new StringBuilder(
+                    "select c from RoomCategory c where c.retired = false");
+            Map<String, Object> params = new HashMap<>();
+            if (query != null && !query.trim().isEmpty()) {
+                jpql.append(" and upper(c.name) like :q");
+                params.put("q", "%" + query.trim().toUpperCase() + "%");
+            }
+            jpql.append(" order by c.name");
+            List<Category> results = categoryFacade.findByJpql(jpql.toString(), params, limit);
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (results != null) {
+                for (Category c : results) {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("id", c.getId());
+                    row.put("name", c.getName());
+                    payload.add(row);
+                }
+            }
+            return successResponse(payload);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
     // =========================================================================
     // Helpers
     // =========================================================================
 
     private InwardPriceAdjustment findDuplicate(Department department, Category category,
-            PaymentMethod paymentMethod, Double fromPrice, Double toPrice, Institution creditCompany) {
+            PaymentMethod paymentMethod, Double fromPrice, Double toPrice, Institution creditCompany,
+            Category roomCategory) {
 
         StringBuilder jpql = new StringBuilder(
                 "select a from InwardPriceAdjustment a where a.retired = false");
@@ -762,6 +839,12 @@ public class InwardPriceAdjustmentApi {
         } else {
             jpql.append(" and a.creditCompany = :cc");
             params.put("cc", creditCompany);
+        }
+        if (roomCategory == null) {
+            jpql.append(" and a.roomCategory is null");
+        } else {
+            jpql.append(" and a.roomCategory = :rc");
+            params.put("rc", roomCategory);
         }
 
         @SuppressWarnings("unchecked")
@@ -829,6 +912,15 @@ public class InwardPriceAdjustmentApi {
             row.put("creditCompany", cc);
         } else {
             row.put("creditCompany", null);
+        }
+
+        if (pm.getRoomCategory() != null) {
+            Map<String, Object> rc = new LinkedHashMap<>();
+            rc.put("id", pm.getRoomCategory().getId());
+            rc.put("name", pm.getRoomCategory().getName());
+            row.put("roomCategory", rc);
+        } else {
+            row.put("roomCategory", null);
         }
 
         row.put("retired", pm.isRetired());
@@ -955,6 +1047,7 @@ public class InwardPriceAdjustmentApi {
             double price = priceParam != null ? priceParam : item.getTotal();
             AdmissionType admissionType = encounter.getAdmissionType();
             Institution creditCompany = resolveSingleCreditCompany(encounter);
+            RoomCategory roomCategory = resolveCurrentRoomCategory(encounter);
 
             // The category actually used by the price-matrix lookup: for an
             // Investigation it is the investigation category (unless the config
@@ -967,8 +1060,9 @@ public class InwardPriceAdjustmentApi {
                 effectiveCategory = item.getCategory();
             }
 
-            // Price-matrix lookup: reuse the exact cascade + config gating used in billing.
-            PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(item, price, department, paymentMethod, creditCompany);
+            // Price-matrix lookup: reuse the exact cascade + config gating used in billing,
+            // including the admission-type and room-category dimensions (issues #21551, #21977).
+            PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(item, price, department, paymentMethod, creditCompany, admissionType, roomCategory);
 
             // Margin is applied to every non-Staff fee on the item: BillBhtController
             // creates a BillFee per item fee and calls setBillFeeMargin, whose
@@ -1039,6 +1133,8 @@ public class InwardPriceAdjustmentApi {
             data.put("patientEncounterId", encounter.getId());
             data.put("admissionTypeId", admissionType != null ? admissionType.getId() : null);
             data.put("creditCompanyId", creditCompany != null ? creditCompany.getId() : null);
+            data.put("roomCategoryId", roomCategory != null ? roomCategory.getId() : null);
+            data.put("roomCategoryName", roomCategory != null ? roomCategory.getName() : null);
             data.put("price", price);
             data.put("marginWillBeApplied", marginWillBeApplied);
             data.put("expectedMarginPercent", matrixFound ? priceMatrix.getMargin() : null);
@@ -1082,6 +1178,21 @@ public class InwardPriceAdjustmentApi {
             return list.get(0).getInstitution();
         }
         return null;
+    }
+
+    /**
+     * Room category of the encounter's current room, or null when the patient is
+     * not in a room (or the room has no facility charge / category) — mirrors
+     * InwardBeanController.resolveCurrentRoomCategory so the diagnostic matches
+     * real billing (issue #21977).
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
     }
 
     /**

--- a/src/main/webapp/inward/inward_price_adjustment_service.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_service.xhtml
@@ -112,6 +112,22 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Room Category" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbRoomCategory"
+                                            value="#{inwardPriceAdjustmntController.roomCategory}">
+                                            <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                            <f:selectItems value="#{roomCategoryController.items}" var="rc"
+                                                           itemValue="#{rc}" itemLabel="#{rc.name}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="From" class="mt-2"></h:outputLabel>
                                     </div>
                                     <div class="col-4">
@@ -278,6 +294,14 @@
                                     <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
+                                <p:column
+                                    headerText="Room Category"
+                                    filterBy="#{empty a.roomCategory ? '' : a.roomCategory.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}">
+                                    <h:outputText value="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}"/>
+                                </p:column>
+
                                 <p:column headerText="Action" width="12%" >
                                     <div class="d-flex">
                                         <p:commandButton
@@ -359,6 +383,13 @@
                                 <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
                                 <f:selectItems value="#{admissionTypeController.items}" var="at"
                                                itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <h:outputLabel value="Room Category"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.roomCategory}" class="w-100">
+                                <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                <f:selectItems value="#{roomCategoryController.items}" var="rc"
+                                               itemValue="#{rc}" itemLabel="#{rc.name}" />
                             </p:selectOneMenu>
                         </h:panelGrid>
 


### PR DESCRIPTION
Closes #21977

## What

Makes the inpatient **service margin** (a.k.a. service charge) in the Inward Price Adjustment matrix depend on the **room facility category** the patient occupies. Wires the already-existing `PriceMatrix.roomCategory` field through the config UI, the REST API, and the billing lookup. **No schema migration** — the column already existed and was simply never used.

Semantics mirror the `admissionType` dimension added in #21551:
- A matrix row **with** a room category applies only to that room category.
- A row **without** one is a **wildcard** applying to all (every existing row).
- When both match the same dept/category/price-range, the **room-category-specific row wins**.
- When the patient is not yet in a room, only wildcard rows apply.
- Pure additive, backward compatible.

## Changes

- **`PriceMatrixController`** — consolidated the inward-margin lookup into one predicate-builder threading `paymentMethod` / `creditCompany` / `admissionType` / `roomCategory`. Existing public overloads are **retained as thin delegates** (no signature removed — CLAUDE.md rule #8); new room-category-aware `fetchInwardMargin` / `getInwardPriceAdjustment` overloads added. Tie-break between admission-type and room-category specificity is config-driven: `"Inward Matrix - Room Category takes priority over Admission Type"` (Boolean, default `false`).
- **`BillBhtController`** (inpatient + surgery settle/add/fee-edit), **`ServiceFeeEdit`**, and **`InwardBeanController`** credit-company overrides now pass `patientEncounter.currentPatientRoom.roomFacilityCharge.roomCategory` (null-safe → wildcard).
- **`InwardPriceAdjustmntController`** + **`inward_price_adjustment_service.xhtml`** — Room Category selector on the add form and edit dialog, a Room Category column in the matrix table, persisted in `saveSelected` and `addForAllCategory`.
- **`InwardPriceAdjustmentApi`** — `roomCategoryId` in list/create/update/getById + duplicate detection, new `GET /room-categories/search` lookup, and threaded into `/diagnose` so the diagnostic matches real billing.
- **Docs** — new Playwright gotcha (§21) for the inward item picker's department-scoped list.

## Verification (local Payara, real settled bills)

Added one room-category-specific row (Inward / ETU / Cash / **A/C** / 25%) via the new UI, alongside the pre-existing wildcard ETU/Cash row (10%). Billed the **same** service (`SUTURING & DRESSING CHARGES E T U`, gross 1900) on two Cash BHTs with the same admission type that differ **only** by room category, and settled each:

| BHT | Room Category | Row applied | Margin % | persisted `feeMargin` |
|---|---|---|---|---|
| BHT/53354 | **A/C** | room-specific | 25% | **475** |
| BHT/53357 | **Non A/C** | wildcard (fallback) | 10% | **190** |

Values read back from the persisted `billfee` rows. The `/api/inward-price-adjustment/diagnose` endpoint reported the same row IDs/margins. Full build (`mvn package`) succeeds; deployed and exercised on local Payara.

![Room Category UI](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/inward_price_adjustment_room_category_ui.png)

Wiki: [Inward Price Adjustment Matrix](https://github.com/hmislk/hmis/wiki/Inward-Price-Adjustment-Matrix) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added room category support to inward price adjustments and margin calculations.
  - Users can now filter, create, edit, and export adjustments by room category.
  - Pricing can prioritize admission type or room category based on configuration.
  - Margin diagnosis now displays the applicable room category.

- **Documentation**
  - Added Playwright testing guidance for selecting services across departments in the “Add Services” picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->