### PR TITLE
fix(pharmacy): enforce privilege guards across GRN & GRN Return workflow

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -791,6 +791,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyGrnSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnSave, "Pharmacy GRN Save"), ProcumentNode);
         TreeNode pharmacyGrnFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnFinalize, "Pharmacy GRN Finalize"), ProcumentNode);
         TreeNode pharmacyGrnApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnApprove, "Pharmacy GRN Approve"), ProcumentNode);
+        TreeNode pharmacyGrnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnCancel, "Pharmacy GRN Cancel"), ProcumentNode);
+        TreeNode pharmacyGrnReturnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnReturnCancel, "Pharmacy GRN Return Cancel"), ProcumentNode);
         TreeNode pharmacyReturnReceviedGoods = new DefaultTreeNode(new PrivilegeHolder(Privileges.ReturnReceviedGoods, "Pharmacy Return Recevied Goods"), ProcumentNode);
         TreeNode pharmacyCreateGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.CreateGrnReturn, "Create GRN Return"), ProcumentNode);
         TreeNode pharmacyFinalizeGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.FinalizeGrnReturn, "Finalize GRN Return"), ProcumentNode);

--- a/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GoodsReturnController.java
@@ -5,6 +5,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -35,6 +36,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -47,6 +50,8 @@ import javax.inject.Named;
 @Named
 @SessionScoped
 public class GoodsReturnController implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(GoodsReturnController.class.getName());
 
     /**
      * EJBs
@@ -78,6 +83,8 @@ public class GoodsReturnController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     /**
      * Properties
      */
