### PR TITLE
fix(pharmacy): enforce privilege guards across Purchase Order workflow

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -514,6 +514,37 @@ with a `Finance` API-key header — it runs the identical `fetchInwardMargin(...
 controllers use and returns the matched row id + margin %. Verified while testing room-category
 pharmacy margins (issue #21981).
 
+## 23. Granting a privilege that doesn't exist on the checked-out branch silently blanks ALL privileges for that department
+
+If you insert a `webuserprivilege` row for a `Privileges` enum value that exists on
+*another* branch (e.g. one you tested earlier today) but not on the branch currently
+checked out and deployed, the entire menu goes blank and every `hasPrivilege(...)` check
+returns `false` for that user **in that department** — not just the one bad privilege.
+`WebUserPrivilege.privilege` is `@Enumerated(EnumType.STRING)`; EclipseLink converts the
+DB string to the Java enum via `Enum.valueOf(...)` when it hydrates the full result list
+for `SessionController.fillUserPrivileges()`, and a single row whose string isn't a valid
+constant on the *currently running* code silently poisons that entire fetch — with no
+`SEVERE` entry in `server.log` and no visible page error, just empty menus / "not
+authorized" everywhere for that department, while other departments the row doesn't
+affect work fine (a strong tell if you compare departments). A domain restart or a full
+undeploy+redeploy does **not** fix this — it's a data/branch mismatch, not a cache.
+
+Diagnose fast: enable the MySQL general log to a table (`SET GLOBAL log_output='TABLE';
+SET GLOBAL general_log='ON';`) and check `mysql.general_log` for the exact
+`SELECT ... FROM WEBUSERPRIVILEGE WHERE ...` query, run it directly, then diff the
+distinct `PRIVILEGE` values for that user/department against
+`grep -oP '(?<=^    )[A-Za-z0-9_]+(?=\(")' src/main/java/com/divudi/core/data/Privileges.java`
+(note: some enum lines have a trailing `//` comment that breaks a naive end-of-line
+regex — verify any apparent mismatch with a direct `grep` before trusting the diff).
+
+This came up switching from the GRN privilege-guard branch (issue #22019, which added
+`PharmacyGrnCancel`/`PharmacyGrnReturnCancel`) to the PO privilege-guard branch (#22020,
+checked out fresh from `origin/development` since #22019 wasn't merged yet) — rows
+granted while testing #22019 were still sitting in the shared local DB and broke every
+privilege check for that department under the PO branch's code. Fix: delete (or retire)
+the rows for privileges that don't exist on the currently deployed branch, re-grant only
+what the current branch's `Privileges.java` actually declares, then re-login.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -787,6 +787,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyDirectPurchaseFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseFinalize, "Pharmacy Direct Purchase Finalize"), ProcumentNode);
         TreeNode pharmacyDirectPurchaseApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseApprove, "Pharmacy Direct Purchase Approve"), ProcumentNode);
         TreeNode pharmacyPurchaseOrderApprovel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrdersApprovel, "Purchase Orders Approvel"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderSave, "Purchase Order Save"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderFinalize, "Purchase Order Finalize"), ProcumentNode);
         TreeNode pharmacyGoodRecipt = new DefaultTreeNode(new PrivilegeHolder(Privileges.GoodsRecipt, "Pharmacy Good Recipt"), ProcumentNode);
         TreeNode pharmacyGrnSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnSave, "Pharmacy GRN Save"), ProcumentNode);
         TreeNode pharmacyGrnFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnFinalize, "Pharmacy GRN Finalize"), ProcumentNode);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -78,6 +78,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -99,6 +101,8 @@ import java.util.stream.Collectors;
 @Named
 @SessionScoped
 public class PharmacyBillSearch implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(PharmacyBillSearch.class.getName());
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
@@ -1310,7 +1314,39 @@ public class PharmacyBillSearch implements Serializable {
         return false;
     }
 
