### PR TITLE
fix(inward): prefill payment details on inward deposit cancellation (#18195)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -318,6 +318,8 @@ public class InwardSearch implements Serializable {
                 
                 paymentMethodData = new PaymentMethodData();
                 
+                refillPaymentDetail();
+                
                 return "inward_deposit_cancel_bill_payment?faces-redirect=true";
             case INWARD_DEPOSIT_REFUND:
                 return "inward_deposit_refund_cancel_bill_payment?faces-redirect=true";
@@ -893,6 +895,7 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("Already Cancelled. Can not cancel again");
             return true;
         }
+        
         if (getBill().isRefunded()) {
             JsfUtil.addErrorMessage("Already Returned. Can not cancel.");
             return true;
@@ -902,6 +905,7 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("You can't cancel Because this Bill has no BHT");
             return true;
         }
+        
         if (getBill().getPatientEncounter().isDischarged()) {
             JsfUtil.addErrorMessage("You can't cancel. Because this BHT is Already Discharged.");
             return true;
@@ -911,6 +915,7 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("Please select a payment Method.");
             return true;
         }
+        
         if (getComment() == null || getComment().trim().equals("")) {
             JsfUtil.addErrorMessage("Please enter a comment");
             return true;


### PR DESCRIPTION
## Summary

Fixes the error page shown after cancelling an **Inward Deposit Bill** paid via **Patient Deposit** on `/inward/inward_deposit_cancel_bill_payment.xhtml`.

When navigating to the deposit payment cancellation page, `refillPaymentDetail()` is now called so the payment method data (including the patient deposit account) is populated from the original bill before the page renders. Previously the payment details were not pre-filled on navigation, so cancelling could fail and render an error page even though the deposit balance had been reduced.

## Changes

- `InwardSearch.navigateToPaymentBillCancellation()` now calls `refillPaymentDetail()` for the `INWARD_DEPOSIT` case after initializing `paymentMethodData`.

## Testing

- Verified against the local `qa_rh` database that inward deposit bills paid via Patient Deposit reach the cancellation page with payment details populated.

Closes #18195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment details are now correctly restored when navigating to bill payment cancellation.
  * Improved consistency of payment information displayed during cancellation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->