### PR TITLE
fix(pharmacy): enforce privilege guards across Disbursement/Transfer workflow

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -206,6 +206,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestSearch, "Pharmacy Issue Request Search"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestCancel, "Pharmacy Issue Request Cancel"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnCancel, "Pharmacy Return Cancel"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnSubmit, "Pharmacy Return Submit"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyBhtReceive, "Pharmacy BHT Receive"), inwardPharmacyNode);
 
         TreeNode searchNode = new DefaultTreeNode(new PrivilegeHolder(null, "Search"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearch, "Search Menu"), searchNode);
@@ -752,8 +754,11 @@ public class UserPrivilageController implements Serializable {
         TreeNode issueForRequestApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestApprove, "Issue for Request Approve"), disbursementNode);
         TreeNode disbursementDirectIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementDirectIssue, "Direct Issue"), disbursementNode);
         TreeNode disbursementRecieve = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRecieve, "Recieve"), disbursementNode);
+        TreeNode receiveSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveSave, "Receive Save"), disbursementNode);
         TreeNode receiveFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveFinalize, "Receive Finalize"), disbursementNode);
         TreeNode receiveApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveApprove, "Receive Approve"), disbursementNode);
+        TreeNode transferIssueCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferIssueCancel, "Transfer Issue Cancel"), disbursementNode);
+        TreeNode transferReceiveCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferReceiveCancel, "Transfer Receive Cancel"), disbursementNode);
         TreeNode TransferReciveApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.TransferReciveApproval, "Recieve Approval"), disbursementNode);
         TreeNode PharmacyDisbursementReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementReports, "Pharmacy Disbursement Reports"), disbursementNode);
         TreeNode PharmacyTransferViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferViewRates, "Pharmacy Transfer View Rates"), disbursementNode);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -78,6 +78,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -99,6 +101,8 @@ import java.util.stream.Collectors;
 @Named
 @SessionScoped
 public class PharmacyBillSearch implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(PharmacyBillSearch.class.getName());
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
@@ -3568,7 +3572,39 @@ public class PharmacyBillSearch implements Serializable {
         }
     }
 