+    /**
+     * Authorization helper method to check Purchase Order cancellation
+     * privileges and audit denied access
+     *
+     * @param action The action being attempted (CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, bill != null ? bill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = bill != null ? bill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            return false;
+        }
+
+        return true;
+    }
+
     public String cancelPoBill() {
+        if (!isAuthorized("CANCEL", "PharmacyOrderCancellation")) {
+            return "";
+        }
         if (getSelectedBills() == null || getSelectedBills().isEmpty()) {
             JsfUtil.addErrorMessage("Please select Bills");
             return "";
@@ -3379,6 +3415,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public void pharmacyPoRequestCancel() {
+        if (!isAuthorized("CANCEL", "PharmacyOrderCancellation")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (getBill().getReferenceBill() != null && !getBill().getReferenceBill().isCancelled()) {
                 JsfUtil.addErrorMessage("Sorry You cant Cancell Approved Bill");

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -3380,6 +3380,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public void pharmacyPoCancel() {
+        if (!isAuthorized("CANCEL", "PharmacyOrderCancellation")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (pharmacyErrorCheck()) {
                 return;

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.core.util.JsfUtil;
@@ -36,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -52,8 +55,12 @@ import com.divudi.core.entity.pharmacy.Amp;
 @SessionScoped
 public class PurchaseOrderController implements Serializable {
 
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderController.class.getName());
+
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @EJB
     private BillFacade billFacade;
     @EJB
@@ -171,7 +178,39 @@ public class PurchaseOrderController implements Serializable {
         return "/pharmacy/pharmacy_purhcase_order_approving?faces-redirect=true";
     }
 
+    /**
+     * Authorization helper method to check Purchase Order Approval
+     * privileges and audit denied access
+     *
+     * @param action The action being attempted (APPROVE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, requestedBill != null ? requestedBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = requestedBill != null ? requestedBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            return false;
+        }
+
+        return true;
+    }
+
     public String approve() {
+        if (!isAuthorized("APPROVE", "PurchaseOrdersApprovel")) {
+            return "";
+        }
         // Check if the requested bill is already approved to prevent double approving
         if (getRequestedBill() != null && getRequestedBill().getReferenceBill() != null) {
             JsfUtil.addErrorMessage("This purchase order is already approved");

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -11,6 +11,7 @@ import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.DepartmentType;
@@ -93,6 +94,8 @@ public class PurchaseOrderRequestController implements Serializable {
 
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
@@ -1041,7 +1044,39 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
+    /**
+     * Authorization helper method to check Purchase Order privileges and
+     * audit denied access
+     *
+     * @param action The action being attempted (SAVE, FINALIZE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, currentBill != null ? currentBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = currentBill != null ? currentBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase order requests.");
+            return false;
+        }
+
+        return true;
+    }
+
     public void saveRequest() {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
         boolean saved = saveRequestWithoutMessage();
         if (saved) {
             JsfUtil.addSuccessMessage("Request Saved");
@@ -1122,6 +1157,9 @@ public class PurchaseOrderRequestController implements Serializable {
     }
 
     public synchronized void finalizeRequest() {
+        if (!isAuthorized("FINALIZE", "PurchaseOrderFinalize")) {
+            return;
+        }
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -127,6 +127,9 @@ public class PurchaseOrderRequestController implements Serializable {
     private String emailRecipient;
 
     public void removeSelected() {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
         if (selectedBillItems == null) {
             return;
         }
@@ -273,6 +276,9 @@ public class PurchaseOrderRequestController implements Serializable {
     }
 
     public void removeItem(BillItem bi) {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
         if (currentBill == null || bi == null) {
             return;
         }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -636,6 +636,8 @@ public enum Privileges {
     PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
     PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
     PurchaseOrdersApprovel("Purchase Orders Approval"),
+    PurchaseOrderSave("Purchase Order Save"),
+    PurchaseOrderFinalize("Purchase Order Finalize"),
     TransferReciveApproval("Transfer Receive Approval"),
     GoodsRecipt("Goods Receipt"),
     ReturnReceviedGoods("Return Received Goods"),
@@ -949,6 +951,8 @@ public enum Privileges {
             case PharmacyDirectPurchaseFinalize:
             case PharmacyDirectPurchaseApprove:
             case PurchaseOrdersApprovel:
+            case PurchaseOrderSave:
+            case PurchaseOrderFinalize:
             case GoodsRecipt:
             case ReturnReceviedGoods:
             case CreateGrnReturn:

--- a/src/main/webapp/pharmacy/pharmacy_cancel_po.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_po.xhtml
@@ -10,6 +10,10 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
+                    You are NOT authorized
+                </h:panelGroup>
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
                 <h:form>
                     <h:panelGroup rendered="#{!pharmacyBillSearch.printPreview}" styleClass="alignTop" >
                         <p:panel>
@@ -23,8 +27,9 @@
                                         value="Cancel Bill" 
                                         icon="fa fa-cancel"
                                         style="float: right"
-                                        class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyPoCancel}" >
-                                    </p:commandButton>  
+                                        class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyPoCancel}"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
+                                    </p:commandButton>
                                 </h:panelGrid>
                             </f:facet>
                             <p:panel>
@@ -118,7 +123,8 @@
                     </p:panel>
 
 
-                </h:form>                
+                </h:form>
+                </h:panelGroup>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/pharmacy/pharmacy_cancel_po_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_po_request.xhtml
@@ -10,6 +10,10 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
+                    You are NOT authorized
+                </h:panelGroup>
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
                 <h:form>
                     <h:panelGroup rendered="#{!pharmacyBillSearch.printPreview}" styleClass="alignTop" >
                         <p:panel  header="Cancellation">
@@ -21,8 +25,8 @@
                                     <div class="d-flex align-items-center" style="width: 50%">
                                         <p:inputText class="w-100" placeholder="Enter a Reason to Cancel" style="width: 100%" value="#{pharmacyBillSearch.bill.comments}"/>
                                         <p:spacer width="20%"></p:spacer>
-                                        <p:commandButton class="ui-button-danger mx-1" ajax="false" icon="fas fa-cancel" value="Cancel" action="#{pharmacyBillSearch.pharmacyPoRequestCancel()}" disabled="#{pharmacyBillSearch.bill.cancelled}" >
-                                        </p:commandButton> 
+                                        <p:commandButton class="ui-button-danger mx-1" ajax="false" icon="fas fa-cancel" value="Cancel" action="#{pharmacyBillSearch.pharmacyPoRequestCancel()}" disabled="#{pharmacyBillSearch.bill.cancelled or not webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
+                                        </p:commandButton>
                                     </div>
                                 </div>
                             </f:facet>            
@@ -111,7 +115,8 @@
                     </h:panelGroup>
 
 
-                </h:form>                
+                </h:form>
+                </h:panelGroup>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -11,6 +11,11 @@
     <ui:define name="content">
         <h:form id="form">
 
+            <h:panelGroup rendered="#{!webUserController.hasPrivilege('PurchaseOrdersApprovel')}" >
+                You are NOT authorized
+            </h:panelGroup>
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel')}" >
+
             <h:panelGroup rendered="#{!purchaseOrderController.printPreview}">
                 <p:panel >
                     <f:facet name="header">
@@ -303,6 +308,8 @@
                     </h:panelGroup>
 
                 </p:panel>
+            </h:panelGroup>
+
             </h:panelGroup>
 
         </h:form>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_cancel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_cancel.xhtml
@@ -7,6 +7,10 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="subcontent">
+        <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
+            You are NOT authorized
+        </h:panelGroup>
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyOrderCancellation')}" >
         <h:form>
             <p:panel >
                 <f:facet name="header">
@@ -173,8 +177,9 @@
                         </p:panel> 
                     </div>
                 </div>
-            </p:panel>            
+            </p:panel>
         </h:form>
-    </ui:define>  
+        </h:panelGroup>
+    </ui:define>
 
 </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -316,18 +316,18 @@
                                         ajax="false" 
                                         value="Save" 
                                         action="#{purchaseOrderRequestController.saveRequest}"
-                                        icon="pi pi-save" 
+                                        icon="pi pi-save"
                                         class="ui-button-success m-1"
-                                        disabled="#{purchaseOrderRequestController.currentBill.checked}"/>
-                                    <p:commandButton 
+                                        disabled="#{purchaseOrderRequestController.currentBill.checked or not webUserController.hasPrivilege('PurchaseOrderSave')}"/>
+                                    <p:commandButton
                                         id="btnFinalize"
-                                        ajax="false" 
-                                        value="Finalize" 
+                                        ajax="false"
+                                        value="Finalize"
                                         action="#{purchaseOrderRequestController.finalizeRequest()}"
-                                        icon="pi pi-check" 
+                                        icon="pi pi-check"
                                         class="ui-button-warning m-1"
                                         onclick="return confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.');"
-                                        disabled="#{purchaseOrderRequestController.currentBill.checked}"/>
+                                        disabled="#{purchaseOrderRequestController.currentBill.checked or not webUserController.hasPrivilege('PurchaseOrderFinalize')}"/>
                                     <p:commandButton 
                                         ajax="false"  
                                         value="New Order" 

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -56,6 +56,7 @@
                                                         styleClass="ui-button-secondary"/>
                                                 </h:panelGroup>
                                                 <p:commandButton ajax="false" class="ui-button-danger" value="Remove Selected"
+                                                                 disabled="#{not webUserController.hasPrivilege('PurchaseOrderSave')}"
                                                                  action="#{purchaseOrderRequestController.removeSelected()}"/>
                                             </div>
                                         </div>
@@ -204,6 +205,7 @@
                                             update="itemList :#{p:resolveFirstComponentWithId('tot',view).clientId} :form:itemHistoryAboveWrapper :form:itemHistoryBelowWrapper"
                                             tabindex="-1"
                                             style="padding: 0;"
+                                            disabled="#{not webUserController.hasPrivilege('PurchaseOrderSave')}"
                                             action="#{purchaseOrderRequestController.removeItem(bi)}"/>
                                     </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_order_request.xhtml
@@ -34,13 +34,13 @@
                                         class="ui-button-warning mx-1" 
                                         icon="fas fa-arrow-left">
                                     </p:commandButton>
-                                    <p:commandButton  
-                                        value="Cancel" 
-                                        action="pharmacy_cancel_po_request" 
-                                        disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.referenceBill.creater ne null}" 
+                                    <p:commandButton
+                                        value="Cancel"
+                                        action="pharmacy_cancel_po_request"
+                                        disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.referenceBill.creater ne null or not webUserController.hasPrivilege('PharmacyOrderCancellation')}"
                                         ajax="false"
-                                        class="ui-button-danger mx-1" icon="fas fa-ban">                           
-                                    </p:commandButton> 
+                                        class="ui-button-danger mx-1" icon="fas fa-ban">
+                                    </p:commandButton>
                                     <p:commandButton
                                         rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
                                         value="Settings"


### PR DESCRIPTION
## Summary
- Adds server-side `isAuthorized()` privilege checks (same pattern established in #22019/GRN) to `saveRequest()`, `finalizeRequest()` (`PurchaseOrderRequestController`), `approve()` (`PurchaseOrderController`), `cancelPoBill()`, `pharmacyPoRequestCancel()` (`PharmacyBillSearch`) — previously none of these had any server-side check.
- **New privileges:** `PurchaseOrderSave`, `PurchaseOrderFinalize` — previously Save/Finalize had no dedicated privilege at all, only riding implicitly on the page's `CreatePurchaseOrder` wrapper.
- Adds a page-level "not authorized" guard to `pharmacy_purhcase_order_approving.xhtml` (previously had none — a user without `PurchaseOrdersApprovel` could view all PO pricing/supplier detail, only the Approve button itself was guarded).
- Adds a page-level guard to `pharmacy_purhcase_order_list_to_cancel.xhtml` (button was already guarded, page wasn't).
- **The sharpest gap found in the whole privilege-guard review**: `pharmacy_cancel_po_request.xhtml` (and its `pharmacy_reprint_order_request.xhtml` entry point) had **zero privilege reference of any kind, client or server** — any authenticated user who could reach a PO's reprint/view page could cancel it. Fixed with both a page guard and button guard using the existing `PharmacyOrderCancellation` privilege.
- Confirmed no PO Return workflow exists in the codebase (grep-verified) — not invented here.
- Confirmed and avoided the exact cross-call bug found in #22019: none of the newly-guarded methods call each other internally with mismatched privilege requirements (verified each is only reachable from its own dedicated UI button).

## Test plan
- [x] `mvn clean package -DskipTests` — builds clean
- [x] Deployed to local Payara, logged in as `buddhika` in department "Matara - Pharmacy"
- [x] Positive path: with `PurchaseOrderSave`/`Finalize`, Save and Finalize buttons render enabled on `pharmacy_purhcase_order_request.xhtml`
- [x] Negative path: after revoking `PurchaseOrderFinalize` and re-authenticating, Finalize renders **disabled** while Save (still held) stays enabled
- [x] New page guard on the approving page: confirmed no regression — a privileged user still sees full page content
- Full evidence + screenshots: see [issue #22020 comment](https://github.com/hmislk/hmis/issues/22020#issuecomment-4940118901)
- Also documented a local multi-branch-testing gotcha discovered during this pass in `developer_docs/testing/playwright-e2e-workflow.md` §23 (unrelated to this PR's correctness — a stale cross-branch privilege row in the shared local DB, not a code bug)

Part of #21994
Part of #21992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate permissions for saving and finalizing purchase orders.
  - Added procurement menu entries for the new purchase order permissions.
- **Bug Fixes**
  - Purchase order saving, finalization, approval, cancellation, and removal actions now enforce authorization consistently across both backend checks and UI gating.
  - Unauthorized users see clear “You are NOT authorized” panels; restricted actions are disabled and guarded.
- **Documentation**
  - Added troubleshooting guidance for privilege configuration issues that can cause empty menus or failed permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->