### PR TITLE
feat(admin): role-template user management — reset/expand/narrow privileges, icons, subscriptions & per-department default login page (single + bulk)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -514,6 +514,33 @@ with a `Finance` API-key header — it runs the identical `fetchInwardMargin(...
 controllers use and returns the matched row id + margin %. Verified while testing room-category
 pharmacy margins (issue #21981).
 
+## 23. Three authoring gotchas found via E2E on the role-template pages (issue #22023)
+
+Testing `admin/users/user_role_users.xhtml` / `user_role_bulk_operations.xhtml` surfaced
+three silent-failure patterns worth checking on any new admin page:
+
+1. **`p:selectManyCheckbox` over a `List<Entity>` needs an explicit named converter.**
+   The `@FacesConverter(forClass = Department.class)` converter is *not* applied to
+   `UISelectMany` bound to a generic `List` (type erasure — JSF can't detect the element
+   type), so submitted values stay `String`s and the action later dies with
+   `ClassCastException: java.lang.String cannot be cast to ... Department` inside the EJB.
+   Fix: register a named converter (e.g. `userRoleDepartmentConverter`) and set
+   `converter="..."` on the component explicitly.
+2. **`process="cmbA cmbB"` without `@this` silently skips the button's own action.**
+   The AJAX request fires, inputs are applied, the `update` render runs — but the
+   `action` never executes because the button itself wasn't in the execute list.
+   Symptom: "No records found" with no error anywhere. Always write
+   `process="@this cmbA cmbB"`.
+3. **Multi-select checkbox column: this PrimeFaces version wants `selectionMode="multiple"`
+   on the `p:dataTable` + `<p:column selectionBox="true"/>`** — a
+   `<p:column selectionMode="multiple"/>` (the pattern current PF docs show) renders an
+   *empty* cell. Copy the working pattern from `user_remove_multiple.xhtml`.
+
+Also (rendering): a `p:selectOneMenu` bound to `#{bean.current.field}` blows up the whole
+page with `PropertyNotFoundException: Target Unreachable` when `current` is null on first
+GET — unlike `p:inputText`, select components resolve the value expression's *type* during
+render. Guard with `rendered="#{bean.current ne null}"`.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -19,6 +19,7 @@ import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.Icon;
 import com.divudi.core.data.IconGroup;
 import com.divudi.core.data.InstitutionType;
+import com.divudi.core.data.LoginPage;
 import com.divudi.core.data.UserIconGroup;
 import static com.divudi.core.data.LoginPage.CHANNELLING_QUEUE_PAGE;
 import static com.divudi.core.data.LoginPage.CHANNELLING_TV_DISPLAY;
@@ -41,6 +42,7 @@ import com.divudi.core.entity.UserIcon;
 import com.divudi.core.entity.UserPreference;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.WebUserDashboard;
+import com.divudi.core.entity.WebUserDefaultLoginPage;
 import com.divudi.core.entity.WebUserDepartment;
 import com.divudi.core.entity.WebUserPrivilege;
 import com.divudi.core.entity.WebUserRole;
@@ -50,6 +52,7 @@ import com.divudi.core.facade.LoginsFacade;
 import com.divudi.core.facade.PersonFacade;
 import com.divudi.core.facade.UserPreferenceFacade;
 import com.divudi.core.facade.WebUserDashboardFacade;
+import com.divudi.core.facade.WebUserDefaultLoginPageFacade;
 import com.divudi.core.facade.WebUserDepartmentFacade;
 import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.facade.WebUserPrivilegeFacade;