@@ -307,6 +314,9 @@ public class GoodsReturnController implements Serializable {
     }
 
     public void settle() {
+        if (!isAuthorized("SETTLE", "ReturnReceviedGoods")) {
+            return;
+        }
         if (bill == null) {
             JsfUtil.addErrorMessage("Select a Bill");
             return;
@@ -634,6 +644,41 @@ public class GoodsReturnController implements Serializable {
         bill.setBalance(Math.abs(bill.getNetTotal()) - Math.abs(bill.getRefundAmount()));
         bill.setBackwardReferenceBill(getReturnBill());
         billFacade.edit(bill);
+    }
+
+    /**
+     * Authorization helper method to check Goods Return privileges and audit
+     * denied access
+     *
+     * @param action The action being attempted (SETTLE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = null;
+            if (returnBill != null) {
+                billId = returnBill.getId();
+            } else if (bill != null) {
+                billId = bill.getId();
+            }
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Goods Return access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " goods return requests.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -5,6 +5,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
@@ -46,6 +47,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -61,8 +64,12 @@ import org.primefaces.event.RowEditEvent;
 @SessionScoped
 public class GrnController implements Serializable {
 
+    private static final Logger LOGGER = Logger.getLogger(GrnController.class.getName());
+
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     private BilledBill bill;
     @EJB
     private BillNumberGenerator billNumberBean;
@@ -500,6 +507,21 @@ public class GrnController implements Serializable {
     }
 
     public void request() {
+        if (!isAuthorized("REQUEST", "PharmacyGrnSave")) {
+            return;
+        }
+        doRequest();
+    }
+
+    /**
+     * Unguarded core of {@link #request()}. Called directly (bypassing the
+     * PharmacyGrnSave check) by {@link #finalizeBill()} when it needs to
+     * auto-save a not-yet-persisted draft as part of a Finalize action that
+     * has already been authorized under PharmacyGrnFinalize — a user with
+     * only the Finalize privilege must still be able to finalize a brand
+     * new GRN in one step.
+     */
+    private void doRequest() {
 //        if (Math.abs(difference) > 1) {
 //            JsfUtil.addErrorMessage("The invoice does not match..! Check again");
 //            return;
@@ -593,6 +615,9 @@ public class GrnController implements Serializable {
     }
 
     public void requestFinalize() {
+        if (!isAuthorized("REQUEST_FINALIZE", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (Math.abs(difference) > 1) {
             JsfUtil.addErrorMessage("The invoice does not match..! Check again");
             return;
@@ -692,6 +717,9 @@ public class GrnController implements Serializable {
     }
 
     public void settle() {
+        if (!isAuthorized("SETTLE", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (Math.abs(difference) > 1) {
             JsfUtil.addErrorMessage("The invoice does not match..! Check again");
             return;
@@ -849,6 +877,9 @@ public class GrnController implements Serializable {
 
 
     public void settleWholesale() {
+        if (!isAuthorized("SETTLE_WHOLESALE", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (insTotal == 0 && difference != 0) {
             JsfUtil.addErrorMessage("Fill the invoice Total");
             return;
@@ -1039,7 +1070,7 @@ public class GrnController implements Serializable {
             return;
         }
         if (currentGrnBillPre.getId() == null) {
-            request();
+            doRequest();
         }
         getCurrentGrnBillPre().setEditedAt(new Date());
         getCurrentGrnBillPre().setEditor(sessionController.getLoggedUser());
@@ -1965,9 +1996,23 @@ public class GrnController implements Serializable {
     }
     
     public void requestWithSaveApprove() {
+        if (!isAuthorized("REQUEST_WITH_SAVE_APPROVE", "PharmacyGrnSave")) {
+            return;
+        }
+        doRequestWithSaveApprove();
+    }
+
+    /**
+     * Unguarded core of {@link #requestWithSaveApprove()}. Called directly
+     * (bypassing the PharmacyGrnSave check) by
+     * {@link #approveGrnWithSaveApprove()} when it needs to auto-save a
+     * not-yet-persisted draft as part of an Approve action that has already
+     * been authorized under PharmacyGrnApprove.
+     */
+    private void doRequestWithSaveApprove() {
         // Simple save method for save/approve workflow
         // Allow saving with incomplete data - no validation required
-        
+
         // Set basic bill information
         getCurrentGrnBillPre().setBillDate(new Date());
         getCurrentGrnBillPre().setBillTime(new Date());
@@ -2058,6 +2103,9 @@ public class GrnController implements Serializable {
     }
 
     public void approveGrnWithSaveApprove() {
+        if (!isAuthorized("APPROVE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnApprove")) {
+            return;
+        }
         // Always use bill's invoice number, ignore controller reference
         if (getCurrentGrnBillPre().getInvoiceNumber() == null || getCurrentGrnBillPre().getInvoiceNumber().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please fill invoice number");
@@ -2089,7 +2137,7 @@ public class GrnController implements Serializable {
 
         // First ensure the bill is saved
         if (getCurrentGrnBillPre().getId() == null) {
-            requestWithSaveApprove(); // Save first if not already saved
+            doRequestWithSaveApprove(); // Save first if not already saved
         }
 
         // Process bill items for finalization with full stock management
@@ -2186,6 +2234,43 @@ public class GrnController implements Serializable {
         double profitMargin = getProfitMargin(bi);
         double threshold = 20.0; // Example threshold
         return profitMargin > threshold;
+    }
+
+    /**
+     * Authorization helper method to check GRN privileges and audit denied
+     * access
+     *
+     * @param action The action being attempted (SAVE, FINALIZE, APPROVE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = null;
+            if (grnBill != null) {
+                billId = grnBill.getId();
+            } else if (currentGrnBillPre != null) {
+                billId = currentGrnBillPre.getId();
+            } else if (approveBill != null) {
+                billId = approveBill.getId();
+            }
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " GRN.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -763,7 +763,7 @@ public class GrnCostingController implements Serializable {
     }
 
     private void saveGrnBill() {
-        saveBill();
+        doSaveBill();
     }
 
     private void distributeValuesToItems() {
@@ -1116,6 +1116,17 @@ public class GrnCostingController implements Serializable {
         if (!isAuthorized("SAVE_BILL", "PharmacyGrnSave")) {
             return;
         }
+        doSaveBill();
+    }
+
+    /**
+     * Unguarded core of {@link #saveBill()}. Called directly (bypassing the
+     * PharmacyGrnSave check) by {@link #saveGrnBill()}, which is invoked from
+     * {@link #settle()} — a single-step create+finalize action already
+     * authorized under PharmacyGrnFinalize. A user with only the Finalize
+     * privilege must still be able to settle a brand new GRN in one step.
+     */
+    private void doSaveBill() {
         getGrnBill().setBillDate(new Date());
         getGrnBill().setBillTime(new Date());
 //        getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -5,6 +5,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
@@ -51,6 +52,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -79,8 +82,12 @@ public class GrnCostingController implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final int PRICE_SCALE = 6;
 
+    private static final Logger LOGGER = Logger.getLogger(GrnCostingController.class.getName());
+
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     private BilledBill bill;
     @EJB
     private BillNumberGenerator billNumberBean;
@@ -476,6 +483,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void requestFinalize() {
+        if (!isAuthorized("REQUEST_FINALIZE", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (Math.abs(difference) > 1) {
             JsfUtil.addErrorMessage("The invoice does not match..! Check again");
             return;
@@ -546,6 +556,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void settle() {
+        if (!isAuthorized("SETTLE", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (!validateInputs()) {
             return;
         }
@@ -1041,6 +1054,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void finalizeBill() {
+        if (!isAuthorized("FINALIZE_BILL", "PharmacyGrnFinalize")) {
+            return;
+        }
         if (currentGrnBillPre == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;
@@ -1058,6 +1074,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void saveGrnPreBill() {
+        if (!isAuthorized("SAVE_GRN_PRE_BILL", "PharmacyGrnSave")) {
+            return;
+        }
         getCurrentGrnBillPre().setBillDate(new Date());
         getCurrentGrnBillPre().setBillTime(new Date());
         getCurrentGrnBillPre().setPaymentMethod(getApproveBill().getPaymentMethod());
@@ -1094,6 +1113,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void saveBill() {
+        if (!isAuthorized("SAVE_BILL", "PharmacyGrnSave")) {
+            return;
+        }
         getGrnBill().setBillDate(new Date());
         getGrnBill().setBillTime(new Date());
 //        getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
@@ -1124,6 +1146,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void saveWholesaleBill() {
+        if (!isAuthorized("SAVE_WHOLESALE_BILL", "PharmacyGrnSave")) {
+            return;
+        }
         getGrnBill().setBillDate(new Date());
         getGrnBill().setBillTime(new Date());
         getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
@@ -2822,6 +2847,21 @@ public class GrnCostingController implements Serializable {
     }
 
     public void requestWithSaveApprove() {
+        if (!isAuthorized("REQUEST_WITH_SAVE_APPROVE", "PharmacyGrnSave")) {
+            return;
+        }
+        doRequestWithSaveApprove();
+    }
+
+    /**
+     * Unguarded core of {@link #requestWithSaveApprove()}. Called directly
+     * (bypassing the PharmacyGrnSave check) by
+     * {@link #finalizeGrnWithSaveApprove()} and
+     * {@link #approveGrnWithSaveApprove()}, which auto-save a not-yet-
+     * persisted draft as part of a Finalize/Approve action that has already
+     * been authorized under its own privilege.
+     */
+    private void doRequestWithSaveApprove() {
         // Simple save method for costing save/approve workflow
         // Allow saving with incomplete data - no validation required
 
@@ -2919,6 +2959,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void finalizeGrnWithSaveApprove() {
+        if (!isAuthorized("FINALIZE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnFinalize")) {
+            return;
+        }
         // Apply same validations as authorize button
         if (getCurrentGrnBillPre().getInvoiceNumber() == null || getCurrentGrnBillPre().getInvoiceNumber().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please fill invoice number");
@@ -2961,7 +3004,7 @@ public class GrnCostingController implements Serializable {
         }
 
         // First perform the save operation
-        requestWithSaveApprove();
+        doRequestWithSaveApprove();
 
         // Mark the bill as completed
         getCurrentGrnBillPre().setCompleted(true);
@@ -3091,6 +3134,9 @@ public class GrnCostingController implements Serializable {
     }
 
     public void approveGrnWithSaveApprove() {
+        if (!isAuthorized("APPROVE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnApprove")) {
+            return;
+        }
         // Always use bill's invoice number, ignore controller reference
         if (getCurrentGrnBillPre().getInvoiceNumber() == null || getCurrentGrnBillPre().getInvoiceNumber().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please fill invoice number");
@@ -3117,7 +3163,7 @@ public class GrnCostingController implements Serializable {
 
         // First ensure the bill is saved
         if (getCurrentGrnBillPre().getId() == null) {
-            requestWithSaveApprove(); // Save first if not already saved
+            doRequestWithSaveApprove(); // Save first if not already saved
         }
 
         // Ensure bill discount distribution and calculate totals BEFORE processing items
@@ -4453,6 +4499,41 @@ public class GrnCostingController implements Serializable {
     
     public String convertToWord(Double d) {
         return d == null ? "" : CommonFunctions.convertToWord(d);
+    }
+
+    /**
+     * Authorization helper method to check GRN Costing privileges and audit
+     * denied access
+     *
+     * @param action The action being attempted (SAVE, FINALIZE, APPROVE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = null;
+            if (currentGrnBillPre != null) {
+                billId = currentGrnBillPre.getId();
+            } else if (approveBill != null) {
+                billId = approveBill.getId();
+            }
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN Costing access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " GRN.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnApprovalController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnApprovalController.java
@@ -10,6 +10,7 @@ import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -18,6 +19,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -30,6 +33,8 @@ import javax.inject.Named;
 @SessionScoped
 public class GrnReturnApprovalController implements Serializable {
 
+    private static final Logger LOGGER = Logger.getLogger(GrnReturnApprovalController.class.getName());
+
     @EJB
     private BillFacade billFacade;
     @EJB
@@ -41,6 +46,8 @@ public class GrnReturnApprovalController implements Serializable {
 
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
 
     private Bill grnBill;
     private Bill pendingReturn;
@@ -98,6 +105,9 @@ public class GrnReturnApprovalController implements Serializable {
     }
 
     public void approveReturn(Bill b) {
+        if (!isAuthorized("APPROVE_RETURN", "ApproveGrnReturn")) {
+            return;
+        }
         if (b == null) {
             return;
         }
@@ -137,6 +147,41 @@ public class GrnReturnApprovalController implements Serializable {
 
     public void setPendingReturn(Bill pendingReturn) {
         this.pendingReturn = pendingReturn;
+    }
+
+    /**
+     * Authorization helper method to check GRN Return approval privileges
+     * and audit denied access
+     *
+     * @param action The action being attempted (APPROVE_RETURN)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = null;
+            if (pendingReturn != null) {
+                billId = pendingReturn.getId();
+            } else if (grnBill != null) {
+                billId = grnBill.getId();
+            }
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN Return approval access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " GRN return requests.");
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -5,6 +5,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.BillClassType;
@@ -49,6 +50,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -61,6 +64,8 @@ import javax.inject.Named;
 @Named
 @SessionScoped
 public class GrnReturnWithCostingController implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(GrnReturnWithCostingController.class.getName());
 
     /**
      * EJBs
@@ -95,6 +100,8 @@ public class GrnReturnWithCostingController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
     /**
@@ -1149,6 +1156,9 @@ public class GrnReturnWithCostingController implements Serializable {
     }
 
     public void settleGrnReturn() {
+        if (!isAuthorized("SETTLE_GRN_RETURN", "ReturnReceviedGoods")) {
+            return;
+        }
         if (returnBill == null) {
             JsfUtil.addErrorMessage("No GRN Return bill");
             return;
@@ -1728,6 +1738,41 @@ public class GrnReturnWithCostingController implements Serializable {
 
     public void setPaymentFacade(PaymentFacade paymentFacade) {
         this.paymentFacade = paymentFacade;
+    }
+
+    /**
+     * Authorization helper method to check GRN Return (costing) privileges
+     * and audit denied access
+     *
+     * @param action The action being attempted (SETTLE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = null;
+            if (returnBill != null) {
+                billId = returnBill.getId();
+            } else if (bill != null) {
+                billId = bill.getId();
+            }
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN Return access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " GRN return requests.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -78,6 +78,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -99,6 +101,8 @@ import java.util.stream.Collectors;
 @Named
 @SessionScoped
 public class PharmacyBillSearch implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(PharmacyBillSearch.class.getName());
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
@@ -3474,6 +3478,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public void pharmacyGrnCancel() {
+        if (!isAuthorized("PHARMACY_GRN_CANCEL", "PharmacyGrnCancel")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (pharmacyErrorCheck()) {
                 return;
@@ -3779,6 +3786,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public void pharmacyGrnReturnCancel() {
+        if (!isAuthorized("PHARMACY_GRN_RETURN_CANCEL", "PharmacyGrnReturnCancel")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (pharmacyErrorCheck()) {
                 return;
@@ -5753,6 +5763,37 @@ public class PharmacyBillSearch implements Serializable {
         if (issueSearchDtos == null) {
             issueSearchDtos = new ArrayList<>();
         }
+    }
+
+    /**
+     * Authorization helper method to check GRN cancellation privileges and
+     * audit denied access
+     *
+     * @param action The action being attempted (PHARMACY_GRN_CANCEL,
+     * PHARMACY_GRN_RETURN_CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
+                    action);
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = bill != null ? bill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase().replace('_', ' ') + ".");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -654,6 +654,8 @@ public enum Privileges {
     PharmacyGrnSave("Pharmacy GRN Save"),
     PharmacyGrnFinalize("Pharmacy GRN Finalize"),
     PharmacyGrnApprove("Pharmacy GRN Approve"),
+    PharmacyGrnCancel("Pharmacy GRN Cancel"),
+    PharmacyGrnReturnCancel("Pharmacy GRN Return Cancel"),
     PharmacyItemSearch("Pharmacy Item Search"),
     PharmacyGenarateReports("Pharmacy Generate Reports"),
     PharmacySummaryViews("Pharmacy Summary Views"),
@@ -1043,6 +1045,8 @@ public enum Privileges {
             case PharmacyGrnSave:
             case PharmacyGrnFinalize:
             case PharmacyGrnApprove:
+            case PharmacyGrnCancel:
+            case PharmacyGrnReturnCancel:
             case PrintOriginalPoBillFromReprint:
             case PrintOriginalGrnBillFromReprint:
             case PharmacyItemNameEdit:

--- a/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
+++ b/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
@@ -10,6 +10,12 @@
     <ui:define name="content">
         <h:form>
 
+            <h:panelGroup rendered="#{!webUserController.hasPrivilege('ReturnReceviedGoods')}" >
+                You are NOT authorized
+            </h:panelGroup>
+
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ReturnReceviedGoods')}" >
+
             <h:panelGroup rendered="#{!grnReturnWithCostingController.printPreview}" styleClass="alignTop" >
 
                 <p:panel 
@@ -170,12 +176,13 @@
                                 >
                                 <f:facet name="header" >
                                     <h:outputText value="Return Details" ></h:outputText>
-                                    <p:commandButton  
+                                    <p:commandButton
                                         value="Return"
                                         action="#{grnReturnWithCostingController.settleGrnReturn}"
-                                        ajax="false"  
+                                        ajax="false"
                                         style="float: right;"
                                         class="ui-button-warning"
+                                        disabled="#{not webUserController.hasPrivilege('ReturnReceviedGoods')}"
                                         >
                                     </p:commandButton>
                                 </f:facet>
@@ -277,6 +284,8 @@
                     <ph:grn_return_receipt_with_costing bill="#{grnReturnWithCostingController.returnBill}"/>
                 </p:panel>
             </p:panel>
+
+            </h:panelGroup>
 
         </h:form>
     </ui:define>

--- a/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
+++ b/src/main/webapp/pharmacy/grn_return_with_costing.xhtml
@@ -177,12 +177,14 @@
                                 <f:facet name="header" >
                                     <h:outputText value="Return Details" ></h:outputText>
                                     <p:commandButton
+                                        id="btnGrnReturnWithCostingSettle"
                                         value="Return"
                                         action="#{grnReturnWithCostingController.settleGrnReturn}"
                                         ajax="false"
                                         style="float: right;"
                                         class="ui-button-warning"
                                         disabled="#{not webUserController.hasPrivilege('ReturnReceviedGoods')}"
+                                        onclick="return confirm('Are you sure you want to settle this GRN return? This action cannot be undone.');"
                                         >
                                     </p:commandButton>
                                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_cancel_grn.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_grn.xhtml
@@ -11,6 +11,12 @@
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
 
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyGrnCancel')}" >
+                    You are NOT authorized
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyGrnCancel')}" >
+
                 <h:panelGroup rendered="#{not configOptionApplicationController.getBooleanValueByKey('GRN Cancellations are allowed',true)}">
                     <h1>Configuration Settings has disabled GRN Cancellations. Please change the option <span>GRN Cancellations are allowed</span>  </h1>
                 </h:panelGroup>
@@ -25,13 +31,14 @@
 
                                         <div class="d-flex gap-2">
                                             <p:inputText value="#{pharmacyBillSearch.bill.comments}" style="width: 50em;" placeholder="Enter Comments to Cancel Bill"/>
-                                            <p:commandButton 
-                                                value="Cancel" 
+                                            <p:commandButton
+                                                value="Cancel"
                                                 ajax="false"
                                                 icon="fa fa-cancel"
-                                                class="ui-button-danger" 
+                                                class="ui-button-danger"
+                                                disabled="#{not webUserController.hasPrivilege('PharmacyGrnCancel')}"
                                                 action="#{pharmacyBillSearch.pharmacyGrnCancel()}" >
-                                            </p:commandButton> 
+                                            </p:commandButton>
                                         </div>
                                     </div>
                                 </f:facet>
@@ -184,7 +191,9 @@
                             </h:panelGroup>
 
                         </p:panel>
-                    </h:form>   
+                    </h:form>
+
+                </h:panelGroup>
 
                 </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_cancel_grn_bill.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_grn_bill.xhtml
@@ -10,6 +10,13 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyGrnCancel')}" >
+                    You are NOT authorized
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyGrnCancel')}" >
+
                 <h:form>
 <!--                    <h:panelGroup rendered="#{!pharmacyBillSearch.printPreview}" styleClass="alignTop" >
                         <p:panel  header="Cancellation">
@@ -176,7 +183,10 @@
                         </h:panelGroup>
                         
                     </p:panel>
-                </h:form>                
+                </h:form>
+
+                </h:panelGroup>
+
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/pharmacy/pharmacy_cancel_grn_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_grn_return.xhtml
@@ -10,14 +10,22 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyGrnReturnCancel')}" >
+                    You are NOT authorized
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyGrnReturnCancel')}" >
+
                 <h:form>
                     <h:panelGroup rendered="#{!pharmacyBillSearch.printPreview}" styleClass="alignTop" >
                         <p:panel  header="Cancellation">
                             <p:selectOneMenu   id="cmbPs" value="#{pharmacyBillSearch.bill.paymentMethod}" required="true"  >
                                 <f:selectItems value="#{enumController.paymentMethods}"/>
                             </p:selectOneMenu>
-                            <h:commandButton value="Cancel" action="#{pharmacyBillSearch.pharmacyGrnReturnCancel()}" >
-                            </h:commandButton>                            
+                            <h:commandButton value="Cancel" action="#{pharmacyBillSearch.pharmacyGrnReturnCancel()}"
+                                             disabled="#{not webUserController.hasPrivilege('PharmacyGrnReturnCancel')}" >
+                            </h:commandButton>
                         </p:panel>
                         <p:panelGrid columns="2" style="width: 100%;">
                             <p:panel header="Supplier Detail">
@@ -78,7 +86,10 @@
                     </h:panelGroup>
 
 
-                </h:form>                
+                </h:form>
+
+                </h:panelGroup>
+
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/pharmacy/pharmacy_grn.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn.xhtml
@@ -30,6 +30,7 @@
                         class="ui-button-success"
                         icon="fas fa-check"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnFinalize')}"
                         style="float: right;">
                     </p:commandButton>
                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing.xhtml
@@ -33,6 +33,7 @@
                             class="ui-button-success"
                             icon="fas fa-check"
                             ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyGrnFinalize')}"
                             style="float: right;">
                         </p:commandButton>
                     </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
@@ -468,7 +468,8 @@
                                         class="ui-button-success mx-1"
                                         icon="pi pi-save"
                                         ajax="false"
-                                        rendered="#{!grnCostingController.currentGrnBillPre.completed and webUserController.hasPrivilege('PharmacyGrnSave')}">
+                                        rendered="#{!grnCostingController.currentGrnBillPre.completed}"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnSave')}">
                                     </p:commandButton>
                                     <p:commandButton
                                         value="Finalize"
@@ -477,7 +478,8 @@
                                         icon="fas fa-flag"
                                         ajax="false"
                                         onclick="return confirm('Are you sure you want to finalize this GRN? This action cannot be undone.');"
-                                        rendered="#{!grnCostingController.currentGrnBillPre.completed and webUserController.hasPrivilege('PharmacyGrnFinalize')}">
+                                        rendered="#{!grnCostingController.currentGrnBillPre.completed}"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnFinalize')}">
                                     </p:commandButton>
                                     <p:commandButton
                                         value="Approve"
@@ -486,7 +488,8 @@
                                         icon="fas fa-check"
                                         ajax="false"
                                         onclick="return confirm('Are you sure you want to approve this GRN? This action cannot be undone.');"
-                                        rendered="#{grnCostingController.currentGrnBillPre.completed and webUserController.hasPrivilege('PharmacyGrnApprove')}">
+                                        rendered="#{grnCostingController.currentGrnBillPre.completed}"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnApprove')}">
                                     </p:commandButton>
                                 </f:facet>
 

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_approval.xhtml
@@ -6,18 +6,18 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
     <ui:define name="content">
-        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Returns is only after Approval')}">
-            <h:panelGroup rendered="#{!webUserController.hasPrivilege('ApproveGrnReturn')}">
-                <p:panel header="Access Denied" styleClass="ui-panel-danger">
-                    <p:messages id="msgs" showDetail="true" closable="true" />
-                    <div style="text-align: center; padding: 20px;">
-                        <i class="fas fa-exclamation-triangle" style="font-size: 24px; color: #d9534f; margin-bottom: 10px;"></i>
-                        <h:outputText value="Not Authorized" style="display: block; font-size: 18px; color: #d9534f; font-weight: bold;" />
-                        <h:outputText value="You do not have permission to approve GRN returns." style="display: block; margin-top: 5px; color: #666;" />
-                    </div>
-                </p:panel>
-            </h:panelGroup>
-            <h:panelGroup rendered="#{webUserController.hasPrivilege('ApproveGrnReturn')}">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('ApproveGrnReturn')}">
+            <p:panel header="Access Denied" styleClass="ui-panel-danger">
+                <p:messages id="msgs" showDetail="true" closable="true" />
+                <div style="text-align: center; padding: 20px;">
+                    <i class="fas fa-exclamation-triangle" style="font-size: 24px; color: #d9534f; margin-bottom: 10px;"></i>
+                    <h:outputText value="Not Authorized" style="display: block; font-size: 18px; color: #d9534f; font-weight: bold;" />
+                    <h:outputText value="You do not have permission to approve GRN returns." style="display: block; margin-top: 5px; color: #666;" />
+                </div>
+            </p:panel>
+        </h:panelGroup>
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('ApproveGrnReturn')}">
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN Returns is only after Approval')}">
                 <h:form>
                     <p:panel header="Pending GRN Return Approvals">
                         <p:dataTable value="#{grnReturnApprovalController.pendingReturns}" var="r">

--- a/src/main/webapp/pharmacy/pharmacy_grn_wh.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_wh.xhtml
@@ -20,6 +20,7 @@
                         class="ui-button-success"
                         icon="fas fa-check"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnFinalize')}"
                         style="float: right;">
                     </p:commandButton>
                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_grn_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_with_approval.xhtml
@@ -28,6 +28,7 @@
                         class="ui-button-warning mx-1"
                         icon="fas fa-check"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnFinalize')}"
                         style="float: right;">
                     </p:commandButton>
                     <p:commandButton
@@ -36,6 +37,7 @@
                         class="ui-button-success"
                         icon="fas fa-floppy-disk"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnSave')}"
                         style="float: right;">
                     </p:commandButton>
 

--- a/src/main/webapp/pharmacy/pharmacy_grn_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_with_save_approve.xhtml
@@ -30,6 +30,7 @@
                         class="ui-button-success"
                         icon="fas fa-check"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnApprove')}"
                         style="float: right; margin-right: 0.5em;">
                     </p:commandButton>
                     <p:commandButton
@@ -38,6 +39,7 @@
                         class="ui-button-info"
                         icon="pi pi-save"
                         ajax="false"
+                        disabled="#{not webUserController.hasPrivilege('PharmacyGrnSave')}"
                         style="float: right; margin-right: 0.5em;">
                     </p:commandButton>
                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
@@ -11,6 +11,13 @@
     <ui:define name="content">
         <h:form>
             <h:outputStylesheet library="css" name="pharmacyA4.css"/>
+
+            <h:panelGroup rendered="#{!webUserController.hasPrivilege('ReturnReceviedGoods')}" >
+                You are NOT authorized
+            </h:panelGroup>
+
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('ReturnReceviedGoods')}" >
+
             <h:panelGroup rendered="#{!goodsReturnController.printPreview}" >
                 <p:panel header="Return Received Goods" class="w-100 m-1">
                     <div class="row" >
@@ -189,6 +196,7 @@
                                 ajax="false"
                                 icon="fa fa-cancel"
                                 style="float: right;"
+                                disabled="#{not webUserController.hasPrivilege('ReturnReceviedGoods')}"
                                 class="ui-button-danger m-1">
                             </p:commandButton>
                         </div>
@@ -217,6 +225,8 @@
 
                 </p:panel>
             </p:panel>
+
+            </h:panelGroup>
 
         </h:form>
     </ui:define>

--- a/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_good.xhtml
@@ -191,12 +191,14 @@
                                 </h:selectOneMenu>
                             </h:panelGrid>
                             <p:commandButton
+                                id="btnGoodsReturnSettle"
                                 value="Return"
                                 action="#{goodsReturnController.settle}"
                                 ajax="false"
                                 icon="fa fa-cancel"
                                 style="float: right;"
                                 disabled="#{not webUserController.hasPrivilege('ReturnReceviedGoods')}"
+                                onclick="return confirm('Are you sure you want to settle this return? This action cannot be undone.');"
                                 class="ui-button-danger m-1">
                             </p:commandButton>
                         </div>


### PR DESCRIPTION
## Summary
- Adds server-side `isAuthorized()` privilege checks (modeled on `GrnReturnWorkflowController`'s existing pattern) to every mutating GRN/GRN-Return controller method — previously enforcement was almost entirely client-side `rendered`/`disabled` on menu/list links only, not on the destination pages or their actions.
- Converts privilege-gated action buttons from `rendered` to `disabled` per project convention (buttons stay visible so users/admins can see the feature exists rather than wondering why it's missing).
- Adds page-level "not authorized" guards to previously-unguarded pages (`pharmacy_cancel_grn.xhtml`, `pharmacy_cancel_grn_bill.xhtml`, `pharmacy_cancel_grn_return.xhtml`, the legacy GRN-return pages).
- Fixes the legacy GRN-return-approval page's guard being nested inside a config-flag `rendered`, which made the "not authorized" message disappear entirely when that config was off.
- Adds two new privileges: `PharmacyGrnCancel`, `PharmacyGrnReturnCancel` — Cancel GRN / Cancel GRN Return had **no privilege at all** before this change.
- Fixes a real bug found while adding the guards: `GrnController`/`GrnCostingController`'s Finalize/Approve-guarded methods internally call a Save-guarded method to auto-persist a not-yet-saved draft in one step. Naively guarding the inner method would have silently broken "finalize/approve a brand-new GRN in one click" for a user who holds Finalize/Approve but not Save. Fixed by splitting each inner method into a guarded public wrapper + an unguarded private core that the already-authorized outer action calls directly.

## Test plan
- [x] `mvn clean package -DskipTests` — builds clean
- [x] Deployed to local Payara, logged in as `buddhika` in department "Matara - Pharmacy" (chosen for real `PHARMACY_GRN` bill history in the local `ruhunu` DB)
- [x] Positive path: with `PharmacyGrnSave`/`Finalize`/`Approve`, Save and Approve buttons render enabled on `pharmacy_grn_with_save_approve.xhtml`
- [x] Negative path: after revoking `PharmacyGrnApprove` and re-authenticating, Approve renders **disabled** while Save (still held) stays enabled; force-enabling the disabled button via devtools and submitting produced no state change, confirming the server-side guard is a true early return, not just a UI cosmetic
- [x] New page guard: `pharmacy_cancel_grn.xhtml` correctly shows "not authorized" for the new `PharmacyGrnCancel` privilege before it's granted, and proceeds to the real form once granted
- Full evidence + screenshots: see [issue #22019 comment](https://github.com/hmislk/hmis/issues/22019#issuecomment-4939943517)

Closes #15221
Closes #15223
Closes #16839
Part of #21994
Part of #21992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated permissions for pharmacy GRN cancellation and GRN return cancellation.
  * Added privilege-based access controls for GRN creation, finalization, approval, costing, returns, and cancellations.
  * Unauthorized actions now display clear access-denied messages and remain unavailable.
  * Updated pharmacy screens to disable or hide actions based on the user’s permissions.
* **Bug Fixes**
  * Improved visibility of authorization messages on GRN return approval screens.
  * Corrected page layout structure for affected pharmacy forms and panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->