### PR TITLE
Comment for IP pharmacy request + BHT issue request improvements (#15381)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -551,7 +551,12 @@ public class PharmacyRequestForBhtController implements Serializable {
             billItem.setPharmaceuticalBillItem(pbi);
         }
         if (billItem.getPrescription() == null) {
-            billItem.setPrescription(new Prescription());
+            Prescription newPrescription = new Prescription();
+            // Default the "Prescribed From" date to today at the start of every new
+            // cycle. Once a duration is entered, calculateToDateFromDuration() derives
+            // the "Prescribed To" date from this from-date + duration.
+            newPrescription.setPrescribedFrom(new Date());
+            billItem.setPrescription(newPrescription);
         }
         return billItem;
     }
@@ -1335,7 +1340,16 @@ public class PharmacyRequestForBhtController implements Serializable {
             // Create a detached prescription instance for in-memory use only
             // This will be persisted later during settle operations
             Prescription inMemoryPrescription = new Prescription();
-            inMemoryPrescription.setItem(billItem.getItem());
+            // Carry the PRESCRIBED medicine (selected in the Prescription panel's
+            // acMedicine) onto the prescription, NOT the resolved dispense item.
+            // The Directions text is built from the prescription's own item, so it
+            // must reflect what was prescribed (e.g. the VTM/ATM/VMP the doctor
+            // ordered), not the concrete AMP/VMP chosen for dispensing. Fall back
+            // to the dispense item only when no prescription medicine was picked.
+            Item prescribedItem = billItem.getPrescription().getItem() != null
+                    ? billItem.getPrescription().getItem()
+                    : billItem.getItem();
+            inMemoryPrescription.setItem(prescribedItem);
             inMemoryPrescription.setDose(billItem.getPrescription().getDose());
             inMemoryPrescription.setDoseUnit(billItem.getPrescription().getDoseUnit());
             inMemoryPrescription.setFrequencyUnit(billItem.getPrescription().getFrequencyUnit());
@@ -1463,7 +1477,12 @@ public class PharmacyRequestForBhtController implements Serializable {
         newBillItem.setBill(getPreBill());
 
         Prescription inMemoryPrescription = new Prescription();
-        inMemoryPrescription.setItem(dispensableItem);
+        // Carry the PRESCRIBED medicine onto the prescription so the Directions
+        // text reflects what was ordered, not the resolved dispensable AMP/VMP.
+        Item prescribedItem = sourcePrescription.getItem() != null
+                ? sourcePrescription.getItem()
+                : dispensableItem;
+        inMemoryPrescription.setItem(prescribedItem);
         inMemoryPrescription.setDose(sourcePrescription.getDose());
         inMemoryPrescription.setDoseUnit(sourcePrescription.getDoseUnit());
         inMemoryPrescription.setFrequencyUnit(sourcePrescription.getFrequencyUnit());
@@ -2621,13 +2640,15 @@ public class PharmacyRequestForBhtController implements Serializable {
             return false;
         }
 
-        // Check if any of the key prescription fields have meaningful values
+        // Check if any of the key prescription fields have meaningful values.
+        // Note: prescribedFrom is intentionally excluded here because it is now
+        // auto-defaulted to today for every new cycle (see getBillItem()), so on
+        // its own it does not indicate the user entered prescription details.
         return prescription.getDose() != null
                 || prescription.getDoseUnit() != null
                 || prescription.getFrequencyUnit() != null
                 || prescription.getDuration() != null
                 || prescription.getDurationUnit() != null
-                || prescription.getPrescribedFrom() != null
                 || prescription.getPrescribedTo() != null
                 || (prescription.getComment() != null && !prescription.getComment().trim().isEmpty())
                 || (prescription.getItem() != null && billItem != null && !prescription.getItem().equals(billItem.getItem()));

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -2613,6 +2613,61 @@ public class PharmacyRequestForBhtController implements Serializable {
     }
 
     /**
+     * Case 1 — Generate but do NOT add.
+     *
+     * Recomputes the dispense item and quantity from the current prescription
+     * details, then leaves the resolved values in the Dispense Request panel so
+     * the user can review and adjust them before adding. Focus is moved to the
+     * Dispense item field on the page (see the button's update/focus wiring).
+     * This intentionally does not touch the bill-items table.
+     */
+    public void generateDispenseFromPrescription() {
+        calculateItemAndQuantityFromPrescription();
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            JsfUtil.addErrorMessage(errorMessage);
+        }
+    }
+
+    /**
+     * Case 2 — Calculate and Add in one step.
+     *
+     * Recomputes the dispense item and quantity from the prescription and, only
+     * if the calculation succeeds, adds the resolved line to the dispense
+     * request. If the calculation cannot produce an item and quantity (e.g. a
+     * missing dose or frequency), the error is shown and nothing is added, so a
+     * blank or stale line can never be appended.
+     */
+    public void calculateAndAddBillItem() {
+        if (billItem == null || billItem.getPrescription() == null) {
+            JsfUtil.addErrorMessage("No prescription available for calculation");
+            return;
+        }
+
+        try {
+            com.divudi.ejb.PrescriptionToItemService.PrescriptionToItemResult result
+                    = prescriptionToItemService.calculateItemAndQuantity(billItem.getPrescription());
+
+            if (!result.isSuccess() || result.getItem() == null || result.getQuantity() == null) {
+                String msg = result.getErrorMessage() != null && !result.getErrorMessage().isEmpty()
+                        ? result.getErrorMessage()
+                        : "Could not calculate the item and quantity from the prescription";
+                JsfUtil.addErrorMessage("Calculation Error: " + msg);
+                return;
+            }
+
+            setItem(result.getItem());
+            billItem.setItem(result.getItem());
+            setQty(result.getQuantity());
+            setErrorMessage("");
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error calculating item and quantity: " + e.getMessage());
+            return;
+        }
+
+        addBillItem();
+    }
+
+    /**
      * Check if prescription has enough information for item/quantity
      * calculation
      */

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -6,6 +6,7 @@
 package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SessionController;
@@ -41,6 +42,7 @@ import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.pharmacy.Amp;
+import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.UserStockContainer;
@@ -90,6 +92,8 @@ public class PharmacyRequestForBhtController implements Serializable {
     PharmacyCalculation pharmacyCalculation;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    ItemController itemController;
 
 ////////////////////////
     @EJB
@@ -138,6 +142,15 @@ public class PharmacyRequestForBhtController implements Serializable {
     boolean billPreview = false;
     Department department;
     String errorMessage = "";
+    // Prescription medicine-type toggle filters (VTM/ATM/VMP/AMP). Default all on = list all pharmaceutical items.
+    private boolean includeVtm = true;
+    private boolean includeAtm = true;
+    private boolean includeVmp = true;
+    private boolean includeAmp = true;
+    // Edit-a-bill-item modal state: the row being edited and the same-generic substitute options
+    private BillItem billItemForEdit;
+    private List<Item> substituteAmps;
+    private Item selectedSubstituteAmp;
     /////////////////
     List<Stock> replaceableStocks;
     //List<BillItem> billItems;
@@ -2074,6 +2087,170 @@ public class PharmacyRequestForBhtController implements Serializable {
         savePreBillFinallyRequest(pt, matrixDepartment, btp, billNumberSuffix);
         savePreBillItemsFinallyRequest(tmpBillItems);
         JsfUtil.addSuccessMessage("Request Saved");
+    }
+
+    /**
+     * Opens the edit modal for a bill item already in the request. Loads the
+     * same-generic substitute options (other AMPs sharing the resolved item's VMP)
+     * so the user can swap the algorithm-picked item for an equivalent one.
+     *
+     * @param bi the bill item row to edit
+     */
+    public void prepareEditBillItem(BillItem bi) {
+        billItemForEdit = bi;
+        selectedSubstituteAmp = null;
+        substituteAmps = new ArrayList<>();
+        if (bi == null || bi.getItem() == null) {
+            return;
+        }
+        selectedSubstituteAmp = bi.getItem();
+        fillSubstituteAmpsFor(bi.getItem());
+    }
+
+    /**
+     * Populates {@link #substituteAmps} with AMPs that share the same VMP (generic)
+     * as the given item, i.e. true therapeutic substitutes. The current item is
+     * included so the dropdown shows the present selection.
+     */
+    private void fillSubstituteAmpsFor(Item currentItem) {
+        substituteAmps = new ArrayList<>();
+        if (!(currentItem instanceof Amp)) {
+            // Only AMPs have a VMP-based generic equivalence to substitute within.
+            if (currentItem != null) {
+                substituteAmps.add(currentItem);
+            }
+            return;
+        }
+        Vmp vmp = ((Amp) currentItem).getVmp();
+        if (vmp == null) {
+            substituteAmps.add(currentItem);
+            return;
+        }
+        String jpql = "select amp from Amp amp "
+                + "where amp.retired = false "
+                + "and amp.vmp = :vmp "
+                + "order by amp.name";
+        Map<String, Object> m = new HashMap<>();
+        m.put("vmp", vmp);
+        List<Item> found = itemFacade.findByJpql(jpql, m);
+        if (found != null && !found.isEmpty()) {
+            substituteAmps.addAll(found);
+        } else {
+            substituteAmps.add(currentItem);
+        }
+    }
+
+    /**
+     * Applies the substitute item and quantity chosen in the edit modal to the
+     * bill item, and regenerates the directions text so it reflects the new item.
+     */
+    public void saveEditedBillItem() {
+        if (billItemForEdit == null) {
+            JsfUtil.addErrorMessage("No item selected to edit.");
+            return;
+        }
+        if (selectedSubstituteAmp == null) {
+            JsfUtil.addErrorMessage("Please select an item.");
+            return;
+        }
+        if (billItemForEdit.getQty() == null || billItemForEdit.getQty() <= 0) {
+            JsfUtil.addErrorMessage("Please enter a valid quantity.");
+            return;
+        }
+        billItemForEdit.setItem(selectedSubstituteAmp);
+        // Keep the prescription's item aligned with the substituted dispensable item.
+        if (billItemForEdit.getPrescription() != null) {
+            billItemForEdit.getPrescription().setItem(selectedSubstituteAmp);
+        }
+        rebuildBillItemDescription(billItemForEdit);
+        JsfUtil.addSuccessMessage("Item updated.");
+    }
+
+    /**
+     * Rebuilds a bill item's directions text from its prescription (or a simple
+     * item + qty fallback), mirroring how {@link #addBillItem()} builds it.
+     */
+    private void rebuildBillItemDescription(BillItem bi) {
+        Prescription rx = bi.getPrescription();
+        if (rx != null && hasMeaningfulPrescriptionData(rx)) {
+            String prescriptionText = rx.getFormattedPrescriptionWithoutIndoorOutdoor();
+            if (rx.getComment() != null && !rx.getComment().trim().isEmpty()) {
+                prescriptionText += " - " + rx.getComment();
+            }
+            bi.setDescreption(prescriptionText);
+        } else if (bi.getItem() != null) {
+            bi.setDescreption(bi.getItem().getName() + " - Qty: " + bi.getQty());
+        }
+    }
+
+    public BillItem getBillItemForEdit() {
+        return billItemForEdit;
+    }
+
+    public void setBillItemForEdit(BillItem billItemForEdit) {
+        this.billItemForEdit = billItemForEdit;
+    }
+
+    public List<Item> getSubstituteAmps() {
+        return substituteAmps;
+    }
+
+    public void setSubstituteAmps(List<Item> substituteAmps) {
+        this.substituteAmps = substituteAmps;
+    }
+
+    public Item getSelectedSubstituteAmp() {
+        return selectedSubstituteAmp;
+    }
+
+    public void setSelectedSubstituteAmp(Item selectedSubstituteAmp) {
+        this.selectedSubstituteAmp = selectedSubstituteAmp;
+    }
+
+    /**
+     * Autocomplete for the Prescription item field, filtered by the VTM/ATM/VMP/AMP
+     * toggle buttons. Delegates to the shared ItemController query so the filtering
+     * logic stays in one place. When no type is selected, returns an empty list and
+     * warns the user.
+     */
+    public List<Item> completePrescriptionMedicineWithTypeFilter(String query) {
+        if (!includeVtm && !includeAtm && !includeVmp && !includeAmp) {
+            JsfUtil.addErrorMessage("Please select at least one medicine type to search");
+            return new ArrayList<>();
+        }
+        return itemController.completeMedicineByTypeWithFilter(query, includeVtm, includeAtm, includeVmp, includeAmp);
+    }
+
+    public boolean isIncludeVtm() {
+        return includeVtm;
+    }
+
+    public void setIncludeVtm(boolean includeVtm) {
+        this.includeVtm = includeVtm;
+    }
+
+    public boolean isIncludeAtm() {
+        return includeAtm;
+    }
+
+    public void setIncludeAtm(boolean includeAtm) {
+        this.includeAtm = includeAtm;
+    }
+
+    public boolean isIncludeVmp() {
+        return includeVmp;
+    }
+
+    public void setIncludeVmp(boolean includeVmp) {
+        this.includeVmp = includeVmp;
+    }
+
+    public boolean isIncludeAmp() {
+        return includeAmp;
+    }
+
+    public void setIncludeAmp(boolean includeAmp) {
+        this.includeAmp = includeAmp;
     }
 
     public SessionController getSessionController() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -551,12 +551,16 @@ public class PharmacyRequestForBhtController implements Serializable {
             billItem.setPharmaceuticalBillItem(pbi);
         }
         if (billItem.getPrescription() == null) {
-            Prescription newPrescription = new Prescription();
-            // Default the "Prescribed From" date to today at the start of every new
-            // cycle. Once a duration is entered, calculateToDateFromDuration() derives
-            // the "Prescribed To" date from this from-date + duration.
-            newPrescription.setPrescribedFrom(new Date());
-            billItem.setPrescription(newPrescription);
+            billItem.setPrescription(new Prescription());
+        }
+        // Default the "Prescribed From" date to today whenever it is missing. This
+        // covers the start of every new cycle (a fresh prescription after
+        // clearBillItem()) as well as recovery from a postback that submitted the
+        // calendar empty and nulled the field. Once a duration is entered,
+        // calculateToDateFromDuration() derives "Prescribed To" from this
+        // from-date + duration.
+        if (billItem.getPrescription().getPrescribedFrom() == null) {
+            billItem.getPrescription().setPrescribedFrom(new Date());
         }
         return billItem;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -68,6 +68,7 @@ import javax.inject.Named;
 
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.BillService;
+import org.primefaces.PrimeFaces;
 import org.primefaces.event.RowEditEvent;
 import org.primefaces.event.SelectEvent;
 
@@ -151,6 +152,18 @@ public class PharmacyRequestForBhtController implements Serializable {
     private BillItem billItemForEdit;
     private List<Item> substituteAmps;
     private Item selectedSubstituteAmp;
+    // Detached edit-model quantity. The dialog binds to this, not to the live
+    // billItemForEdit.qty, so a failed validation never leaves a bad quantity on
+    // the row. The value is committed to the row only when saveEditedBillItem()
+    // fully passes.
+    private Double editQty;
+    // True only when the last saveEditedBillItem() call passed all validation and
+    // committed. The dialog reads this in oncomplete to decide whether to close,
+    // so a failed edit keeps the dialog open with the bad value visible.
+    private boolean editSavedSuccessfully;
+    // Re-entrancy guard for settleBhtRequest() so a rapid double-submit cannot
+    // create duplicate bills / notifications.
+    private boolean settlingBhtRequest;
     /////////////////
     List<Stock> replaceableStocks;
     //List<BillItem> billItems;
@@ -928,6 +941,22 @@ public class PharmacyRequestForBhtController implements Serializable {
     }
 
     public void settleBhtRequest() {
+        // Server-side re-entry guard: a rapid double-submit (double-click, duplicate
+        // AJAX) must not create a second request bill / notification. The first call
+        // sets the flag; any overlapping call is rejected until this one finishes.
+        if (settlingBhtRequest) {
+            JsfUtil.addErrorMessage("This request is already being settled. Please wait.");
+            return;
+        }
+        settlingBhtRequest = true;
+        try {
+            settleBhtRequestInternal();
+        } finally {
+            settlingBhtRequest = false;
+        }
+    }
+
+    private void settleBhtRequestInternal() {
         if (getPatientEncounter() == null || getPatientEncounter().getPatient() == null) {
             JsfUtil.addErrorMessage("Please Select a BHT");
             return;
@@ -1338,7 +1367,7 @@ public class PharmacyRequestForBhtController implements Serializable {
         newBillItem.setBill(getPreBill());
 
         // Handle prescription only if prescription data is available
-        boolean hasPrescriptionData = hasMeaningfulPrescriptionData(billItem.getPrescription());
+        boolean hasPrescriptionData = hasMeaningfulPrescriptionData(billItem.getPrescription(), billItem.getItem());
 
         if (hasPrescriptionData) {
             // Create a detached prescription instance for in-memory use only
@@ -2123,10 +2152,12 @@ public class PharmacyRequestForBhtController implements Serializable {
         billItemForEdit = bi;
         selectedSubstituteAmp = null;
         substituteAmps = new ArrayList<>();
+        editQty = null;
         if (bi == null || bi.getItem() == null) {
             return;
         }
         selectedSubstituteAmp = bi.getItem();
+        editQty = bi.getQty();
         fillSubstituteAmpsFor(bi.getItem());
     }
 
@@ -2168,25 +2199,37 @@ public class PharmacyRequestForBhtController implements Serializable {
      * bill item, and regenerates the directions text so it reflects the new item.
      */
     public void saveEditedBillItem() {
-        if (billItemForEdit == null) {
-            JsfUtil.addErrorMessage("No item selected to edit.");
-            return;
+        editSavedSuccessfully = false;
+        try {
+            if (billItemForEdit == null) {
+                JsfUtil.addErrorMessage("No item selected to edit.");
+                return;
+            }
+            if (selectedSubstituteAmp == null) {
+                JsfUtil.addErrorMessage("Please select an item.");
+                return;
+            }
+            // Validate the detached edit-model quantity; the live row is untouched
+            // until every check below passes, so a failed edit never corrupts the row.
+            if (editQty == null || editQty <= 0) {
+                JsfUtil.addErrorMessage("Please enter a valid quantity.");
+                return;
+            }
+            // All checks passed — commit the edit to the live row.
+            billItemForEdit.setItem(selectedSubstituteAmp);
+            billItemForEdit.setQty(editQty);
+            // The prescription keeps the originally prescribed medicine; only the
+            // dispensed bill-item changes when a therapeutic substitute is chosen.
+            rebuildBillItemDescription(billItemForEdit);
+            editSavedSuccessfully = true;
+            JsfUtil.addSuccessMessage("Item updated.");
+        } finally {
+            // Tell the client whether the save passed so the dialog closes only on
+            // success (see btnSaveEditBillItem oncomplete).
+            if (PrimeFaces.current().isAjaxRequest()) {
+                PrimeFaces.current().ajax().addCallbackParam("editSaved", editSavedSuccessfully);
+            }
         }
-        if (selectedSubstituteAmp == null) {
-            JsfUtil.addErrorMessage("Please select an item.");
-            return;
-        }
-        if (billItemForEdit.getQty() == null || billItemForEdit.getQty() <= 0) {
-            JsfUtil.addErrorMessage("Please enter a valid quantity.");
-            return;
-        }
-        billItemForEdit.setItem(selectedSubstituteAmp);
-        // Keep the prescription's item aligned with the substituted dispensable item.
-        if (billItemForEdit.getPrescription() != null) {
-            billItemForEdit.getPrescription().setItem(selectedSubstituteAmp);
-        }
-        rebuildBillItemDescription(billItemForEdit);
-        JsfUtil.addSuccessMessage("Item updated.");
     }
 
     /**
@@ -2194,8 +2237,8 @@ public class PharmacyRequestForBhtController implements Serializable {
      * item + qty fallback), mirroring how {@link #addBillItem()} builds it.
      */
     private void rebuildBillItemDescription(BillItem bi) {
-        Prescription rx = bi.getPrescription();
-        if (rx != null && hasMeaningfulPrescriptionData(rx)) {
+        Prescription rx = bi.hasPrescription() ? bi.getPrescription() : null;
+        if (rx != null && hasMeaningfulPrescriptionData(rx, bi.getItem())) {
             String prescriptionText = rx.getFormattedPrescriptionWithoutIndoorOutdoor();
             if (rx.getComment() != null && !rx.getComment().trim().isEmpty()) {
                 prescriptionText += " - " + rx.getComment();
@@ -2228,6 +2271,22 @@ public class PharmacyRequestForBhtController implements Serializable {
 
     public void setSelectedSubstituteAmp(Item selectedSubstituteAmp) {
         this.selectedSubstituteAmp = selectedSubstituteAmp;
+    }
+
+    public Double getEditQty() {
+        return editQty;
+    }
+
+    public void setEditQty(Double editQty) {
+        this.editQty = editQty;
+    }
+
+    public boolean isEditSavedSuccessfully() {
+        return editSavedSuccessfully;
+    }
+
+    public void setEditSavedSuccessfully(boolean editSavedSuccessfully) {
+        this.editSavedSuccessfully = editSavedSuccessfully;
     }
 
     /**
@@ -2647,7 +2706,11 @@ public class PharmacyRequestForBhtController implements Serializable {
             com.divudi.ejb.PrescriptionToItemService.PrescriptionToItemResult result
                     = prescriptionToItemService.calculateItemAndQuantity(billItem.getPrescription());
 
-            if (!result.isSuccess() || result.getItem() == null || result.getQuantity() == null) {
+            // Require a positive quantity too: setQty() silently drops values <= 0,
+            // so a non-positive result would otherwise leave the prior quantity in
+            // place and add a stale line.
+            if (!result.isSuccess() || result.getItem() == null
+                    || result.getQuantity() == null || result.getQuantity() <= 0) {
                 String msg = result.getErrorMessage() != null && !result.getErrorMessage().isEmpty()
                         ? result.getErrorMessage()
                         : "Could not calculate the item and quantity from the prescription";
@@ -2694,7 +2757,7 @@ public class PharmacyRequestForBhtController implements Serializable {
      * @param prescription The prescription to check
      * @return true if prescription has meaningful data, false otherwise
      */
-    private boolean hasMeaningfulPrescriptionData(Prescription prescription) {
+    private boolean hasMeaningfulPrescriptionData(Prescription prescription, Item dispenseItem) {
         if (prescription == null) {
             return false;
         }
@@ -2703,6 +2766,9 @@ public class PharmacyRequestForBhtController implements Serializable {
         // Note: prescribedFrom is intentionally excluded here because it is now
         // auto-defaulted to today for every new cycle (see getBillItem()), so on
         // its own it does not indicate the user entered prescription details.
+        // The item check compares the prescribed medicine against the passed-in
+        // dispensed item (a therapeutic substitute) rather than the controller-level
+        // billItem, which may already have been cleared after a row was added.
         return prescription.getDose() != null
                 || prescription.getDoseUnit() != null
                 || prescription.getFrequencyUnit() != null
@@ -2710,7 +2776,7 @@ public class PharmacyRequestForBhtController implements Serializable {
                 || prescription.getDurationUnit() != null
                 || prescription.getPrescribedTo() != null
                 || (prescription.getComment() != null && !prescription.getComment().trim().isEmpty())
-                || (prescription.getItem() != null && billItem != null && !prescription.getItem().equals(billItem.getItem()));
+                || (prescription.getItem() != null && !Objects.equals(prescription.getItem(), dispenseItem));
     }
 
     public List<ClinicalFindingValue> getAllergyListOfPatient() {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -52,7 +52,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -52,7 +52,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/resources/pharmacy/pharmacy_bht_issue_request_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_bht_issue_request_receipt.xhtml
@@ -103,11 +103,11 @@
                         <td><h:outputLabel value=":" /></td>
                         <td colspan="4"><h:outputLabel value="#{cc.attrs.bill.creater.webUserPerson.nameWithTitle}" /></td>
                     </tr>
-                    <h:panelGroup rendered="#{cc.attrs.comment ne null and cc.attrs.comment ne ''}">
+                    <h:panelGroup rendered="#{(cc.attrs.comment ne null and cc.attrs.comment ne '') or (cc.attrs.bill.comments ne null and cc.attrs.bill.comments ne '')}">
                         <tr>
                             <td><h:outputLabel value="Comments" styleClass="label" /></td>
                             <td><h:outputLabel value=":" /></td>
-                            <td colspan="4"><h:outputLabel value="#{cc.attrs.comment}" /></td>
+                            <td colspan="4"><h:outputLabel value="#{(cc.attrs.comment ne null and cc.attrs.comment ne '') ? cc.attrs.comment : cc.attrs.bill.comments}" /></td>
                         </tr>
                     </h:panelGroup>
                 </table>
@@ -137,6 +137,10 @@
                                 </td>
                                 <td class="item-name">
                                     <h:outputLabel value="#{bip.descreption}" />
+                                    <h:panelGroup layout="block"
+                                                  rendered="#{bip.prescription.comment ne null and bip.prescription.comment ne ''}">
+                                        <h:outputLabel value="Comment: #{bip.prescription.comment}" styleClass="item-comment" style="font-size:0.85em;font-style:italic;color:#333;display:block;" />
+                                    </h:panelGroup>
                                 </td>
                             </tr>
                         </ui:repeat>

--- a/src/main/webapp/resources/pharmacy/pharmacy_bht_issue_request_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacy_bht_issue_request_receipt.xhtml
@@ -136,11 +136,9 @@
                                     </h:outputLabel>
                                 </td>
                                 <td class="item-name">
+                                    <!-- The prescription comment is already appended to descreption
+                                         when the bill item is built, so it is not repeated here. -->
                                     <h:outputLabel value="#{bip.descreption}" />
-                                    <h:panelGroup layout="block"
-                                                  rendered="#{bip.prescription.comment ne null and bip.prescription.comment ne ''}">
-                                        <h:outputLabel value="Comment: #{bip.prescription.comment}" styleClass="item-comment" style="font-size:0.85em;font-style:italic;color:#333;display:block;" />
-                                    </h:panelGroup>
                                 </td>
                             </tr>
                         </ui:repeat>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -6,6 +6,7 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward"
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
                 xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="content">
@@ -39,6 +40,17 @@
                                 class="ui-button-info"
                                 rendered="#{pharmacySaleBhtController.bhtRequestBill ne null}"
                                 action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(pharmacySaleBhtController.bhtRequestBill.patientEncounter)}">
+                            </p:commandButton>
+
+                            <p:commandButton
+                                id="btnViewRequest"
+                                value="View Request"
+                                icon="fa fa-file-alt"
+                                type="button"
+                                class="ui-button-help"
+                                title="View the original request with comments"
+                                rendered="#{pharmacySaleBhtController.bhtRequestBill ne null}"
+                                onclick="PF('viewRequestDialog').show();">
                             </p:commandButton>
 
                             <p:selectBooleanCheckbox
@@ -489,8 +501,19 @@
 
             </p:panel>
 
-
-
+            <p:dialog
+                id="viewRequestDlg"
+                widgetVar="viewRequestDialog"
+                header="Original Request"
+                modal="true"
+                appendTo="@(body)"
+                width="60%"
+                fitViewport="true"
+                position="top"
+                rendered="#{pharmacySaleBhtController.bhtRequestBill ne null}">
+                <ph:pharmacy_bht_issue_request_receipt
+                    bill="#{pharmacySaleBhtController.bhtRequestBill}" />
+            </p:dialog>
 
         </h:form>
     </ui:define>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -16,7 +16,7 @@
             <ui:define name="content">
 
                 <h:form id="bill" >
-                    <p:defaultCommand  target="btnAdd" />
+                    <p:defaultCommand target="#{configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true) ? 'btnAdd' : 'btnAddNoRx'}" />
                     <h:panelGroup
                         rendered="#{!pharmacyRequestForBhtController.billPreview}"
                         style="width: fit-content;" >
@@ -295,11 +295,11 @@
                                         <p:panel>
                                             <f:facet name="header" >
                                                 <h:outputText styleClass="fa-solid fa-circle-plus"  />
-                                                <h:outputLabel value="Add Medicines" class="mx-4"/>
+                                                <h:outputLabel value="Prescription" class="mx-4"/>
                                                 <p:commandButton
                                                     id="btnSave"
                                                     ajax="false"
-                                                    value="Save"
+                                                    value="Save Draft"
                                                     action="#{pharmacyRequestForBhtController.saveBhtIssueRequestFrompharmacy()}"
                                                     icon="pi pi-save"
                                                     class="ui-button-success"
@@ -309,6 +309,40 @@
 
 
                                             <div class="row mt-1">
+                                                <div class="col-md-12 d-flex align-items-center gap-2 flex-wrap">
+                                                    <p:outputLabel value="Show:" styleClass="me-1" />
+                                                    <p:selectBooleanButton id="tglVtm"
+                                                                           value="#{pharmacyRequestForBhtController.includeVtm}"
+                                                                           onLabel="VTM" offLabel="VTM"
+                                                                           onIcon="pi pi-check" offIcon="pi pi-times"
+                                                                           styleClass="ui-button-sm">
+                                                        <p:ajax process="@this" update="acMedicine" />
+                                                    </p:selectBooleanButton>
+                                                    <p:selectBooleanButton id="tglAtm"
+                                                                           value="#{pharmacyRequestForBhtController.includeAtm}"
+                                                                           onLabel="ATM" offLabel="ATM"
+                                                                           onIcon="pi pi-check" offIcon="pi pi-times"
+                                                                           styleClass="ui-button-sm">
+                                                        <p:ajax process="@this" update="acMedicine" />
+                                                    </p:selectBooleanButton>
+                                                    <p:selectBooleanButton id="tglVmp"
+                                                                           value="#{pharmacyRequestForBhtController.includeVmp}"
+                                                                           onLabel="VMP" offLabel="VMP"
+                                                                           onIcon="pi pi-check" offIcon="pi pi-times"
+                                                                           styleClass="ui-button-sm">
+                                                        <p:ajax process="@this" update="acMedicine" />
+                                                    </p:selectBooleanButton>
+                                                    <p:selectBooleanButton id="tglAmp"
+                                                                           value="#{pharmacyRequestForBhtController.includeAmp}"
+                                                                           onLabel="AMP" offLabel="AMP"
+                                                                           onIcon="pi pi-check" offIcon="pi pi-times"
+                                                                           styleClass="ui-button-sm">
+                                                        <p:ajax process="@this" update="acMedicine" />
+                                                    </p:selectBooleanButton>
+                                                </div>
+                                            </div>
+
+                                            <div class="row mt-1">
                                                 <div class="col-md-8">
                                                     <p:autoComplete
                                                         class= "w-100"
@@ -316,7 +350,7 @@
                                                         forceSelection="true"
                                                         id="acMedicine"
                                                         value="#{pharmacyRequestForBhtController.billItem.prescription.item}"
-                                                        completeMethod="#{itemController.completeMedicine}"
+                                                        completeMethod="#{pharmacyRequestForBhtController.completePrescriptionMedicineWithTypeFilter}"
                                                         var="i"
                                                         inputStyleClass="form-control"
                                                         itemLabel="#{i.name}"
@@ -471,19 +505,33 @@
                                                 </div>
                                             </div>
 
+                                            <div class="row mt-2">
+                                                <div class="col-md-12 d-flex justify-content-end">
+                                                    <p:commandButton
+                                                        accesskey="a"
+                                                        id="btnAdd"
+                                                        value="Add to Dispense Request"
+                                                        icon="fa fa-plus"
+                                                        class="ui-button-success"
+                                                        action="#{pharmacyRequestForBhtController.addBillItem}"
+                                                        process="@this acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"
+                                                        update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acMedicine acItem focusItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"   >
+                                                    </p:commandButton>
+                                                </div>
+                                            </div>
+
                                         </p:panel>
                                     </h:panelGroup>
 
                                     <p:panel class="mt-2">
                                         <f:facet name="header" >
                                             <h:outputText styleClass="fa-solid fa-circle-plus"  />
-                                            <h:outputLabel value="Drug Order" class="mx-2"/>
+                                            <h:outputLabel value="Dispense Request" class="mx-2"/>
                                         </f:facet>
 
                                         <div class="row">
                                             <div class="col-md-8"><p:outputLabel value="Medicines/Devices" ></p:outputLabel></div>
-                                            <div class="col-md-2"><p:outputLabel value="Quantity" ></p:outputLabel></div>
-                                            <div class="col-md-2"></div>
+                                            <div class="col-md-4"><p:outputLabel value="Quantity" ></p:outputLabel></div>
                                         </div>
 
                                         <p:growl id="growl" showDetail="false" life="5500" />
@@ -511,7 +559,7 @@
                                                     </p:ajax>
                                                 </p:autoComplete>
                                             </div>
-                                            <div class="col-md-2">
+                                            <div class="col-md-4">
                                                 <p:inputText
                                                     autocomplete="off"
                                                     accesskey="q"
@@ -521,18 +569,6 @@
                                                     <p:ajax event="keyup"  listener="#{pharmacyRequestForBhtController.calculateBillItemListner}" process="acItem txtQty"></p:ajax>
                                                     <p:ajax event="blur"  listener="#{pharmacyRequestForBhtController.calculateBillItemListner}" process="acItem txtQty"></p:ajax>
                                                 </p:inputText>
-                                            </div>
-                                            <div class="col-md-2">
-                                                <p:commandButton
-                                                    accesskey="a"
-                                                    id="btnAdd"
-                                                    value="Add"
-                                                    icon="fa fa-plus"
-                                                    class="ui-button-success w-100"
-                                                    action="#{pharmacyRequestForBhtController.addBillItem}"
-                                                    process="@this acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"
-                                                    update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acMedicine acItem focusItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"   >
-                                                </p:commandButton>
                                             </div>
 
                                             <p:focus id="focusQty" for="txtQty" ></p:focus>
@@ -544,6 +580,28 @@
                                                 <p:outputLabel value="Comment" />
                                                 <p:inputTextarea id="txtDrugOrderComments" value="#{pharmacyRequestForBhtController.billItem.prescription.comment}" class="w-100" />
                                             </div>
+                                        </div>
+
+                                        <!--
+                                            Fallback Add button (id btnAddNoRx): only rendered when prescription
+                                            details are disabled, so the Prescription panel's btnAdd is absent.
+                                            Distinct id avoids a duplicate-component-id build error; p:defaultCommand
+                                            targets whichever button is actually rendered.
+                                        -->
+                                        <div class="row mt-2">
+                                            <h:panelGroup layout="block" class="col-md-12 d-flex justify-content-end"
+                                                          rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true)}">
+                                                <p:commandButton
+                                                    accesskey="a"
+                                                    id="btnAddNoRx"
+                                                    value="Add to Dispense Request"
+                                                    icon="fa fa-plus"
+                                                    class="ui-button-success"
+                                                    action="#{pharmacyRequestForBhtController.addBillItem}"
+                                                    process="@this acItem txtQty txtDrugOrderComments"
+                                                    update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acItem focusItem txtQty txtDrugOrderComments"   >
+                                                </p:commandButton>
+                                            </h:panelGroup>
                                         </div>
 
                                     </p:panel>
@@ -560,8 +618,28 @@
                                                     <p:ajax event="blur" process="@this"/>
                                                 </p:inputText>
                                             </p:column>
-                                            <p:column headerText="Directions" style="color: red;" width="20em">
-                                                <h:outputLabel value="#{bi.descreption}" />
+                                            <p:column headerText="Directions" width="20em">
+                                                <h:panelGroup layout="block">
+                                                    <h:outputText value="#{bi.descreption}" style="color: red;" />
+                                                    <h:panelGroup layout="block"
+                                                                  rendered="#{bi.prescription ne null and (bi.prescription.dose ne null or bi.prescription.frequencyUnit ne null or bi.prescription.duration ne null)}"
+                                                                  style="font-size:0.85em;color:#555;margin-top:2px;">
+                                                        <h:outputText rendered="#{bi.prescription.dose ne null}" value="Dose: #{bi.prescription.dose} #{bi.prescription.doseUnit.name}  " />
+                                                        <h:outputText rendered="#{bi.prescription.frequencyUnit ne null}" value="Freq: #{bi.prescription.frequencyUnit.name}  " />
+                                                        <h:outputText rendered="#{bi.prescription.duration ne null}" value="Duration: #{bi.prescription.duration} #{bi.prescription.durationUnit.name}" />
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </p:column>
+                                            <p:column headerText="Edit" width="5em">
+                                                <p:commandButton
+                                                    icon="fa-solid fa-pen-to-square"
+                                                    title="Edit / Substitute Item"
+                                                    class="ui-button-warning"
+                                                    action="#{pharmacyRequestForBhtController.prepareEditBillItem(bi)}"
+                                                    process="@this"
+                                                    update=":#{p:resolveFirstComponentWithId('editBillItemDlg',view).clientId}"
+                                                    oncomplete="PF('editBillItemDialog').show();" >
+                                                </p:commandButton>
                                             </p:column>
                                             <p:column headerText="Remove" width="5em">
                                                 <p:commandButton
@@ -575,6 +653,48 @@
                                             </p:column>
 
                                         </p:dataTable>
+
+                                        <p:dialog
+                                            id="editBillItemDlg"
+                                            widgetVar="editBillItemDialog"
+                                            header="Edit / Substitute Item"
+                                            modal="true"
+                                            appendTo="@(body)"
+                                            width="40%"
+                                            fitViewport="true">
+                                            <h:panelGrid columns="2" cellpadding="6" styleClass="w-100"
+                                                         rendered="#{pharmacyRequestForBhtController.billItemForEdit ne null}">
+                                                <p:outputLabel value="Requested Item" />
+                                                <h:outputText value="#{pharmacyRequestForBhtController.billItemForEdit.item.name}"
+                                                              styleClass="fw-bold" />
+
+                                                <p:outputLabel value="Substitute (same generic)" for="cmbSubstitute" />
+                                                <p:selectOneMenu id="cmbSubstitute"
+                                                                 value="#{pharmacyRequestForBhtController.selectedSubstituteAmp}"
+                                                                 filter="true" filterMatchMode="contains"
+                                                                 style="width:100%">
+                                                    <f:selectItems value="#{pharmacyRequestForBhtController.substituteAmps}"
+                                                                   var="sub" itemLabel="#{sub.name}" itemValue="#{sub}" />
+                                                </p:selectOneMenu>
+
+                                                <p:outputLabel value="Quantity" for="txtEditQty" />
+                                                <p:inputText id="txtEditQty" autocomplete="off"
+                                                             value="#{pharmacyRequestForBhtController.billItemForEdit.qty}"
+                                                             style="width:100%" />
+                                            </h:panelGrid>
+
+                                            <f:facet name="footer">
+                                                <p:commandButton
+                                                    id="btnSaveEditBillItem"
+                                                    value="Save"
+                                                    icon="fa fa-check"
+                                                    class="ui-button-success"
+                                                    action="#{pharmacyRequestForBhtController.saveEditedBillItem}"
+                                                    process="@this cmbSubstitute txtEditQty"
+                                                    update=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId}"
+                                                    oncomplete="PF('editBillItemDialog').hide();" />
+                                            </f:facet>
+                                        </p:dialog>
                                     </p:panel>
 
                                 </div>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -16,7 +16,7 @@
             <ui:define name="content">
 
                 <h:form id="bill" >
-                    <p:defaultCommand target="#{configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true) ? 'btnAdd' : 'btnAddNoRx'}" />
+                    <p:defaultCommand target="#{configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true) ? 'btnCalcAdd' : 'btnAddNoRx'}" />
                     <h:panelGroup
                         rendered="#{!pharmacyRequestForBhtController.billPreview}"
                         style="width: fit-content;" >
@@ -530,15 +530,40 @@
                                             </div>
 
                                             <div class="row mt-2">
-                                                <div class="col-md-12 d-flex justify-content-end">
+                                                <div class="col-md-12 d-flex justify-content-end gap-2">
+                                                    <!--
+                                                        Case 1 — Generate but do NOT add. Recalculates the
+                                                        dispense item + qty from the prescription and moves
+                                                        focus to the Dispense item so the user can review /
+                                                        adjust before adding.
+                                                    -->
+                                                    <p:commandButton
+                                                        id="btnGenerate"
+                                                        value="Generate"
+                                                        icon="fa fa-calculator"
+                                                        class="ui-button-secondary ui-button-outlined"
+                                                        title="Calculate the dispense item and quantity from the prescription without adding it, so you can review and adjust"
+                                                        action="#{pharmacyRequestForBhtController.generateDispenseFromPrescription}"
+                                                        process="@this acMedicine txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo"
+                                                        update="growl acItem txtQty focusItem" >
+                                                    </p:commandButton>
+
+                                                    <!--
+                                                        Case 2 — Calculate & Add in one step. Recomputes item +
+                                                        qty from the prescription, then adds. Aborts with a
+                                                        message if the calculation cannot resolve an item/qty.
+                                                        This is the p:defaultCommand target when prescription
+                                                        details are enabled.
+                                                    -->
                                                     <p:commandButton
                                                         accesskey="a"
-                                                        id="btnAdd"
-                                                        value="Add to Dispense Request"
+                                                        id="btnCalcAdd"
+                                                        value="Calculate &amp; Add"
                                                         icon="fa fa-plus"
                                                         class="ui-button-success"
-                                                        action="#{pharmacyRequestForBhtController.addBillItem}"
-                                                        process="@this acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"
+                                                        title="Calculate the dispense item and quantity from the prescription and add it to the dispense request"
+                                                        action="#{pharmacyRequestForBhtController.calculateAndAddBillItem}"
+                                                        process="@this acMedicine acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"
                                                         update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acMedicine acItem focusItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"   >
                                                     </p:commandButton>
                                                 </div>
@@ -549,8 +574,29 @@
 
                                     <p:panel class="mt-2">
                                         <f:facet name="header" >
-                                            <h:outputText styleClass="fa-solid fa-circle-plus"  />
-                                            <h:outputLabel value="Dispense Request" class="mx-2"/>
+                                            <div class="d-flex justify-content-between align-items-center w-100">
+                                                <div class="d-flex align-items-center gap-2">
+                                                    <h:outputText styleClass="fa-solid fa-circle-plus"  />
+                                                    <h:outputLabel value="Dispense Request" class="mx-2"/>
+                                                </div>
+                                                <!--
+                                                    Case 3 — Add the current dispense line directly, skipping
+                                                    the prescription. Always available; when prescription
+                                                    details are disabled this is the only Add button and is the
+                                                    p:defaultCommand target (hence the stable btnAddNoRx id).
+                                                -->
+                                                <p:commandButton
+                                                    accesskey="d"
+                                                    id="btnAddNoRx"
+                                                    value="Add Dispense Only"
+                                                    icon="fa fa-plus"
+                                                    class="ui-button-info"
+                                                    title="Add the item and quantity shown below directly to the dispense request, without prescription details"
+                                                    action="#{pharmacyRequestForBhtController.addBillItem}"
+                                                    process="@this acItem txtQty txtDrugOrderComments"
+                                                    update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acItem focusItem txtQty txtDrugOrderComments" >
+                                                </p:commandButton>
+                                            </div>
                                         </f:facet>
 
                                         <div class="row">
@@ -604,28 +650,6 @@
                                                 <p:outputLabel value="Comment" />
                                                 <p:inputTextarea id="txtDrugOrderComments" value="#{pharmacyRequestForBhtController.billItem.prescription.comment}" class="w-100" />
                                             </div>
-                                        </div>
-
-                                        <!--
-                                            Fallback Add button (id btnAddNoRx): only rendered when prescription
-                                            details are disabled, so the Prescription panel's btnAdd is absent.
-                                            Distinct id avoids a duplicate-component-id build error; p:defaultCommand
-                                            targets whichever button is actually rendered.
-                                        -->
-                                        <div class="row mt-2">
-                                            <h:panelGroup layout="block" class="col-md-12 d-flex justify-content-end"
-                                                          rendered="#{!configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true)}">
-                                                <p:commandButton
-                                                    accesskey="a"
-                                                    id="btnAddNoRx"
-                                                    value="Add to Dispense Request"
-                                                    icon="fa fa-plus"
-                                                    class="ui-button-success"
-                                                    action="#{pharmacyRequestForBhtController.addBillItem}"
-                                                    process="@this acItem txtQty txtDrugOrderComments"
-                                                    update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acItem focusItem txtQty txtDrugOrderComments"   >
-                                                </p:commandButton>
-                                            </h:panelGroup>
                                         </div>
 
                                     </p:panel>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -36,6 +36,7 @@
                                     <div class="d-flex gap-2">
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                             <p:commandButton
+                                                id="btnInpatientDashboard"
                                                 ajax="false"
                                                 icon="fa-solid fa-address-card"
                                                 styleClass="ui-button-info ui-button-outlined"
@@ -51,6 +52,7 @@
 
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                             <p:commandButton
+                                                id="btnNursingWorkBenchStart"
                                                 value="Nursing WorkBench"
                                                 title="Back to the nursing workbench"
                                                 action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
@@ -183,6 +185,7 @@
                             <div class="my-3 d-flex flex-column justify-content-end">
                                 <div class="col-12 d-flex align-item-center justify-content-center">
                                     <p:commandButton
+                                        id="btnProceed"
                                         ajax="false"
                                         style="width: 250px"
                                         class="ui-button-success px-5"
@@ -213,6 +216,7 @@
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                             <div class="d-flex gap-2">
                                                 <p:commandButton
+                                                    id="btnLookupPatient"
                                                     value="Lookup"
                                                     ajax="false"
                                                     icon="fa fa-search"
@@ -222,6 +226,7 @@
                                                 </p:commandButton>
 
                                                 <p:commandButton
+                                                    id="btnPatientProfile"
                                                     value="Profile"
                                                     ajax="false"
                                                     icon="fa fa-user"
@@ -235,6 +240,7 @@
                                                 </p:commandButton>
 
                                                 <p:commandButton
+                                                    id="btnInpatientDashboardMain"
                                                     ajax="false"
                                                     icon="fa-solid fa-address-card"
                                                     styleClass="ui-button-info ui-button-outlined"
@@ -247,6 +253,7 @@
 
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                             <p:commandButton
+                                                id="btnNursingWorkBenchMain"
                                                 value="Nursing WorkBench"
                                                 title="Back to the nursing workbench"
                                                 action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
@@ -260,6 +267,7 @@
                                     <!-- RIGHT: actions, left=least important -> right=primary -->
                                     <div class="d-flex gap-2 align-items-center">
                                         <p:commandButton
+                                            id="btnNewBill"
                                             accesskey="n"
                                             value="New Bill"
                                             ajax="false"
@@ -278,6 +286,7 @@
                                             style="min-width:120px"
                                             ajax="false"
                                             title="Settle this BHT issue request"
+                                            onclick="return confirm('Settle this BHT issue request?');"
                                             action="#{pharmacyRequestForBhtController.settleBhtRequest}"
                                             actionListener="#{pharmacyRequestForBhtController.calculateAllRates}"  >
                                         </p:commandButton>
@@ -296,10 +305,10 @@
                                     </p:panel>
                                     <p:panel class="w-100 my-2">
                                         <f:facet name="header">
-                                            <h:outputLabel value="Comment" />
+                                            <h:outputText value="Comment" />
                                         </f:facet>
                                         <p:inputTextarea
-                                            value="#{pharmacyRequestForBhtController.comment}" 
+                                            value="#{pharmacyRequestForBhtController.comment}"
                                             class="w-100" />
                                     </p:panel>
                                 </div>
@@ -310,7 +319,7 @@
                                         <p:panel>
                                             <f:facet name="header" >
                                                 <h:outputText styleClass="fa-solid fa-circle-plus"  />
-                                                <h:outputLabel value="Prescription" class="mx-4"/>
+                                                <h:outputText value="Prescription" styleClass="mx-4"/>
 <!--
     Save Draft is hidden for now (rendered="false"). It persists a PharmacyBhtPre
     PreBill, but there is currently no mechanism on this page to reload a saved
@@ -334,7 +343,7 @@
 
                                             <div class="row mt-1">
                                                 <div class="col-md-12 d-flex align-items-center gap-2 flex-wrap">
-                                                    <p:outputLabel value="Show:" styleClass="me-1" />
+                                                    <h:outputText value="Show:" styleClass="me-1" />
                                                     <p:selectBooleanButton id="tglVtm"
                                                                            value="#{pharmacyRequestForBhtController.includeVtm}"
                                                                            onLabel="VTM" offLabel="VTM"
@@ -577,7 +586,7 @@
                                             <div class="d-flex justify-content-between align-items-center w-100">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <h:outputText styleClass="fa-solid fa-circle-plus"  />
-                                                    <h:outputLabel value="Dispense Request" class="mx-2"/>
+                                                    <h:outputText value="Dispense Request" styleClass="mx-2"/>
                                                 </div>
                                                 <!--
                                                     Case 3 — Add the current dispense line directly, skipping
@@ -600,8 +609,8 @@
                                         </f:facet>
 
                                         <div class="row">
-                                            <div class="col-md-8"><p:outputLabel value="Medicines/Devices" ></p:outputLabel></div>
-                                            <div class="col-md-4"><p:outputLabel value="Quantity" ></p:outputLabel></div>
+                                            <div class="col-md-8"><h:outputText value="Medicines/Devices" /></div>
+                                            <div class="col-md-4"><h:outputText value="Quantity" /></div>
                                         </div>
 
                                         <p:growl id="growl" showDetail="false" life="5500" />
@@ -669,8 +678,10 @@
                                             <p:column headerText="Directions" width="20em">
                                                 <h:panelGroup layout="block">
                                                     <h:outputText value="#{bi.descreption}" style="color: red;" />
+                                                    <!-- Guard with hasPrescription(): reading bi.prescription directly
+                                                         auto-creates a Prescription during rendering and can persist blanks. -->
                                                     <h:panelGroup layout="block"
-                                                                  rendered="#{bi.prescription ne null and (bi.prescription.dose ne null or bi.prescription.frequencyUnit ne null or bi.prescription.duration ne null)}"
+                                                                  rendered="#{bi.hasPrescription() and (bi.prescription.dose ne null or bi.prescription.frequencyUnit ne null or bi.prescription.duration ne null)}"
                                                                   style="font-size:0.85em;color:#555;margin-top:2px;">
                                                         <h:outputText rendered="#{bi.prescription.dose ne null}" value="Dose: #{bi.prescription.dose} #{bi.prescription.doseUnit.name}  " />
                                                         <h:outputText rendered="#{bi.prescription.frequencyUnit ne null}" value="Freq: #{bi.prescription.frequencyUnit.name}  " />
@@ -680,6 +691,7 @@
                                             </p:column>
                                             <p:column headerText="Edit" width="5em">
                                                 <p:commandButton
+                                                    id="btnEditBillItem"
                                                     icon="fa-solid fa-pen-to-square"
                                                     title="Edit / Substitute Item"
                                                     class="ui-button-warning"
@@ -691,6 +703,7 @@
                                             </p:column>
                                             <p:column headerText="Remove" width="5em">
                                                 <p:commandButton
+                                                    id="btnRemoveBillItem"
                                                     value="Remove"
                                                     icon="fa-solid fa-trash"
                                                     class="ui-button-danger"
@@ -726,8 +739,10 @@
                                                 </p:selectOneMenu>
 
                                                 <p:outputLabel value="Quantity" for="txtEditQty" />
+                                                <!-- Bound to the detached editQty, not the live row, so a failed
+                                                     save never leaves a bad quantity on the bill item. -->
                                                 <p:inputText id="txtEditQty" autocomplete="off"
-                                                             value="#{pharmacyRequestForBhtController.billItemForEdit.qty}"
+                                                             value="#{pharmacyRequestForBhtController.editQty}"
                                                              style="width:100%" />
                                             </h:panelGrid>
 
@@ -739,8 +754,8 @@
                                                     class="ui-button-success"
                                                     action="#{pharmacyRequestForBhtController.saveEditedBillItem}"
                                                     process="@this cmbSubstitute txtEditQty"
-                                                    update=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId}"
-                                                    oncomplete="PF('editBillItemDialog').hide();" />
+                                                    update=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} @(.ui-messages)"
+                                                    oncomplete="if (args &amp;&amp; args.editSaved) { PF('editBillItemDialog').hide(); }" />
                                             </f:facet>
                                         </p:dialog>
                                     </p:panel>
@@ -769,6 +784,7 @@
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                         <div class="d-flex gap-2">
                                             <p:commandButton
+                                                id="btnLookupPatientView"
                                                 value="Lookup"
                                                 ajax="false"
                                                 icon="fa fa-search"
@@ -778,6 +794,7 @@
                                             </p:commandButton>
 
                                             <p:commandButton
+                                                id="btnPatientProfileView"
                                                 value="Patient Profile"
                                                 ajax="false"
                                                 icon="fa fa-user"
@@ -791,6 +808,7 @@
                                             </p:commandButton>
 
                                             <p:commandButton
+                                                id="btnInpatientDashboardView"
                                                 ajax="false"
                                                 icon="fa-solid fa-address-card"
                                                 styleClass="ui-button-info ui-button-outlined"
@@ -807,6 +825,7 @@
 
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
                                         <p:commandButton
+                                            id="btnNursingWorkBenchView"
                                             value="Nursing WorkBench"
                                             title="Back to the nursing workbench"
                                             action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
@@ -830,6 +849,7 @@
                                     </p:commandButton>
 
                                     <p:commandButton
+                                        id="btnNewMedicineRequest"
                                         value="New Medicine Request for BHT"
                                         ajax="false"
                                         style="min-width:120px"

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -24,33 +24,38 @@
                         <p:panel
                             rendered="#{pharmacyRequestForBhtController.department eq null or pharmacyRequestForBhtController.patientEncounter eq null}">
                             <f:facet name="header">
-                                <div class="d-flex justify-content-between">
-                                    <div>
-                                        <h:outputLabel value="Start Pharmacy Request for Inpatients" class="mt-2"/>
+                                <div class="d-flex justify-content-between align-items-center w-100">
+
+                                    <!-- LEFT: title -->
+                                    <div class="d-flex align-items-center gap-2">
+                                        <h:outputText styleClass="fa fa-hospital-user" />
+                                        <h:outputText value="Start Pharmacy Request for Inpatients"/>
                                     </div>
-                                    <div class="d-flex justify-content-between align-items-center" >
-                                        <h:panelGroup class="mx-2" rendered="#{webUserController.hasPrivilege('InwardSearch')}">
-                                            <div class="d-flex gap-2">
-                                                <p:commandButton
-                                                    ajax="false"
-                                                    icon="fa-solid fa-address-card"
-                                                    class="ui-button-secondary "
-                                                    value="Inpatient Dashboard"
-                                                    action="#{admissionController.navigateToAdmissionProfilePage}">
-                                                    <f:setPropertyActionListener 
-                                                        value="#{pharmacyRequestForBhtController.patientEncounter}" 
-                                                        target="#{admissionController.current}" >
-                                                    </f:setPropertyActionListener>
-                                                </p:commandButton>
-                                            </div>
+
+                                    <!-- CENTER: entity-level navigation -->
+                                    <div class="d-flex gap-2">
+                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
+                                            <p:commandButton
+                                                ajax="false"
+                                                icon="fa-solid fa-address-card"
+                                                styleClass="ui-button-info ui-button-outlined"
+                                                value="Inpatient Dashboard"
+                                                title="Open the inpatient dashboard"
+                                                action="#{admissionController.navigateToAdmissionProfilePage}">
+                                                <f:setPropertyActionListener
+                                                    value="#{pharmacyRequestForBhtController.patientEncounter}"
+                                                    target="#{admissionController.current}" >
+                                                </f:setPropertyActionListener>
+                                            </p:commandButton>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                            <p:commandButton 
-                                                value="Nursing WorkBench" 
-                                                action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
+                                            <p:commandButton
+                                                value="Nursing WorkBench"
+                                                title="Back to the nursing workbench"
+                                                action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                                 ajax="false"
-                                                class="ui-button-operating-theatre"
+                                                styleClass="ui-button-info ui-button-outlined"
                                                 icon="fa fa-arrow-left">
                                             </p:commandButton>
                                         </h:panelGroup>
@@ -194,30 +199,25 @@
                             rendered="#{pharmacyRequestForBhtController.patientEncounter ne null and pharmacyRequestForBhtController.department ne null}"
                             >
                             <f:facet name="header" >
-                                <div class="d-flex justify-content-between">
-                                    <div>
-                                        <i class="fas fa-exclamation-circle mt-2" />
-                                        <h:outputLabel value="BHT ISSUE REQUEST FOR - " class="mx-2" />
-                                        <h:outputLabel value="#{pharmacyRequestForBhtController.department.name}" />
-                                    </div>
-                                    <div  class="d-flex gap-2">
-                                        <p:commandButton
-                                            accesskey="n"
-                                            value="New Bill"
-                                            ajax="false"
-                                            icon="fas fa-file-invoice"
-                                            class="ui-button-warning"
-                                            action="pharmacy_bill_issue_bht?faces-redirect=true"
-                                            actionListener="#{pharmacyRequestForBhtController.resetAll}"  >
-                                        </p:commandButton>
+                                <div class="d-flex justify-content-between align-items-center w-100">
 
+                                    <!-- LEFT: title -->
+                                    <div class="d-flex align-items-center gap-2">
+                                        <h:outputText styleClass="fas fa-exclamation-circle" />
+                                        <h:outputText value="BHT Issue Request for - " />
+                                        <h:outputText value="#{pharmacyRequestForBhtController.department.name}" styleClass="fw-bold" />
+                                    </div>
+
+                                    <!-- CENTER: entity-level navigation -->
+                                    <div class="d-flex gap-2">
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                             <div class="d-flex gap-2">
                                                 <p:commandButton
                                                     value="Lookup"
                                                     ajax="false"
                                                     icon="fa fa-search"
-                                                    class="ui-button-warning "
+                                                    title="Search for a patient"
+                                                    styleClass="ui-button-info ui-button-outlined"
                                                     action="#{patientController.navigateToSearchPatients()}">
                                                 </p:commandButton>
 
@@ -225,7 +225,8 @@
                                                     value="Profile"
                                                     ajax="false"
                                                     icon="fa fa-user"
-                                                    class="ui-button-warning"
+                                                    title="Open the patient profile"
+                                                    styleClass="ui-button-info ui-button-outlined"
                                                     action="#{patientController.navigateToOpdPatientProfile()}">
                                                     <f:setPropertyActionListener
                                                         value="#{pharmacyRequestForBhtController.patientEncounter.patient}"
@@ -236,39 +237,53 @@
                                                 <p:commandButton
                                                     ajax="false"
                                                     icon="fa-solid fa-address-card"
-                                                    class="ui-button-secondary "
+                                                    styleClass="ui-button-info ui-button-outlined"
                                                     value="Inpatient Dashboard"
+                                                    title="Open the inpatient dashboard"
                                                     action="#{bhtSummeryController.navigateToInpatientProfile()}">
                                                 </p:commandButton>
-
                                             </div>
                                         </h:panelGroup>
 
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                            <p:commandButton 
-                                                value="Nursing WorkBench" 
-                                                action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
+                                            <p:commandButton
+                                                value="Nursing WorkBench"
+                                                title="Back to the nursing workbench"
+                                                action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                                 ajax="false"
-                                                class="ui-button-operating-theatre"
+                                                styleClass="ui-button-info ui-button-outlined"
                                                 icon="fa fa-arrow-left">
                                             </p:commandButton>
                                         </h:panelGroup>
                                     </div>
+
+                                    <!-- RIGHT: actions, left=least important -> right=primary -->
+                                    <div class="d-flex gap-2 align-items-center">
+                                        <p:commandButton
+                                            accesskey="n"
+                                            value="New Bill"
+                                            ajax="false"
+                                            icon="fas fa-file-invoice"
+                                            title="Start a new BHT issue request"
+                                            styleClass="ui-button-warning"
+                                            action="pharmacy_bill_issue_bht?faces-redirect=true"
+                                            actionListener="#{pharmacyRequestForBhtController.resetAll}"  >
+                                        </p:commandButton>
+
+                                        <p:commandButton
+                                            id="btnSettleRequest"
+                                            value="Settle Request"
+                                            styleClass="ui-button-success"
+                                            icon="fa fa-check"
+                                            style="min-width:120px"
+                                            ajax="false"
+                                            title="Settle this BHT issue request"
+                                            action="#{pharmacyRequestForBhtController.settleBhtRequest}"
+                                            actionListener="#{pharmacyRequestForBhtController.calculateAllRates}"  >
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </f:facet>
-
-                            <div class="row mt-2 mb-3">
-                                <div class="d-flex  justify-content-end">
-                                    <p:commandButton
-                                        value="Settle Request"
-                                        class="ui-button-success"
-                                        icon="fa fa-check"
-                                        ajax="false"
-                                        action="#{pharmacyRequestForBhtController.settleBhtRequest}"
-                                        actionListener="#{pharmacyRequestForBhtController.calculateAllRates}"  >
-                                    </p:commandButton>
-                                </div>
-                            </div>
 
                             <div class="row">
                                 <div class="col-4">
@@ -296,8 +311,17 @@
                                             <f:facet name="header" >
                                                 <h:outputText styleClass="fa-solid fa-circle-plus"  />
                                                 <h:outputLabel value="Prescription" class="mx-4"/>
+<!--
+    Save Draft is hidden for now (rendered="false"). It persists a PharmacyBhtPre
+    PreBill, but there is currently no mechanism on this page to reload a saved
+    draft and continue editing it, so a saved draft cannot be picked up from where
+    it was left off. Until that "resume draft" capability is built, the button is
+    kept in place but not rendered to avoid confusing users. Re-enable once draft
+    retrieval is implemented.
+-->
                                                 <p:commandButton
                                                     id="btnSave"
+                                                    rendered="false"
                                                     ajax="false"
                                                     value="Save Draft"
                                                     action="#{pharmacyRequestForBhtController.saveBhtIssueRequestFrompharmacy()}"
@@ -708,38 +732,24 @@
                 <h:form>
                     <p:panel id="printPanel"  rendered="#{pharmacyRequestForBhtController.billPreview}" >
                         <f:facet name="header">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h:outputText styleClass="fa-solid fa-address-card fa-lg" /> 
-                                    <p:outputLabel value="View Bill" class="m-2"/>
+                            <div class="d-flex justify-content-between align-items-center w-100">
+
+                                <!-- LEFT: title -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <h:outputText styleClass="fa-solid fa-address-card fa-lg" />
+                                    <h:outputText value="View Bill"/>
                                 </div>
+
+                                <!-- CENTER: entity-level navigation -->
                                 <div class="d-flex gap-2">
-                                    <p:commandButton
-                                        id="btnPrint"
-                                        value="Print"
-                                        ajax="false"
-                                        class="ui-button-info"
-                                        icon="fa fa-print">
-                                        <p:printer target="gpBillPreview" ></p:printer>
-                                    </p:commandButton>
-
-                                    <p:commandButton
-                                        value="New Medicine Request for BHT"
-                                        ajax="false"
-                                        class="ui-button-success"
-                                        action="pharmacy_bill_issue_request?faces-redirect=true"
-                                        actionListener="#{pharmacyRequestForBhtController.resetAll()}"
-                                        icon="fa fa-plus-circle"> <!-- Font Awesome icon -->
-                                    </p:commandButton>
-
-
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
                                         <div class="d-flex gap-2">
                                             <p:commandButton
                                                 value="Lookup"
                                                 ajax="false"
                                                 icon="fa fa-search"
-                                                class="ui-button-warning "
+                                                title="Search for a patient"
+                                                styleClass="ui-button-info ui-button-outlined"
                                                 action="#{patientController.navigateToSearchPatients()}">
                                             </p:commandButton>
 
@@ -747,7 +757,8 @@
                                                 value="Patient Profile"
                                                 ajax="false"
                                                 icon="fa fa-user"
-                                                class="ui-button-warning"
+                                                title="Open the patient profile"
+                                                styleClass="ui-button-info ui-button-outlined"
                                                 action="#{patientController.navigateToOpdPatientProfile()}">
                                                 <f:setPropertyActionListener
                                                     value="#{admissionController.current.patient}"
@@ -758,11 +769,12 @@
                                             <p:commandButton
                                                 ajax="false"
                                                 icon="fa-solid fa-address-card"
-                                                class="ui-button-secondary "
+                                                styleClass="ui-button-info ui-button-outlined"
                                                 value="Inpatient Dashboard"
+                                                title="Open the inpatient dashboard"
                                                 action="#{admissionController.navigateToAdmissionProfilePage}">
-                                                <f:setPropertyActionListener 
-                                                    value="#{pharmacyRequestForBhtController.patientEncounter}" 
+                                                <f:setPropertyActionListener
+                                                    value="#{pharmacyRequestForBhtController.patientEncounter}"
                                                     target="#{admissionController.current}" >
                                                 </f:setPropertyActionListener>
                                             </p:commandButton>
@@ -770,14 +782,39 @@
                                     </h:panelGroup>
 
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                        <p:commandButton 
-                                            value="Nursing WorkBench" 
-                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
+                                        <p:commandButton
+                                            value="Nursing WorkBench"
+                                            title="Back to the nursing workbench"
+                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
                                             ajax="false"
-                                            class="ui-button-operating-theatre"
+                                            styleClass="ui-button-info ui-button-outlined"
                                             icon="fa fa-arrow-left">
                                         </p:commandButton>
                                     </h:panelGroup>
+                                </div>
+
+                                <!-- RIGHT: actions, left=least important -> right=primary -->
+                                <div class="d-flex gap-2 align-items-center">
+                                    <p:commandButton
+                                        id="btnPrint"
+                                        value="Print"
+                                        ajax="false"
+                                        title="Print this bill"
+                                        styleClass="ui-button-info"
+                                        icon="fa fa-print">
+                                        <p:printer target="gpBillPreview" ></p:printer>
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        value="New Medicine Request for BHT"
+                                        ajax="false"
+                                        style="min-width:120px"
+                                        title="Start a new medicine request for a BHT"
+                                        styleClass="ui-button-success"
+                                        action="pharmacy_bill_issue_request?faces-redirect=true"
+                                        actionListener="#{pharmacyRequestForBhtController.resetAll()}"
+                                        icon="fa fa-plus-circle">
+                                    </p:commandButton>
                                 </div>
                             </div>
 

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -5,6 +5,7 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
                 xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward">
 
     <ui:define name="content">
@@ -92,27 +93,10 @@
                         </div>
                         <div class="col-8">
                             <p:panel header="Bill" style="height: 100%">
-                                <div class="d-flex justify-content-end gap-2" >
-                                    <p:outputLabel value="Paper Type" class="mt-2"></p:outputLabel>
-                                    <p:selectOneMenu value="#{sessionController.departmentPreference.inwardServiceBillPaperType}" class="" style="width: 13em;">
-                                        <f:selectItem itemLabel="Please Select Paper Type" />
-                                        <f:selectItems value="#{enumController.paperTypes}" />
-                                    </p:selectOneMenu>
-                                    <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button " title="Redraw Bill"></p:commandButton>
-                                </div>
-
                                 <h:panelGroup id="gpBillPreview">
-                                    <h:panelGroup id="groupPrint" >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.inwardServiceBillPaperType eq 'PosPaper'}" >
-                                            <phe:issueBill_five_five bill="#{pharmacyBillSearch.bill}"/>    
-                                        </h:panelGroup>
-
-
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.inwardServiceBillPaperType eq 'A4Paper'}" >
-                                            <phe:A4_paper_with_headings bill="#{pharmacyBillSearch.bill}"/> 
-                                        </h:panelGroup>
-                                    </h:panelGroup>
-
+                                    <ph:pharmacy_bht_issue_request_receipt
+                                        bill="#{pharmacyBillSearch.bill}"
+                                        duplicate="true" />
                                 </h:panelGroup>
                             </p:panel>
                         </div>
@@ -139,6 +123,11 @@
                             <p:column>
                                 <f:facet name="header">Direction</f:facet>
                                 <p:outputLabel value="#{bip.descreption}" ></p:outputLabel>
+                                <h:panelGroup layout="block"
+                                              rendered="#{bip.prescription.comment ne null and bip.prescription.comment ne ''}">
+                                    <p:outputLabel value="Comment: #{bip.prescription.comment}"
+                                                   style="font-size:0.85em;font-style:italic;color:#333;display:block;" />
+                                </h:panelGroup>
                             </p:column>
                         </p:dataTable>
                     </p:panel>

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -122,12 +122,11 @@
                             </p:column>
                             <p:column>
                                 <f:facet name="header">Direction</f:facet>
+                                <!-- The prescription comment is already appended to descreption
+                                     when the bill item is built, so it is not repeated here.
+                                     (Reading bip.prescription directly would also auto-create a
+                                     blank Prescription during rendering.) -->
                                 <p:outputLabel value="#{bip.descreption}" ></p:outputLabel>
-                                <h:panelGroup layout="block"
-                                              rendered="#{bip.prescription.comment ne null and bip.prescription.comment ne ''}">
-                                    <p:outputLabel value="Comment: #{bip.prescription.comment}"
-                                                   style="font-size:0.85em;font-style:italic;color:#333;display:block;" />
-                                </h:panelGroup>
                             </p:column>
                         </p:dataTable>
                     </p:panel>


### PR DESCRIPTION
## Summary

Adds comment support for inpatient (IP) pharmacy requests and improves the BHT Issue Request workflow, addressing issue #15381.

Changes span the BHT issue request page (`ward/ward_pharmacy_bht_issue.xhtml`), the issue request bill, receipt, and reprint pages, plus the `PharmacyRequestForBhtController`.

## Changes

- **Comments for IP pharmacy requests** — comments are now captured, printed on the settle receipt, and shown consistently on the reprint page (`ward_pharmacy_reprint_bht_issue_request.xhtml`) — both comments render, matching the settle print.
- **Item filtering** — items on the BHT Issue Request are now filtered by VTM, ATM, VMP and AMP.
- **Prescription-to-dispense calculation** — completed the calculation of prescription-to-dispense request for inpatient requests, including from/to time computation for inpatient medicine requests.
- **Navigation buttons** — improved navigation buttons on the request pages.

## Testing

- JSF/XHTML rendering and controller changes for the BHT issue request, receipt, and reprint flows.

Closes #15381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added medicine-type toggle filters for prescription autocomplete (VTM/ATM/VMP/AMP) to refine search results.
  * Introduced prescription-driven “Generate” and “Calculate & Add” dispense actions.
  * Added bill-item editing with therapeutic substitute selection and quantity updates.
  * Added “View Request” access and enhanced bill/receipt rendering with prescription comments.

* **UI Improvements**
  * Updated request, dialogs, and bill preview layouts, including improved directions and conditional dose/frequency/duration display.

* **Bug Fixes**
  * Prevented double-submit during settlement; improved handling when prescription data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->