### PR TITLE
fix(inward): show correct pharmacy-issue refund rows in BHT Table Format breakdown

### DIFF
--- a/src/main/webapp/inward/inward_bill_final_break_down.xhtml
+++ b/src/main/webapp/inward/inward_bill_final_break_down.xhtml
@@ -77,7 +77,7 @@
                                                       and
                                                       ((iss.bill.billClass eq 'class com.divudi.core.entity.PreBill')
                                                       or
-                                                      (iss.bill.billedBill eq null and iss.bill.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
+                                                      (iss.bill.billedBill ne null and iss.bill.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
                             <p:column headerText="Bill No">
                                 <f:facet name="header">
                                     <h:outputLabel value="Bill No"/>

--- a/src/main/webapp/inward/inward_reports.xhtml
+++ b/src/main/webapp/inward/inward_reports.xhtml
@@ -49,7 +49,7 @@
                                         <p:commandButton ajax="false" value="Discount Report" icon="fa fa-fw fa-percentage" action="inward_report_discount?faces-redirect=true" />
                                         <p:commandButton ajax="false" value="BHT VAT Report" icon="fa fa-fw fa-receipt" action="inward_report_bht_inward_vat?faces-redirect=true" />
                                         <p:commandButton ajax="false" value="BHT Break Down (TAB Format)" icon="fa fa-fw fa-table" action="inward_bill_intrim_finalized?faces-redirect=true" actionListener="#{bhtSummeryFinalizedController.makeNull()}" />
-                                        <p:commandButton ajax="false" value="BHT Break Down (Table Format)" icon="fa fa-fw fa-list-alt" action="inward_bill_final_break_down?faces-redirect=true" />
+                                        <p:commandButton ajax="false" value="BHT Break Down (Table Format)" icon="fa fa-fw fa-list-alt" action="inward_bill_final_break_down?faces-redirect=true" actionListener="#{bhtSummeryFinalizedController.makeNull()}" />
                                         <p:commandButton
                                             value="Inpatient Invoice Journal"
                                             icon="fa fa-fw fa-book"


### PR DESCRIPTION
## Summary
- Fixes issue #17560: the "BHT Break Down (Table Format)" page (`inward_bill_final_break_down.xhtml`) hid legitimate Pharmacy Issue refund/return line items because the row-visibility condition for `RefundBill`-classed items was inverted (`billedBill eq null` instead of `ne null`). Since `billedBill` is always set on real refund bills (it points back to the original issue bill), the old condition matched almost no real rows, hiding item-wise breakdown data for Insurance Claim Bills.
- Fixed to match the working "TAB Format" page's (`inward_bill_intrim_finalized.xhtml`) proven-correct condition.
- Also added the missing `makeNull()` actionListener on the "Table Format" nav button in `inward_reports.xhtml`, matching its "TAB Format" sibling, to reset stale session state (`@SessionScoped` bean) when navigating to the page directly.

## Test plan
- [x] Verified against a live BHT (with a pharmacy-issue return, refund bill `MPPHISSRET/167` linked back to original bill `MP//25/005230`) on local Payara.
- [x] Confirmed the Table Format Pharmacy Issue table now shows the refund row `Pencan 25g -4,239.50` alongside the original issue rows, matching item-wise breakdown behavior of the TAB Format page — see [screenshot](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-17560-table-format-pharmacy-issue-fixed.png) and [issue comment](https://github.com/hmislk/hmis/issues/17560#issuecomment-4949188199).
- [x] XHTML-only change; no Java recompile required (CLAUDE.md rule 12).

Closes #17560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of refund bill entries in pharmacy issue breakdowns.
  * Ensured BHT breakdown reports reset the relevant state before loading, providing more reliable report results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->