### PR TITLE
feat(inward): show Checked By / Checked At and Pending Check Count in interim bill Service Details

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -157,6 +157,7 @@ public class BhtSummeryController implements Serializable {
     InwardPaymentController inwardPaymentController;
     ////////////////////////
     private List<DepartmentBillItems> departmentBillItems;
+    private Map<Long, BillItem> latestCheckedBillItemsByItem;
     private List<BillFee> profesionallFee;
     private List<BillFee> doctorAndNurseFee;
     private List<BillFee> allDoctorCharges;
@@ -2282,12 +2283,28 @@ public class BhtSummeryController implements Serializable {
         if (getPatientEncounter().getAdmissionType() == null) {
             return "";
         }
-
+        
+        System.out.println("Patient Encounter = " + getPatientEncounter());
+        System.out.println("Admission Type = " + getPatientEncounter().getAdmissionType()); 
+        System.out.println("Admission Type Enum = " + getPatientEncounter().getAdmissionType().getAdmissionTypeEnum());
+        
+        System.out.println("Match = " + (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission));
+        
+        System.out.println("Privilege = " + getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck"));
+        
+        System.out.println("Option = " + configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge"));
+        
+        System.out.println("Starting Bills Checking Process.... ");
         if (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission && !getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck")) {
+            System.out.println("Checking.... ---> ");
             if (checkBill()) {
                 return "";
             }
+        }else{
+            System.out.println("Ignore Checking.... ---> ");
         }
+        
+        System.out.println("End Bills Checking Process.... ");
 
         if (getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
             if (getPatientEncounter().getCreditCompany() == null) {
@@ -2879,6 +2896,7 @@ public class BhtSummeryController implements Serializable {
         patientItems = null;
         paymentBill = null;
         departmentBillItems = null;
+        latestCheckedBillItemsByItem = null;
         printPreview = false;
         current = null;
         tmpPI = null;
@@ -3884,6 +3902,22 @@ public class BhtSummeryController implements Serializable {
 
     public void setDepartmentBillItems(List<DepartmentBillItems> departmentBillItems) {
         this.departmentBillItems = departmentBillItems;
+    }
+
+    /**
+     * Returns the most recently checked inward BillItem for the given service
+     * item of the current patient encounter, or null if none has been checked.
+     * The Service Details tab binds to its {@code bill.checkedBy} /
+     * {@code bill.checkeAt} to show "Checked By" / "Checked At".
+     */
+    public BillItem getLatestCheckedBillItem(Item item) {
+        if (item == null || item.getId() == null) {
+            return null;
+        }
+        if (latestCheckedBillItemsByItem == null) {
+            latestCheckedBillItemsByItem = getInwardBean().getLatestCheckedBillItemsByItem(patientEncounter);
+        }
+        return latestCheckedBillItemsByItem.get(item.getId());
     }
 
     public DepartmentFacade getDepartmentFacade() {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2000,6 +2000,48 @@ public class InwardBeanController implements Serializable {
         return countMap;
     }
 
+    /**
+     * Bulk query returning the most recently checked inward BillItem for each
+     * item of the given patient encounter. Used by the Service Details tab to
+     * display "Checked By" / "Checked At" per aggregated item row without adding
+     * transient fields to the shared Item entity.
+     *
+     * @return map of itemId -> latest checked BillItem
+     */
+    public Map<Long, BillItem> getLatestCheckedBillItemsByItem(PatientEncounter patientEncounter) {
+        Map<Long, BillItem> map = new HashMap<>();
+        if (patientEncounter == null) {
+            return map;
+        }
+
+        HashMap hm = new HashMap();
+        String sql = "SELECT b FROM BillItem b "
+                + " WHERE b.retired=false "
+                + " and b.bill.billType=:btp "
+                + " and b.bill.patientEncounter=:pe "
+                + " and type(b.bill)=:cls "
+                + " and b.bill.checkedBy is not null "
+                + " and b.bill.checkeAt is not null "
+                + " and b.bill.cancelled=false "
+                + " order by b.bill.checkeAt desc ";
+
+        hm.put("btp", BillType.InwardBill);
+        hm.put("pe", patientEncounter);
+        hm.put("cls", BilledBill.class);
+
+        List<BillItem> results = getBillItemFacade().findByJpql(sql, hm, TemporalType.TIMESTAMP);
+        if (results != null) {
+            // Ordered by checkeAt desc, so the first row seen per item is the latest.
+            for (BillItem bi : results) {
+                if (bi.getItem() != null && bi.getItem().getId() != null
+                        && !map.containsKey(bi.getItem().getId())) {
+                    map.put(bi.getItem().getId(), bi);
+                }
+            }
+        }
+        return map;
+    }
+
     public Fee getStaffFeeForInward(WebUser webUser) {
         String sql = "Select f From InwardFee f "
                 + " where f.retired=false "

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -566,7 +566,25 @@
 
                                                 <p:column >
                                                     <f:facet name="header">
+                                                        <h:outputLabel value="Pending Check Count"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column >
+                                                    <f:facet name="header">
                                                         <h:outputLabel value="Inward Charge Type"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column >
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Checked By"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column >
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Checked At"/>
                                                     </f:facet>
                                                 </p:column>
 
@@ -592,9 +610,24 @@
                                             <p:column styleClass="text-end">
                                                 <h:outputLabel value="#{ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}"/>
                                             </p:column>
+                                            <p:column styleClass="text-end">
+                                                <h:outputLabel value="#{ser.transBillItemCount - ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0"/>
+                                                </h:outputLabel>
+                                            </p:column>
                                             <p:column styleClass="text-start">
                                                 <h:outputLabel value="#{ser.inwardChargeType}" rendered="#{ser.transBillItemCount ne 0}"/>
                                             </p:column>
+
+                                            <p:column styleClass="text-start">
+                                                <h:outputLabel value="#{bhtSummeryController.getLatestCheckedBillItem(ser).bill.checkedBy.webUserPerson.name}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                            </p:column>
+                                            <p:column styleClass="text-start">
+                                                <h:outputLabel value="#{bhtSummeryController.getLatestCheckedBillItem(ser).bill.checkeAt}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                </h:outputLabel>
+                                            </p:column>
+
                                             <p:column styleClass="text-start">
                                                 <p:commandButton 
                                                     ajax="false" 


### PR DESCRIPTION
## Summary
Adds **Checked By**, **Checked At**, and **Pending Check Count** to the **Service Details** tab of the Inward Interim Bill page (`inward/inward_bill_intrim.xhtml`).

Closes #21983

## Changes
**Backend**
- `InwardBeanController.getLatestCheckedBillItemsByItem(PatientEncounter)` — bulk query returning a `Map<itemId, BillItem>` of the most recently checked inward `BillItem` per item (checked bills only, ordered by `checkeAt` desc).
- `BhtSummeryController.getLatestCheckedBillItem(Item)` — lazily builds/caches that map and returns the latest checked `BillItem` for a given item; cache reset in `makeNull()` so it rebuilds on patient change.

**Frontend (`inward_bill_intrim.xhtml`, Service Details tab)**
- **Pending Check Count** = `transBillItemCount - transCheckedCount`.
- **Checked By** = `getLatestCheckedBillItem(ser).bill.checkedBy.webUserPerson.name`.
- **Checked At** = `getLatestCheckedBillItem(ser).bill.checkeAt` (long date-time, Asia/Colombo).
- Header column group and subTable body kept in sync at 8 columns.

## Design notes
- Check info (`checkedBy` / `checkeAt`) is sourced from **Bill via BillItem**, **not** by adding transient fields to the shared master `Item` entity.
- Rows aggregate an item across possibly several bills, so **Checked By / Checked At show the most recent checked bill** for that item. Where nothing is checked yet, the cells render blank via EL null-safe navigation.

## Testing
- `mvn -o compile` — BUILD SUCCESS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pending Check Count, Checked By, and Checked At columns to the Service Details table.
  * Displayed the latest checker and check timestamp for each service.
  * Added support for retrieving the most recently checked item details.

* **Bug Fixes**
  * Improved handling of bill-check information during discharge settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->