### PR TITLE
fix(pharmacy): remove duplicate isAuthorized helpers breaking compilation on development

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1315,10 +1315,10 @@ public class PharmacyBillSearch implements Serializable {
     }
 
     /**
-     * Authorization helper method to check Purchase Order cancellation
-     * privileges and audit denied access
+     * Authorization helper shared by the PO / transfer-issue / GRN
+     * cancellation actions: checks the privilege and audits denied access.
      *
-     * @param action The action being attempted (CANCEL)
+     * @param action The action being attempted (e.g. CANCEL, PHARMACY_GRN_CANCEL)
      * @param requiredPrivilege The specific privilege required
      * @return true if authorized, false if not
      */
@@ -1333,10 +1333,10 @@ public class PharmacyBillSearch implements Serializable {
             Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
             Long billId = bill != null ? bill.getId() : null;
 
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
                     new Object[]{action, userId, billId, requiredPrivilege});
 
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase().replace('_', ' ') + ".");
             return false;
         }
 
@@ -3613,35 +3613,6 @@ public class PharmacyBillSearch implements Serializable {
         }
     }
 
-    /**
-     * Authorization helper method to check Transfer Issue cancellation
-     * privileges and audit denied access
-     *
-     * @param action The action being attempted (CANCEL)
-     * @param requiredPrivilege The specific privilege required
-     * @return true if authorized, false if not
-     */
-    private boolean isAuthorized(String action, String requiredPrivilege) {
-        if (webUserController == null || sessionController == null) {
-            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
-                    new Object[]{action, bill != null ? bill.getId() : "null"});
-            return false;
-        }
-
-        if (!webUserController.hasPrivilege(requiredPrivilege)) {
-            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
-            Long billId = bill != null ? bill.getId() : null;
-
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Transfer Issue cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
-                    new Object[]{action, userId, billId, requiredPrivilege});
-
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " this transfer issue.");
-            return false;
-        }
-
-        return true;
-    }
-
     public void pharmacyTransferIssueCancel() {
         if (!isAuthorized("CANCEL", "PharmacyTransferIssueCancel")) {
             return;
@@ -5836,37 +5807,6 @@ public class PharmacyBillSearch implements Serializable {
         if (issueSearchDtos == null) {
             issueSearchDtos = new ArrayList<>();
         }
-    }
-
-    /**
-     * Authorization helper method to check GRN cancellation privileges and
-     * audit denied access
-     *
-     * @param action The action being attempted (PHARMACY_GRN_CANCEL,
-     * PHARMACY_GRN_RETURN_CANCEL)
-     * @param requiredPrivilege The specific privilege required
-     * @return true if authorized, false if not
-     */
-    private boolean isAuthorized(String action, String requiredPrivilege) {
-        if (webUserController == null || sessionController == null) {
-            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null",
-                    action);
-            return false;
-        }
-
-        if (!webUserController.hasPrivilege(requiredPrivilege)) {
-            // Audit denied access attempt
-            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
-            Long billId = bill != null ? bill.getId() : null;
-
-            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized GRN cancellation access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
-                    new Object[]{action, userId, billId, requiredPrivilege});
-
-            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase().replace('_', ' ') + ".");
-            return false;
-        }
-
-        return true;
     }
 
 }


### PR DESCRIPTION
## Summary

`development` currently does not compile: three parallel privilege-guard PRs (#22019, #22020, #22021 — merged via #22025/#22026) each added an identical-signature `private isAuthorized(String, String)` helper to `PharmacyBillSearch`, so `validate-compilation` fails on every open PR with:

```
method isAuthorized(java.lang.String,java.lang.String) is already defined in class com.divudi.bean.pharmacy.PharmacyBillSearch
```

This keeps one generic helper (the underscore-to-space message variant, correct for all existing call sites: `CANCEL`, `PHARMACY_GRN_CANCEL`, `PHARMACY_GRN_RETURN_CANCEL`) and removes the two duplicates. No behavior change beyond unified log/message wording.

Verified locally: `mvn compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)