### PR TITLE
feat(inward): room-facility-category-aware pharmacy margin matrix

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -493,6 +493,27 @@ before clicking the option, and click the visible listbox row (the hidden native
 with the same text is not clickable). Verified while testing room-category service margins
 (issue #21977).
 
+## 22. Inward pharmacy margin lookup uses the *inpatient* department, not the issuing pharmacy
+
+When testing the inward price-adjustment (service-charge) margin for **pharmacy** issues to an
+inpatient, the matrix department is resolved by `PharmacySaleBhtController.determineMatrixDepartment()`,
+which is gated by config `"Price Matrix is calculated from Inpatient Department for <issuing dept>"`
+(**default true**). When on, the lookup uses the patient's **current room's facility-charge
+department** — for A/C/Non-A/C rooms in the model DB that is **Inward**, *not* the pharmacy you
+are logged into (e.g. Main Pharmacy). Symptom if you create the matrix row against the pharmacy
+department: the margin resolves to 0 / the wrong row even though the row exists. Fix: create the
+`InwardPriceAdjustment` row for the **room facility charge's department**
+(`SELECT rfc.department_id FROM patientencounter pe JOIN patientroom pr ON pe.currentpatientroom_id=pr.id
+JOIN roomfacilitycharge rfc ON pr.roomfacilitycharge_id=rfc.id WHERE pe.id=<enc>`), and set the
+row's payment method to match the encounter's (`patientencounter.paymentMethod`). Also beware
+**pre-existing overlapping rows** for the same dept/category/price-range/payment-method — they make
+the wildcard-vs-specific comparison ambiguous; temporarily `retired=1` them for a clean A/B test,
+then restore. Fastest confirmation without the full multi-page issue flow:
+`GET /api/inward-price-adjustment/diagnose?itemId=&departmentId=&paymentMethod=&patientEncounterId=&price=`
+with a `Finance` API-key header — it runs the identical `fetchInwardMargin(...)` call the pharmacy
+controllers use and returns the matched row id + margin %. Verified while testing room-category
+pharmacy margins (issue #21981).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -18,6 +18,8 @@ import com.divudi.ejb.PharmacyCalculation;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -313,11 +315,28 @@ public class BhtIssueReturnController implements Serializable {
 
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward pharmacy-margin matrix (issue #21981);
+     * null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public void updateMargin(BillItem bi, Department matrixDepartment, PaymentMethod paymentMethod) {
         double rate = Math.abs(bi.getRate());
         double margin = 0;
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+        PatientEncounter encounter = bi.getBill() != null ? bi.getBill().getPatientEncounter() : null;
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
 
         if (priceMatrix != null) {
             margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -27,6 +27,8 @@ import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.pharmacy.Ampp;
@@ -836,11 +838,28 @@ public class IssueReturnController implements Serializable {
         }
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward pharmacy-margin matrix (issue #21981);
+     * null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public void updateMargin(BillItem bi, Department matrixDepartment, PaymentMethod paymentMethod) {
         double rate = Math.abs(bi.getRate());
         double margin = 0;
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+        PatientEncounter encounter = bi.getBill() != null ? bi.getBill().getPatientEncounter() : null;
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
 
         if (priceMatrix != null) {
             margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -35,6 +35,8 @@ import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.CancelledBill;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.PriceMatrix;
@@ -1128,15 +1130,32 @@ public class PharmacyBillSearch implements Serializable {
         this.priceMatrixController = priceMatrixController;
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward pharmacy-margin matrix (issue #21981);
+     * null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public void updateMargin(List<BillItem> billItems, Bill bill, Department matrixDepartment, PaymentMethod paymentMethod) {
         double total = 0;
         double netTotal = 0;
+        PatientEncounter encounter = bill != null ? bill.getPatientEncounter() : null;
         for (BillItem bi : billItems) {
 
             double rate = Math.abs(bi.getRate());
             double margin = 0;
 
-            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                    encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
 
             if (priceMatrix != null) {
                 margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.pharmacy.Amp;
@@ -1184,16 +1185,33 @@ public class PharmacyRequestForBhtController implements Serializable {
 
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward pharmacy-margin matrix (issue #21981);
+     * null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public void updateMargin(List<BillItem> billItems, Bill bill, Department matrixDepartment, PaymentMethod paymentMethod) {
         double total = 0;
         double netTotal = 0;
         double marginTotal = 0;
+        PatientEncounter encounter = bill != null ? bill.getPatientEncounter() : null;
         for (BillItem bi : billItems) {
 
             double rate = Math.abs(bi.getRate());
             double margin = 0;
 
-            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                    encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
 
             if (priceMatrix != null) {
                 margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -43,6 +43,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.PriceMatrix;
@@ -2085,10 +2086,27 @@ public class PharmacySaleBhtController implements Serializable {
         return true;
     }
 
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not in a room (or the room has no facility charge / category). Drives the
+     * room-category dimension of the inward pharmacy-margin matrix (issue #21981);
+     * null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
     public void updateMargin(BillItem bi, Department matrixDepartment, PaymentMethod paymentMethod) {
         double rate = Math.abs(bi.getRate());
         double margin;
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+        PatientEncounter encounter = bi.getBill() != null ? bi.getBill().getPatientEncounter() : null;
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
         if (priceMatrix != null) {
             margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);
             bi.setMarginRate((bi.getRate() * (priceMatrix.getMargin() + 100)) / 100);
@@ -2107,12 +2125,14 @@ public class PharmacySaleBhtController implements Serializable {
         double total = 0;
         double netTotal = 0;
         double marginTotal = 0;
+        PatientEncounter encounter = bill != null ? bill.getPatientEncounter() : null;
         for (BillItem bi : billItems) {
 
             double rate = Math.abs(bi.getRate());
             double margin;
 
-            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod);
+            PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, rate, matrixDepartment, paymentMethod, null,
+                    encounter != null ? encounter.getAdmissionType() : null, resolveCurrentRoomCategory(encounter));
 
             if (priceMatrix != null) {
                 margin = ((bi.getGrossValue() * priceMatrix.getMargin()) / 100);
@@ -2599,7 +2619,10 @@ public class PharmacySaleBhtController implements Serializable {
                     bi,
                     estimatedValueBeforeAddingMarginToCalculateMatrix,
                     matrixDept,
-                    paymentMethod
+                    paymentMethod,
+                    null,
+                    getPatientEncounter() != null ? getPatientEncounter().getAdmissionType() : null,
+                    resolveCurrentRoomCategory(getPatientEncounter())
             );
         }
 
@@ -2645,7 +2668,8 @@ public class PharmacySaleBhtController implements Serializable {
         PriceMatrix priceMatrix = null;
         // Discharge medicines are issued without the inward price matrix (no service charge).
         if (!dischargeIssueMode && bi.getItem() != null) {
-            priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, estimatedValue, matrixDept, paymentMethod);
+            priceMatrix = getPriceMatrixController().fetchInwardMargin(bi, estimatedValue, matrixDept, paymentMethod, null,
+                    getPatientEncounter() != null ? getPatientEncounter().getAdmissionType() : null, resolveCurrentRoomCategory(getPatientEncounter()));
         }
 
         double marginPercentage = priceMatrix != null ? priceMatrix.getMargin() / 100 : 0.0;

--- a/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_pharmacy.xhtml
@@ -121,6 +121,22 @@
 
                                 <div class="row mt-1">
                                     <div class="col-2">
+                                        <h:outputLabel value="Room Category" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbRoomCategory"
+                                            value="#{inwardPriceAdjustmntController.roomCategory}">
+                                            <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                            <f:selectItems value="#{roomCategoryController.items}" var="rc"
+                                                           itemValue="#{rc}" itemLabel="#{rc.name}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
                                         <h:outputLabel value="From" class="mt-2"></h:outputLabel>
                                     </div>
                                     <div class="col-4">
@@ -283,6 +299,14 @@
                                     <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
                                 </p:column>
 
+                                <p:column
+                                    headerText="Room Category"
+                                    filterBy="#{empty a.roomCategory ? '' : a.roomCategory.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}">
+                                    <h:outputText value="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}"/>
+                                </p:column>
+
                                 <p:column headerText="Action" width="11%">
                                     <div class="d-flex">
                                         <p:commandButton
@@ -371,6 +395,13 @@
                                 <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
                                 <f:selectItems value="#{admissionTypeController.items}" var="at"
                                                itemValue="#{at}" itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <h:outputLabel value="Room Category"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.roomCategory}" class="w-100">
+                                <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                <f:selectItems value="#{roomCategoryController.items}" var="rc"
+                                               itemValue="#{rc}" itemLabel="#{rc.name}" />
                             </p:selectOneMenu>
                         </h:panelGrid>
 


### PR DESCRIPTION
## Summary

Closes #21981. Extends the room-facility-category margin dimension (delivered for **services** in #21977 / PR #21979) to the **pharmacy** Inward Price Adjustment matrix, so the pharmacy margin can depend on the room category the patient occupies.

The service side is already merged into `development`. `PriceMatrix.roomCategory`, the room-category-aware `fetchInwardMargin(..., RoomCategory)` overloads on `PriceMatrixController`, the `InwardPriceAdjustmntController.roomCategory` persistence, and the `InwardPriceAdjustmentApi` `roomCategoryId` handling (already scope-agnostic) all exist from #21977. This PR is purely **UI wiring + pharmacy billing call sites** — no schema migration.

## Changes

**UI** — `inward_price_adjustment_pharmacy.xhtml` (mirrors the service page):
- Room Category selector on the add form and edit dialog
- Room Category column in the matrix table

**Pharmacy billing call sites** — now pass the patient's current room category to `fetchInwardMargin` (previously these passed neither credit company, admission type, nor room category). A null-safe `resolveCurrentRoomCategory(PatientEncounter)` helper (same pattern as `BillBhtController` from #21977) reads `currentPatientRoom.roomFacilityCharge.roomCategory`; the encounter comes from the bill item's bill, so **no method signatures change**:
- `PharmacySaleBhtController` — ward BHT issue, theatre surgery issue, inpatient direct issues (4 sites)
- `PharmacyRequestForBhtController`
- `BhtIssueReturnController`
- `IssueReturnController`
- `PharmacyBillSearch`

The **store** controllers named in the issue (`StoreSaleBhtController`, `StoreBhtIssueReturnController`, `StoreIssueReturnController`) were confirmed unused and skipped; the theatre surgery issue page is backed by `PharmacySaleBhtController`, which is covered.

## Semantics (same as #21977, backward compatible)

- Row **with** a room category → applies only to that category.
- Row **without** one → wildcard, applies to all.
- Both match → room-category-specific row wins.
- Patient not in a room → wildcard only (null → legacy behaviour).

## Verification (local Payara, CareCode Model Hospital)

Added an **Inward / Tablet / Cash** matrix pair — an **A/C-specific row (25%)** beside an **all-room-categories wildcard row (10%)** — both persisted with the correct `roomcategory_id` (DB verified):

![Room Category selector on the pharmacy price adjustment page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21981-pharmacy-matrix-room-category-form.png)

![Pharmacy matrix with A/C-specific (25%) and wildcard (10%) rows](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21981-pharmacy-matrix-two-rows.png)

**Billing path proven two ways:**

1. **Live ward BHT issue page** (`PharmacySaleBhtController.calculateRates`) for an **A/C** patient (Ward 105/I) issuing Panadol computed a **Matrix Value of 8.73 on a 34.90 gross = exactly 25%** — the A/C-specific row.

2. **`/api/inward-price-adjustment/diagnose`** (runs the identical `fetchInwardMargin(item, price, dept, paymentMethod, creditCompany, admissionType, roomCategory)` call the pharmacy controllers now use):

   | Patient | Room Category | Matched row | Margin |
   |---|---|---|---|
   | A/C (enc 9596611) | 1382 / A/C | `5958108` | **25.0%** |
   | Non-A/C (enc 9596606) | 1187 / Non A/C | `5958107` (wildcard) | **10.0%** |

The A/C patient gets the room-specific 25% and the Non-A/C patient falls back to the wildcard 10%.

## Docs

[Inward Price Adjustment Matrix wiki](https://github.com/hmislk/hmis/wiki/Inward-Price-Adjustment-Matrix) updated to note the pharmacy page also supports Room Category.

Related: #21977, #21979, #21551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added room category selection when creating and editing inward pharmacy price adjustments.
  * Added room category filtering and display to the price adjustment matrix.
  * Inward pharmacy margins now account for the patient’s admission type and current room category when available.
* **Documentation**
  * Added guidance for configuring room-based margin lookup, resolving incorrect matrix matches, and verifying results through the diagnostic endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->