### PR TITLE
fix(inward): mark/persist patient foreigner category at admission (#21934)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1713,10 +1713,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         Person person = getPatient().getPerson();
         // DON'T set to null - keep reference throughout
-        
-        if(patientForiegner){
-            getPatient().getPerson().setForeigner(true);
-        }
+
+        // Persist the "Mark as Foreigner" checkbox state onto the patient. This
+        // marks a new (or existing) patient as a foreigner when checked, and
+        // clears the flag when unchecked, keeping the record in sync with the UI.
+        getPatient().getPerson().setForeigner(patientForiegner);
 
         // Save Person first (no flush yet)
         if (person != null) {
@@ -2836,6 +2837,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (current != null) {
             current.setPatient(patient);
             patientAllergies = clinicalFindingValueController.findClinicalFindingValues(patient, ClinicalFindingValueType.PatientAllergy);
+        }
+        // When a patient is searched/selected, reflect their foreigner status on the
+        // "Mark as Foreigner" checkbox so it is ticked automatically for foreigners.
+        if (patient != null && patient.getPerson() != null) {
+            patientForiegner = patient.getPerson().isForeigner();
+        } else {
+            patientForiegner = false;
         }
         selectPaymentSchemeAsPerPatientMembership();
     }

--- a/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/patient_details_for_addmission.xhtml
@@ -78,9 +78,9 @@
                                 id="btnSearchbyPhoneNo"
                                 icon="fa fa-search" 
                                 title="Quick Search from Phone Number"
-                                action="#{patientController.quickSearchPatientLongPhoneNumber(cc.attrs.controller)}" 
+                                action="#{patientController.quickSearchPatientLongPhoneNumber(cc.attrs.controller)}"
                                 process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber"
-                                update="ptImp selectPatient editPatient viewPatient ptAl"
+                                update="ptImp selectPatient editPatient viewPatient ptAl #{cc.attrs.extraUpdateIds}"
                                 styleClass="btn-sm mx-1"/>
                             <p:defaultCommand target="btnSearchbyPhoneNo"> </p:defaultCommand>
                             <p:commandButton 


### PR DESCRIPTION
## Summary

Fixes the Interim Bill (`/inward/inward_bill_intrim.xhtml`) displaying a patient registered as **Foreigner** with the category **Local**.

**Root cause:** the patient's `foreigner` flag was not being reliably set at admission. The "Mark as Foreigner" checkbox on the admission page only ever wrote `true` when checked (never cleared it) and was never populated from an existing patient's stored foreigner status. As a result the persisted patient category did not reflect the intended Foreigner status, so downstream documents such as the Interim Bill showed the patient as Local.

## Changes

- **`AdmissionController.setPatient(...)`** — when a patient is searched/selected during admission, the "Mark as Foreigner" checkbox now reflects that patient's stored foreigner status (ticked automatically for foreigners, cleared otherwise).
- **`AdmissionController.savePatient()`** — on admit, the checkbox state is now persisted onto the patient (marks foreigner when checked, clears when unchecked), keeping the recorded category in sync with the UI. Previously it only set `true` and never cleared.
- **`patient_details_for_addmission.xhtml`** — the phone-number quick-search button now includes the caller-supplied `extraUpdateIds` in its AJAX update so the checkbox (rendered outside the composite) is re-rendered when a single patient is found, matching the datatable-select path.

## Testing

- Register a patient as Foreigner and admit → "Mark as Foreigner" is ticked automatically and the patient remains a Foreigner.
- Add a new patient, tick "Mark as Foreigner", admit → patient is stored as Foreigner.
- Generate/view the Interim Bill → patient category now displays **Foreigner**.

Closes #21934


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Foreign patient status is now saved correctly when the checkbox is selected or cleared.
  * The “Mark as Foreigner” checkbox now reflects the selected patient’s saved status.
  * Quick phone-number searches now refresh additional configured details automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->