### PR TITLE
fix(admin): don't crash Add Missing Fields page on config-option lookup failure

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2391,7 +2391,14 @@ public class DataAdministrationController implements Serializable {
     }
 
     public String getStoredDdlVersion() {
-        return configOptionApplicationController.getShortTextValueByKey(CONFIG_KEY_DDL_VERSION);
+        try {
+            return configOptionApplicationController.getShortTextValueByKey(CONFIG_KEY_DDL_VERSION);
+        } catch (Exception e) {
+            // Reading/creating this config option can fail on a database that is itself
+            // mid-migration (e.g. config_option.id not yet AUTO_INCREMENT) — this page
+            // exists to fix that exact situation, so it must not crash rendering because of it.
+            return null;
+        }
     }
 
     public String getWikiDdlVersion() {


### PR DESCRIPTION
## Summary
- `mf.xhtml` ("Add Missing Fields") throws a server-side exception on every render, on any database that hasn't yet applied migration v2.2.0 (`GenerationType.AUTO` → `IDENTITY`, requiring `config_option.id` to be `AUTO_INCREMENT`). The exception happens mid-render while writing `getStoredDdlVersion()`'s output, which is the first place a brand-new `ConfigOption` row (`DATABASE_DDL_VERSION`) gets inserted.
- Because the exception fires after the response is already partially flushed, Payara appends the full `errorPages/generalError.xhtml` document onto the tail of the same response instead of replacing it. The browser can't parse the resulting malformed HTML, so the PrimeFaces `AccordionPanel` widget never initializes client-side — no tab or button on the page responds to clicks.
- This is a chicken-and-egg bug: the admin tool that exists specifically to fix a database mid-migration crashes because of that same mid-migration state (observed live on `qa.carecode.org/qa4/faces/mf.xhtml`).
- Fix: wrap `DataAdministrationController.getStoredDdlVersion()` in a try/catch so a config-option lookup/creation failure degrades to `null` ("(not set)" in the UI) instead of aborting the whole page render.

## Test plan
- [x] `mvn compile` succeeds
- [ ] Verify on qa4 after merge: `mf.xhtml` loads fully, both accordion tabs are clickable, and "Check Missing Fields" / "Fix Missing Fields" buttons work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented administration pages from crashing when the database version setting cannot be read during migration.
  * The page now loads safely even if the configuration option is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->