@@ -126,8 +129,10 @@ public class SessionController implements Serializable, HttpSessionListener {
     WebUserRoleFacade rFacade;
     @EJB
     private WebUserPasswordHistoryFacade webUserPasswordHistoryFacade;
+    @EJB
+    private WebUserDefaultLoginPageFacade webUserDefaultLoginPageFacade;
 
-    // </editor-fold>  
+    // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
     private SecurityController securityController;
@@ -1843,14 +1848,38 @@ public class SessionController implements Serializable, HttpSessionListener {
         return true;
     }
 
+    /**
+     * Resolves the login page to navigate to: an active per-user-per-department
+     * {@link WebUserDefaultLoginPage} row takes priority, then the legacy
+     * {@link WebUser#getLoginPage()} value, then HOME.
+     */
+    private LoginPage resolveLoginPage() {
+        if (loggedUser == null) {
+            return LoginPage.HOME;
+        }
+        if (department != null) {
+            Map m = new HashMap();
+            m.put("user", loggedUser);
+            m.put("dept", department);
+            WebUserDefaultLoginPage wuLp = webUserDefaultLoginPageFacade.findFirstByJpql(
+                    "select w from WebUserDefaultLoginPage w where w.webUser=:user and w.department=:dept and w.retired=false order by w.id desc",
+                    m);
+            if (wuLp != null && wuLp.getLoginPage() != null) {
+                return wuLp.getLoginPage();
+            }
+        }
+        if (loggedUser.getLoginPage() != null) {
+            return loggedUser.getLoginPage();
+        }
+        return LoginPage.HOME;
+    }
+
     public String navigateToLoginPageByUsersDefaultLoginPage() {
         if (loggedUser == null) {
             return null;
         }
-        if (loggedUser.getLoginPage() == null) {
-            return "/home?faces-redirect=true";
-        }
-        switch (loggedUser.getLoginPage()) {
+        LoginPage resolvedLoginPage = resolveLoginPage();
+        switch (resolvedLoginPage) {
             case CHANNELLING_QUEUE_PAGE:
                 return bookingController.navigateToChannelQueueFromMenu();
             case CHANNELLING_TV_DISPLAY:

--- a/src/main/java/com/divudi/bean/common/UserRoleManagementController.java
+++ b/src/main/java/com/divudi/bean/common/UserRoleManagementController.java
@@ -1,0 +1,704 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Role-template based user management: reset/expand/narrow a user's
+ * privileges/icons/subscriptions/login-page against a WebUserRole template,
+ * for a single user or in bulk. Thin UI layer over
+ * com.divudi.service.UserRoleApplicationService (the single engine also used
+ * by the REST API and the AI assistant).
+ */
+package com.divudi.bean.common;
+
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.WebUserRole;
+import com.divudi.core.facade.DepartmentFacade;
+import com.divudi.core.facade.InstitutionFacade;
+import com.divudi.core.facade.WebUserFacade;
+import com.divudi.core.facade.WebUserRoleFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.UserRoleApplicationService;
+import com.divudi.service.UserRoleApplicationService.RoleAspect;
+import com.divudi.service.UserRoleApplicationService.RoleApplicationResult;
+import com.divudi.service.UserRoleApplicationService.RoleOperation;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ *
+ * @author www.divudi.com
+ */
+@Named
+@SessionScoped
+public class UserRoleManagementController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // <editor-fold desc="EJBs / injected controllers">
+    @EJB
+    private UserRoleApplicationService userRoleApplicationService;
+    @EJB
+    private DepartmentFacade departmentFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+    @EJB
+    private WebUserRoleFacade webUserRoleFacade;
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @Inject
+    private SessionController sessionController;
+    // </editor-fold>
+
+    // <editor-fold desc="Per-user page state">
+    private WebUser currentUser;
+    private WebUserRole selectedRole;
+    private List<WebUserRole> roles;
+    private List<Department> userDepartments;
+    private List<Department> selectedDepartments;
+
+    private boolean aspectPrivileges = true;
+    private boolean aspectIcons;
+    private boolean aspectSubscriptions;
+    private boolean aspectLoginPage;
+
+    private boolean updateUserRole = true;
+
+    private String previewText;
+    private List<UserRoleApplicationService.RoleApplicationResult> results;
+    // </editor-fold>
+
+    // <editor-fold desc="Bulk page state">
+    private WebUserRole filterRole;
+    private Department filterDepartment;
+    private Institution filterInstitution;
+    private List<Department> allDepartments;
+    private List<Institution> institutions;
+    private List<WebUser> filteredUsers;
+    private List<WebUser> selectedUsers;
+    // </editor-fold>
+
+    /**
+     * Re-entrancy guard shared across the action methods on this
+     * session-scoped bean, so a double click (or two tabs racing) cannot
+     * apply the same role operation twice.
+     */
+    private volatile boolean processing;
+
+    // <editor-fold desc="Navigation">
+    public String navigateToManageUserRoleDefaults(WebUser user) {
+        if (user == null) {
+            JsfUtil.addErrorMessage("Please select a user");
+            return "";
+        }
+        currentUser = user;
+        selectedRole = user.getRole();
+        userDepartments = fillWebUserDepartments(user);
+        selectedDepartments = new ArrayList<>();
+        results = null;
+        previewText = null;
+        return "/admin/users/user_role_users?faces-redirect=true";
+    }
+
+    public String navigateToBulkRoleOperations() {
+        filterRole = null;
+        filterDepartment = null;
+        filterInstitution = null;
+        allDepartments = null;
+        institutions = null;
+        filteredUsers = null;
+        selectedUsers = new ArrayList<>();
+        selectedDepartments = new ArrayList<>();
+        selectedRole = null;
+        results = null;
+        previewText = null;
+        return "/admin/users/user_role_bulk_operations?faces-redirect=true";
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Per-user actions">
+    public void saveUserRole() {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            if (currentUser == null) {
+                JsfUtil.addErrorMessage("No user selected.");
+                return;
+            }
+            currentUser.setRole(selectedRole);
+            webUserFacade.edit(currentUser);
+            JsfUtil.addSuccessMessage("User role saved.");
+        } finally {
+            processing = false;
+        }
+    }
+
+    public void previewOperation(String op) {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            previewText = null;
+            RoleOperation operation = parseOperation(op);
+            if (operation == null) {
+                JsfUtil.addErrorMessage("Unknown operation.");
+                return;
+            }
+            if (currentUser == null) {
+                JsfUtil.addErrorMessage("No user selected.");
+                return;
+            }
+            WebUserRole effectiveRole = selectedRole != null ? selectedRole : currentUser.getRole();
+            if (effectiveRole == null) {
+                JsfUtil.addErrorMessage("No role available: select a role or ensure the user has a default role.");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            Map<RoleAspect, Long> counts = userRoleApplicationService.previewCounts(
+                    operation, currentUser, effectiveRole, selectedDepartments, aspects);
+            previewText = formatPreview(counts);
+        } finally {
+            processing = false;
+        }
+    }
+
+    public void executeResetToDefaultRole() {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            if (currentUser == null) {
+                JsfUtil.addErrorMessage("No user selected.");
+                return;
+            }
+            WebUserRole role = currentUser.getRole();
+            if (role == null) {
+                JsfUtil.addErrorMessage("User has no default role");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            RoleApplicationResult result = userRoleApplicationService.apply(
+                    RoleOperation.RESET, currentUser, role, selectedDepartments, aspects, false, actor());
+            applyResult(result);
+        } finally {
+            processing = false;
+        }
+    }
+
+    public void executeResetToSelectedRole() {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            if (currentUser == null) {
+                JsfUtil.addErrorMessage("No user selected.");
+                return;
+            }
+            if (selectedRole == null) {
+                JsfUtil.addErrorMessage("Select a role.");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            RoleApplicationResult result = userRoleApplicationService.apply(
+                    RoleOperation.RESET, currentUser, selectedRole, selectedDepartments, aspects, updateUserRole, actor());
+            applyResult(result);
+        } finally {
+            processing = false;
+        }
+    }
+
+    public void executeExpand() {
+        executeRoleOperation(RoleOperation.EXPAND);
+    }
+
+    public void executeNarrow() {
+        executeRoleOperation(RoleOperation.NARROW);
+    }
+
+    private void executeRoleOperation(RoleOperation operation) {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            if (currentUser == null) {
+                JsfUtil.addErrorMessage("No user selected.");
+                return;
+            }
+            if (selectedRole == null) {
+                JsfUtil.addErrorMessage("Select a role.");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            RoleApplicationResult result = userRoleApplicationService.apply(
+                    operation, currentUser, selectedRole, selectedDepartments, aspects, false, actor());
+            applyResult(result);
+        } finally {
+            processing = false;
+        }
+    }
+
+    private void applyResult(RoleApplicationResult result) {
+        results = java.util.Collections.singletonList(result);
+        if (result.isSuccess()) {
+            JsfUtil.addSuccessMessage("Applied: " + result.summary());
+        } else {
+            JsfUtil.addErrorMessage(result.getErrorMessage());
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Bulk actions">
+    public void fillUsersByFilter() {
+        StringBuilder jpql = new StringBuilder("select u from WebUser u where u.retired=false");
+        Map<String, Object> params = new HashMap<>();
+        if (filterRole != null) {
+            jpql.append(" and u.role=:r");
+            params.put("r", filterRole);
+        }
+        if (filterDepartment != null) {
+            jpql.append(" and u.id in (select wd.webUser.id from WebUserDepartment wd where wd.department=:d and wd.retired=false)");
+            params.put("d", filterDepartment);
+        }
+        if (filterInstitution != null) {
+            jpql.append(" and u.institution=:ins");
+            params.put("ins", filterInstitution);
+        }
+        jpql.append(" order by u.name");
+        filteredUsers = webUserFacade.findByJpql(jpql.toString(), params);
+        selectedUsers = new ArrayList<>();
+    }
+
+    public void selectAllFilteredUsers() {
+        selectedUsers = filteredUsers == null ? new ArrayList<>() : new ArrayList<>(filteredUsers);
+    }
+
+    public void executeBulk(String op) {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            RoleOperation operation = parseOperation(op);
+            if (operation == null) {
+                JsfUtil.addErrorMessage("Unknown operation.");
+                return;
+            }
+            if (selectedUsers == null || selectedUsers.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one user.");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            WebUserRole role = selectedRole;
+            if (role == null && operation != RoleOperation.RESET) {
+                JsfUtil.addErrorMessage("Select a role.");
+                return;
+            }
+            results = userRoleApplicationService.applyBulk(
+                    operation, selectedUsers, role, selectedDepartments, aspects, updateUserRole, actor());
+            JsfUtil.addSuccessMessage(RoleApplicationResult.summarize(results));
+        } finally {
+            processing = false;
+        }
+    }
+
+    public void previewBulk(String op) {
+        if (processing) {
+            JsfUtil.addErrorMessage("Already processing a request. Please wait.");
+            return;
+        }
+        processing = true;
+        try {
+            previewText = null;
+            RoleOperation operation = parseOperation(op);
+            if (operation == null) {
+                JsfUtil.addErrorMessage("Unknown operation.");
+                return;
+            }
+            if (selectedUsers == null || selectedUsers.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one user.");
+                return;
+            }
+            if (selectedDepartments == null || selectedDepartments.isEmpty()) {
+                JsfUtil.addErrorMessage("Select at least one department.");
+                return;
+            }
+            Set<RoleAspect> aspects = selectedAspects();
+            if (aspects == null) {
+                return;
+            }
+            if (selectedRole == null && operation != RoleOperation.RESET) {
+                JsfUtil.addErrorMessage("Select a role.");
+                return;
+            }
+            Map<RoleAspect, Long> totals = new EnumMap<>(RoleAspect.class);
+            int usersCounted = 0;
+            for (WebUser u : selectedUsers) {
+                if (u == null) {
+                    continue;
+                }
+                WebUserRole effectiveRole = selectedRole != null ? selectedRole : u.getRole();
+                if (effectiveRole == null) {
+                    continue;
+                }
+                Map<RoleAspect, Long> counts = userRoleApplicationService.previewCounts(
+                        operation, u, effectiveRole, selectedDepartments, aspects);
+                for (Map.Entry<RoleAspect, Long> e : counts.entrySet()) {
+                    totals.merge(e.getKey(), e.getValue(), Long::sum);
+                }
+                usersCounted++;
+            }
+            previewText = usersCounted + " users; " + formatPreview(totals);
+        } finally {
+            processing = false;
+        }
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Helpers">
+    private WebUser actor() {
+        return sessionController.getLoggedUser();
+    }
+
+    private RoleOperation parseOperation(String op) {
+        if (op == null) {
+            return null;
+        }
+        try {
+            return RoleOperation.valueOf(op);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private Set<RoleAspect> selectedAspects() {
+        Set<RoleAspect> aspects = new LinkedHashSet<>();
+        if (aspectPrivileges) {
+            aspects.add(RoleAspect.PRIVILEGES);
+        }
+        if (aspectIcons) {
+            aspects.add(RoleAspect.ICONS);
+        }
+        if (aspectSubscriptions) {
+            aspects.add(RoleAspect.SUBSCRIPTIONS);
+        }
+        if (aspectLoginPage) {
+            aspects.add(RoleAspect.LOGIN_PAGE);
+        }
+        if (aspects.isEmpty()) {
+            JsfUtil.addErrorMessage("Select at least one aspect (Privileges, Icons, Subscriptions, Login Page).");
+            return null;
+        }
+        return aspects;
+    }
+
+    private String formatPreview(Map<RoleAspect, Long> counts) {
+        if (counts == null || counts.isEmpty()) {
+            return "No changes";
+        }
+        StringBuilder sb = new StringBuilder();
+        appendAspect(sb, "Privileges", counts.get(RoleAspect.PRIVILEGES));
+        appendAspect(sb, "Icons", counts.get(RoleAspect.ICONS));
+        appendAspect(sb, "Subscriptions", counts.get(RoleAspect.SUBSCRIPTIONS));
+        appendAspect(sb, "Login Page", counts.get(RoleAspect.LOGIN_PAGE));
+        return sb.length() == 0 ? "No changes" : sb.toString();
+    }
+
+    private void appendAspect(StringBuilder sb, String label, Long count) {
+        if (count == null) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append("; ");
+        }
+        sb.append(label).append(": ").append(count).append(" changes");
+    }
+
+    /**
+     * Pattern reused from UserPrivilageController.fillWebUserDepartments /
+     * WebUserRoleUserController.fillWebUserDepartments.
+     */
+    public List<Department> fillWebUserDepartments(WebUser wu) {
+        Set<Department> departmentSet = new HashSet<>();
+        String jpql = "SELECT i.department "
+                + " FROM WebUserDepartment i "
+                + " WHERE i.retired = :ret "
+                + " AND i.webUser = :wu "
+                + " AND i.department.name is not null "
+                + " ORDER BY i.department.name";
+        Map<String, Object> m = new HashMap<>();
+        m.put("ret", false);
+        m.put("wu", wu);
+        List<Department> depts = departmentFacade.findByJpql(jpql, m);
+        departmentSet.addAll(depts);
+        return new ArrayList<>(departmentSet);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Getters / Setters">
+    public WebUser getCurrentUser() {
+        return currentUser;
+    }
+
+    public void setCurrentUser(WebUser currentUser) {
+        this.currentUser = currentUser;
+    }
+
+    public WebUserRole getSelectedRole() {
+        return selectedRole;
+    }
+
+    public void setSelectedRole(WebUserRole selectedRole) {
+        this.selectedRole = selectedRole;
+    }
+
+    public List<WebUserRole> getRoles() {
+        if (roles == null) {
+            roles = webUserRoleFacade.findByJpql("select r from WebUserRole r where r.retired=false order by r.name");
+        }
+        return roles;
+    }
+
+    public void setRoles(List<WebUserRole> roles) {
+        this.roles = roles;
+    }
+
+    public List<Department> getUserDepartments() {
+        return userDepartments;
+    }
+
+    public void setUserDepartments(List<Department> userDepartments) {
+        this.userDepartments = userDepartments;
+    }
+
+    public List<Department> getSelectedDepartments() {
+        return selectedDepartments;
+    }
+
+    public void setSelectedDepartments(List<Department> selectedDepartments) {
+        this.selectedDepartments = selectedDepartments;
+    }
+
+    public boolean isAspectPrivileges() {
+        return aspectPrivileges;
+    }
+
+    public void setAspectPrivileges(boolean aspectPrivileges) {
+        this.aspectPrivileges = aspectPrivileges;
+    }
+
+    public boolean isAspectIcons() {
+        return aspectIcons;
+    }
+
+    public void setAspectIcons(boolean aspectIcons) {
+        this.aspectIcons = aspectIcons;
+    }
+
+    public boolean isAspectSubscriptions() {
+        return aspectSubscriptions;
+    }
+
+    public void setAspectSubscriptions(boolean aspectSubscriptions) {
+        this.aspectSubscriptions = aspectSubscriptions;
+    }
+
+    public boolean isAspectLoginPage() {
+        return aspectLoginPage;
+    }
+
+    public void setAspectLoginPage(boolean aspectLoginPage) {
+        this.aspectLoginPage = aspectLoginPage;
+    }
+
+    public boolean isUpdateUserRole() {
+        return updateUserRole;
+    }
+
+    public void setUpdateUserRole(boolean updateUserRole) {
+        this.updateUserRole = updateUserRole;
+    }
+
+    public String getPreviewText() {
+        return previewText;
+    }
+
+    public void setPreviewText(String previewText) {
+        this.previewText = previewText;
+    }
+
+    public List<UserRoleApplicationService.RoleApplicationResult> getResults() {
+        return results;
+    }
+
+    public void setResults(List<UserRoleApplicationService.RoleApplicationResult> results) {
+        this.results = results;
+    }
+
+    public WebUserRole getFilterRole() {
+        return filterRole;
+    }
+
+    public void setFilterRole(WebUserRole filterRole) {
+        this.filterRole = filterRole;
+    }
+
+    public Department getFilterDepartment() {
+        return filterDepartment;
+    }
+
+    public void setFilterDepartment(Department filterDepartment) {
+        this.filterDepartment = filterDepartment;
+    }
+
+    public Institution getFilterInstitution() {
+        return filterInstitution;
+    }
+
+    public void setFilterInstitution(Institution filterInstitution) {
+        this.filterInstitution = filterInstitution;
+    }
+
+    public List<Department> getAllDepartments() {
+        if (allDepartments == null) {
+            // d.name is not null: legacy rows with null names would NPE the checkbox label renderer
+            allDepartments = departmentFacade.findByJpql("select d from Department d where d.retired=false and d.name is not null order by d.name");
+        }
+        return allDepartments;
+    }
+
+    public void setAllDepartments(List<Department> allDepartments) {
+        this.allDepartments = allDepartments;
+    }
+
+    public List<Institution> getInstitutions() {
+        if (institutions == null) {
+            institutions = institutionFacade.findByJpql("select i from Institution i where i.retired=false and i.name is not null order by i.name");
+        }
+        return institutions;
+    }
+
+    public void setInstitutions(List<Institution> institutions) {
+        this.institutions = institutions;
+    }
+
+    public List<WebUser> getFilteredUsers() {
+        return filteredUsers;
+    }
+
+    public void setFilteredUsers(List<WebUser> filteredUsers) {
+        this.filteredUsers = filteredUsers;
+    }
+
+    public List<WebUser> getSelectedUsers() {
+        return selectedUsers;
+    }
+
+    public void setSelectedUsers(List<WebUser> selectedUsers) {
+        this.selectedUsers = selectedUsers;
+    }
+
+    public DepartmentFacade getDepartmentFacade() {
+        return departmentFacade;
+    }
+    // </editor-fold>
+
+    /**
+     * Explicit converter for Department multi-selects. UISelectMany over a
+     * List cannot detect the element type (generics erasure), so the
+     * forClass Department converter is never applied and submitted values
+     * stay Strings — this named converter must be set on the component.
+     */
+    @FacesConverter("userRoleDepartmentConverter")
+    public static class UserRoleDepartmentConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.trim().isEmpty()) {
+                return null;
+            }
+            UserRoleManagementController controller = (UserRoleManagementController) facesContext.getApplication().getELResolver().
+                    getValue(facesContext.getELContext(), null, "userRoleManagementController");
+            try {
+                return controller.getDepartmentFacade().find(Long.valueOf(value));
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return null;
+            }
+            if (object instanceof Department) {
+                Department d = (Department) object;
+                return d.getId() == null ? null : String.valueOf(d.getId());
+            }
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/divudi/bean/common/UserRoleManagementController.java
+++ b/src/main/java/com/divudi/bean/common/UserRoleManagementController.java
@@ -50,6 +50,12 @@ public class UserRoleManagementController implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Same cap as UserManagementApi.bulkRoleOperations — bulk role
+     * operations run synchronously, so bound one run's size.
+     */
+    private static final int MAX_BULK_USERS = 500;
+
     // <editor-fold desc="EJBs / injected controllers">
     @EJB
     private UserRoleApplicationService userRoleApplicationService;
@@ -343,6 +349,11 @@ public class UserRoleManagementController implements Serializable {
                 JsfUtil.addErrorMessage("Select at least one user.");
                 return;
             }
+            if (selectedUsers.size() > MAX_BULK_USERS) {
+                JsfUtil.addErrorMessage("Too many users selected (" + selectedUsers.size()
+                        + "). Narrow the filter to " + MAX_BULK_USERS + " users or fewer per run.");
+                return;
+            }
             if (selectedDepartments == null || selectedDepartments.isEmpty()) {
                 JsfUtil.addErrorMessage("Select at least one department.");
                 return;
@@ -379,6 +390,11 @@ public class UserRoleManagementController implements Serializable {
             }
             if (selectedUsers == null || selectedUsers.isEmpty()) {
                 JsfUtil.addErrorMessage("Select at least one user.");
+                return;
+            }
+            if (selectedUsers.size() > MAX_BULK_USERS) {
+                JsfUtil.addErrorMessage("Too many users selected (" + selectedUsers.size()
+                        + "). Narrow the filter to " + MAX_BULK_USERS + " users or fewer per run.");
                 return;
             }
             if (selectedDepartments == null || selectedDepartments.isEmpty()) {

--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -114,6 +114,8 @@ public class WebUserController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     WebUserRoleController webUserRoleController;
+    @Inject
+    private UserRoleManagementController userRoleManagementController;
 
     /**
      * Class Variables
@@ -1202,12 +1204,7 @@ public class WebUserController implements Serializable {
             JsfUtil.addErrorMessage("Please select a user");
             return "";
         }
-        webUserRoleController.setActivatediItems(null);
-        webUserRoleUserController.setWebUser(selected);
-        webUserRoleUserController.setDepartments(fillWebUserDepartments(selected));
-        webUserRoleUserController.loadWebUserRoles();
-        webUserRoleUserController.clear();
-        return "/admin/users/user_role_users?faces-redirect=true";
+        return userRoleManagementController.navigateToManageUserRoleDefaults(selected);
     }
     
     public List<Department> fillWebUserDepartments(WebUser wu) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1315,10 +1315,10 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     /**
-     * Authorization helper method to check Purchase Order cancellation
-     * privileges and audit denied access
+     * Authorization helper shared by the PO / transfer-issue / GRN
+     * cancellation actions: checks the privilege and audits denied access.
      *
-     * @param action The action being attempted (CANCEL)
+     * @param action The action being attempted (e.g. CANCEL, PHARMACY_GRN_CANCEL)
      * @param requiredPrivilege The specific privilege required
      * @return true if authorized, false if not
      */
@@ -1333,10 +1333,10 @@ public class PharmacyBillSearch implements Serializable {
             Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
             Long billId = bill != null ? bill.getId() : null;
 
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
                     new Object[]{action, userId, billId, requiredPrivilege});
 
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase().replace('_', ' ') + ".");
             return false;
         }
 
@@ -3613,35 +3613,6 @@ public class PharmacyBillSearch implements Serializable {
         }
     }
 
-    /**
-     * Authorization helper method to check Transfer Issue cancellation
-     * privileges and audit denied access
-     *
-     * @param action The action being attempted (CANCEL)
-     * @param requiredPrivilege The specific privilege required
-     * @return true if authorized, false if not
-     */
-    private boolean isAuthorized(String action, String requiredPrivilege) {
-        if (webUserController == null || sessionController == null) {
-            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
-                    new Object[]{action, bill != null ? bill.getId() : "null"});
-            return false;
-        }
-
-        if (!webUserController.hasPrivilege(requiredPrivilege)) {
-            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
-            Long billId = bill != null ? bill.getId() : null;
-
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Issue cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
-                    new Object[]{action, userId, billId, requiredPrivilege});
-
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " this transfer issue.");
-            return false;
-        }
-
-        return true;
-    }
-
     public void pharmacyTransferIssueCancel() {
         if (!isAuthorized("CANCEL", "PharmacyTransferIssueCancel")) {
             return;
@@ -5836,37 +5807,6 @@ public class PharmacyBillSearch implements Serializable {
         if (issueSearchDtos == null) {
             issueSearchDtos = new ArrayList<>();
         }
-    }
-
-    /**
-     * Authorization helper method to check GRN cancellation privileges and
-     * audit denied access
-     *
-     * @param action The action being attempted (PHARMACY_GRN_CANCEL,
-     * PHARMACY_GRN_RETURN_CANCEL)
-     * @param requiredPrivilege The specific privilege required
-     * @return true if authorized, false if not
-     */
-    private boolean isAuthorized(String action, String requiredPrivilege) {
-        if (webUserController == null || sessionController == null) {
-            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
-                    action);
-            return false;
-        }
-
-        if (!webUserController.hasPrivilege(requiredPrivilege)) {
-            // Audit denied access attempt
-            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
-            Long billId = bill != null ? bill.getId() : null;
-
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
-                    new Object[]{action, userId, billId, requiredPrivilege});
-
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase().replace('_', ' ') + ".");
-            return false;
-        }
-
-        return true;
     }
 
 }

--- a/src/main/java/com/divudi/core/entity/WebUserDefaultLoginPage.java
+++ b/src/main/java/com/divudi/core/entity/WebUserDefaultLoginPage.java
@@ -1,0 +1,155 @@
+/*
+* Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity;
+
+import com.divudi.core.data.LoginPage;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+
+/**
+ * Per user + department default login page. Runtime resolution reads this
+ * entity first; falls back to {@link WebUser#getLoginPage()} then HOME.
+ *
+ * @author www.divudi.com
+ */
+@Entity
+public class WebUserDefaultLoginPage implements Serializable {
+
+    static final long serialVersionUID = 1L;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+    @ManyToOne
+    private WebUser webUser;
+    @ManyToOne
+    private Department department;
+    @Enumerated(EnumType.STRING)
+    private LoginPage loginPage;
+    //Created Properties
+    @ManyToOne
+    WebUser creater;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    Date createdAt;
+    //Retairing properties
+    boolean retired;
+    @ManyToOne
+    WebUser retirer;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    Date retiredAt;
+    String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public WebUser getWebUser() {
+        return webUser;
+    }
+
+    public void setWebUser(WebUser webUser) {
+        this.webUser = webUser;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public LoginPage getLoginPage() {
+        return loginPage;
+    }
+
+    public void setLoginPage(LoginPage loginPage) {
+        this.loginPage = loginPage;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof WebUserDefaultLoginPage)) {
+            return false;
+        }
+        WebUserDefaultLoginPage other = (WebUserDefaultLoginPage) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.WebUserDefaultLoginPage[ id=" + id + " ]";
+    }
+
+}

--- a/src/main/java/com/divudi/core/entity/WebUserRole.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRole.java
@@ -7,10 +7,13 @@
  */
 package com.divudi.core.entity;
 
+import com.divudi.core.data.LoginPage;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -62,6 +65,10 @@ public class WebUserRole implements Serializable {
     Date activatedAt;
     @JsonIgnore
     String activateComments;
+
+    // Template login page for this role (admin-time only; never read at runtime).
+    @Enumerated(EnumType.STRING)
+    private LoginPage loginPage;
 
     public Long getId() {
         return id;
@@ -165,6 +172,14 @@ public class WebUserRole implements Serializable {
 
     public void setRetirer(WebUser retirer) {
         this.retirer = retirer;
+    }
+
+    public LoginPage getLoginPage() {
+        return loginPage;
+    }
+
+    public void setLoginPage(LoginPage loginPage) {
+        this.loginPage = loginPage;
     }
 
     @Override

--- a/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
@@ -30,6 +30,7 @@ public class WebUserRoleUser implements Serializable {
     private WebUserRole webUserRole;
     @ManyToOne
     private WebUser webUser;
+    @ManyToOne
     private Department department;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/facade/WebUserDefaultLoginPageFacade.java
+++ b/src/main/java/com/divudi/core/facade/WebUserDefaultLoginPageFacade.java
@@ -1,0 +1,29 @@
+/*
+* Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.WebUserDefaultLoginPage;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author www.divudi.com
+ */
+@Stateless
+public class WebUserDefaultLoginPageFacade extends AbstractFacade<WebUserDefaultLoginPage> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if(em == null){}return em;
+    }
+
+    public WebUserDefaultLoginPageFacade() {
+        super(WebUserDefaultLoginPage.class);
+    }
+}

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1217,6 +1217,132 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject userRoleResetTool = Json.createObjectBuilder()
+                .add("name", "user_role_reset")
+                .add("description",
+                        "Reset a user's role-template aspects (privileges/icons/subscriptions/login page) to exactly match a "
+                        + "role template for the given departments: retires records the user has that the template doesn't, "
+                        + "and adds records the template has that the user lacks. Roles are admin-time templates only — "
+                        + "this stamps user-level records; it never changes runtime behavior directly. "
+                        + "roleId is optional — omit it to reset to the user's own current role (the API 400s if the user "
+                        + "has no role). Set preview=true first to see added/retired counts per aspect without writing "
+                        + "anything, then call again with preview omitted/false to apply. Always confirm with the user "
+                        + "before applying (preview=false).")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("id", Json.createObjectBuilder().add("type", "string").add("description", "Target WebUser ID"))
+                                .add("roleId", Json.createObjectBuilder().add("type", "string").add("description", "Role template ID; omit to use the user's own role"))
+                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs to reset"))
+                                .add("aspects", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated aspects: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE. Default PRIVILEGES"))
+                                .add("updateUserRole", Json.createObjectBuilder().add("type", "string").add("description", "'true' or 'false' — also set WebUser.role to roleId. Default true"))
+                                .add("preview", Json.createObjectBuilder().add("type", "string").add("description", "'true' to preview counts without writing. Default false")))
+                        .add("required", Json.createArrayBuilder().add("id").add("departmentIds")))
+                .build();
+
+        JsonObject userRoleExpandTool = Json.createObjectBuilder()
+                .add("name", "user_role_expand")
+                .add("description",
+                        "Add role-template records (privileges/icons/subscriptions/login page) the user is missing, for the "
+                        + "given departments. Existing extra records the user already has beyond the template are left "
+                        + "untouched. roleId is required. Set preview=true first to see how many records would be added "
+                        + "per aspect, then call again with preview omitted/false to apply. Always confirm with the user "
+                        + "before applying.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("id", Json.createObjectBuilder().add("type", "string").add("description", "Target WebUser ID"))
+                                .add("roleId", Json.createObjectBuilder().add("type", "string").add("description", "Role template ID (required)"))
+                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs"))
+                                .add("aspects", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated aspects: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE. Default PRIVILEGES"))
+                                .add("preview", Json.createObjectBuilder().add("type", "string").add("description", "'true' to preview counts without writing. Default false")))
+                        .add("required", Json.createArrayBuilder().add("id").add("roleId").add("departmentIds")))
+                .build();
+
+        JsonObject userRoleNarrowTool = Json.createObjectBuilder()
+                .add("name", "user_role_narrow")
+                .add("description",
+                        "Retire the user's records (privileges/icons/subscriptions/login page) that match a role template, "
+                        + "for the given departments. Records the user has that are NOT part of the template are left "
+                        + "untouched. roleId is required. Set preview=true first to see how many records would be retired "
+                        + "per aspect, then call again with preview omitted/false to apply. Always confirm with the user "
+                        + "before applying.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("id", Json.createObjectBuilder().add("type", "string").add("description", "Target WebUser ID"))
+                                .add("roleId", Json.createObjectBuilder().add("type", "string").add("description", "Role template ID (required)"))
+                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs"))
+                                .add("aspects", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated aspects: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE. Default PRIVILEGES"))
+                                .add("preview", Json.createObjectBuilder().add("type", "string").add("description", "'true' to preview counts without writing. Default false")))
+                        .add("required", Json.createArrayBuilder().add("id").add("roleId").add("departmentIds")))
+                .build();
+
+        JsonObject userBulkRoleOperationsTool = Json.createObjectBuilder()
+                .add("name", "user_bulk_role_operations")
+                .add("description",
+                        "Apply RESET, EXPAND, or NARROW role-template operations to many users at once. Target users are "
+                        + "either an explicit userIds list (wins if given) or a filter by filterRoleId/filterDepartmentId "
+                        + "(users with that role and/or an active loggable department assignment). "
+                        + "Two-step safety gate mirroring the UI confirm dialog: first call with preview=true (confirm "
+                        + "omitted/false) to see the resolved user count and per-aspect totals (capped at the first 200 "
+                        + "users); only after showing this to the user and getting explicit approval, repeat the identical "
+                        + "call with confirm=true (preview omitted/false) to actually apply. Calling with neither preview "
+                        + "nor confirm set is rejected by the API.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("action", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("RESET").add("EXPAND").add("NARROW"))
+                                        .add("description", "Operation to apply to every resolved user"))
+                                .add("userIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated WebUser IDs. Wins over filterRoleId/filterDepartmentId if given"))
+                                .add("filterRoleId", Json.createObjectBuilder().add("type", "string").add("description", "Only used when userIds is omitted: match users with this role"))
+                                .add("filterDepartmentId", Json.createObjectBuilder().add("type", "string").add("description", "Only used when userIds is omitted: match users with an active loggable assignment to this department"))
+                                .add("roleId", Json.createObjectBuilder().add("type", "string").add("description", "Target template role ID. Omit to use each user's own current role"))
+                                .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs to operate on (required)"))
+                                .add("aspects", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated aspects: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE. Default PRIVILEGES"))
+                                .add("updateUserRole", Json.createObjectBuilder().add("type", "string").add("description", "'true' or 'false' — for RESET, also set each user's WebUser.role to roleId. Default true"))
+                                .add("preview", Json.createObjectBuilder().add("type", "string").add("description", "'true' for the first, read-only call"))
+                                .add("confirm", Json.createObjectBuilder().add("type", "string").add("description", "'true' for the second call that actually applies the operation")))
+                        .add("required", Json.createArrayBuilder().add("action").add("departmentIds")))
+                .build();
+
+        JsonObject listUserRolesTool = Json.createObjectBuilder()
+                .add("name", "list_user_roles")
+                .add("description",
+                        "List active user roles with their role-template summary: id, name, description, template login "
+                        + "page, and counts of active role-level privileges, template icons, and template subscriptions. "
+                        + "Use this to discover valid roleId values before calling user_role_reset/expand/narrow or "
+                        + "user_bulk_role_operations.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder())
+                        .add("required", Json.createArrayBuilder()))
+                .build();
+
+        JsonObject setUserLoginPageTool = Json.createObjectBuilder()
+                .add("name", "set_user_login_page")
+                .add("description",
+                        "Set or remove a user's default login page override for one department. This is separate from a "
+                        + "role's template login page (admin-time only) and from the legacy WebUser.loginPage fallback. "
+                        + "Runtime resolution order: this user+department override, then WebUser.loginPage, then HOME. "
+                        + "action SET (default) requires loginPage (a LoginPage enum name); action DELETE removes the "
+                        + "override for that department, falling back to the legacy behavior. Always confirm with the "
+                        + "user before calling.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("action", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("SET").add("DELETE"))
+                                        .add("description", "SET to upsert the override (default), DELETE to remove it"))
+                                .add("id", Json.createObjectBuilder().add("type", "string").add("description", "Target WebUser ID"))
+                                .add("departmentId", Json.createObjectBuilder().add("type", "string").add("description", "Department ID"))
+                                .add("loginPage", Json.createObjectBuilder().add("type", "string").add("description", "LoginPage enum name — required for action SET")))
+                        .add("required", Json.createArrayBuilder().add("id").add("departmentId")))
+                .build();
+
         JsonObject managePharmacyItemsTool = Json.createObjectBuilder()
                 .add("name", "manage_pharmacy_items")
                 .add("description",
@@ -1566,6 +1692,12 @@ public class AnthropicApiService implements Serializable {
                 .add(manageSubscriptionsTool)
                 .add(manageStaffTool)
                 .add(manageUsersTool)
+                .add(userRoleResetTool)
+                .add(userRoleExpandTool)
+                .add(userRoleNarrowTool)
+                .add(userBulkRoleOperationsTool)
+                .add(listUserRolesTool)
+                .add(setUserLoginPageTool)
                 .add(managePharmacyItemsTool)
                 .add(managePharmacyDiscountsTool)
                 .add(managePaymentSchemesTool)
@@ -1867,6 +1999,24 @@ public class AnthropicApiService implements Serializable {
                 }
                 case "manage_users": {
                     return callUsersApi(toolInput, hmisBaseUrl, hmisApiKey);
+                }
+                case "user_role_reset": {
+                    return callUserRoleOperationApi("reset", toolInput, false, hmisBaseUrl, hmisApiKey);
+                }
+                case "user_role_expand": {
+                    return callUserRoleOperationApi("expand", toolInput, true, hmisBaseUrl, hmisApiKey);
+                }
+                case "user_role_narrow": {
+                    return callUserRoleOperationApi("narrow", toolInput, true, hmisBaseUrl, hmisApiKey);
+                }
+                case "user_bulk_role_operations": {
+                    return callUserBulkRoleOperationsApi(toolInput, hmisBaseUrl, hmisApiKey);
+                }
+                case "list_user_roles": {
+                    return callListUserRolesApi(hmisBaseUrl, hmisApiKey);
+                }
+                case "set_user_login_page": {
+                    return callSetUserLoginPageApi(toolInput, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_pharmacy_items": {
                     return callPharmacyItemsApi(toolInput, hmisBaseUrl, hmisApiKey);
@@ -4284,6 +4434,111 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    private String callUserRoleOperationApi(String action, JsonObject input, boolean roleRequired, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        try {
+            String id = requireText(jsonString(input, "id"), "id");
+            String url = hmisBaseUrl.replaceAll("/$", "") + "/api/users/" + id + "/role/" + action;
+            String roleId = jsonString(input, "roleId");
+            if (roleRequired && roleId.isEmpty()) {
+                return "Error: roleId is required for role " + action + ".";
+            }
+            javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+            addLong(b, "roleId", roleId);
+            b.add("departmentIds", csvLongArray(jsonString(input, "departmentIds")));
+            String aspects = jsonString(input, "aspects");
+            if (!aspects.isEmpty()) b.add("aspects", csvArray(aspects));
+            addBoolean(b, "updateUserRole", jsonString(input, "updateUserRole"));
+            addBoolean(b, "preview", jsonString(input, "preview"));
+            return callHmisApi(url, "POST", b.build().toString(), hmisApiKey);
+        } catch (Exception e) {
+            return "User role " + action + " error: " + e.getMessage();
+        }
+    }
+
+    private String callUserBulkRoleOperationsApi(JsonObject input, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        try {
+            String url = hmisBaseUrl.replaceAll("/$", "") + "/api/users/bulk/role-operations";
+            javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+            b.add("action", requireText(jsonString(input, "action"), "action"));
+            String userIds = jsonString(input, "userIds");
+            if (!userIds.isEmpty()) {
+                b.add("userIds", csvLongArray(userIds));
+            } else {
+                String filterRoleId = jsonString(input, "filterRoleId");
+                String filterDepartmentId = jsonString(input, "filterDepartmentId");
+                if (!filterRoleId.isEmpty() || !filterDepartmentId.isEmpty()) {
+                    javax.json.JsonObjectBuilder filter = Json.createObjectBuilder();
+                    addLong(filter, "roleId", filterRoleId);
+                    addLong(filter, "departmentId", filterDepartmentId);
+                    b.add("filter", filter);
+                }
+            }
+            addLong(b, "roleId", jsonString(input, "roleId"));
+            b.add("departmentIds", csvLongArray(jsonString(input, "departmentIds")));
+            String aspects = jsonString(input, "aspects");
+            if (!aspects.isEmpty()) b.add("aspects", csvArray(aspects));
+            addBoolean(b, "updateUserRole", jsonString(input, "updateUserRole"));
+            addBoolean(b, "preview", jsonString(input, "preview"));
+            addBoolean(b, "confirm", jsonString(input, "confirm"));
+            return callHmisApi(url, "POST", b.build().toString(), hmisApiKey);
+        } catch (Exception e) {
+            return "Bulk role operations error: " + e.getMessage();
+        }
+    }
+
+    private String callListUserRolesApi(String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        try {
+            String url = hmisBaseUrl.replaceAll("/$", "") + "/api/users/roles";
+            return callHmisApi(url, "GET", null, hmisApiKey);
+        } catch (Exception e) {
+            return "List user roles error: " + e.getMessage();
+        }
+    }
+
+    private String callSetUserLoginPageApi(JsonObject input, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: HMIS API key is not configured.";
+        }
+        try {
+            String id = requireText(jsonString(input, "id"), "id");
+            String departmentId = requireText(jsonString(input, "departmentId"), "departmentId");
+            String action = input.containsKey("action") ? input.getString("action", "SET").toUpperCase() : "SET";
+            String base = hmisBaseUrl.replaceAll("/$", "") + "/api/users/" + id + "/login-page";
+            if ("DELETE".equals(action)) {
+                return callHmisApi(base + "/" + departmentId, "DELETE", null, hmisApiKey);
+            }
+            String loginPage = requireText(jsonString(input, "loginPage"), "loginPage");
+            String body = Json.createObjectBuilder()
+                    .add("departmentId", Long.parseLong(departmentId))
+                    .add("loginPage", loginPage)
+                    .build().toString();
+            return callHmisApi(base, "PUT", body, hmisApiKey);
+        } catch (Exception e) {
+            return "Set user login page error: " + e.getMessage();
+        }
+    }
+
     private String callPharmacyItemsApi(JsonObject input, String hmisBaseUrl, String hmisApiKey) {
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
             return "Error: HMIS base URL is not configured.";
@@ -5182,7 +5437,19 @@ public class AnthropicApiService implements Serializable {
                 + "DELETE /{id}/departments/{assignmentId} removes one loggable department. "
                 + "DELETE /{id}/departments/{deptId}/privileges bulk-revokes all privileges for a department. "
                 + "POST /{id}/departments/{deptId}/privileges/all grants every privilege for a department. "
-                + "POST /{id}/privileges/all with optional body {departmentIds:[...]} grants every privilege across multiple departments at once.",
+                + "POST /{id}/privileges/all with optional body {departmentIds:[...]} grants every privilege across multiple departments at once.\n\n"
+                + "Role-template operations: roles (WebUserRole) are admin-time templates only — runtime behavior "
+                + "(privilege checks, login-page resolution, icons, subscriptions) reads user-level records exclusively. "
+                + "These endpoints stamp/reset a user's own records FROM a role template; they never change runtime behavior directly. "
+                + "aspects (default [\"PRIVILEGES\"]): PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE. "
+                + "RESET converges the user's records to exactly the template (retires extras, adds missing); roleId omitted defaults to the "
+                + "user's own WebUser.role and 400s if the user has none. EXPAND adds template records the user lacks, leaving extras untouched "
+                + "(roleId required). NARROW retires the user's records that match the template, leaving non-template records untouched "
+                + "(roleId required). Any single-user call with preview=true returns counts (added/retired per aspect) without writing. "
+                + "Bulk operations (POST /users/bulk/role-operations) target either explicit userIds or a {roleId?, departmentId?} filter "
+                + "(userIds wins) and use a two-step safety gate: call once with preview=true to see the resolved user count and per-aspect "
+                + "totals (capped at first 200 users), then repeat the identical call with confirm=true to actually apply — calling with "
+                + "neither preview nor confirm is rejected. GET /users/roles lists active roles with template summary counts.",
                 githubUrl(branch, "developer_docs/API_USER_MANAGEMENT.md"),
                 new String[][]{
                     {"GET",    "/users",                          "List users. Filters: query, departmentId, page, size"},
@@ -5204,7 +5471,14 @@ public class AnthropicApiService implements Serializable {
                     {"DELETE", "/users/{id}/departments/{departmentId}/privileges",  "Bulk-revoke all active privileges for a user scoped to a department"},
                     {"POST",   "/users/{id}/departments/{departmentId}/privileges/all", "Assign every Privileges enum value to a user for a department (skips duplicates)"},
                     {"PUT",    "/users/{id}/staff",               "Link an existing Staff record to the user (body: {staffId})"},
-                    {"POST",   "/users/{id}/privileges/all",      "Assign every privilege across supplied departmentIds (or all loggable depts). Returns per-dept summary"}
+                    {"POST",   "/users/{id}/privileges/all",      "Assign every privilege across supplied departmentIds (or all loggable depts). Returns per-dept summary"},
+                    {"POST",   "/users/{id}/role/reset",          "Reset a user's aspects to a role template (roleId optional; defaults to the user's own role)"},
+                    {"POST",   "/users/{id}/role/expand",         "Add role-template records the user lacks (roleId required)"},
+                    {"POST",   "/users/{id}/role/narrow",         "Retire the user's records that match a role template (roleId required)"},
+                    {"POST",   "/users/bulk/role-operations",     "Bulk RESET/EXPAND/NARROW for many users; preview=true then confirm=true"},
+                    {"GET",    "/users/roles",                    "List active roles with template summary counts (privileges/icons/subscriptions, template login page)"},
+                    {"PUT",    "/users/{id}/login-page",          "Upsert the user's default login page for a department (body: {departmentId, loginPage})"},
+                    {"DELETE", "/users/{id}/login-page/{departmentId}", "Retire the user's default login-page override for a department"}
                 });
 
         appendModule(sb, "User Roles", "/user-roles",

--- a/src/main/java/com/divudi/service/UserRoleApplicationService.java
+++ b/src/main/java/com/divudi/service/UserRoleApplicationService.java
@@ -1,0 +1,813 @@
+/*
+* Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service;
+
+import com.divudi.core.data.Icon;
+import com.divudi.core.data.LoginPage;
+import com.divudi.core.data.Privileges;
+import com.divudi.core.data.TriggerType;
+import com.divudi.core.entity.AuditEvent;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.TriggerSubscription;
+import com.divudi.core.entity.UserIcon;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.WebUserDefaultLoginPage;
+import com.divudi.core.entity.WebUserPrivilege;
+import com.divudi.core.entity.WebUserRole;
+import com.divudi.core.entity.WebUserRoleUser;
+import com.divudi.core.facade.TriggerSubscriptionFacade;
+import com.divudi.core.facade.UserIconFacade;
+import com.divudi.core.facade.WebUserDefaultLoginPageFacade;
+import com.divudi.core.facade.WebUserFacade;
+import com.divudi.core.facade.WebUserPrivilegeFacade;
+import com.divudi.core.facade.WebUserRolePrivilegeFacade;
+import com.divudi.core.facade.WebUserRoleUserFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+/**
+ * Single engine for role-template based user-management operations (used by
+ * the admin UI, the REST API, and the AI assistant). Roles are admin-time
+ * templates only; runtime behaviour reads user-level records exclusively.
+ * This service stamps/resets those user-level records from a role template.
+ *
+ * JPQL only, batched writes, one AuditEvent + one WebUserRoleUser history
+ * row per {@link #apply} call.
+ *
+ * @author www.divudi.com
+ */
+@Stateless
+public class UserRoleApplicationService {
+
+    @EJB
+    private WebUserPrivilegeFacade webUserPrivilegeFacade;
+    @EJB
+    private WebUserRolePrivilegeFacade webUserRolePrivilegeFacade;
+    @EJB
+    private UserIconFacade userIconFacade;
+    @EJB
+    private TriggerSubscriptionFacade triggerSubscriptionFacade;
+    @EJB
+    private WebUserDefaultLoginPageFacade webUserDefaultLoginPageFacade;
+    @EJB
+    private WebUserRoleUserFacade webUserRoleUserFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+    @EJB
+    private AuditEventService auditEventService;
+
+    public enum RoleAspect {
+        PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE
+    }
+
+    public enum RoleOperation {
+        RESET, EXPAND, NARROW
+    }
+
+    /**
+     * Result of applying one role operation to one user. Counts are keyed by
+     * aspect so the UI/AI can report "added N privileges, retired M icons"
+     * style summaries.
+     */
+    public static class RoleApplicationResult implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+        private final WebUser user;
+        private final Map<RoleAspect, Integer> added = new EnumMap<>(RoleAspect.class);
+        private final Map<RoleAspect, Integer> retired = new EnumMap<>(RoleAspect.class);
+        private String errorMessage;
+
+        public RoleApplicationResult(WebUser user) {
+            this.user = user;
+        }
+
+        void addCounts(RoleAspect aspect, int addedCount, int retiredCount) {
+            added.merge(aspect, addedCount, Integer::sum);
+            retired.merge(aspect, retiredCount, Integer::sum);
+        }
+
+        public WebUser getUser() {
+            return user;
+        }
+
+        public Map<RoleAspect, Integer> getAdded() {
+            return added;
+        }
+
+        public Map<RoleAspect, Integer> getRetired() {
+            return retired;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+
+        public void setErrorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+        }
+
+        public boolean isSuccess() {
+            return errorMessage == null;
+        }
+
+        public int getTotalAdded() {
+            int total = 0;
+            for (int v : added.values()) {
+                total += v;
+            }
+            return total;
+        }
+
+        public int getTotalRetired() {
+            int total = 0;
+            for (int v : retired.values()) {
+                total += v;
+            }
+            return total;
+        }
+
+        public String summary() {
+            if (!isSuccess()) {
+                return "error=" + errorMessage;
+            }
+            return "added=" + added + ", retired=" + retired;
+        }
+
+        public static String summarize(List<RoleApplicationResult> results) {
+            if (results == null || results.isEmpty()) {
+                return "no users processed";
+            }
+            int succeeded = 0;
+            int failed = 0;
+            int totalAdded = 0;
+            int totalRetired = 0;
+            for (RoleApplicationResult r : results) {
+                if (r.isSuccess()) {
+                    succeeded++;
+                    totalAdded += r.getTotalAdded();
+                    totalRetired += r.getTotalRetired();
+                } else {
+                    failed++;
+                }
+            }
+            return "users=" + results.size() + ", succeeded=" + succeeded + ", failed=" + failed
+                    + ", totalAdded=" + totalAdded + ", totalRetired=" + totalRetired;
+        }
+    }
+
+    /**
+     * Applies a role operation to one user across the given departments and
+     * aspects. RESET converges the user's active set to exactly the role
+     * template's set (records already matching the template are left
+     * untouched rather than being blindly retired-and-recreated, so audit
+     * counts reflect real changes only).
+     */
+    public RoleApplicationResult apply(RoleOperation op, WebUser targetUser, WebUserRole role, List<Department> departments,
+            Set<RoleAspect> aspects, boolean updateUserRole, WebUser actor) {
+
+        RoleApplicationResult result = new RoleApplicationResult(targetUser);
+
+        if (op == null) {
+            result.setErrorMessage("Operation is required");
+            return result;
+        }
+        if (targetUser == null) {
+            result.setErrorMessage("Target user is required");
+            return result;
+        }
+        if (departments == null || departments.isEmpty()) {
+            result.setErrorMessage("At least one department is required");
+            return result;
+        }
+        if (aspects == null || aspects.isEmpty()) {
+            result.setErrorMessage("At least one aspect is required");
+            return result;
+        }
+
+        WebUserRole effectiveRole = role != null ? role : targetUser.getRole();
+        if (effectiveRole == null) {
+            result.setErrorMessage("No role available: role not specified and user has no default role");
+            return result;
+        }
+
+        Date now = new Date();
+
+        List<WebUserPrivilege> privilegesToCreate = new ArrayList<>();
+        List<WebUserPrivilege> privilegesToEdit = new ArrayList<>();
+        List<UserIcon> iconsToCreate = new ArrayList<>();
+        List<UserIcon> iconsToEdit = new ArrayList<>();
+        List<TriggerSubscription> subscriptionsToCreate = new ArrayList<>();
+        List<TriggerSubscription> subscriptionsToEdit = new ArrayList<>();
+        List<WebUserDefaultLoginPage> loginPagesToCreate = new ArrayList<>();
+        List<WebUserDefaultLoginPage> loginPagesToEdit = new ArrayList<>();
+        List<WebUserRoleUser> historyRows = new ArrayList<>();
+
+        for (Department dept : departments) {
+            if (dept == null) {
+                continue;
+            }
+            if (aspects.contains(RoleAspect.PRIVILEGES)) {
+                applyPrivilegesAspect(op, targetUser, effectiveRole, dept, actor, now, result, privilegesToCreate, privilegesToEdit);
+            }
+            if (aspects.contains(RoleAspect.ICONS)) {
+                applyIconsAspect(op, targetUser, effectiveRole, dept, now, result, iconsToCreate, iconsToEdit);
+            }
+            if (aspects.contains(RoleAspect.SUBSCRIPTIONS)) {
+                applySubscriptionsAspect(op, targetUser, effectiveRole, dept, actor, now, result, subscriptionsToCreate, subscriptionsToEdit);
+            }
+            if (aspects.contains(RoleAspect.LOGIN_PAGE)) {
+                applyLoginPageAspect(op, targetUser, effectiveRole, dept, actor, now, result, loginPagesToCreate, loginPagesToEdit);
+            }
+            if (op == RoleOperation.RESET || op == RoleOperation.EXPAND) {
+                WebUserRoleUser history = new WebUserRoleUser();
+                history.setWebUserRole(effectiveRole);
+                history.setWebUser(targetUser);
+                history.setDepartment(dept);
+                history.setCreater(actor);
+                history.setCreatedAt(now);
+                historyRows.add(history);
+            }
+        }
+
+        if (!privilegesToEdit.isEmpty()) {
+            webUserPrivilegeFacade.batchEdit(privilegesToEdit);
+        }
+        if (!privilegesToCreate.isEmpty()) {
+            webUserPrivilegeFacade.batchCreate(privilegesToCreate);
+        }
+        if (!iconsToEdit.isEmpty()) {
+            userIconFacade.batchEdit(iconsToEdit);
+        }
+        if (!iconsToCreate.isEmpty()) {
+            userIconFacade.batchCreate(iconsToCreate);
+        }
+        if (!subscriptionsToEdit.isEmpty()) {
+            triggerSubscriptionFacade.batchEdit(subscriptionsToEdit);
+        }
+        if (!subscriptionsToCreate.isEmpty()) {
+            triggerSubscriptionFacade.batchCreate(subscriptionsToCreate);
+        }
+        if (!loginPagesToEdit.isEmpty()) {
+            webUserDefaultLoginPageFacade.batchEdit(loginPagesToEdit);
+        }
+        if (!loginPagesToCreate.isEmpty()) {
+            webUserDefaultLoginPageFacade.batchCreate(loginPagesToCreate);
+        }
+        if (!historyRows.isEmpty()) {
+            webUserRoleUserFacade.batchCreate(historyRows);
+        }
+
+        if (op == RoleOperation.RESET && updateUserRole && !effectiveRole.equals(targetUser.getRole())) {
+            targetUser.setRole(effectiveRole);
+            webUserFacade.edit(targetUser);
+        }
+
+        writeAuditEvent(op, targetUser, effectiveRole, departments, aspects, result, actor);
+
+        return result;
+    }
+
+    /**
+     * Loops {@link #apply} over many users. When {@code role} is null each
+     * user's own current role is used; a user with no role and no role
+     * specified gets an error result instead of being skipped silently.
+     */
+    public List<RoleApplicationResult> applyBulk(RoleOperation op, List<WebUser> targetUsers, WebUserRole role,
+            List<Department> departments, Set<RoleAspect> aspects, boolean updateUserRole, WebUser actor) {
+        List<RoleApplicationResult> results = new ArrayList<>();
+        if (targetUsers == null) {
+            return results;
+        }
+        for (WebUser user : targetUsers) {
+            if (user == null) {
+                continue;
+            }
+            WebUserRole effectiveRole = role != null ? role : user.getRole();
+            if (effectiveRole == null) {
+                RoleApplicationResult r = new RoleApplicationResult(user);
+                r.setErrorMessage("User has no default role and no role was specified");
+                results.add(r);
+                continue;
+            }
+            results.add(apply(op, user, effectiveRole, departments, aspects, updateUserRole, actor));
+        }
+        return results;
+    }
+
+    /**
+     * Read-only preview of how many records each aspect would add+retire,
+     * without writing anything. Used by UI confirm dialogs and the AI
+     * assistant's confirm flow.
+     */
+    public Map<RoleAspect, Long> previewCounts(RoleOperation op, WebUser targetUser, WebUserRole role,
+            List<Department> departments, Set<RoleAspect> aspects) {
+        Map<RoleAspect, Long> preview = new EnumMap<>(RoleAspect.class);
+        if (op == null || targetUser == null || departments == null || departments.isEmpty()
+                || aspects == null || aspects.isEmpty()) {
+            return preview;
+        }
+        WebUserRole effectiveRole = role != null ? role : targetUser.getRole();
+        if (effectiveRole == null) {
+            return preview;
+        }
+        for (RoleAspect aspect : aspects) {
+            long total = 0;
+            for (Department dept : departments) {
+                if (dept == null) {
+                    continue;
+                }
+                total += previewAspectCount(op, targetUser, effectiveRole, dept, aspect);
+            }
+            preview.put(aspect, total);
+        }
+        return preview;
+    }
+
+    // <editor-fold desc="Privileges aspect">
+    private void applyPrivilegesAspect(RoleOperation op, WebUser user, WebUserRole role, Department dept, WebUser actor, Date now,
+            RoleApplicationResult result, List<WebUserPrivilege> toCreate, List<WebUserPrivilege> toEdit) {
+        Set<Privileges> templateSet = fetchTemplatePrivileges(role);
+        List<WebUserPrivilege> active = fetchActivePrivileges(user, dept);
+        Set<Privileges> activeValues = new HashSet<>();
+        for (WebUserPrivilege w : active) {
+            if (w.getPrivilege() != null) {
+                activeValues.add(w.getPrivilege());
+            }
+        }
+
+        int added = 0;
+        int retired = 0;
+
+        if (op == RoleOperation.RESET || op == RoleOperation.NARROW) {
+            for (WebUserPrivilege w : active) {
+                boolean matchesTemplate = w.getPrivilege() != null && templateSet.contains(w.getPrivilege());
+                boolean shouldRetire = op == RoleOperation.NARROW ? matchesTemplate : !matchesTemplate;
+                if (shouldRetire) {
+                    w.setRetired(true);
+                    w.setRetirer(actor);
+                    w.setRetiredAt(now);
+                    toEdit.add(w);
+                    retired++;
+                }
+            }
+        }
+
+        if (op == RoleOperation.RESET || op == RoleOperation.EXPAND) {
+            Set<Privileges> missing = new HashSet<>();
+            for (Privileges p : templateSet) {
+                if (!activeValues.contains(p)) {
+                    missing.add(p);
+                }
+            }
+            Map<Privileges, WebUserPrivilege> retiredCandidates = fetchRetiredPrivilegeCandidates(user, dept, missing);
+            for (Privileges p : missing) {
+                WebUserPrivilege candidate = retiredCandidates.get(p);
+                if (candidate != null) {
+                    candidate.setRetired(false);
+                    toEdit.add(candidate);
+                } else {
+                    WebUserPrivilege fresh = new WebUserPrivilege();
+                    fresh.setWebUser(user);
+                    fresh.setDepartment(dept);
+                    fresh.setPrivilege(p);
+                    fresh.setCreater(actor);
+                    fresh.setCreatedAt(now);
+                    toCreate.add(fresh);
+                }
+                added++;
+            }
+        }
+
+        result.addCounts(RoleAspect.PRIVILEGES, added, retired);
+    }
+
+    private Set<Privileges> fetchTemplatePrivileges(WebUserRole role) {
+        List<?> rows = webUserRolePrivilegeFacade.findLightsByJpql(
+                "select distinct p.privilege from WebUserRolePrivilege p where p.webUserRole=:role and p.retired=false and p.privilege is not null",
+                params("role", role));
+        Set<Privileges> set = new HashSet<>();
+        for (Object o : rows) {
+            set.add((Privileges) o);
+        }
+        return set;
+    }
+
+    private List<WebUserPrivilege> fetchActivePrivileges(WebUser user, Department dept) {
+        return webUserPrivilegeFacade.findByJpql(
+                "select w from WebUserPrivilege w where w.webUser=:user and w.department=:dept and w.retired=false",
+                params("user", user, "dept", dept));
+    }
+
+    private Map<Privileges, WebUserPrivilege> fetchRetiredPrivilegeCandidates(WebUser user, Department dept, Set<Privileges> values) {
+        Map<Privileges, WebUserPrivilege> map = new HashMap<>();
+        if (values.isEmpty()) {
+            return map;
+        }
+        List<WebUserPrivilege> rows = webUserPrivilegeFacade.findByJpql(
+                "select w from WebUserPrivilege w where w.webUser=:user and w.department=:dept and w.retired=true and w.privilege in :vals order by w.id desc",
+                params("user", user, "dept", dept, "vals", values));
+        for (WebUserPrivilege w : rows) {
+            map.putIfAbsent(w.getPrivilege(), w);
+        }
+        return map;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Icons aspect">
+    private void applyIconsAspect(RoleOperation op, WebUser user, WebUserRole role, Department dept, Date now,
+            RoleApplicationResult result, List<UserIcon> toCreate, List<UserIcon> toEdit) {
+        Map<Icon, UserIcon> template = fetchTemplateIcons(role);
+        Set<Icon> templateSet = template.keySet();
+        List<UserIcon> active = fetchActiveIcons(user, dept);
+        Set<Icon> activeValues = new HashSet<>();
+        for (UserIcon u : active) {
+            if (u.getIcon() != null) {
+                activeValues.add(u.getIcon());
+            }
+        }
+
+        int added = 0;
+        int retired = 0;
+
+        if (op == RoleOperation.RESET || op == RoleOperation.NARROW) {
+            for (UserIcon u : active) {
+                boolean matchesTemplate = u.getIcon() != null && templateSet.contains(u.getIcon());
+                boolean shouldRetire = op == RoleOperation.NARROW ? matchesTemplate : !matchesTemplate;
+                if (shouldRetire) {
+                    u.setRetired(true);
+                    toEdit.add(u);
+                    retired++;
+                }
+            }
+        }
+
+        if (op == RoleOperation.RESET || op == RoleOperation.EXPAND) {
+            Set<Icon> missing = new HashSet<>();
+            for (Icon icon : templateSet) {
+                if (!activeValues.contains(icon)) {
+                    missing.add(icon);
+                }
+            }
+            Map<Icon, UserIcon> retiredCandidates = fetchRetiredIconCandidates(user, dept, missing);
+            for (Icon icon : missing) {
+                UserIcon candidate = retiredCandidates.get(icon);
+                if (candidate != null) {
+                    candidate.setRetired(false);
+                    toEdit.add(candidate);
+                } else {
+                    UserIcon fresh = new UserIcon();
+                    fresh.setWebUser(user);
+                    fresh.setDepartment(dept);
+                    fresh.setIcon(icon);
+                    UserIcon templateRow = template.get(icon);
+                    fresh.setOrderNumber(templateRow != null ? templateRow.getOrderNumber() : 0d);
+                    toCreate.add(fresh);
+                }
+                added++;
+            }
+        }
+
+        result.addCounts(RoleAspect.ICONS, added, retired);
+    }
+
+    private Map<Icon, UserIcon> fetchTemplateIcons(WebUserRole role) {
+        List<UserIcon> rows = userIconFacade.findByJpql(
+                "select u from UserIcon u where u.webUserRole=:role and u.webUser is null and u.retired=false and u.icon is not null",
+                params("role", role));
+        Map<Icon, UserIcon> map = new LinkedHashMap<>();
+        for (UserIcon u : rows) {
+            map.put(u.getIcon(), u);
+        }
+        return map;
+    }
+
+    private List<UserIcon> fetchActiveIcons(WebUser user, Department dept) {
+        return userIconFacade.findByJpql(
+                "select u from UserIcon u where u.webUser=:user and u.department=:dept and u.retired=false",
+                params("user", user, "dept", dept));
+    }
+
+    private Map<Icon, UserIcon> fetchRetiredIconCandidates(WebUser user, Department dept, Set<Icon> values) {
+        Map<Icon, UserIcon> map = new HashMap<>();
+        if (values.isEmpty()) {
+            return map;
+        }
+        List<UserIcon> rows = userIconFacade.findByJpql(
+                "select u from UserIcon u where u.webUser=:user and u.department=:dept and u.retired=true and u.icon in :vals order by u.id desc",
+                params("user", user, "dept", dept, "vals", values));
+        for (UserIcon u : rows) {
+            map.putIfAbsent(u.getIcon(), u);
+        }
+        return map;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Subscriptions aspect">
+    private void applySubscriptionsAspect(RoleOperation op, WebUser user, WebUserRole role, Department dept, WebUser actor, Date now,
+            RoleApplicationResult result, List<TriggerSubscription> toCreate, List<TriggerSubscription> toEdit) {
+        Map<TriggerType, TriggerSubscription> template = fetchTemplateSubscriptions(role);
+        Set<TriggerType> templateSet = template.keySet();
+        List<TriggerSubscription> active = fetchActiveSubscriptions(user, dept);
+        Set<TriggerType> activeValues = new HashSet<>();
+        for (TriggerSubscription t : active) {
+            if (t.getTriggerType() != null) {
+                activeValues.add(t.getTriggerType());
+            }
+        }
+
+        int added = 0;
+        int retired = 0;
+
+        if (op == RoleOperation.RESET || op == RoleOperation.NARROW) {
+            for (TriggerSubscription t : active) {
+                boolean matchesTemplate = t.getTriggerType() != null && templateSet.contains(t.getTriggerType());
+                boolean shouldRetire = op == RoleOperation.NARROW ? matchesTemplate : !matchesTemplate;
+                if (shouldRetire) {
+                    t.setRetired(true);
+                    t.setRetirer(actor);
+                    t.setRetiredAt(now);
+                    toEdit.add(t);
+                    retired++;
+                }
+            }
+        }
+
+        if (op == RoleOperation.RESET || op == RoleOperation.EXPAND) {
+            Set<TriggerType> missing = new HashSet<>();
+            for (TriggerType tt : templateSet) {
+                if (!activeValues.contains(tt)) {
+                    missing.add(tt);
+                }
+            }
+            Map<TriggerType, TriggerSubscription> retiredCandidates = fetchRetiredSubscriptionCandidates(user, dept, missing);
+            for (TriggerType tt : missing) {
+                TriggerSubscription candidate = retiredCandidates.get(tt);
+                if (candidate != null) {
+                    candidate.setRetired(false);
+                    toEdit.add(candidate);
+                } else {
+                    TriggerSubscription fresh = new TriggerSubscription();
+                    fresh.setWebUser(user);
+                    fresh.setDepartment(dept);
+                    fresh.setTriggerType(tt);
+                    TriggerSubscription templateRow = template.get(tt);
+                    fresh.setOrderNumber(templateRow != null ? templateRow.getOrderNumber() : 0d);
+                    fresh.setCreater(actor);
+                    fresh.setCreatedAt(now);
+                    toCreate.add(fresh);
+                }
+                added++;
+            }
+        }
+
+        result.addCounts(RoleAspect.SUBSCRIPTIONS, added, retired);
+    }
+
+    private Map<TriggerType, TriggerSubscription> fetchTemplateSubscriptions(WebUserRole role) {
+        List<TriggerSubscription> rows = triggerSubscriptionFacade.findByJpql(
+                "select t from TriggerSubscription t where t.webUserRole=:role and t.webUser is null and t.retired=false and t.triggerType is not null",
+                params("role", role));
+        Map<TriggerType, TriggerSubscription> map = new LinkedHashMap<>();
+        for (TriggerSubscription t : rows) {
+            map.put(t.getTriggerType(), t);
+        }
+        return map;
+    }
+
+    private List<TriggerSubscription> fetchActiveSubscriptions(WebUser user, Department dept) {
+        return triggerSubscriptionFacade.findByJpql(
+                "select t from TriggerSubscription t where t.webUser=:user and t.department=:dept and t.retired=false",
+                params("user", user, "dept", dept));
+    }
+
+    private Map<TriggerType, TriggerSubscription> fetchRetiredSubscriptionCandidates(WebUser user, Department dept, Set<TriggerType> values) {
+        Map<TriggerType, TriggerSubscription> map = new HashMap<>();
+        if (values.isEmpty()) {
+            return map;
+        }
+        List<TriggerSubscription> rows = triggerSubscriptionFacade.findByJpql(
+                "select t from TriggerSubscription t where t.webUser=:user and t.department=:dept and t.retired=true and t.triggerType in :vals order by t.id desc",
+                params("user", user, "dept", dept, "vals", values));
+        for (TriggerSubscription t : rows) {
+            map.putIfAbsent(t.getTriggerType(), t);
+        }
+        return map;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Login page aspect">
+    private void applyLoginPageAspect(RoleOperation op, WebUser user, WebUserRole role, Department dept, WebUser actor, Date now,
+            RoleApplicationResult result, List<WebUserDefaultLoginPage> toCreate, List<WebUserDefaultLoginPage> toEdit) {
+        LoginPage templateValue = role.getLoginPage();
+        WebUserDefaultLoginPage active = fetchActiveLoginPage(user, dept);
+
+        int added = 0;
+        int retired = 0;
+
+        switch (op) {
+            case RESET:
+                if (active != null) {
+                    active.setRetired(true);
+                    active.setRetirer(actor);
+                    active.setRetiredAt(now);
+                    toEdit.add(active);
+                    retired++;
+                }
+                if (templateValue != null) {
+                    WebUserDefaultLoginPage fresh = new WebUserDefaultLoginPage();
+                    fresh.setWebUser(user);
+                    fresh.setDepartment(dept);
+                    fresh.setLoginPage(templateValue);
+                    fresh.setCreater(actor);
+                    fresh.setCreatedAt(now);
+                    toCreate.add(fresh);
+                    added++;
+                }
+                break;
+            case EXPAND:
+                if (active == null && templateValue != null) {
+                    WebUserDefaultLoginPage fresh = new WebUserDefaultLoginPage();
+                    fresh.setWebUser(user);
+                    fresh.setDepartment(dept);
+                    fresh.setLoginPage(templateValue);
+                    fresh.setCreater(actor);
+                    fresh.setCreatedAt(now);
+                    toCreate.add(fresh);
+                    added++;
+                }
+                break;
+            case NARROW:
+                if (active != null && templateValue != null && templateValue == active.getLoginPage()) {
+                    active.setRetired(true);
+                    active.setRetirer(actor);
+                    active.setRetiredAt(now);
+                    toEdit.add(active);
+                    retired++;
+                }
+                break;
+            default:
+                break;
+        }
+
+        result.addCounts(RoleAspect.LOGIN_PAGE, added, retired);
+    }
+
+    private WebUserDefaultLoginPage fetchActiveLoginPage(WebUser user, Department dept) {
+        return webUserDefaultLoginPageFacade.findFirstByJpql(
+                "select w from WebUserDefaultLoginPage w where w.webUser=:user and w.department=:dept and w.retired=false order by w.id desc",
+                params("user", user, "dept", dept));
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="Preview">
+    private long previewAspectCount(RoleOperation op, WebUser user, WebUserRole role, Department dept, RoleAspect aspect) {
+        switch (aspect) {
+            case PRIVILEGES: {
+                Set<Privileges> templateSet = fetchTemplatePrivileges(role);
+                Set<Privileges> activeSet = new HashSet<>();
+                for (WebUserPrivilege w : fetchActivePrivileges(user, dept)) {
+                    if (w.getPrivilege() != null) {
+                        activeSet.add(w.getPrivilege());
+                    }
+                }
+                return previewDiffCount(op, templateSet, activeSet);
+            }
+            case ICONS: {
+                Set<Icon> templateSet = fetchTemplateIcons(role).keySet();
+                Set<Icon> activeSet = new HashSet<>();
+                for (UserIcon u : fetchActiveIcons(user, dept)) {
+                    if (u.getIcon() != null) {
+                        activeSet.add(u.getIcon());
+                    }
+                }
+                return previewDiffCount(op, templateSet, activeSet);
+            }
+            case SUBSCRIPTIONS: {
+                Set<TriggerType> templateSet = fetchTemplateSubscriptions(role).keySet();
+                Set<TriggerType> activeSet = new HashSet<>();
+                for (TriggerSubscription t : fetchActiveSubscriptions(user, dept)) {
+                    if (t.getTriggerType() != null) {
+                        activeSet.add(t.getTriggerType());
+                    }
+                }
+                return previewDiffCount(op, templateSet, activeSet);
+            }
+            case LOGIN_PAGE: {
+                LoginPage templateValue = role.getLoginPage();
+                WebUserDefaultLoginPage active = fetchActiveLoginPage(user, dept);
+                switch (op) {
+                    case RESET:
+                        return (active != null ? 1 : 0) + (templateValue != null ? 1 : 0);
+                    case EXPAND:
+                        return (active == null && templateValue != null) ? 1 : 0;
+                    case NARROW:
+                        return (active != null && templateValue != null && templateValue == active.getLoginPage()) ? 1 : 0;
+                    default:
+                        return 0;
+                }
+            }
+            default:
+                return 0;
+        }
+    }
+
+    private <V> long previewDiffCount(RoleOperation op, Set<V> templateSet, Set<V> activeSet) {
+        switch (op) {
+            case RESET: {
+                long count = 0;
+                for (V v : activeSet) {
+                    if (!templateSet.contains(v)) {
+                        count++;
+                    }
+                }
+                for (V v : templateSet) {
+                    if (!activeSet.contains(v)) {
+                        count++;
+                    }
+                }
+                return count;
+            }
+            case EXPAND: {
+                long count = 0;
+                for (V v : templateSet) {
+                    if (!activeSet.contains(v)) {
+                        count++;
+                    }
+                }
+                return count;
+            }
+            case NARROW: {
+                long count = 0;
+                for (V v : activeSet) {
+                    if (templateSet.contains(v)) {
+                        count++;
+                    }
+                }
+                return count;
+            }
+            default:
+                return 0;
+        }
+    }
+    // </editor-fold>
+
+    private void writeAuditEvent(RoleOperation op, WebUser targetUser, WebUserRole role, List<Department> departments,
+            Set<RoleAspect> aspects, RoleApplicationResult result, WebUser actor) {
+        try {
+            AuditEvent ae = new AuditEvent();
+            ae.setEventDataTime(new Date());
+            ae.setEventTrigger("ROLE_TEMPLATE_" + op.name());
+            ae.setEntityType("WebUser");
+            ae.setObjectId(targetUser.getId());
+            if (actor != null) {
+                ae.setWebUserId(actor.getId());
+            }
+            ae.setBeforeJson(buildRequestSummary(op, targetUser, role, departments, aspects));
+            ae.setAfterJson(result.summary());
+            auditEventService.saveAuditEvent(ae);
+        } catch (Exception e) {
+            // Audit logging must never break the role-template operation itself.
+        }
+    }
+
+    private String buildRequestSummary(RoleOperation op, WebUser targetUser, WebUserRole role, List<Department> departments, Set<RoleAspect> aspects) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("operation=").append(op.name());
+        sb.append(", user=").append(targetUser.getName());
+        sb.append(", role=").append(role != null ? role.getName() : "null");
+        sb.append(", departments=").append(departmentNames(departments));
+        sb.append(", aspects=").append(aspects);
+        return sb.toString();
+    }
+
+    private List<String> departmentNames(List<Department> departments) {
+        List<String> names = new ArrayList<>();
+        for (Department d : departments) {
+            if (d != null) {
+                names.add(d.getName());
+            }
+        }
+        return names;
+    }
+
+    private Map<String, Object> params(Object... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+}

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -350,7 +350,19 @@ public class CapabilityStatementResource {
                         + "Supports filtering by departmentId and query string. "
                         + "DELETE /{id}/departments/{assignmentId} revokes one loggable department. "
                         + "DELETE /{id}/departments/{departmentId}/privileges bulk-revokes all privileges for a department. "
-                        + "POST /{id}/departments/{departmentId}/privileges/all assigns every privilege for a department.",
+                        + "POST /{id}/departments/{departmentId}/privileges/all assigns every privilege for a department. "
+                        + "Role-template operations (roles are admin-time templates; runtime reads user-level records only): "
+                        + "POST /{id}/role/reset resets a user's records for the given aspects/departments to a role template "
+                        + "(roleId optional — defaults to the user's own role; body: {roleId?, departmentIds[], aspects[]?, updateUserRole?, preview?}). "
+                        + "POST /{id}/role/expand and POST /{id}/role/narrow add/strip a role template's records "
+                        + "(body: {roleId, departmentIds[], aspects[]?, preview?}; roleId required). "
+                        + "aspects values: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE (default [\"PRIVILEGES\"]). "
+                        + "preview=true returns counts without writing. "
+                        + "POST /bulk/role-operations applies RESET/EXPAND/NARROW to many users at once (explicit userIds or a role/department filter); "
+                        + "for safety it requires preview=true first, then confirm=true to actually apply. "
+                        + "GET /roles lists active roles with template summary counts (privileges/icons/subscriptions) and template login page. "
+                        + "PUT /{id}/login-page (body: {departmentId, loginPage}) and DELETE /{id}/login-page/{departmentId} manage the "
+                        + "per-user-per-department default login page override.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("User Bulk Privileges", "/api/users/bulk-privileges",

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -13,6 +13,10 @@ import com.divudi.core.data.dto.user.UserUpsertRequestDTO;
 import com.divudi.core.entity.*;
 import com.divudi.core.facade.*;
 import com.divudi.core.light.common.WebUserLight;
+import com.divudi.service.UserRoleApplicationService;
+import com.divudi.service.UserRoleApplicationService.RoleAspect;
+import com.divudi.service.UserRoleApplicationService.RoleApplicationResult;
+import com.divudi.service.UserRoleApplicationService.RoleOperation;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -59,6 +63,14 @@ public class UserManagementApi {
     private PersonFacade personFacade;
     @EJB
     private StaffFacade staffFacade;
+    @EJB
+    private UserIconFacade userIconFacade;
+    @EJB
+    private TriggerSubscriptionFacade triggerSubscriptionFacade;
+    @EJB
+    private WebUserDefaultLoginPageFacade webUserDefaultLoginPageFacade;
+    @EJB
+    private UserRoleApplicationService userRoleApplicationService;
 
     private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
 
@@ -876,6 +888,579 @@ public class UserManagementApi {
             return errorResponse("Invalid JSON format", 400);
         } catch (Exception e) {
             return errorResponse("Internal server error", 500);
+        }
+    }
+
+    // ── Role-template operations (issue #22023) ─────────────────────────────
+    // Roles are admin-time templates; these endpoints stamp/reset user-level
+    // records (privileges/icons/subscriptions/login page) from a role
+    // template via UserRoleApplicationService — same engine used by the UI
+    // and the AI assistant.
+
+    /**
+     * POST /api/users/{id}/role/reset
+     * Body: {"roleId": optional long, "departmentIds": [long,...] required,
+     * "aspects": optional ["PRIVILEGES","ICONS","SUBSCRIPTIONS","LOGIN_PAGE"] default ["PRIVILEGES"],
+     * "updateUserRole": optional bool default true, "preview": optional bool default false}
+     * roleId omitted/null uses the target user's own WebUser.role (400 if the user has no role).
+     */
+    @POST
+    @Path("/{id}/role/reset")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response resetUserRole(@PathParam("id") Long id, String body) {
+        return applyRoleOperation(RoleOperation.RESET, id, body, false);
+    }
+
+    /**
+     * POST /api/users/{id}/role/expand
+     * Body: {"roleId": required long, "departmentIds": [long,...] required,
+     * "aspects": optional default ["PRIVILEGES"], "preview": optional bool default false}
+     */
+    @POST
+    @Path("/{id}/role/expand")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response expandUserRole(@PathParam("id") Long id, String body) {
+        return applyRoleOperation(RoleOperation.EXPAND, id, body, true);
+    }
+
+    /**
+     * POST /api/users/{id}/role/narrow
+     * Body: {"roleId": required long, "departmentIds": [long,...] required,
+     * "aspects": optional default ["PRIVILEGES"], "preview": optional bool default false}
+     */
+    @POST
+    @Path("/{id}/role/narrow")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response narrowUserRole(@PathParam("id") Long id, String body) {
+        return applyRoleOperation(RoleOperation.NARROW, id, body, true);
+    }
+
+    private Response applyRoleOperation(RoleOperation op, Long id, String body, boolean roleRequired) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+            WebUser u = webUserFacade.find(id);
+            if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+
+            Map<String, Object> req = parseJsonBody(body);
+            WebUserRole role;
+            Object roleIdObj = req.get("roleId");
+            if (roleIdObj != null) {
+                role = findRoleOrThrow(toLong(roleIdObj, "roleId"));
+            } else if (roleRequired) {
+                throw new ApiValidationException("roleId is required", 400);
+            } else {
+                role = u.getRole();
+                if (role == null) {
+                    return errorResponse("User has no default role; specify roleId explicitly", 400);
+                }
+            }
+
+            List<Department> departments = resolveDepartments(extractLongList(req, "departmentIds", true));
+            Set<RoleAspect> aspects = parseAspects(extractStringList(req, "aspects", Collections.singletonList("PRIVILEGES")));
+            boolean updateUserRole = toBoolean(req.get("updateUserRole"), true);
+            boolean preview = toBoolean(req.get("preview"), false);
+
+            if (preview) {
+                Map<RoleAspect, Long> counts = userRoleApplicationService.previewCounts(op, u, role, departments, aspects);
+                return successResponse(previewResponse(op, u, role, departments, aspects, counts));
+            }
+
+            RoleApplicationResult result = userRoleApplicationService.apply(op, u, role, departments, aspects, updateUserRole, apiUser);
+            if (!result.isSuccess()) return errorResponse(result.getErrorMessage(), 400);
+            return successResponse(resultResponse(op, result));
+        } catch (ApiValidationException e) {
+            return errorResponse(e.getMessage(), e.getCode());
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    /**
+     * POST /api/users/bulk/role-operations
+     * Body: {"action": "RESET"|"EXPAND"|"NARROW", "userIds": [long] optional,
+     * "filter": {"roleId": long optional, "departmentId": long optional} optional,
+     * "roleId": optional (target template role), "departmentIds": [long] required,
+     * "aspects": optional default ["PRIVILEGES"], "updateUserRole": optional bool default true,
+     * "preview": optional bool default false, "confirm": optional bool default false}
+     * Explicit userIds wins over filter. Safety gate: preview=false and confirm=false is
+     * rejected — callers must preview first, then repeat with confirm=true to apply.
+     */
+    @POST
+    @Path("/bulk/role-operations")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response bulkRoleOperations(String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+
+            Map<String, Object> req = parseJsonBody(body);
+            Object actionObj = req.get("action");
+            if (!(actionObj instanceof String) || ((String) actionObj).trim().isEmpty()) {
+                return errorResponse("action is required", 400);
+            }
+            RoleOperation op;
+            try {
+                op = RoleOperation.valueOf(((String) actionObj).trim());
+            } catch (IllegalArgumentException e) {
+                return errorResponse("Invalid action: " + actionObj + ". Valid values: RESET, EXPAND, NARROW", 400);
+            }
+
+            Long roleId = req.get("roleId") != null ? toLong(req.get("roleId"), "roleId") : null;
+            WebUserRole role = roleId != null ? findRoleOrThrow(roleId) : null;
+
+            List<Department> departments = resolveDepartments(extractLongList(req, "departmentIds", true));
+            Set<RoleAspect> aspects = parseAspects(extractStringList(req, "aspects", Collections.singletonList("PRIVILEGES")));
+            boolean updateUserRole = toBoolean(req.get("updateUserRole"), true);
+            boolean preview = toBoolean(req.get("preview"), false);
+            boolean confirm = toBoolean(req.get("confirm"), false);
+
+            // Resolve target users: explicit userIds wins over filter.
+            List<Long> userIds = extractLongList(req, "userIds", false);
+            List<WebUser> users;
+            List<Long> missingUserIds = new ArrayList<>();
+            if (userIds != null && !userIds.isEmpty()) {
+                users = new ArrayList<>();
+                for (Long uid : userIds) {
+                    WebUser candidate = webUserFacade.find(uid);
+                    if (candidate == null || candidate.isRetired()) {
+                        missingUserIds.add(uid);
+                    } else {
+                        users.add(candidate);
+                    }
+                }
+            } else {
+                users = resolveUsersByFilter(req.get("filter"));
+            }
+
+            final int MAX_BULK_USERS = 500;
+            if (users.size() > MAX_BULK_USERS) {
+                return errorResponse("Too many users resolved (" + users.size() + "). Narrow the filter; max allowed: " + MAX_BULK_USERS, 400);
+            }
+
+            if (!preview && !confirm) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("status", "error");
+                m.put("code", 400);
+                m.put("message", "Safety gate: call again with preview=true to review impact, then repeat with confirm=true to apply.");
+                m.put("resolvedUserCount", users.size());
+                if (!missingUserIds.isEmpty()) m.put("missingUserIds", missingUserIds);
+                return Response.status(400).entity(gson.toJson(m)).build();
+            }
+
+            if (preview) {
+                Map<RoleAspect, Long> totals = new EnumMap<>(RoleAspect.class);
+                for (RoleAspect a : aspects) totals.put(a, 0L);
+                int previewedCount = Math.min(users.size(), 200);
+                for (int i = 0; i < previewedCount; i++) {
+                    WebUser targetUser = users.get(i);
+                    WebUserRole effectiveRole = role != null ? role : targetUser.getRole();
+                    if (effectiveRole == null) continue;
+                    Map<RoleAspect, Long> counts = userRoleApplicationService.previewCounts(op, targetUser, effectiveRole, departments, aspects);
+                    for (RoleAspect a : aspects) {
+                        totals.merge(a, counts.getOrDefault(a, 0L), Long::sum);
+                    }
+                }
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("preview", true);
+                m.put("action", op.name());
+                m.put("userCount", users.size());
+                m.put("previewedUserCount", previewedCount);
+                Map<String, Long> aspectTotals = new LinkedHashMap<>();
+                for (RoleAspect a : aspects) aspectTotals.put(a.name(), totals.get(a));
+                m.put("previewCounts", aspectTotals);
+                if (!missingUserIds.isEmpty()) m.put("missingUserIds", missingUserIds);
+                return successResponse(m);
+            }
+
+            // confirm == true: apply for real
+            List<RoleApplicationResult> results = userRoleApplicationService.applyBulk(op, users, role, departments, aspects, updateUserRole, apiUser);
+            List<Map<String, Object>> perUser = new ArrayList<>();
+            int succeeded = 0;
+            int failed = 0;
+            int totalAdded = 0;
+            int totalRetired = 0;
+            for (RoleApplicationResult r : results) {
+                perUser.add(resultResponse(op, r));
+                if (r.isSuccess()) {
+                    succeeded++;
+                    totalAdded += r.getTotalAdded();
+                    totalRetired += r.getTotalRetired();
+                } else {
+                    failed++;
+                }
+            }
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("action", op.name());
+            summary.put("usersProcessed", results.size());
+            summary.put("succeeded", succeeded);
+            summary.put("failed", failed);
+            summary.put("totalAdded", totalAdded);
+            summary.put("totalRetired", totalRetired);
+
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("preview", false);
+            out.put("summary", summary);
+            out.put("results", perUser);
+            if (!missingUserIds.isEmpty()) out.put("missingUserIds", missingUserIds);
+            return successResponse(out);
+        } catch (ApiValidationException e) {
+            return errorResponse(e.getMessage(), e.getCode());
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<WebUser> resolveUsersByFilter(Object filterObj) {
+        Map<String, Object> filter = (filterObj instanceof Map) ? (Map<String, Object>) filterObj : null;
+        if (filter == null || filter.isEmpty()) {
+            throw new ApiValidationException("Either userIds or filter is required", 400);
+        }
+        Long filterRoleId = filter.get("roleId") != null ? toLong(filter.get("roleId"), "filter.roleId") : null;
+        Long filterDeptId = filter.get("departmentId") != null ? toLong(filter.get("departmentId"), "filter.departmentId") : null;
+        WebUserRole filterRole = filterRoleId != null ? findRoleOrThrow(filterRoleId) : null;
+        Department filterDept = null;
+        if (filterDeptId != null) {
+            filterDept = departmentFacade.find(filterDeptId);
+            if (filterDept == null) {
+                throw new ApiValidationException("filter.departmentId not found: " + filterDeptId, 404);
+            }
+        }
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder("select distinct w from WebUser w");
+        if (filterDept != null) {
+            jpql.append(" join WebUserDepartment wud on wud.webUser=w");
+        }
+        jpql.append(" where w.retired=false");
+        if (filterRole != null) {
+            jpql.append(" and w.role=:role");
+            params.put("role", filterRole);
+        }
+        if (filterDept != null) {
+            jpql.append(" and wud.retired=false and wud.department=:dept");
+            params.put("dept", filterDept);
+        }
+        jpql.append(" order by w.name");
+        return webUserFacade.findByJpql(jpql.toString(), params);
+    }
+
+    /**
+     * GET /api/users/roles
+     * Active roles with template summary: id, name, description, template login page,
+     * and counts of active role-level privileges / template icons / template subscriptions.
+     */
+    @GET
+    @Path("/roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listUserRolesWithTemplateCounts() {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        List<WebUserRole> roles = webUserRoleFacade.findByJpql("select r from WebUserRole r where r.retired=false order by r.name");
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (WebUserRole role : roles) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("id", role.getId());
+            m.put("name", role.getName());
+            m.put("description", role.getDescription());
+            m.put("loginPage", role.getLoginPage() != null ? role.getLoginPage().name() : null);
+            Map<String, Object> rp = kv("role", role);
+            long privilegeCount = webUserRolePrivilegeFacade.findLongByJpql(
+                    "select count(p) from WebUserRolePrivilege p where p.retired=false and p.webUserRole=:role", rp);
+            long iconCount = userIconFacade.findLongByJpql(
+                    "select count(u) from UserIcon u where u.retired=false and u.webUserRole=:role and u.webUser is null", rp);
+            long subscriptionCount = triggerSubscriptionFacade.findLongByJpql(
+                    "select count(t) from TriggerSubscription t where t.retired=false and t.webUserRole=:role and t.webUser is null", rp);
+            m.put("privilegeCount", privilegeCount);
+            m.put("iconCount", iconCount);
+            m.put("subscriptionCount", subscriptionCount);
+            out.add(m);
+        }
+        return successResponse(out);
+    }
+
+    /**
+     * PUT /api/users/{id}/login-page
+     * Body: {"departmentId": required long, "loginPage": required string (LoginPage enum name)}
+     * Upserts the active WebUserDefaultLoginPage row for user+department: retires the old
+     * active row (if any) and creates a new one.
+     */
+    @PUT
+    @Path("/{id}/login-page")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response setUserLoginPage(@PathParam("id") Long id, String body) {
+        try {
+            WebUser apiUser = validateApiUser();
+            if (apiUser == null) return errorResponse("Not a valid key", 401);
+            if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+            WebUser u = webUserFacade.find(id);
+            if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+
+            Map<String, Object> req = parseJsonBody(body);
+            Long departmentId = req.get("departmentId") != null ? toLong(req.get("departmentId"), "departmentId") : null;
+            if (departmentId == null) return errorResponse("departmentId is required", 400);
+            Department dept = departmentFacade.find(departmentId);
+            if (dept == null) return errorResponse("Department not found: " + departmentId, 404);
+
+            Object loginPageObj = req.get("loginPage");
+            if (!(loginPageObj instanceof String) || ((String) loginPageObj).trim().isEmpty()) {
+                return errorResponse("loginPage is required", 400);
+            }
+            LoginPage loginPage;
+            try {
+                loginPage = LoginPage.valueOf(((String) loginPageObj).trim());
+            } catch (IllegalArgumentException e) {
+                return errorResponse("Invalid loginPage: " + loginPageObj, 400);
+            }
+
+            Date now = new Date();
+            WebUserDefaultLoginPage active = webUserDefaultLoginPageFacade.findFirstByJpql(
+                    "select w from WebUserDefaultLoginPage w where w.retired=false and w.webUser=:u and w.department=:d order by w.id desc",
+                    kv("u", u, "d", dept));
+            if (active != null) {
+                active.setRetired(true);
+                active.setRetirer(apiUser);
+                active.setRetiredAt(now);
+                webUserDefaultLoginPageFacade.edit(active);
+            }
+            WebUserDefaultLoginPage fresh = new WebUserDefaultLoginPage();
+            fresh.setWebUser(u);
+            fresh.setDepartment(dept);
+            fresh.setLoginPage(loginPage);
+            fresh.setCreater(apiUser);
+            fresh.setCreatedAt(now);
+            webUserDefaultLoginPageFacade.create(fresh);
+
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("id", fresh.getId());
+            m.put("userId", u.getId());
+            m.put("departmentId", dept.getId());
+            m.put("loginPage", fresh.getLoginPage().name());
+            return successResponse(m);
+        } catch (JsonSyntaxException e) {
+            return errorResponse("Invalid JSON format", 400);
+        } catch (Exception e) {
+            return errorResponse("Internal server error", 500);
+        }
+    }
+
+    /**
+     * DELETE /api/users/{id}/login-page/{departmentId}
+     * Retires the active WebUserDefaultLoginPage row for this user+department, if any.
+     */
+    @DELETE
+    @Path("/{id}/login-page/{departmentId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deleteUserLoginPage(@PathParam("id") Long id, @PathParam("departmentId") Long departmentId) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        WebUser u = webUserFacade.find(id);
+        if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+        Department dept = departmentFacade.find(departmentId);
+        if (dept == null) return errorResponse("Department not found: " + departmentId, 404);
+
+        WebUserDefaultLoginPage active = webUserDefaultLoginPageFacade.findFirstByJpql(
+                "select w from WebUserDefaultLoginPage w where w.retired=false and w.webUser=:u and w.department=:d order by w.id desc",
+                kv("u", u, "d", dept));
+        if (active == null) return errorResponse("No active login page override for this user/department", 404);
+        active.setRetired(true);
+        active.setRetirer(apiUser);
+        active.setRetiredAt(new Date());
+        webUserDefaultLoginPageFacade.edit(active);
+        return successResponse("Login page override retired");
+    }
+
+    // ── Role-template helpers ────────────────────────────────────────────────
+
+    private Map<String, Object> previewResponse(RoleOperation op, WebUser user, WebUserRole role, List<Department> departments,
+            Set<RoleAspect> aspects, Map<RoleAspect, Long> counts) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("preview", true);
+        m.put("operation", op.name());
+        m.put("userId", user.getId());
+        m.put("roleId", role.getId());
+        m.put("roleName", role.getName());
+        m.put("departmentIds", departmentIdsOf(departments));
+        Map<String, Long> aspectCounts = new LinkedHashMap<>();
+        for (RoleAspect a : aspects) aspectCounts.put(a.name(), counts.getOrDefault(a, 0L));
+        m.put("previewCounts", aspectCounts);
+        return m;
+    }
+
+    private Map<String, Object> resultResponse(RoleOperation op, RoleApplicationResult result) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("preview", false);
+        m.put("operation", op.name());
+        m.put("userId", result.getUser() != null ? result.getUser().getId() : null);
+        m.put("userName", result.getUser() != null ? result.getUser().getName() : null);
+        m.put("success", result.isSuccess());
+        if (!result.isSuccess()) {
+            m.put("errorMessage", result.getErrorMessage());
+        }
+        Map<String, Integer> added = new LinkedHashMap<>();
+        for (Map.Entry<RoleAspect, Integer> e : result.getAdded().entrySet()) added.put(e.getKey().name(), e.getValue());
+        Map<String, Integer> retired = new LinkedHashMap<>();
+        for (Map.Entry<RoleAspect, Integer> e : result.getRetired().entrySet()) retired.put(e.getKey().name(), e.getValue());
+        m.put("added", added);
+        m.put("retired", retired);
+        m.put("totalAdded", result.getTotalAdded());
+        m.put("totalRetired", result.getTotalRetired());
+        return m;
+    }
+
+    private List<Long> departmentIdsOf(List<Department> departments) {
+        List<Long> ids = new ArrayList<>();
+        for (Department d : departments) ids.add(d.getId());
+        return ids;
+    }
+
+    private WebUserRole findRoleOrThrow(Long roleId) {
+        WebUserRole role = roleId != null ? webUserRoleFacade.find(roleId) : null;
+        if (role == null || role.isRetired()) {
+            throw new ApiValidationException("Role not found: " + roleId, 404);
+        }
+        return role;
+    }
+
+    private List<Department> resolveDepartments(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            throw new ApiValidationException("departmentIds is required and must be non-empty", 400);
+        }
+        List<Department> depts = new ArrayList<>();
+        List<Long> invalid = new ArrayList<>();
+        for (Long deptId : ids) {
+            Department d = departmentFacade.find(deptId);
+            if (d == null) {
+                invalid.add(deptId);
+            } else {
+                depts.add(d);
+            }
+        }
+        if (!invalid.isEmpty()) {
+            throw new ApiValidationException("Department(s) not found: " + invalid, 404);
+        }
+        return depts;
+    }
+
+    private Set<RoleAspect> parseAspects(List<String> names) {
+        Set<RoleAspect> set = new LinkedHashSet<>();
+        for (String n : names) {
+            try {
+                set.add(RoleAspect.valueOf(n == null ? null : n.trim()));
+            } catch (IllegalArgumentException | NullPointerException e) {
+                throw new ApiValidationException(
+                        "Invalid aspect: " + n + ". Valid values: PRIVILEGES, ICONS, SUBSCRIPTIONS, LOGIN_PAGE", 400);
+            }
+        }
+        if (set.isEmpty()) {
+            throw new ApiValidationException("aspects must contain at least one value", 400);
+        }
+        return set;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseJsonBody(String body) {
+        if (body == null || body.trim().isEmpty()) {
+            return new HashMap<>();
+        }
+        Map<String, Object> parsed = gson.fromJson(body, Map.class);
+        return parsed != null ? parsed : new HashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> extractLongList(Map<String, Object> req, String key, boolean required) {
+        Object obj = req.get(key);
+        if (obj == null) {
+            if (required) throw new ApiValidationException(key + " is required", 400);
+            return null;
+        }
+        if (!(obj instanceof List)) {
+            throw new ApiValidationException(key + " must be an array", 400);
+        }
+        List<Long> out = new ArrayList<>();
+        for (Object item : (List<Object>) obj) {
+            if (item instanceof Number) {
+                out.add(((Number) item).longValue());
+            } else {
+                throw new ApiValidationException(key + " must be an array of integers, got: " + item, 400);
+            }
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractStringList(Map<String, Object> req, String key, List<String> defaultVal) {
+        Object obj = req.get(key);
+        if (obj == null) return defaultVal;
+        if (!(obj instanceof List)) {
+            throw new ApiValidationException(key + " must be an array", 400);
+        }
+        List<String> out = new ArrayList<>();
+        for (Object item : (List<Object>) obj) {
+            if (item instanceof String) {
+                out.add((String) item);
+            } else {
+                throw new ApiValidationException(key + " must be an array of strings, got: " + item, 400);
+            }
+        }
+        return out;
+    }
+
+    private Long toLong(Object obj, String field) {
+        if (obj == null) return null;
+        if (obj instanceof Number) return ((Number) obj).longValue();
+        if (obj instanceof String) {
+            try {
+                return Long.parseLong(((String) obj).trim());
+            } catch (NumberFormatException e) {
+                throw new ApiValidationException(field + " must be numeric", 400);
+            }
+        }
+        throw new ApiValidationException(field + " must be numeric", 400);
+    }
+
+    private boolean toBoolean(Object obj, boolean defaultVal) {
+        if (obj == null) return defaultVal;
+        if (obj instanceof Boolean) return (Boolean) obj;
+        if (obj instanceof String) return Boolean.parseBoolean((String) obj);
+        return defaultVal;
+    }
+
+    private Map<String, Object> kv(Object... pairs) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            m.put((String) pairs[i], pairs[i + 1]);
+        }
+        return m;
+    }
+
+    /** Lightweight validation exception carrying the intended HTTP status code (400/404). */
+    private static class ApiValidationException extends RuntimeException {
+        private final int code;
+
+        ApiValidationException(String message, int code) {
+            super(message);
+            this.code = code;
+        }
+
+        int getCode() {
+            return code;
         }
     }
 

--- a/src/main/webapp/admin/users/index.xhtml
+++ b/src/main/webapp/admin/users/index.xhtml
@@ -43,11 +43,19 @@
 
                                         <hr/>
 
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="User Roles" 
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="User Roles"
                                             icon="fa fa-user-tag"
                                             action="#{webUserRoleController.navigateToManageWebUserRoles()}" >
+                                        </p:commandButton>
+
+                                        <p:commandButton
+                                            id="btnBulkRoleOperations"
+                                            ajax="false"
+                                            value="Bulk Role Operations"
+                                            icon="fa fa-users-cog"
+                                            action="#{userRoleManagementController.navigateToBulkRoleOperations()}" >
                                         </p:commandButton>
 
 <!--                                    <p:commandButton

--- a/src/main/webapp/admin/users/index.xhtml
+++ b/src/main/webapp/admin/users/index.xhtml
@@ -44,6 +44,7 @@
                                         <hr/>
 
                                         <p:commandButton
+                                            id="btnUserRoles"
                                             ajax="false"
                                             value="User Roles"
                                             icon="fa fa-user-tag"

--- a/src/main/webapp/admin/users/user_role_bulk_operations.xhtml
+++ b/src/main/webapp/admin/users/user_role_bulk_operations.xhtml
@@ -1,0 +1,295 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:na="http://xmlns.jcp.org/jsf/composite/template"
+      xmlns:p="http://primefaces.org/ui"
+      >
+
+    <h:body>
+
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('AdminManagingUsers')}">
+                    <na:not_authorize />
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('AdminManagingUsers')}" layout="block">
+                    <h:form id="frmBulk">
+
+                        <p:messages id="messages" showDetail="true" closable="true" />
+
+                        <div class="row">
+                            <div class="col-md-3">
+                                <p:panel class="w-100">
+                                    <f:facet name="header">
+                                        <i class="fa fa-filter" aria-hidden="true" />
+                                        <h:outputLabel value="Filter Users" class="mx-2" />
+                                    </f:facet>
+
+                                    <p:outputLabel value="Role" for="cmbFilterRole" class="d-block" />
+                                    <p:selectOneMenu
+                                        id="cmbFilterRole"
+                                        value="#{userRoleManagementController.filterRole}"
+                                        class="w-100 mb-2"
+                                        filter="true"
+                                        filterMatchMode="contains">
+                                        <f:selectItem itemLabel="Any Role" ></f:selectItem>
+                                        <f:selectItems
+                                            value="#{userRoleManagementController.roles}"
+                                            var="r"
+                                            itemLabel="#{r.name}"
+                                            itemValue="#{r}" />
+                                    </p:selectOneMenu>
+
+                                    <p:outputLabel value="Department" for="cmbFilterDepartment" class="d-block" />
+                                    <p:selectOneMenu
+                                        id="cmbFilterDepartment"
+                                        value="#{userRoleManagementController.filterDepartment}"
+                                        class="w-100 mb-2"
+                                        filter="true"
+                                        filterMatchMode="contains">
+                                        <f:selectItem itemLabel="Any Department" ></f:selectItem>
+                                        <f:selectItems
+                                            value="#{userRoleManagementController.allDepartments}"
+                                            var="d"
+                                            itemLabel="#{d.name}"
+                                            itemValue="#{d}" />
+                                    </p:selectOneMenu>
+
+                                    <p:outputLabel value="Institution" for="cmbFilterInstitution" class="d-block" />
+                                    <p:selectOneMenu
+                                        id="cmbFilterInstitution"
+                                        value="#{userRoleManagementController.filterInstitution}"
+                                        class="w-100 mb-2"
+                                        filter="true"
+                                        filterMatchMode="contains">
+                                        <f:selectItem itemLabel="Any Institution" ></f:selectItem>
+                                        <f:selectItems
+                                            value="#{userRoleManagementController.institutions}"
+                                            var="i"
+                                            itemLabel="#{i.name}"
+                                            itemValue="#{i}" />
+                                    </p:selectOneMenu>
+
+                                    <p:commandButton
+                                        id="btnFilterUsers"
+                                        value="List Users"
+                                        icon="fa fa-list"
+                                        class="ui-button-info w-100 mt-2"
+                                        process="@this cmbFilterRole cmbFilterDepartment cmbFilterInstitution"
+                                        update="tblUsers messages"
+                                        action="#{userRoleManagementController.fillUsersByFilter()}" />
+                                </p:panel>
+                            </div>
+
+                            <div class="col-md-9">
+                                <p:panel class="w-100">
+                                    <f:facet name="header">
+                                        <i class="fa fa-users" aria-hidden="true" />
+                                        <h:outputLabel value="Matching Users" class="mx-2" />
+                                    </f:facet>
+
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton
+                                            id="btnSelectAll"
+                                            value="Select All"
+                                            icon="fa fa-check-double"
+                                            class="ui-button-secondary"
+                                            process="@this tblUsers"
+                                            update="tblUsers messages"
+                                            action="#{userRoleManagementController.selectAllFilteredUsers()}" />
+                                    </div>
+
+                                    <p:dataTable
+                                        id="tblUsers"
+                                        var="u"
+                                        value="#{userRoleManagementController.filteredUsers}"
+                                        selection="#{userRoleManagementController.selectedUsers}"
+                                        selectionMode="multiple"
+                                        rowKey="#{u.id}"
+                                        paginator="true"
+                                        rows="25"
+                                        paginatorAlwaysVisible="false"
+                                        rowsPerPageTemplate="25,50,100"
+                                        styleClass="p-datatable-sm"
+                                        stickyHeader="true">
+                                        <p:column selectionBox="true" style="width:3rem; text-align:center;" />
+                                        <p:column headerText="Name">
+                                            <h:outputText value="#{u.name}" />
+                                        </p:column>
+                                        <p:column headerText="Code">
+                                            <h:outputText value="#{u.code}" />
+                                        </p:column>
+                                        <p:column headerText="Role">
+                                            <h:outputText value="#{u.role ne null ? u.role.name : '(none)'}" />
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:panel>
+
+                                <p:panel class="w-100 mt-3">
+                                    <f:facet name="header">
+                                        <i class="fa fa-user-cog" aria-hidden="true" />
+                                        <h:outputLabel value="Role Operation for Selected Users" class="mx-2" />
+                                    </f:facet>
+
+                                    <div class="row mb-3">
+                                        <div class="col-md-4">
+                                            <p:outputLabel value="Role" for="cmbBulkRole" class="d-block" />
+                                            <p:selectOneMenu
+                                                id="cmbBulkRole"
+                                                value="#{userRoleManagementController.selectedRole}"
+                                                class="w-100"
+                                                filter="true"
+                                                filterMatchMode="contains">
+                                                <f:selectItem itemLabel="Select Role" ></f:selectItem>
+                                                <f:selectItems
+                                                    value="#{userRoleManagementController.roles}"
+                                                    var="r"
+                                                    itemLabel="#{r.name}"
+                                                    itemValue="#{r}" />
+                                            </p:selectOneMenu>
+                                            <h:outputText value="Leave empty on Reset to use each user's own role." class="text-muted" style="font-size:0.85em;" />
+                                        </div>
+                                    </div>
+
+                                    <div class="row mb-3">
+                                        <div class="col-md-6">
+                                            <p:outputLabel value="Departments to Apply Operations In" for="chkBulkDepartments" class="d-block" />
+                                            <p:selectManyCheckbox
+                                                id="chkBulkDepartments"
+                                                value="#{userRoleManagementController.selectedDepartments}"
+                                                converter="userRoleDepartmentConverter"
+                                                layout="grid"
+                                                columns="2"
+                                                class="w-100">
+                                                <f:selectItems
+                                                    value="#{userRoleManagementController.allDepartments}"
+                                                    var="d"
+                                                    itemLabel="#{d.name}"
+                                                    itemValue="#{d}" />
+                                            </p:selectManyCheckbox>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <p:outputLabel value="Aspects to Apply" class="d-block" />
+                                            <div class="d-flex flex-wrap gap-3 mt-1">
+                                                <p:selectBooleanCheckbox id="chkAspectPrivileges" value="#{userRoleManagementController.aspectPrivileges}" itemLabel="Privileges" />
+                                                <p:selectBooleanCheckbox id="chkAspectIcons" value="#{userRoleManagementController.aspectIcons}" itemLabel="Icons" />
+                                                <p:selectBooleanCheckbox id="chkAspectSubscriptions" value="#{userRoleManagementController.aspectSubscriptions}" itemLabel="Subscriptions" />
+                                                <p:selectBooleanCheckbox id="chkAspectLoginPage" value="#{userRoleManagementController.aspectLoginPage}" itemLabel="Default Login Page" />
+                                            </div>
+                                            <div class="mt-2">
+                                                <p:selectBooleanCheckbox id="chkUpdateUserRole" value="#{userRoleManagementController.updateUserRole}" itemLabel="Also set selected role as each user's role on reset" />
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="row mb-2">
+                                        <div class="col-md-12 d-flex flex-wrap gap-2">
+                                            <p:commandButton
+                                                id="btnBulkPreviewReset"
+                                                value="Preview Reset"
+                                                icon="fa fa-eye"
+                                                class="ui-button-info ui-button-outlined"
+                                                process="@form"
+                                                update="opPreview messages"
+                                                action="#{userRoleManagementController.previewBulk('RESET')}" />
+                                            <p:commandButton
+                                                id="btnBulkPreviewExpand"
+                                                value="Preview Expand"
+                                                icon="fa fa-eye"
+                                                class="ui-button-info ui-button-outlined"
+                                                process="@form"
+                                                update="opPreview messages"
+                                                action="#{userRoleManagementController.previewBulk('EXPAND')}" />
+                                            <p:commandButton
+                                                id="btnBulkPreviewNarrow"
+                                                value="Preview Narrow"
+                                                icon="fa fa-eye"
+                                                class="ui-button-info ui-button-outlined"
+                                                process="@form"
+                                                update="opPreview messages"
+                                                action="#{userRoleManagementController.previewBulk('NARROW')}" />
+                                        </div>
+                                    </div>
+
+                                    <!-- Enter key only ever triggers the harmless "List Users" filter action, never a destructive execute action -->
+                                    <p:defaultCommand target="btnFilterUsers" />
+
+                                    <h:panelGroup id="opPreview" layout="block" class="mb-3">
+                                        <p:outputPanel
+                                            styleClass="ui-g ui-widget ui-state-highlight ui-corner-all p-2"
+                                            rendered="#{userRoleManagementController.previewText ne null}">
+                                            <i class="fa fa-info-circle" aria-hidden="true" />
+                                            <h:outputText value=" #{userRoleManagementController.previewText}" style="font-weight:bold;" />
+                                        </p:outputPanel>
+                                    </h:panelGroup>
+
+                                    <div class="row mb-3">
+                                        <div class="col-md-12 d-flex flex-wrap gap-2">
+                                            <p:commandButton
+                                                id="btnBulkReset"
+                                                value="Reset Selected Users"
+                                                icon="fa fa-undo"
+                                                class="ui-button-warning"
+                                                process="@form"
+                                                update="bulkResultsWrap messages opPreview"
+                                                onclick="return confirm('This rewrites the selected aspects for ALL selected users to the role template (their own role if none is selected here) in the selected departments. Existing records outside the template will be retired. Continue?');"
+                                                action="#{userRoleManagementController.executeBulk('RESET')}" />
+                                            <p:commandButton
+                                                id="btnBulkExpand"
+                                                value="Expand Selected Users"
+                                                icon="fa fa-plus-circle"
+                                                class="ui-button-secondary"
+                                                process="@form"
+                                                update="bulkResultsWrap messages opPreview"
+                                                onclick="return confirm('This adds the selected role\'s template records to ALL selected users in the selected departments. Existing extras are left untouched. Continue?');"
+                                                action="#{userRoleManagementController.executeBulk('EXPAND')}" />
+                                            <p:commandButton
+                                                id="btnBulkNarrow"
+                                                value="Narrow Selected Users"
+                                                icon="fa fa-minus-circle"
+                                                class="ui-button-danger"
+                                                process="@form"
+                                                update="bulkResultsWrap messages opPreview"
+                                                onclick="return confirm('This rewrites privileges for ALL selected users: records matching the selected role template will be RETIRED in the selected departments. Non-role records remain. Continue?');"
+                                                action="#{userRoleManagementController.executeBulk('NARROW')}" />
+                                        </div>
+                                    </div>
+
+                                    <h:panelGroup id="bulkResultsWrap" layout="block">
+                                    <p:dataTable
+                                        id="tblBulkResults"
+                                        var="res"
+                                        value="#{userRoleManagementController.results}"
+                                        rendered="#{not empty userRoleManagementController.results}"
+                                        styleClass="p-datatable-sm"
+                                        stickyHeader="true">
+                                        <p:column headerText="User">
+                                            <h:outputText value="#{res.user.name}" />
+                                        </p:column>
+                                        <p:column headerText="Added">
+                                            <h:outputText value="#{res.totalAdded}" />
+                                        </p:column>
+                                        <p:column headerText="Retired">
+                                            <h:outputText value="#{res.totalRetired}" />
+                                        </p:column>
+                                        <p:column headerText="Error">
+                                            <h:outputText value="#{res.errorMessage}" style="color:#d9534f;" />
+                                        </p:column>
+                                    </p:dataTable>
+                                    </h:panelGroup>
+                                </p:panel>
+                            </div>
+                        </div>
+
+                    </h:form>
+                </h:panelGroup>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/admin/users/user_role_users.xhtml
+++ b/src/main/webapp/admin/users/user_role_users.xhtml
@@ -4,134 +4,203 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:p="http://primefaces.org/ui"
       xmlns:na="http://xmlns.jcp.org/jsf/composite/template"
+      xmlns:p="http://primefaces.org/ui"
       >
+
     <h:body>
+
         <ui:composition template="/admin/users/user_list.xhtml">
+
             <ui:define name="users">
-                <h:panelGroup rendered="#{not webUserController.hasPrivilege('AdminManagingUsers') and not sessionController.firstLogin}" >
+
+                <h:panelGroup rendered="#{!webUserController.hasPrivilege('AdminManagingUsers')}">
                     <na:not_authorize />
                 </h:panelGroup>
 
-                <p:panel
-                    class="w-100"
-                    rendered="#{webUserController.hasPrivilege('AdminManagingUsers') or sessionController.firstLogin}">
+                <p:panel class="w-100" rendered="#{webUserController.hasPrivilege('AdminManagingUsers')}">
                     <f:facet name="header">
-                        <i class="fa fa-icons" />
-                        <h:outputLabel class="mx-2" value="Manage User Role Users"/>
+                        <i class="fa fa-user-cog" aria-hidden="true" />
+                        <h:outputLabel value="Manage User Role &amp; Defaults" class="mx-2" />
                     </f:facet>
 
-                    <p:panelGrid class="w-100" columns="2">
+                    <p:messages id="messages" showDetail="true" closable="true" />
 
-                        <p:outputLabel value="User" ></p:outputLabel>
-                        <p:selectOneMenu
-                            value="#{webUserRoleUserController.webUser}"
-                            filter="true"
-                            filterMatchMode="contains"
-                            disabled="true"
-                            class="w-100"
-                            autoWidth="false">
-                            <f:selectItems 
-                                value="#{webUserRoleUserController.users}"
-                                var="i"
-                                itemLabel="#{i.name}"
-                                itemValue="#{i}"/>
-                        </p:selectOneMenu>
-
-                        <p:outputLabel value="Department"  ></p:outputLabel>  
-                        <h:panelGroup id="gpDept" >
-                            <p:selectOneMenu 
-                                class="w-100"
-                                value="#{webUserRoleUserController.department}" >
-                                <f:selectItem itemLabel="Select" ></f:selectItem>
-                                <f:selectItems 
-                                    value="#{webUserRoleUserController.departments}" 
-                                    var="ur" 
-                                    itemLabel="#{ur.name}" 
-                                    itemValue="#{ur}" >
-                                </f:selectItems>
-                            </p:selectOneMenu>
-                        </h:panelGroup>
-
-                        <p:outputLabel  value="Role" ></p:outputLabel>
-                        <p:selectOneMenu
-                            class="w-100"
-                            value="#{webUserRoleUserController.webUserRole}" >
-                            <f:selectItem itemLabel="Select" ></f:selectItem>
-                            <f:selectItems 
-                                value="#{webUserRoleController.activatediItems}" 
-                                var="ur" 
-                                itemLabel="#{ur.name}" 
-                                itemValue="#{ur}" ></f:selectItems>
-                        </p:selectOneMenu>
-
-                    </p:panelGrid>
-
-                    <div class="d-flex justify-content-end">
-                        <p:commandButton
-                            value="Add Role Privileges to Department"
-                            icon="fa fa-plus"
-                            class="ui-button-success"
-                            action="#{webUserRoleUserController.addUsersToDepartmentRoleWithPrivileges}"
-                            ajax="false">
-                        </p:commandButton>
+                    <div class="row mb-3">
+                        <div class="col-md-12">
+                            <p:outputLabel value="User: " style="font-weight:bold;" />
+                            <h:outputText value="#{userRoleManagementController.currentUser.name}" style="font-weight:bold; font-size:1.1em;" />
+                        </div>
                     </div>
-                    
+
+                    <div class="row mb-3">
+                        <div class="col-md-4">
+                            <p:outputLabel value="User's Role" for="cmbRole" class="d-block" />
+                            <p:selectOneMenu
+                                id="cmbRole"
+                                value="#{userRoleManagementController.selectedRole}"
+                                class="w-100"
+                                filter="true"
+                                filterMatchMode="contains">
+                                <f:selectItem itemLabel="Select Role" ></f:selectItem>
+                                <f:selectItems
+                                    value="#{userRoleManagementController.roles}"
+                                    var="r"
+                                    itemLabel="#{r.name}"
+                                    itemValue="#{r}" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3 d-flex align-items-end">
+                            <p:commandButton
+                                id="btnSaveRole"
+                                value="Set as User's Role"
+                                icon="fa fa-save"
+                                title="Save this role as the user's own role, without changing any privileges/icons/subscriptions/login page yet"
+                                class="ui-button-success"
+                                process="@this cmbRole"
+                                update="messages"
+                                action="#{userRoleManagementController.saveUserRole()}" />
+                        </div>
+                    </div>
+
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <p:outputLabel value="Departments to Apply Operations In" for="chkDepartments" class="d-block" />
+                            <p:selectManyCheckbox
+                                id="chkDepartments"
+                                value="#{userRoleManagementController.selectedDepartments}"
+                                converter="userRoleDepartmentConverter"
+                                layout="grid"
+                                columns="2"
+                                class="w-100">
+                                <f:selectItems
+                                    value="#{userRoleManagementController.userDepartments}"
+                                    var="d"
+                                    itemLabel="#{d.name}"
+                                    itemValue="#{d}" />
+                            </p:selectManyCheckbox>
+                        </div>
+                        <div class="col-md-6">
+                            <p:outputLabel value="Aspects to Apply" class="d-block" />
+                            <div class="d-flex flex-wrap gap-3 mt-1">
+                                <p:selectBooleanCheckbox id="chkAspectPrivileges" value="#{userRoleManagementController.aspectPrivileges}" itemLabel="Privileges" />
+                                <p:selectBooleanCheckbox id="chkAspectIcons" value="#{userRoleManagementController.aspectIcons}" itemLabel="Icons" />
+                                <p:selectBooleanCheckbox id="chkAspectSubscriptions" value="#{userRoleManagementController.aspectSubscriptions}" itemLabel="Subscriptions" />
+                                <p:selectBooleanCheckbox id="chkAspectLoginPage" value="#{userRoleManagementController.aspectLoginPage}" itemLabel="Default Login Page" />
+                            </div>
+                            <div class="mt-2">
+                                <p:selectBooleanCheckbox id="chkUpdateUserRole" value="#{userRoleManagementController.updateUserRole}" itemLabel="Also set selected role as the user's role on reset" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row mb-2">
+                        <div class="col-md-12 d-flex flex-wrap gap-2">
+                            <p:commandButton
+                                id="btnPreviewReset"
+                                value="Preview Reset"
+                                icon="fa fa-eye"
+                                class="ui-button-info ui-button-outlined"
+                                process="@form"
+                                update="opPreview messages"
+                                action="#{userRoleManagementController.previewOperation('RESET')}" />
+                            <p:commandButton
+                                id="btnPreviewExpand"
+                                value="Preview Expand"
+                                icon="fa fa-eye"
+                                class="ui-button-info ui-button-outlined"
+                                process="@form"
+                                update="opPreview messages"
+                                action="#{userRoleManagementController.previewOperation('EXPAND')}" />
+                            <p:commandButton
+                                id="btnPreviewNarrow"
+                                value="Preview Narrow"
+                                icon="fa fa-eye"
+                                class="ui-button-info ui-button-outlined"
+                                process="@form"
+                                update="opPreview messages"
+                                action="#{userRoleManagementController.previewOperation('NARROW')}" />
+                        </div>
+                    </div>
+
+                    <!-- Enter key only ever triggers a harmless preview, never a destructive execute action -->
+                    <p:defaultCommand target="btnPreviewReset" />
+
+                    <h:panelGroup id="opPreview" layout="block" class="mb-3">
+                        <p:outputPanel
+                            styleClass="ui-g ui-widget ui-state-highlight ui-corner-all p-2"
+                            rendered="#{userRoleManagementController.previewText ne null}">
+                            <i class="fa fa-info-circle" aria-hidden="true" />
+                            <h:outputText value=" #{userRoleManagementController.previewText}" style="font-weight:bold;" />
+                        </p:outputPanel>
+                    </h:panelGroup>
+
+                    <div class="row mb-3">
+                        <div class="col-md-12 d-flex flex-wrap gap-2">
+                            <p:commandButton
+                                id="btnResetDefaultRole"
+                                value="Reset to User's Default Role"
+                                icon="fa fa-undo"
+                                class="ui-button-warning"
+                                process="@form"
+                                update="resultsWrap messages opPreview"
+                                onclick="return confirm('Reset the selected departments/aspects to this user\'s DEFAULT role template? Existing records outside the template will be retired.');"
+                                action="#{userRoleManagementController.executeResetToDefaultRole()}" />
+                            <p:commandButton
+                                id="btnResetSelectedRole"
+                                value="Reset to Selected Role"
+                                icon="fa fa-undo"
+                                class="ui-button-warning"
+                                process="@form"
+                                update="resultsWrap messages opPreview"
+                                onclick="return confirm('Reset the selected departments/aspects to the SELECTED role template? Existing records outside the template will be retired.');"
+                                action="#{userRoleManagementController.executeResetToSelectedRole()}" />
+                            <p:commandButton
+                                id="btnExpand"
+                                value="Expand by Selected Role"
+                                icon="fa fa-plus-circle"
+                                class="ui-button-secondary"
+                                process="@form"
+                                update="resultsWrap messages opPreview"
+                                onclick="return confirm('Add the selected role\'s template records to this user in the selected departments? Existing extras are left untouched.');"
+                                action="#{userRoleManagementController.executeExpand()}" />
+                            <p:commandButton
+                                id="btnNarrow"
+                                value="Narrow by Selected Role"
+                                icon="fa fa-minus-circle"
+                                class="ui-button-danger"
+                                process="@form"
+                                update="resultsWrap messages opPreview"
+                                onclick="return confirm('Retire this user\'s records that match the selected role template in the selected departments? Non-role records remain.');"
+                                action="#{userRoleManagementController.executeNarrow()}" />
+                        </div>
+                    </div>
+
+                    <h:panelGroup id="resultsWrap" layout="block">
+                    <p:dataTable
+                        id="tblResults"
+                        var="res"
+                        value="#{userRoleManagementController.results}"
+                        rendered="#{not empty userRoleManagementController.results}"
+                        styleClass="p-datatable-sm"
+                        stickyHeader="true">
+                        <p:column headerText="User">
+                            <h:outputText value="#{res.user.name}" />
+                        </p:column>
+                        <p:column headerText="Added">
+                            <h:outputText value="#{res.totalAdded}" />
+                        </p:column>
+                        <p:column headerText="Retired">
+                            <h:outputText value="#{res.totalRetired}" />
+                        </p:column>
+                        <p:column headerText="Error">
+                            <h:outputText value="#{res.errorMessage}" style="color:#d9534f;" />
+                        </p:column>
+                    </p:dataTable>
+                    </h:panelGroup>
+
                 </p:panel>
 
-                <p:dataTable
-                    var="user"
-                    class="mt-3"
-                    rendered="false"
-                    value="#{webUserRoleUserController.roleUsers}"
-                    rowKey="#{user.id}"
-                    id="tbl">
-
-                    <p:column headerText="User" style="padding: 10px; width:150px;">
-                        <h:outputText value="#{user.webUser.name}" />
-                    </p:column>
-
-                    <p:column headerText="Institution" style="padding: 10px; ">
-                        <h:outputText value="#{user.department.institution.name}" />
-                    </p:column>
-
-                    <p:column headerText="Department" style="padding: 10px; ">
-                        <h:outputText value="#{user.department.name}" />
-                    </p:column>
-
-                    <p:column headerText="Role" class="text-center" style="padding: 10px; width: 180px;">
-                        <div class="card p-2">
-                            <h:outputText id="role" value="#{user.webUserRole.name}" class="d-flex justify-content-center" style="font-weight: 700;"/>
-                        </div>
-
-                    </p:column>
-
-                    <p:column headerText="Actions" class="text-center" style=" padding: 10px; width: 200px; " >
-                        <h:panelGroup id="combinedActions" class="d-flex justify-content-center gap-2">
-                            <p:commandButton
-
-                                value="Reset Privilege"
-                                icon="fa fa-refresh"
-                                disabled="#{!user.needUpdateUserRole}"
-                                class="ui-button-secondary"
-                                action="#{webUserRoleUserController.resetRolePrivileges(user)}"
-                                onclick="if (!confirm('Are you sure you want to Reset Privileges?'))
-                                            return false;"
-                                ajax="false">
-                            </p:commandButton>
-                            <p:commandButton
-                                id="remove"
-                                title="Remove User Role"
-                                icon="fa fa-trash"
-                                action="#{webUserRoleUserController.removeUserRole(user)}"
-                                class="ui-button-danger"
-                                ajax="false" >
-                            </p:commandButton>
-                        </h:panelGroup>
-                    </p:column>
-
-                </p:dataTable>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/admin/users/user_roles.xhtml
+++ b/src/main/webapp/admin/users/user_roles.xhtml
@@ -77,9 +77,24 @@
                                                             <p:outputLabel value="Description" for="txtComments" ></p:outputLabel>
                                                             <p:inputTextarea
                                                                 class="w-100"
-                                                                value="#{webUserRoleController.current.description}" 
+                                                                value="#{webUserRoleController.current.description}"
                                                                 id="txtComments">
                                                             </p:inputTextarea>
+                                                            <p:outputLabel value="Template Login Page" for="cmbLoginPage" rendered="#{webUserRoleController.current ne null}" ></p:outputLabel>
+                                                            <p:selectOneMenu
+                                                                id="cmbLoginPage"
+                                                                value="#{webUserRoleController.current.loginPage}"
+                                                                rendered="#{webUserRoleController.current ne null}"
+                                                                class="w-100"
+                                                                filter="true"
+                                                                filterMatchMode="contains">
+                                                                <f:selectItem itemLabel="None" itemValue="#{null}" ></f:selectItem>
+                                                                <f:selectItems
+                                                                    value="#{enumController.loginPages}"
+                                                                    var="lp"
+                                                                    itemLabel="#{lp.label}"
+                                                                    itemValue="#{lp}" />
+                                                            </p:selectOneMenu>
                                                             <p:outputLabel value="Active" for="tglswt" ></p:outputLabel>
                                                             <p:toggleSwitch id="tglswt" value="#{webUserRoleController.current.activated}" onIcon="pi pi-check" offIcon="pi pi-times" />
                                                         
@@ -89,7 +104,7 @@
                                                             id="btnSave"
                                                             icon="fas fa-save"
                                                             class="ui-button-warning my-2"
-                                                            process="txtRole txtComments btnSave tglswt"
+                                                            process="txtRole txtComments cmbLoginPage btnSave tglswt"
                                                             update="lstItems focusForList actions growl"
                                                             value="Save" 
                                                             action="#{webUserRoleController.saveCurrent()}" >


### PR DESCRIPTION
## Summary

Implements role-template based user management (#22023): roles become **admin-time templates** that can be stamped onto users' department-level records — for a single user or many users at once — covering **privileges, icons, subscriptions, and a new per-user-per-department default login page**. Runtime behavior continues to read user-level records only.

### Engine
- New `UserRoleApplicationService` (EJB) — single code path for UI, REST, and AI:
  - **RESET** — retire the user's records of an aspect in a department, apply the role template (implemented as a safe diff; end state identical)
  - **EXPAND** — add template records the user lacks (un-retire or create); extras untouched
  - **NARROW** — retire the user's records matching the template; non-template records remain
  - `previewCounts(...)` powers UI preview buttons and the API preview flow
  - Every call writes an `AuditEvent` + a `WebUserRoleUser` history row; all writes batched, JPQL only

### Data model
- New entity `WebUserDefaultLoginPage` (webUser + department + loginPage) — one active row per user+department; DDL regenerated and published to the wiki
- `WebUserRole.loginPage` — the role's template login page (editable on User Roles page)
- `SessionController` login-page resolution: user+dept row → legacy `WebUser.loginPage` → HOME (fully backward compatible)
- Fixed missing `@ManyToOne` on `WebUserRoleUser.department` (latent since #18206)

### UI (no new main-menu item; gated by `AdminManagingUsers`)
- `user_role_users.xhtml` reworked into **Manage User Role & Defaults** (role dropdown, department checklist, aspect checkboxes, preview + 4 operations with confirm dialogs and per-user results)
- New **Bulk Role Operations** page (accordion button on the users index): filter by role/department/institution → select users (select-all) → same operation panel → per-user results table
- `user_roles.xhtml`: Template Login Page dropdown

### REST API + AI (full 4-step registration)
- `POST /api/users/{id}/role/reset|expand|narrow` (supports `preview:true`)
- `POST /api/users/bulk/role-operations` — resolves users by ids or filter; **requires preview→confirm**; 400 with resolved user count otherwise
- `GET /api/users/roles` (template summaries), `PUT`/`DELETE /api/users/{id}/login-page`
- Registered in `CapabilityStatementResource`; 6 new AI tools in `AnthropicApiService`

## Verification (Playwright + MySQL on local coop DB)

- **Per-user** (`rathnayaka`, Main Pharmacy): Preview Reset showed `Privileges: 64; Icons: 2; Subscriptions: 1; Login Page: 1`; Reset to Pharmacy → DB shows exactly the 74 template privileges + 2 icons + 1 subscription + 1 login-page row, `WebUser.role` updated, audit + history written. Narrow by Dispensor retired exactly the 24 overlapping privileges; Expand added its 30; Reset to default role restored exactly 74.
- **Bulk** (filter role=Dispensor → irumi, imasha; select-all): preview `2 users; 44 changes` (identical numbers via REST preview), execute → per-user results 20 added / 2 retired each; DB confirms both hold exactly the 30-privilege Dispensor template.
- **Login page resolution**: logged in as `rathnayaka` → Main Pharmacy → landed on **Pharmacy Token Board**.
- **REST write path**: `role/narrow` retired 24; `role/reset` restored 74.

![Per-user page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/per_user_preview_reset.png)
![Bulk results](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/bulk_reset_results.png)
![Login page resolution](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/login_page_resolution_token_board.png)

**Wiki**: [Role-Template User Management](https://github.com/hmislk/hmis/wiki/Role-Template-User-Management) (admin guide with screenshots)

Closes #22023
Closes #6178
Closes #17493
Closes #4722

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-template operations to manage user privileges, icons, subscriptions, and default login-page settings (reset/expand/narrow) with preview and confirmation flows.
  * Added bulk role operations with user filtering by role/department/institution and per-user result summaries.
  * Added API/assistant support for role-template operations plus listing role templates and setting/unsetting per-user, per-department login-page overrides.
  * Updated the admin UI to include user role-management actions and a bulk operations page, plus a template login-page dropdown.
* **Documentation**
  * Added guidance on common authoring/testing pitfalls for role-management pages, and renumbered an existing section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->