### PR TITLE
feat(inward): route inward service bills to Nursing Laboratory Dashboard

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -775,7 +775,12 @@ public class PatientInvestigationController implements Serializable {
         } else {
             listingEntity = ListingEntity.BILLS;
             bills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
-            return "/lab/generate_barcode_p?faces-redirect=true";
+            
+            if ((configOptionApplicationController.getBooleanValueByKey("Use the Nursing Laboratory Dashboard for inward laboratory process.", false)) && bill.getBillTypeAtomic() == BillTypeAtomic.INWARD_SERVICE_BILL) {
+                return "/inward/inward_lab_dashboard?faces-redirect=true";
+            }else{
+                return "/lab/generate_barcode_p?faces-redirect=true";
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Routes inward service bills to the dedicated **Nursing Laboratory Dashboard** (`/inward/inward_lab_dashboard`) from the sample-management navigation, gated behind a new config option.

## Change

In `PatientInvestigationController.navigateToSampleManagementFromOPDBatchBillView`, the non-laboratory-dashboard branch now checks:

- config option **"Use the Nursing Laboratory Dashboard for inward laboratory process."** (default `false`), and
- `bill.getBillTypeAtomic() == BillTypeAtomic.INWARD_SERVICE_BILL`

When both are true, redirects to `/inward/inward_lab_dashboard`; otherwise keeps the existing `/lab/generate_barcode_p` redirect.

## Backward Compatibility

Option defaults to `false`, so existing deployments see no behaviour change.

## Testing

- [ ] Enable the config option, open an inward service bill's sample management → lands on Nursing Laboratory Dashboard.
- [ ] With the option disabled (or a non-inward bill) → lands on the barcode-generation page as before.

Closes #21988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable navigation to the Inward Lab Dashboard after processing eligible inward service bills.

* **Bug Fixes**
  * Preserved the existing barcode generation workflow for all other bill types and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->