+    /**
+     * Authorization helper method to check Transfer Issue cancellation
+     * privileges and audit denied access
+     *
+     * @param action The action being attempted (CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, bill != null ? bill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = bill != null ? bill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Issue cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " this transfer issue.");
+            return false;
+        }
+
+        return true;
+    }
+
     public void pharmacyTransferIssueCancel() {
+        if (!isAuthorized("CANCEL", "PharmacyTransferIssueCancel")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (pharmacyErrorCheck()) {
                 return;
@@ -3610,6 +3646,9 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     public void pharmacyTransferIssueInpatientCancel() {
+        if (!isAuthorized("CANCEL", "PharmacyTransferIssueCancel")) {
+            return;
+        }
         if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
             if (pharmacyErrorCheck()) {
                 return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -31,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -82,6 +85,7 @@ import javax.transaction.Transactional;
 public class TransferIssueCancellationController implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(TransferIssueCancellationController.class.getName());
 
     // EJB Dependencies
     @EJB
@@ -104,6 +108,8 @@ public class TransferIssueCancellationController implements Serializable {
     private UserStockController userStockController;
     @Inject
     private PharmacyController pharmacyController;
+    @Inject
+    private WebUserController webUserController;
 
     // Properties
     private Bill originalBill;
@@ -532,6 +538,9 @@ public class TransferIssueCancellationController implements Serializable {
      */
     @Transactional
     public void confirmCancellation() {
+        if (!isAuthorized("CANCEL", "PharmacyTransferIssueCancel")) {
+            return;
+        }
         try {
             // Validation: Check cancellation reason
             if (cancellationReason == null || cancellationReason.trim().isEmpty()) {
@@ -764,5 +773,34 @@ public class TransferIssueCancellationController implements Serializable {
 
     public UserStockController getUserStockController() {
         return userStockController;
+    }
+
+    /**
+     * Authorization helper method to check Transfer Issue Cancellation
+     * privileges and audit denied access.
+     *
+     * @param action The action being attempted (CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, originalBillId});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Issue Cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, originalBillId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer issue requests.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -907,7 +907,7 @@ public class TransferIssueDirectController implements Serializable {
             LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Pharmacy Direct Transfer Issue access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
                     new Object[]{action, userId, billId, requiredPrivilege});
 
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " direct transfer issues.");
+            JsfUtil.addErrorMessage("You don't have permission to perform this direct transfer issue action.");
             return false;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.BillService;
 import com.divudi.core.data.BillType;
@@ -42,6 +43,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -55,6 +58,8 @@ import javax.inject.Named;
 @Named
 @SessionScoped
 public class TransferIssueDirectController implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(TransferIssueDirectController.class.getName());
 
     @EJB
     private BillFacade billFacade;
@@ -76,6 +81,8 @@ public class TransferIssueDirectController implements Serializable {
     private NotificationController notificationController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     private PharmacyController pharmacyController;
     @Inject
@@ -225,6 +232,9 @@ public class TransferIssueDirectController implements Serializable {
      * Settles the direct issue transaction
      */
     public synchronized void settleDirectIssue() {
+        if (!isAuthorized("SETTLE_DIRECT_ISSUE", "PharmacyDisbursementDirectIssue")) {
+            return;
+        }
         if (issuedBill != null && issuedBill.getId() != null) {
             JsfUtil.addErrorMessage("This bill has already been saved.");
             return;
@@ -872,6 +882,36 @@ public class TransferIssueDirectController implements Serializable {
 
     public void setBillItemValue(Double billItemValue) {
         this.billItemValue = billItemValue;
+    }
+
+    /**
+     * Authorization helper method to check Pharmacy Direct Transfer Issue
+     * privileges and audit denied access
+     *
+     * @param action The action being attempted (e.g. SETTLE_DIRECT_ISSUE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, issuedBill != null ? issuedBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = issuedBill != null ? issuedBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Pharmacy Direct Transfer Issue access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " direct transfer issues.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -7,6 +7,7 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.admin.ConfigOptionInfo;
 import com.divudi.core.data.admin.PageMetadata;
@@ -49,6 +50,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -65,6 +68,8 @@ import javax.inject.Named;
 @Named
 @SessionScoped
 public class TransferIssueForRequestsController implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(TransferIssueForRequestsController.class.getName());
 
     @EJB
     private BillFacade billFacade;
@@ -88,6 +93,8 @@ public class TransferIssueForRequestsController implements Serializable {
     private UserStockController userStockController;
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     private BillController billController;
     @Inject
@@ -459,6 +466,9 @@ public class TransferIssueForRequestsController implements Serializable {
      * Saves the current items as a PHARMACY_ISSUE_PRE bill without moving stock.
      */
     public void saveDraftIssue() {
+        if (!isAuthorized("SAVE_DRAFT_ISSUE", "PharmacyIssueForRequestSave")) {
+            return;
+        }
         if (getIssuedBill().getToDepartment() == null) {
             JsfUtil.addErrorMessage("Please select a department to issue to");
             return;
@@ -557,6 +567,9 @@ public class TransferIssueForRequestsController implements Serializable {
      * Finalizes the current PHARMACY_ISSUE_PRE draft (sets completed=true).
      */
     public void finalizeDraftIssue() {
+        if (!isAuthorized("FINALIZE_DRAFT_ISSUE", "PharmacyIssueForRequestFinalize")) {
+            return;
+        }
         if (getIssuedBill() == null || getIssuedBill().getId() == null) {
             JsfUtil.addErrorMessage("No draft to finalize. Please save first.");
             return;
@@ -582,6 +595,9 @@ public class TransferIssueForRequestsController implements Serializable {
      * Approves the PHARMACY_ISSUE_PRE draft: moves stock and converts to PHARMACY_ISSUE.
      */
     public synchronized void approveDraftIssue() {
+        if (!isAuthorized("APPROVE_DRAFT_ISSUE", "PharmacyIssueForRequestApprove")) {
+            return;
+        }
         if (getIssuedBill() == null || getIssuedBill().getId() == null) {
             JsfUtil.addErrorMessage("No finalized draft to approve.");
             return;
@@ -741,6 +757,9 @@ public class TransferIssueForRequestsController implements Serializable {
      * Cancels a saved/finalized PHARMACY_ISSUE_PRE draft (retires it before approval).
      */
     public void cancelPendingIssue() {
+        if (!isAuthorized("CANCEL_PENDING_ISSUE", "PharmacyTransferIssueCancel")) {
+            return;
+        }
         if (getIssuedBill() == null || getIssuedBill().getId() == null) {
             JsfUtil.addErrorMessage("No draft to cancel.");
             return;
@@ -771,6 +790,9 @@ public class TransferIssueForRequestsController implements Serializable {
     }
 
     public synchronized void settle() {
+        if (!isAuthorized("SETTLE_ISSUE", "PharmacyIssueForRequestFinalize")) {
+            return;
+        }
         if (getIssuedBill() != null && getIssuedBill().getId() != null) {
             JsfUtil.addErrorMessage("This bill has already been saved.");
             return;
@@ -1920,6 +1942,36 @@ public class TransferIssueForRequestsController implements Serializable {
         ));
 
         pageMetadataRegistry.registerPage(issuedListMetadata);
+    }
+
+    /**
+     * Authorization helper method to check Pharmacy Transfer Issue For
+     * Requests privileges and audit denied access
+     *
+     * @param action The action being attempted (e.g. SAVE_DRAFT_ISSUE, FINALIZE_DRAFT_ISSUE, APPROVE_DRAFT_ISSUE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, issuedBill != null ? issuedBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = issuedBill != null ? issuedBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Pharmacy Transfer Issue For Requests access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer issues.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
@@ -8,6 +8,7 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
@@ -31,6 +32,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -55,6 +58,8 @@ public class TransferIssueNativeSqlController implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOGGER = Logger.getLogger(TransferIssueNativeSqlController.class.getName());
+
     // ---- State ----
     private Bill requestedBill;
     private Long requestedBillId;
@@ -67,6 +72,9 @@ public class TransferIssueNativeSqlController implements Serializable {
     // ---- Injected ----
     @Inject
     private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
@@ -166,6 +174,9 @@ public class TransferIssueNativeSqlController implements Serializable {
     }
 
     public void saveDraftNativeIssue() {
+        if (!isAuthorized("SAVE_DRAFT_NATIVE_ISSUE", "PharmacyIssueForRequestSave")) {
+            return;
+        }
         if (issueItems == null || issueItems.isEmpty()) {
             JsfUtil.addErrorMessage("No items to save. Please check the request.");
             return;
@@ -231,6 +242,9 @@ public class TransferIssueNativeSqlController implements Serializable {
     }
 
     public void finalizeDraftNativeIssue() {
+        if (!isAuthorized("FINALIZE_DRAFT_NATIVE_ISSUE", "PharmacyIssueForRequestFinalize")) {
+            return;
+        }
         if (issuedBill == null || issuedBill.getId() == null) {
             JsfUtil.addErrorMessage("No draft to finalize.");
             return;
@@ -253,6 +267,9 @@ public class TransferIssueNativeSqlController implements Serializable {
     }
 
     public synchronized String approveDraftNativeIssue() {
+        if (!isAuthorized("APPROVE_DRAFT_NATIVE_ISSUE", "PharmacyIssueForRequestApprove")) {
+            return null;
+        }
         if (issueItems == null || issueItems.isEmpty()) {
             JsfUtil.addErrorMessage("No items to issue. Reload the draft and check quantities.");
             return null;
@@ -308,6 +325,9 @@ public class TransferIssueNativeSqlController implements Serializable {
     }
 
     public String cancelPendingNativeIssue() {
+        if (!isAuthorized("CANCEL_PENDING_NATIVE_ISSUE", "PharmacyTransferIssueCancel")) {
+            return "";
+        }
         if (issuedBill == null || issuedBill.getId() == null) {
             JsfUtil.addErrorMessage("No draft to cancel.");
             return null;
@@ -353,6 +373,9 @@ public class TransferIssueNativeSqlController implements Serializable {
      * Mirrors TransferIssueForRequestsController.settle().
      */
     public void settle() {
+        if (!isAuthorized("SETTLE_NATIVE_ISSUE", "PharmacyIssueForRequestFinalize")) {
+            return;
+        }
         if (issueItems == null || issueItems.isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to issue. Please check quantities.");
             return;
@@ -755,5 +778,35 @@ public class TransferIssueNativeSqlController implements Serializable {
 
     public void setDraftMode(boolean draftMode) {
         this.draftMode = draftMode;
+    }
+
+    /**
+     * Authorization helper method to check Pharmacy Transfer Issue (native
+     * SQL / fast issue) privileges and audit denied access
+     *
+     * @param action The action being attempted (e.g. SAVE_DRAFT_NATIVE_ISSUE, FINALIZE_DRAFT_NATIVE_ISSUE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, issuedBill != null ? issuedBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = issuedBill != null ? issuedBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Pharmacy Transfer Issue (native) access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " fast transfer issues.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -32,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -96,6 +99,7 @@ import javax.transaction.Transactional;
 public class TransferReceiveCancellationController implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(TransferReceiveCancellationController.class.getName());
 
     // EJB Dependencies
     @EJB
@@ -116,6 +120,8 @@ public class TransferReceiveCancellationController implements Serializable {
     private BillController billController;
     @Inject
     private PharmacyController pharmacyController;
+    @Inject
+    private WebUserController webUserController;
 
     // Properties
     private Bill originalReceiveBill;
@@ -539,6 +545,9 @@ public class TransferReceiveCancellationController implements Serializable {
      */
     @Transactional
     public void confirmCancellation() {
+        if (!isAuthorized("CANCEL", "PharmacyTransferReceiveCancel")) {
+            return;
+        }
         try {
             // Validation: Check cancellation reason
             if (cancellationReason == null || cancellationReason.trim().isEmpty()) {
@@ -884,5 +893,34 @@ public class TransferReceiveCancellationController implements Serializable {
 
     public BillController getBillController() {
         return billController;
+    }
+
+    /**
+     * Authorization helper method to check Transfer Receive Cancellation
+     * privileges and audit denied access.
+     *
+     * @param action The action being attempted (CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, originalReceiveBillId});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Receive Cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, originalReceiveBillId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer receive requests.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.admin.ConfigOptionInfo;
@@ -53,6 +54,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -68,6 +71,8 @@ import org.primefaces.event.RowEditEvent;
 @SessionScoped
 public class TransferReceiveController implements Serializable {
 
+    private static final Logger LOGGER = Logger.getLogger(TransferReceiveController.class.getName());
+
     private Bill issuedBill;
     private Bill receivedBill;
     private boolean printPreview;
@@ -80,6 +85,8 @@ public class TransferReceiveController implements Serializable {
     private SessionController sessionController;
     @Inject
     private PharmacyController pharmacyController;
+    @Inject
+    private WebUserController webUserController;
     ////
     @EJB
     private BillFacade billFacade;
@@ -471,6 +478,9 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void settle() {
+        if (!isAuthorized("FINALIZE", "PharmacyReceiveFinalize")) {
+            return;
+        }
         // Re-entrancy guard: a second near-simultaneous submit (rapid double-click
         // on the non-AJAX Receive button) is ignored until the first completes.
         if (settling) {
@@ -871,6 +881,9 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void saveRequest() {
+        if (!isAuthorized("SAVE", "PharmacyReceiveSave")) {
+            return;
+        }
 
         getReceivedBill().setBillType(BillType.PharmacyTransferReceive);
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE_PRE);
@@ -905,6 +918,9 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void finalizeRequest() {
+        if (!isAuthorized("FINALIZE", "PharmacyReceiveFinalize")) {
+            return;
+        }
         // Check if a bill has been selected
         if (getReceivedBill() == null) {
             JsfUtil.addErrorMessage("No Bill Selected");
@@ -971,6 +987,9 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void settleApprove() {
+        if (!isAuthorized("APPROVE", "PharmacyReceiveApprove")) {
+            return;
+        }
         if (getReceivedBill().getId() == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;
@@ -1758,6 +1777,36 @@ public class TransferReceiveController implements Serializable {
         ));
 
         pageMetadataRegistry.registerPage(receiveMetadata);
+    }
+
+    /**
+     * Authorization helper method to check Transfer Receive privileges and
+     * audit denied access.
+     *
+     * @param action The action being attempted (SAVE, FINALIZE, APPROVE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, receivedBill != null ? receivedBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = receivedBill != null ? receivedBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Receive access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer receive requests.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -8,6 +8,7 @@ package com.divudi.bean.pharmacy;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -74,6 +75,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
     // ---- Injected ----
     @Inject
     private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
@@ -246,6 +250,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
     }
 
     public String cancelPendingReceive(Long preBillId) {
+        if (!isAuthorized("CANCEL", "PharmacyTransferReceiveCancel")) {
+            return "";
+        }
         if (preBillId == null) {
             JsfUtil.addErrorMessage("No pending receive selected.");
             return null;
@@ -313,6 +320,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
      * Mirrors TransferReceiveController.settle().
      */
     public void settle() {
+        if (!isAuthorized("FINALIZE", "PharmacyReceiveFinalize")) {
+            return;
+        }
         if (itemRowList == null || itemRowList.isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Receive, Please check Received Quantity");
             return;
@@ -360,6 +370,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
      * Mirrors TransferReceiveController.settleApprove().
      */
     public void settleApprove() {
+        if (!isAuthorized("APPROVE", "PharmacyReceiveApprove")) {
+            return;
+        }
         if (receivedBillId == null) {
             JsfUtil.addErrorMessage("No Bill Selected");
             return;
@@ -421,6 +434,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
      * Mirrors TransferReceiveController.saveRequest().
      */
     public void saveRequest() {
+        if (!isAuthorized("SAVE", "PharmacyReceiveSave")) {
+            return;
+        }
         if (issuedBill == null || issuedBill.getId() == null) {
             JsfUtil.addErrorMessage("No issued bill selected");
             return;
@@ -449,6 +465,9 @@ public class TransferReceiveNativeSqlController implements Serializable {
      * Mirrors TransferReceiveController.finalizeRequest().
      */
     public void finalizeRequest() {
+        if (!isAuthorized("FINALIZE", "PharmacyReceiveFinalize")) {
+            return;
+        }
         if (receivedBillId == null) {
             JsfUtil.addErrorMessage("No saved request found. Please save first.");
             return;
@@ -1003,5 +1022,34 @@ public class TransferReceiveNativeSqlController implements Serializable {
 
     public void setSelectedItemRow(TransferReceiveItemRowDto selectedItemRow) {
         this.selectedItemRow = selectedItemRow;
+    }
+
+    /**
+     * Authorization helper method to check Transfer Receive privileges and
+     * audit denied access.
+     *
+     * @param action The action being attempted (SAVE, FINALIZE, APPROVE, CANCEL)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, receivedBillId});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Receive access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, receivedBillId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer receive requests.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -8,6 +8,7 @@ import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.data.*;
 import com.divudi.core.data.admin.ConfigOptionInfo;
@@ -98,6 +99,8 @@ public class TransferRequestController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     private PharmacyCalculation pharmacyBillBean;
     @Inject
@@ -331,6 +334,9 @@ public class TransferRequestController implements Serializable {
     }
 
     public void approveTransferRequestBill() {
+        if (!isAuthorized("APPROVE_REQUEST", "PharmacyDisbursementRequestApproval")) {
+            return;
+        }
         if (billItems == null || billItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return;
@@ -648,6 +654,9 @@ public class TransferRequestController implements Serializable {
     }
 
     public void saveTranserRequestPreBill() {
+        if (!isAuthorized("REQUEST", "PharmacyDisbursementRequest")) {
+            return;
+        }
         if (errorsPresent()) {
             return;
         }
@@ -717,6 +726,9 @@ public class TransferRequestController implements Serializable {
     }
 
     public void finalizeTranserRequestPreBill() {
+        if (!isAuthorized("FINALIZE_REQUEST", "PharmacyDisbursementFinalizeRequest")) {
+            return;
+        }
         if (errorsPresent()) {
             return;
         }
@@ -1891,6 +1903,36 @@ public class TransferRequestController implements Serializable {
         ));
 
         pageMetadataRegistry.registerPage(requestListMetadata);
+    }
+
+    /**
+     * Authorization helper method to check Pharmacy Transfer Request
+     * privileges and audit denied access
+     *
+     * @param action The action being attempted (e.g. REQUEST, FINALIZE_REQUEST, APPROVE_REQUEST)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, bill != null ? bill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            // Audit denied access attempt
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = bill != null ? bill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Pharmacy Transfer Request access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " transfer requests.");
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyBhtIssueReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyBhtIssueReceiveController.java
@@ -1,7 +1,9 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.Privileges;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BilledBill;
@@ -42,6 +44,8 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
 
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
 
     @EJB
     private BillFacade billFacade;
@@ -155,6 +159,10 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
     }
 
     public void settle() {
+        if (!webUserController.hasPrivilege(Privileges.InwardPharmacyBhtReceive.name())) {
+            JsfUtil.addErrorMessage("You do not have the privilege to receive this issue.");
+            return;
+        }
         if (settling) {
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
@@ -227,6 +227,10 @@ public class WardPharmacyReturnToPharmacyController implements Serializable {
     }
 
     public void settle() {
+        if (!webUserController.hasPrivilege(Privileges.InwardPharmacyReturnSubmit.name())) {
+            JsfUtil.addErrorMessage("You do not have the privilege to submit this return.");
+            return;
+        }
         if (settling) {
             return;
         }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -128,6 +128,8 @@ public enum Privileges {
     InwardPharmacyIssueRequestCancel("Inward Pharmacy Issue Request Cancel"),
     InwardPharmacyIssueRequestSearch("Inward Pharmacy Issue Request Search"),
     InwardPharmacyReturnCancel("Inward Pharmacy Return Cancel"),
+    InwardPharmacyReturnSubmit("Inward Pharmacy Return Submit"),
+    InwardPharmacyBhtReceive("Inward Pharmacy BHT Receive"),
     InwardBillSettleWithoutCheck("Inward Bill Settle Without Check"),
     TheaterIssueBHT("Theater Issue BHT"),
     InpatientClinicalAssessment("Inpatient Clinical Assessment"),
@@ -526,8 +528,11 @@ public enum Privileges {
     PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
     PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
     PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveSave("Pharmacy Receive Save"),
     PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
     PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyTransferIssueCancel("Pharmacy Transfer Issue Cancel"),
+    PharmacyTransferReceiveCancel("Pharmacy Transfer Receive Cancel"),
     // Pharmacy Inpatient medication management
     InpatientMedicationManagementMenue("Inpatient Medication Management Menu"),
     PharmacyDirectIssueToBht("Pharmacy Direct Issue to BHT"),
@@ -935,6 +940,8 @@ public enum Privileges {
             case PharmacyBhtRequestForceComplete:
             case PharmacyReturnFromWardForceComplete:
             case InwardPharmacyReturnCancel:
+            case InwardPharmacyReturnSubmit:
+            case InwardPharmacyBhtReceive:
             case PharmacySearchInpatientDirectIssuesbyBill:
             case PharmacySearchInpatientDirectIssuesbyItem:
             case PharmacySearchInpatientDirectIssueReturnsbyBill:
@@ -973,8 +980,11 @@ public enum Privileges {
             case PharmacyIssueForRequestSave:
             case PharmacyIssueForRequestFinalize:
             case PharmacyIssueForRequestApprove:
+            case PharmacyReceiveSave:
             case PharmacyReceiveFinalize:
             case PharmacyReceiveApprove:
+            case PharmacyTransferIssueCancel:
+            case PharmacyTransferReceiveCancel:
 
             // Retail Transactions
             case PharmacyRetailTransaction:

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1350,7 +1350,7 @@
                 </h:panelGroup>
 
                 <!-- Request -->
-                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_request' and webUserController.hasPrivilege('PharmacyTransfer')}">
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_request' and webUserController.hasPrivilege('PharmacyDisbursementRequest')}">
                     <h:form>
                         <p:tooltip for="pharmacy_request" value="Request"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink 
@@ -1367,7 +1367,7 @@
                 </h:panelGroup>
 
                 <!-- Issue for Requests -->
-                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_issue_for_request' and webUserController.hasPrivilege('PharmacyTransfer')}">
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_issue_for_request' and webUserController.hasPrivilege('PharmacyDisbursementIssurForRequest')}">
                     <h:form>
                         <p:tooltip for="pharmacy_issue_for_request" value="Issue for Requests"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink
@@ -1384,7 +1384,7 @@
                 </h:panelGroup>
 
                 <!-- Direct Issue -->
-                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_direct_issue' and webUserController.hasPrivilege('PharmacyTransfer')}">
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_direct_issue' and webUserController.hasPrivilege('PharmacyDisbursementDirectIssue')}">
                     <h:form>
                         <p:tooltip for="pharmacy_direct_issue" value="Direct Issue"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink
@@ -1401,7 +1401,7 @@
                 </h:panelGroup>
 
                 <!-- Receive -->
-                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_receive' and webUserController.hasPrivilege('PharmacyTransfer')}">
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_receive' and webUserController.hasPrivilege('PharmacyDisbursementRecieve')}">
                     <h:form>
                         <p:tooltip for="pharmacy_receive" value="Receive"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink 
@@ -1418,7 +1418,7 @@
                 </h:panelGroup>
 
                 <!-- Reports -->
-                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_disbursement_reports' and webUserController.hasPrivilege('PharmacyTransfer')}">
+                <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_disbursement_reports' and webUserController.hasPrivilege('PharmacyDisbursementReports')}">
                     <h:form>
                         <p:tooltip for="pharmacy_disbursement_reports" value="Reports"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink 

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -978,6 +978,7 @@
                                             ajax="false"
                                             action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
                                             icon="fa fa-truck-medical"
+                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
                                             class="w-100"/>
                                     </div>
                                     <div class="col-6">
@@ -987,6 +988,7 @@
                                             ajax="false"
                                             action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"
                                             icon="fa fa-truck-ramp-box"
+                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyReturnSubmit')}"
                                             class="w-100"/>
                                     </div>
                                 </div>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -504,6 +504,7 @@
                                                             ajax="false"
                                                             action="#{admissionController.navigateToPharmacyBhtRequest}"
                                                             icon="fa fa-prescription-bottle-alt"
+                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest')}"
                                                             class="w-100">
                                                         </p:commandButton>
 
@@ -514,6 +515,7 @@
                                                             ajax="false"
                                                             action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
                                                             icon="fa fa-truck-medical"
+                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
                                                             class="w-100">
                                                         </p:commandButton>
 
@@ -523,6 +525,7 @@
                                                             ajax="false"
                                                             action="#{wardPharmacyReturnToPharmacyController.navigateToReturn}"
                                                             icon="fa fa-truck-ramp-box"
+                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyReturnSubmit')}"
                                                             class="w-100">
                                                         </p:commandButton>
 

--- a/src/main/webapp/pharmacy/pharmacy_cancel_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_transfer_issue.xhtml
@@ -33,8 +33,9 @@
                                             value="Cancel Bill" 
                                             icon="fa fa-cancel"
                                             style="float: right"
-                                            class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyTransferIssueCancel()}" >
-                                        </p:commandButton>  
+                                            class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyTransferIssueCancel()}"
+                                            disabled="#{not webUserController.hasPrivilege('PharmacyTransferIssueCancel')}" >
+                                        </p:commandButton>
                                     </h:panelGrid>
 
                                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_cancel_transfer_issue_for_inpatient_requests.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_transfer_issue_for_inpatient_requests.xhtml
@@ -23,8 +23,9 @@
                                         value="Cancel Bill" 
                                         icon="fa fa-cancel"
                                         style="float: right"
-                                        class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyTransferIssueInpatientCancel()}" >
-                                    </p:commandButton>  
+                                        class="ui-button-danger" action="#{pharmacyBillSearch.pharmacyTransferIssueInpatientCancel()}"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyTransferIssueCancel')}" >
+                                    </p:commandButton>
                                 </h:panelGrid>
 
                             </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue.xhtml
@@ -181,6 +181,7 @@
                                     onclick="if (!confirm('Are you sure you want to Settle This Bill ?')) return false;"
                                     ajax="false"
                                     class="ui-button-success mx-2"
+                                    disabled="#{not webUserController.hasPrivilege('PharmacyIssueForRequestFinalize')}"
                                     rendered="#{!configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Issue for Requests', false) and !transferIssueForRequestsController.draftMode}"/>
 
                                 <!-- 3-step workflow buttons -->

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_cancel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_cancel.xhtml
@@ -170,6 +170,7 @@
                                             value="Cancel Bill"
                                             icon="fas fa-ban"
                                             action="#{transferIssueCancellationController.confirmCancellation()}"
+                                            disabled="#{not webUserController.hasPrivilege('PharmacyTransferIssueCancel')}"
                                             onclick="if (!confirm('Are you sure you want to CANCEL this Transfer Issue Bill?\n\nThis action will:\n- Reverse stock movements\n- Reverse cost accounting\n- Mark the original bill as cancelled\n\nThis cannot be undone!')) return false;"
                                             ajax="false"
                                             class="ui-button-danger m-2"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct.xhtml
@@ -36,7 +36,8 @@
                                 <h:outputText value="#{w.staffCode}" ></h:outputText>
                             </p:column>
                         </p:autoComplete>
-                        <p:commandButton  value="Issue" icon="fas fa-check" action="#{transferIssueDirectController.settleDirectIssue}" ajax="false" class="ui-button-success mx-2" >
+                        <p:commandButton  value="Issue" icon="fas fa-check" action="#{transferIssueDirectController.settleDirectIssue}" ajax="false" class="ui-button-success mx-2"
+                                         disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementDirectIssue')}" >
                         </p:commandButton>
                     </h:panelGrid>
                 </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -57,7 +57,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="card border-success mt-3" rendered="#{not empty transferIssueDirectController.recentToDepartments}">
+                            <h:panelGroup layout="block" styleClass="card border-success mt-3" rendered="#{not empty transferIssueDirectController.recentToDepartments}">
                                 <div class="card-header bg-light">
                                     <h:outputLabel styleClass="fas fa-history me-2 text-success" />
                                     <small class="fw-bold text-success">Quick Access - Recently Issued To</small>
@@ -72,7 +72,7 @@
                                             ajax="false" />
                                     </ui:repeat>
                                 </div>
-                            </div>
+                            </h:panelGroup>
                         </div>
                         <div class="col-2"></div>
                     </div>
@@ -326,6 +326,7 @@
                                             onclick="if (!confirm('Are you sure you want to Settle This Bill ?'))
                                                         return false;"
                                             ajax="false"
+                                            disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementDirectIssue')}"
                                             styleClass="ui-button-success" />
                                     </div>
                                 </f:facet>
@@ -380,7 +381,7 @@
                                     </p:autoComplete>
                                 </div>
 
-                                <div class="card border-success mb-3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
+                                <h:panelGroup layout="block" styleClass="card border-success mb-3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Issue - Show Rate and Value', false) and webUserController.hasPrivilege('PharmacyTransferViewRates')}">
                                     <div class="card-header bg-light">
                                         <h:outputLabel styleClass="fas fa-calculator me-2" />
                                         <small class="fw-bold">Transfer Summary</small>
@@ -403,7 +404,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                </div>
+                                </h:panelGroup>
 
                                 <div class="mb-3">
                                     <p:outputLabel value="Comments" styleClass="form-label fw-bold text-danger"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_native.xhtml
@@ -42,6 +42,7 @@
                             class="ui-button-success mx-2"
                             action="#{transferIssueNativeSqlController.settle}"
                             ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyIssueForRequestFinalize')}"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Use Save Finalize Approve Workflow for Issue for Requests', false) and !transferIssueNativeSqlController.draftMode}"/>
 
                         <!-- Save Draft (when flag ON, not yet completed) -->

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -41,6 +41,7 @@
                             class="ui-button-success mx-2"
                             action="#{transferReceiveController.settle}"
                             ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyReceiveFinalize')}"
                             onclick="return confirm('Are you sure you want to receive this transfer?');" >
                         </p:commandButton>
                         <h:panelGroup rendered="#{transferReceiveController.issuedBill.comments ne null and not empty transferReceiveController.issuedBill.comments}">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_cancel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_cancel.xhtml
@@ -180,6 +180,7 @@
                                                 value="Cancel Bill"
                                                 icon="fas fa-ban"
                                                 action="#{transferReceiveCancellationController.confirmCancellation()}"
+                                                disabled="#{not webUserController.hasPrivilege('PharmacyTransferReceiveCancel')}"
                                                 onclick="if (!confirm('Are you sure you want to CANCEL this Transfer Receive Bill?\n\nThis action will:\n- Reverse stock movements\n- Reverse cost accounting\n- Mark the original bill as cancelled\n\nThis cannot be undone!')) return false;"
                                                 ajax="false"
                                                 class="ui-button-danger m-2"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native.xhtml
@@ -35,7 +35,8 @@
                             style="float: right;"
                             class="ui-button-success mx-2"
                             action="#{transferReceiveNativeSqlController.settle}"
-                            ajax="false">
+                            ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyReceiveFinalize')}">
                         </p:commandButton>
 
                         <h:panelGroup rendered="#{transferReceiveNativeSqlController.issuedBill.comments ne null and not empty transferReceiveNativeSqlController.issuedBill.comments}">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_approval.xhtml
@@ -31,6 +31,7 @@
                             class="ui-button-success mx-1"
                             icon="fas fa-check"
                             ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyReceiveApprove')}"
                             style="float: right;"
                             onclick="if (!confirm('Are you sure you want to settle this transfer receive?'))
                                         return false;">

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native_with_approval.xhtml
@@ -42,6 +42,7 @@
                             styleClass="ui-button-stage-finalize mx-1"
                             icon="fas fa-lock"
                             ajax="false"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyReceiveFinalize')}"
                             onclick="return confirm('Are you sure you want to finalize this receive? This cannot be undone.');"
                             style="float: right;">
                         </p:commandButton>
@@ -50,6 +51,7 @@
                             action="#{transferReceiveNativeSqlController.saveRequest()}"
                             styleClass="ui-button-stage-save mx-1"
                             icon="fas fa-floppy-disk"
+                            disabled="#{not webUserController.hasPrivilege('PharmacyReceiveSave')}"
                             ajax="false"
                             style="float: right;">
                         </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -36,7 +36,7 @@
                             styleClass="ui-button-stage-finalize mx-1"
                             icon="fas fa-lock"
                             ajax="false"
-                            disabled="#{transferReceiveController.receivedBill.checkedBy ne null}"
+                            disabled="#{transferReceiveController.receivedBill.checkedBy ne null or not webUserController.hasPrivilege('PharmacyReceiveFinalize')}"
                             onclick="return confirm('Are you sure you want to finalize this receive? This cannot be undone.');"
                             style="float: right;">
                         </p:commandButton>
@@ -45,7 +45,7 @@
                             action="#{transferReceiveController.saveRequest()}"
                             styleClass="ui-button-stage-save mx-1"
                             icon="fas fa-floppy-disk"
-                            disabled="#{transferReceiveController.receivedBill.checkedBy ne null}"
+                            disabled="#{transferReceiveController.receivedBill.checkedBy ne null or not webUserController.hasPrivilege('PharmacyReceiveSave')}"
                             ajax="false"
                             style="float: right;">
                         </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request.xhtml
@@ -120,6 +120,7 @@
                                         ajax="false"
                                         icon="fas fa-floppy-disk"
                                         styleClass="mx-1 ui-button-stage-save"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementRequest')}"
                                         />
                                     <p:commandButton
                                         id="btnFinalize"
@@ -129,6 +130,7 @@
                                         icon="fas fa-lock"
                                         styleClass="mx-1 ui-button-stage-finalize"
                                         onclick="return confirm('Are you sure you want to finalize this transfer request? This action cannot be undone.');"
+                                        disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}"
                                         />
                                 </div>
                             </div>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -36,7 +36,8 @@
                                     ajax="false"
                                     icon="fas fa-check-double"
                                     styleClass="mx-1 ui-button-stage-approve"
-                                    onclick="return confirm('Are you sure you want to approve this transfer request?');">
+                                    onclick="return confirm('Are you sure you want to approve this transfer request?');"
+                                    disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}">
                                 </p:commandButton>
                             </div>
                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_for_approvel.xhtml
@@ -58,7 +58,8 @@
                                     action="#{transferRequestController.saveTranserRequest()}"
                                     ajax="false"
                                     icon="fas fa-floppy-disk"
-                                    styleClass="mx-1 ui-button-stage-save">
+                                    styleClass="mx-1 ui-button-stage-save"
+                                    disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementRequest')}">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="Send For Approval"
@@ -66,7 +67,8 @@
                                     ajax="false"
                                     icon="fas fa-lock"
                                     styleClass="mx-1 ui-button-stage-finalize"
-                                    onclick="return confirm('Are you sure you want to send this request for approval? This cannot be undone.');">
+                                    onclick="return confirm('Are you sure you want to send this request for approval? This cannot be undone.');"
+                                    disabled="#{not webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="New Bill"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
@@ -112,7 +112,7 @@
                                     title="To Approve" 
                                     icon="fas fa-check-circle"
                                     class="ui-button-success m-1"
-                                    disabled="#{p.checkedBy eq null or p.approveUser ne null or p.cancelled eq true and not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
+                                    disabled="#{p.checkedBy eq null or p.approveUser ne null or p.cancelled eq true or not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
                                     action="#{transferRequestController.navigateToApproveRequest()}">
                                     <f:setPropertyActionListener 
                                         target="#{transferRequestController.transferRequestBillPre}"

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_receive.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_receive.xhtml
@@ -31,6 +31,7 @@
                                 ajax="false"
                                 class="ui-button-success"
                                 action="#{wardPharmacyBhtIssueReceiveController.settle}"
+                                disabled="#{not webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
                                 onclick="return confirm('Confirm that these medicines have been physically received into this ward?');"/>
                         </div>
                     </div>

--- a/src/main/webapp/ward/ward_pharmacy_return_to_pharmacy.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_return_to_pharmacy.xhtml
@@ -151,6 +151,7 @@
                         class="ui-button-success"
                         update=":formWardReturnToPharmacy"
                         actionListener="#{wardPharmacyReturnToPharmacyController.settle}"
+                        disabled="#{not webUserController.hasPrivilege('InwardPharmacyReturnSubmit')}"
                         onclick="if (!confirm('Return the selected items to the pharmacy via the selected porter? This cannot be undone.')) { return false; }"/>
                 </div>
             </p:panel>


### PR DESCRIPTION
## Summary
- Adds server-side `isAuthorized()` privilege checks (matching the pattern from #22019) to every mutating method across `TransferRequestController`, `TransferIssueForRequestsController`, `TransferIssueNativeSqlController`, `TransferIssueDirectController`, `TransferReceiveController`, `TransferReceiveNativeSqlController`, `TransferIssueCancellationController`, `TransferReceiveCancellationController` — previously **zero** `hasPrivilege` calls existed across this entire controller family.
- **New privileges:** `PharmacyReceiveSave`, `PharmacyTransferIssueCancel`, `PharmacyTransferReceiveCancel`, `InwardPharmacyBhtReceive`, `InwardPharmacyReturnSubmit`.
- Fixes a broken EL operator-precedence bug (`A or B or C and notPriv`) that made `PharmacyDisbursementRequestApproval` inert in the normal path on `pharmacy_transfer_request_list_search_for_approval.xhtml`.
- Fixes issue #15982 (JSF `rendered` silently ignored on plain HTML `<div>`s) in `pharmacy_transfer_issue_direct_department.xhtml`.
- Swaps the Home dashboard's coarse `PharmacyTransfer` gate for the same fine-grained privileges the Pharmacy menu uses on identical destination pages.
- Theater menu's separate `Theater*` privilege space on the same controllers is a known open design question, explicitly left untouched.

## Additional gaps found during implementation (beyond the original audit)
- `TransferIssueNativeSqlController.approveDraftNativeIssue()` — client-gated but had no server-side check. Fixed.
- `PharmacyBillSearch.pharmacyTransferIssueCancel()` / `pharmacyTransferIssueInpatientCancel()` — a second, entirely separate Cancel code path (not the one the original audit assumed) with zero privilege checks. Fixed.
- Nursing Workbench "Receive Medicines from Pharmacy" / "Return Medicines to Pharmacy" had no privilege of any kind anywhere in the codebase. Added two new privileges and wired them end-to-end (server + every UI entry point).
- `pharmacy_transfer_request_for_approvel.xhtml` references two controller methods that don't exist (`saveTranserRequest()`/`finalizeTranserRequest`) — pre-existing, unrelated broken binding, flagged but not fixed here.

## Test plan
- [x] `mvn clean package -DskipTests` — builds clean
- [x] Deployed to local Payara, logged in as `buddhika` in department "Matara - Pharmacy"
- [x] Positive path: with `PharmacyDisbursementDirectIssue`, the Direct Transfer Issue page renders with the Issue button enabled
- [x] Negative path: after revoking the privilege and re-authenticating, the Issue button renders **disabled**
- [x] Confirmed the Home dashboard fine-grained swap, EL fix, and full menu render with no regressions for a privileged user
- Full evidence + screenshots: see [issue #22021 comment](https://github.com/hmislk/hmis/issues/22021#issuecomment-4941156599)

Closes #14869
Closes #18558
Closes #15982
Closes #21484
Part of #21994
Part of #21992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular permissions for pharmacy transfers, receiving, cancellations, and inward pharmacy workflows.
  * Pharmacy menus and action buttons now appear or activate only for authorized users.
* **Bug Fixes**
  * Prevented unauthorized saving, approving, finalizing, settling, receiving, and cancellation actions across pharmacy workflows.
  * Added clear access-denied messages when required permissions are missing.
* **Security**
  * Added authorization checks across standard and fast pharmacy transfer processes to prevent unauthorized changes and stock operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->