### PR TITLE
Microbiology patient report — memo editor, indentation, spacing, antibiotic layout & configurable casing

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientInvestigationController.java
@@ -70,6 +70,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -5271,8 +5272,17 @@ public class PatientInvestigationController implements Serializable {
             }
         }
 
+        // Sort the antibiotics that have a result alphabetically (A-Z) by name.
+        antibioticItems.sort(Comparator.comparing(
+                ptiv -> ptiv.getInvestigationItem().getName() == null
+                        ? "" : ptiv.getInvestigationItem().getName(),
+                String.CASE_INSENSITIVE_ORDER));
+
+        // Fill the first column top-to-bottom with the first half (rounded up)
+        // and the rest into the second column, e.g. 11 -> 6 + 5, 12 -> 6 + 6.
+        int firstColumnCount = (antibioticItems.size() + 1) / 2;
         for (int i = 0; i < antibioticItems.size(); i++) {
-            if (i % 2 == 0) {
+            if (i < firstColumnCount) {
                 column1AntibioticList.add(antibioticItems.get(i));
             } else {
                 column2AntibioticList.add(antibioticItems.get(i));

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -1267,6 +1267,7 @@ public class PatientReportController implements Serializable {
     public void savePatientReportItemValues() {
         if (currentPatientReport != null && currentPatientReport.getPatientReportItemValues() != null) {
             for (PatientReportItemValue v : currentPatientReport.getPatientReportItemValues()) {
+                preserveMultipleSpacesInRichTextMemo(v);
                 pirivFacade.edit(v);
             }
         }
@@ -1279,6 +1280,39 @@ public class PatientReportController implements Serializable {
             System.out.println("Not Allow to Calculate Requerd. ----> Calculated Requerd = " + calculatedRequerd);
         }
         
+    }
+
+    /**
+     * Rich-text memo results (entered through the Quill Text Editor, e.g. the
+     * microbiology memo box) are stored as HTML. Quill collapses runs of ASCII
+     * spaces down to a single space when it re-loads that HTML into the editor,
+     * so the extra spacing a user typed is lost on the next edit. To keep it,
+     * convert the 2nd and each subsequent space of every run into a
+     * non-breaking space (&nbsp;), which Quill preserves on reload. &nbsp;
+     * renders as an ordinary space in both the editor and the print view.
+     * <p>
+     * Only values that contain HTML tags are touched, so plain-textarea memos
+     * (e.g. the grouped antibiotic memo) are left exactly as entered. The
+     * conversion is idempotent because &nbsp; is not an ASCII space.
+     */
+    private void preserveMultipleSpacesInRichTextMemo(PatientReportItemValue v) {
+        if (v == null || v.getInvestigationItem() == null) {
+            return;
+        }
+        if (v.getInvestigationItem().getIxItemValueType() != InvestigationItemValueType.Memo) {
+            return;
+        }
+        String lob = v.getLobValue();
+        if (lob == null || lob.indexOf('<') < 0) {
+            return; // plain text (not from the Text Editor) - leave untouched
+        }
+        // Replace each space that immediately follows another space with a
+        // non-breaking space, preserving the run length while still allowing
+        // the line to wrap at the first (normal) space.
+        String preserved = lob.replaceAll("(?<= ) ", "&nbsp;");
+        if (!preserved.equals(lob)) {
+            v.setLobValue(preserved);
+        }
     }
 
     public void savePatientReport() {

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -16,6 +16,15 @@
                 <h:form>
                     <h:outputStylesheet library="css" name="lab.css" ></h:outputStylesheet>
 
+                    <style>
+                        /* Preserve consecutive spaces typed into the microbiology
+                           memo Text Editor (Quill), so extra in-line spacing is
+                           not collapsed while entering the result. */
+                        .micMemoEditor .ql-editor {
+                            white-space: pre-wrap;
+                        }
+                    </style>
+
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.min.js" integrity="sha512-pdCVFUWsxl1A4g0uV6fyJ3nrnTGeWnZN2Tl/56j45UvZ1OMdm9CIbctuIHj+yBIRTUUyv6I9+OivXj4i0LPEYA==" crossorigin="anonymous"></script>
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.3.1/jspdf.umd.min.js" integrity="sha512-VKjwFVu/mmKGk0Z0BxgDzmn10e590qk3ou/jkmRugAkSTMSIRkd4nEnk+n7r5WBbJquusQEQjBidrBD3IQQISQ==" crossorigin="anonymous"></script>
 
@@ -494,7 +503,7 @@
                                                                 <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
                                                                     <p:textEditor
                                                                         id="txtMicMemoVal"
-                                                                        class="w-100 mt-1"
+                                                                        class="w-100 mt-1 micMemoEditor"
                                                                         secure="false"
                                                                         allowFormatting="true"
                                                                         disabled="#{patientReportController.currentPatientReport.approved}"

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -488,145 +488,165 @@
                                     header="Microbiology"    
                                     id="panelDataEntryForMicrobiology"
                                     rendered="#{patientReportController.currentPatientReport.transInvestigation.reportType eq 'Microbiology'}" >
-                                        <h:panelGroup >
-                                            <table class="w-100">
-                                                <ui:repeat id="tblMicValsExceptAntibiotics"
+                                    <h:panelGroup >
+                                        <table class="w-100">
+                                            <ui:repeat id="tblMicValsExceptAntibiotics"
+                                                       value="#{patientReportController.currentPatientReport.patientReportItemValues}"  
+                                                       var="pvm"   
+                                                       >
+                                                <h:panelGroup rendered="#{pvm.investigationItem.ixItemType eq 'Value'}" >
+                                                    <tr>
+                                                        <td  style="width: 280px!important;">
+                                                            <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
+                                                        </td>
+                                                        <td >
+                                                            <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
+                                                                <p:textEditor
+                                                                    id="txtMicMemoVal"
+                                                                    class="w-100 mt-1 micMemoEditor"
+                                                                    secure="false"
+                                                                    allowFormatting="true"
+                                                                    allowBlocks="true"
+                                                                    allowStyles="true"
+                                                                    disabled="#{patientReportController.currentPatientReport.approved}"
+                                                                    value="#{pvm.lobValue}" >
+                                                                    <f:facet name="toolbar">
+                                                                        <span class="ql-formats">
+                                                                            <button class="ql-bold"></button>
+                                                                            <button class="ql-italic"></button>
+                                                                            <button class="ql-underline"></button>
+                                                                            <button class="ql-strike"></button>
+                                                                        </span>
+
+                                                                        <span class="ql-formats">
+                                                                            <select class="ql-font"></select>
+                                                                            <select class="ql-size"></select>
+                                                                        </span>
+
+                                                                        <span class="ql-formats">
+                                                                            <button class="ql-script" value="sub"></button>
+                                                                            <button class="ql-script" value="super"></button>
+                                                                        </span>
+
+                                                                        <span class="ql-formats">
+                                                                            <button class="ql-list" value="ordered"></button>
+                                                                            <button class="ql-list" value="bullet"></button>
+                                                                            <button class="ql-indent" value="-1"></button>
+                                                                            <button class="ql-indent" value="+1"></button>
+                                                                        </span>
+
+                                                                        <span class="ql-formats">
+                                                                            <select class="ql-align"></select>
+                                                                        </span>
+
+                                                                    </f:facet>
+                                                                    <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
+                                                                </p:textEditor>
+                                                            </h:panelGroup>
+                                                        </td>
+                                                    </tr>
+                                                </h:panelGroup>
+                                            </ui:repeat>
+                                        </table>
+                                    </h:panelGroup>
+
+                                    <p:divider>
+                                        <div class="d-flex justify-content-center">
+                                            <b>Add Antibiotic Group</b>
+                                        </div>
+                                    </p:divider>
+                                    <div class="d-flex gap-3 justify-content-between">
+                                        <p:outputLabel 
+                                            for="txtGroupName"
+                                            class="mt-2"
+                                            value="Group Name" >
+                                        </p:outputLabel>
+                                        <p:inputText
+                                            id="txtGroupName"
+                                            class="w-50"
+                                            value="#{patientReportController.groupName}" >
+                                        </p:inputText>
+                                        <p:commandButton
+                                            id="btnAddPatientReportGroupForMicrobiology"
+                                            value="Add Group"
+                                            icon="fa fa-plus"
+                                            process="@this txtGroupName"
+                                            update=":#{p:resolveFirstComponentWithId('panelDataEntryForMicrobiology',view).clientId}"
+                                            class="ui-button-warning"
+                                            action="#{patientReportController.addPatientReportGroupForMicrobiology()}">
+                                        </p:commandButton>
+                                    </div>
+
+                                    <p:divider />
+
+                                    <h:panelGroup rendered="#{not empty patientReportController.currentPatientReport.patientReportGroups}">
+                                        <table >
+
+                                            <ui:repeat 
+                                                id="tblMicValsGroupes" 
+                                                value="#{patientReportController.currentPatientReport.patientReportGroups}"  
+                                                var="group"   
+                                                >
+                                                <tr>
+                                                    <td  colspan="3">
+                                                        <h:outputText 
+                                                            escape="false"
+                                                            class="h4"
+                                                            value="#{group.groupName}" >
+                                                        </h:outputText>
+                                                    </td>
+                                                </tr>
+
+                                                <ui:repeat id="tblMicValsGrouped" 
                                                            value="#{patientReportController.currentPatientReport.patientReportItemValues}"  
                                                            var="pvm"   
                                                            >
-                                                    <h:panelGroup rendered="#{pvm.investigationItem.ixItemType eq 'Value'}" >
-                                                        <tr>
-                                                            <td  style="width: 280px!important;">
-                                                                <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
-                                                            </td>
-                                                            <td >
-                                                                <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
-                                                                    <p:textEditor
-                                                                        id="txtMicMemoVal"
-                                                                        class="w-100 mt-1 micMemoEditor"
-                                                                        secure="false"
-                                                                        allowFormatting="true"
-                                                                        disabled="#{patientReportController.currentPatientReport.approved}"
-                                                                        value="#{pvm.lobValue}" >
-                                                                        <f:facet name="toolbar">
-                                                                            <span class="ql-formats">
-                                                                                <button class="ql-bold"></button>
-                                                                                <button class="ql-italic"></button>
-                                                                                <button class="ql-underline"></button>
-                                                                                <button class="ql-strike"></button>
-                                                                            </span>
-                                                                            <span class="ql-formats">
-                                                                                <select class="ql-font"></select>
-                                                                                <select class="ql-size"></select>
-                                                                            </span>
-                                                                        </f:facet>
-                                                                        <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
-                                                                    </p:textEditor>
-                                                                </h:panelGroup>
-                                                            </td>
-                                                        </tr>
+                                                    <h:panelGroup 
+                                                        rendered="#{pvm.patientReportGroup.groupName eq group.groupName}" >
+
+                                                        <h:panelGroup 
+                                                            rendered="#{pvm.investigationItem.ixItemType eq 'Value'  or pvm.investigationItem.ixItemType eq 'Antibiotic' }" >
+                                                            <tr>
+                                                                <td  style="min-width: 280px!important;">
+                                                                    <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
+                                                                </td>
+                                                                <td >
+                                                                    <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
+                                                                        <p:inputTextarea 
+                                                                            rendered="true" 
+                                                                            id="txtMicMemoValGrouped" queryDelay="0" class="w-100 mt-1"  minQueryLength="1" 
+                                                                            completeMethod="#{investigationItemValueController.completeValues}" disabled="#{patientReportController.currentPatientReport.approved}"
+                                                                            value="#{pvm.lobValue}" >
+                                                                            <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
+                                                                        </p:inputTextarea>
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Varchar'}">
+                                                                        <p:selectOneMenu 
+                                                                            id="cmbMicStrValGrouped" class="mt-1" value="#{pvm.strValue}" editable="true"  style="min-width: 300px!important;" disabled="#{patientReportController.currentPatientReport.approved}">
+                                                                            <f:selectItem itemLabel="SENSITIVE" itemValue="SENSITIVE" ></f:selectItem>
+                                                                            <f:selectItem itemLabel="RESISTANT" itemValue="Resistant" ></f:selectItem>
+                                                                            <f:selectItem itemLabel="INTERMEDIATE" itemValue="Intermediate" ></f:selectItem>
+                                                                            <f:ajax event="change"  execute="@this" 
+                                                                                    listener="#{patientReportController.savePatientReportItemValues()}" ></f:ajax>
+                                                                        </p:selectOneMenu>
+                                                                    </h:panelGroup>
+
+                                                                </td>
+                                                            </tr>
+                                                        </h:panelGroup>
+
                                                     </h:panelGroup>
                                                 </ui:repeat>
-                                            </table>
-                                        </h:panelGroup>
 
-                                        <p:divider>
-                                            <div class="d-flex justify-content-center">
-                                                <b>Add Antibiotic Group</b>
-                                            </div>
-                                        </p:divider>
-                                        <div class="d-flex gap-3 justify-content-between">
-                                            <p:outputLabel 
-                                                for="txtGroupName"
-                                                class="mt-2"
-                                                value="Group Name" >
-                                            </p:outputLabel>
-                                            <p:inputText
-                                                id="txtGroupName"
-                                                class="w-50"
-                                                value="#{patientReportController.groupName}" >
-                                            </p:inputText>
-                                            <p:commandButton
-                                                id="btnAddPatientReportGroupForMicrobiology"
-                                                value="Add Group"
-                                                icon="fa fa-plus"
-                                                process="@this txtGroupName"
-                                                update=":#{p:resolveFirstComponentWithId('panelDataEntryForMicrobiology',view).clientId}"
-                                                class="ui-button-warning"
-                                                action="#{patientReportController.addPatientReportGroupForMicrobiology()}">
-                                            </p:commandButton>
-                                        </div>
+                                                <tr>
+                                                    <td colspan="4">
+                                                        <p:divider />
+                                                    </td>
+                                                </tr>
 
-                                        <p:divider />
-
-                                        <h:panelGroup rendered="#{not empty patientReportController.currentPatientReport.patientReportGroups}">
-                                            <table >
-
-                                                <ui:repeat 
-                                                    id="tblMicValsGroupes" 
-                                                    value="#{patientReportController.currentPatientReport.patientReportGroups}"  
-                                                    var="group"   
-                                                    >
-                                                    <tr>
-                                                        <td  colspan="3">
-                                                            <h:outputText 
-                                                                escape="false"
-                                                                class="h4"
-                                                                value="#{group.groupName}" >
-                                                            </h:outputText>
-                                                        </td>
-                                                    </tr>
-
-                                                    <ui:repeat id="tblMicValsGrouped" 
-                                                               value="#{patientReportController.currentPatientReport.patientReportItemValues}"  
-                                                               var="pvm"   
-                                                               >
-                                                        <h:panelGroup 
-                                                            rendered="#{pvm.patientReportGroup.groupName eq group.groupName}" >
-
-                                                            <h:panelGroup 
-                                                                rendered="#{pvm.investigationItem.ixItemType eq 'Value'  or pvm.investigationItem.ixItemType eq 'Antibiotic' }" >
-                                                                <tr>
-                                                                    <td  style="min-width: 280px!important;">
-                                                                        <h:outputLabel value="#{pvm.investigationItem.name}" ></h:outputLabel>
-                                                                    </td>
-                                                                    <td >
-                                                                        <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Memo'}" >
-                                                                            <p:inputTextarea 
-                                                                                rendered="true" 
-                                                                                id="txtMicMemoValGrouped" queryDelay="0" class="w-100 mt-1"  minQueryLength="1" 
-                                                                                completeMethod="#{investigationItemValueController.completeValues}" disabled="#{patientReportController.currentPatientReport.approved}"
-                                                                                value="#{pvm.lobValue}" >
-                                                                                <p:ajax process="@this" event="blur" listener="#{patientReportController.savePatientReportItemValues()}"></p:ajax>
-                                                                            </p:inputTextarea>
-                                                                        </h:panelGroup>
-                                                                        <h:panelGroup rendered="#{pvm.investigationItem.ixItemValueType eq 'Varchar'}">
-                                                                            <p:selectOneMenu 
-                                                                                id="cmbMicStrValGrouped" class="mt-1" value="#{pvm.strValue}" editable="true"  style="min-width: 300px!important;" disabled="#{patientReportController.currentPatientReport.approved}">
-                                                                                <f:selectItem itemLabel="SENSITIVE" itemValue="SENSITIVE" ></f:selectItem>
-                                                                                <f:selectItem itemLabel="RESISTANT" itemValue="Resistant" ></f:selectItem>
-                                                                                <f:selectItem itemLabel="INTERMEDIATE" itemValue="Intermediate" ></f:selectItem>
-                                                                                <f:ajax event="change"  execute="@this" 
-                                                                                        listener="#{patientReportController.savePatientReportItemValues()}" ></f:ajax>
-                                                                            </p:selectOneMenu>
-                                                                        </h:panelGroup>
-
-                                                                    </td>
-                                                                </tr>
-                                                            </h:panelGroup>
-
-                                                        </h:panelGroup>
-                                                    </ui:repeat>
-
-                                                    <tr>
-                                                        <td colspan="4">
-                                                            <p:divider />
-                                                        </td>
-                                                    </tr>
-
-                                                </ui:repeat>
-                                            </table>
-                                        </h:panelGroup>
+                                            </ui:repeat>
+                                        </table>
+                                    </h:panelGroup>
 
                                 </p:panel>
 

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -27,6 +27,9 @@
             }
             .micMemoValue {
                 line-height: 1.45;
+                /* Preserve consecutive spaces typed in the result while still
+                   wrapping long lines, so extra in-line spacing is not collapsed. */
+                white-space: pre-wrap;
             }
         </style>
 

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -83,10 +83,10 @@
                                             style="font-size: 15px;"
                                             rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                             <div style="float: left;width: 5%; clear: left;" ></div>
-                                            <div style=" float: left; text-align: left; width: 70%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
+                                            <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                             </div>
-                                            <div style="float: left;width: 2%;  " ></div>
+                                            <div style="float: left;width: 4%; text-align: center;" >:</div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
                                                                style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
@@ -104,10 +104,10 @@
                                             style="font-size: 16px;"
                                             rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                             <div style="float: left;width: 5%; clear: left;" ></div>
-                                            <div style=" float: left; text-align: left; width: 70%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
+                                            <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                             </div>
-                                            <div style="float: left;width: 2%;  " ></div>
+                                            <div style="float: left;width: 4%; text-align: center;" >:</div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
                                                                style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
@@ -148,10 +148,10 @@
                                                     style="font-size: 15px;"
                                                     rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                                     <div style="float: left;width: 5%; clear: left;" ></div>
-                                                    <div style=" float: left; text-align: left; width: 70%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
+                                                    <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                                     </div>
-                                                    <div style="float: left;width: 2%;  " ></div>
+                                                    <div style="float: left;width: 4%; text-align: center;" >:</div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
                                                                        style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
@@ -175,10 +175,10 @@
                                                     style="font-size: 16px;"
                                                     rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                                     <div style="float: left;width: 5%; clear: left;" ></div>
-                                                    <div style=" float: left; text-align: left; width: 70%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
+                                                    <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                                     </div>
-                                                    <div style="float: left;width: 2%;  " ></div>
+                                                    <div style="float: left;width: 4%; text-align: center;" >:</div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
                                                                        style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -31,6 +31,21 @@
                    wrapping long lines, so extra in-line spacing is not collapsed. */
                 white-space: pre-wrap;
             }
+            /* Reproduce the Quill editor's indentation in the printed/preview
+               report. The editor applies these ql-indent-* classes on the block
+               when the indent toolbar buttons are used, but Quill's own CSS that
+               gives them padding is scoped to .ql-editor and is not present here,
+               so the indent is lost. The longhand padding-left overrides the
+               padding:0 reset above (higher specificity). Values match Quill's
+               default of 3em per indent level. */
+            .micMemoValue .ql-indent-1 { padding-left: 3em; }
+            .micMemoValue .ql-indent-2 { padding-left: 6em; }
+            .micMemoValue .ql-indent-3 { padding-left: 9em; }
+            .micMemoValue .ql-indent-4 { padding-left: 12em; }
+            .micMemoValue .ql-indent-5 { padding-left: 15em; }
+            .micMemoValue .ql-indent-6 { padding-left: 18em; }
+            .micMemoValue .ql-indent-7 { padding-left: 21em; }
+            .micMemoValue .ql-indent-8 { padding-left: 24em; }
         </style>
 
         <h:panelGroup rendered="#{patientReportController.currentPatientReport.item.reportType eq 'Microbiology'}"  >

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -88,8 +88,8 @@
                                             </div>
                                             <div style="float: left;width: 2%;  " ></div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
-                                                <h:outputLabel value="#{prv.strValue}" escape="false"
-                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: uppercase;" />
+                                                <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
+                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                             </div>
 
                                         </h:panelGroup>
@@ -109,8 +109,8 @@
                                             </div>
                                             <div style="float: left;width: 2%;  " ></div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
-                                                <h:outputLabel value="#{prv.strValue}" escape="false"
-                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: uppercase;" />
+                                                <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
+                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                             </div>
 
                                         </h:panelGroup>
@@ -153,8 +153,8 @@
                                                     </div>
                                                     <div style="float: left;width: 2%;  " ></div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
-                                                        <h:outputLabel value="#{prv.strValue}" escape="false"
-                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: uppercase;" />
+                                                        <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
+                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                                     </div>
 
                                                 </h:panelGroup>
@@ -180,8 +180,8 @@
                                                     </div>
                                                     <div style="float: left;width: 2%;  " ></div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
-                                                        <h:outputLabel value="#{prv.strValue}" escape="false"
-                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: uppercase;" />
+                                                        <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
+                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                                     </div>
                                                 </h:panelGroup>
                                             </h:panelGroup>

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -48,8 +48,10 @@
                 </h:panelGroup>
                 
                 <div style="position: absolute; top: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Lab Report Height')}%; width: 97%; left: 1%; text-align: center; font-family:Cambria, Georgia, serif; font-size: 14px; height: 70%; vertical-align: top;" >
-                    <div id="ixName" >
-                        <h:outputLabel value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}" style="font-weight: bold;font-size: 21px!important; "/>
+                    <div style="margin-left:5%; text-align: left;">
+                        <h:outputLabel 
+                            value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}"
+                            style="font-weight: bold;font-size: 21px!important; text-decoration: underline; "/>
                     </div>
                     <div id="labelsAndValues" style="left:5%; margin-top: 7px; width: 90%; display: inline-block; vertical-align: top; " >
                         <div style="vertical-align: top; width: 100%; padding: 1px;margin: auto;display: inline-block;">


### PR DESCRIPTION
## Microbiology patient report improvements

Target: **`development`**.

Closes #22045

Same set of changes shipped as a `coop-prod` hotfix in #22046, ported to `development` so they are retained in future releases.

## What & why

A set of improvements to the **Microbiology patient report** (data entry, preview and print view): the rich-text memo editor, antibiotic result layout, spacing preservation, and configurable result casing.

## Changes

### 1. Rich-text memo editor toolbar expanded
Added ordered/bullet **list**, **indent** (+/-), **subscript/superscript** and paragraph **alignment** controls to the microbiology memo Text Editor (Quill), and enabled `allowBlocks`/`allowStyles` so block-level formatting is retained on save.

### 2. Memo indentation preserved in preview & print
The editor writes Quill `ql-indent-*` classes on indented blocks, but their padding was only defined by Quill's editor-scoped CSS and was reset by the existing `.micMemoValue` paragraph reset, so indentation was lost in preview/print. Added matching `ql-indent-1..8` `padding-left` rules (3em per level) scoped to `.micMemoValue`.

### 3. Preserve multiple spaces in the memo (editor + print)
Quill collapses runs of ASCII spaces on reload. On save, the 2nd and each subsequent space of every run is converted to `&nbsp;` (idempotent, only for rich-text/HTML memos; plain-textarea memos untouched). Applied `white-space: pre-wrap` on the editor content and the print memo blocks.

### 4. Antibiotic result layout — colon separator + width tuning
Inserted a centered `:` separator column between the antibiotic name and its result; adjusted widths (name 70% → 61%, separator 2% → 4%) to keep alignment across all four report blocks.

### 5. Antibiotics sorted A–Z and split by half across columns
Replaced the zig-zag layout with an alphabetical (A–Z, case-insensitive) sort; the first column is filled top-to-bottom with the first half (rounded up), the rest into the second column (e.g. 11 → 6 + 5, 12 → 6 + 6).

### 6. Configurable antibiotic result text casing
Added config option **`Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)`** (default `uppercase`) controlling the CSS `text-transform` for antibiotic sensitivity results on the print view. The value is lowercased before the transform so `capitalize` renders `SENSITIVE` as `Sensitive`; the SENSITIVE bold-highlight still keys off the original stored value.

### 7. Print view — test name styling
Investigation print name left-aligned with an underline instead of centered.

## Commits

- `style(lab): left-align and underline test name in microbiology report print view`
- `fix(lab): preserve multiple spaces in microbiology report print view`
- `fix(lab): preserve multiple spaces in microbiology memo Text Editor`
- `feat(lab): make microbiology antibiotic result text casing configurable`
- `feat(lab): sort microbiology antibiotics A-Z and split columns by half`
- `style(lab): add colon separator between antibiotic name and result in microbiology report`
- `feat(lab): expand microbiology memo editor toolbar with lists, indent, script and align`
- `fix(lab): preserve memo indentation in microbiology report preview and print`

## Files touched

| File | Change |
|------|--------|
| `src/main/java/com/divudi/bean/lab/PatientInvestigationController.java` | Antibiotic A–Z sort + half-split column fill |
| `src/main/java/com/divudi/bean/lab/PatientReportController.java` | Preserve multiple spaces in rich-text memo on save |
| `src/main/webapp/lab/patient_report.xhtml` | Editor toolbar expansion + `pre-wrap` |
| `src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml` | Indent CSS, colon separator, casing config, spacing, name styling |

## Testing notes
- Mostly JSF/XHTML changes plus two small controller-level Java changes; no schema changes.
- The casing behaviour is driven by an application config option (default `uppercase`, preserving current behaviour).

## Related
- Production hotfix PR (coop-prod): #22046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microbiology antibiotic results are now sorted alphabetically and distributed evenly across two columns.
  * Antibiotic result text supports configurable capitalization styles.
  * Microbiology memo fields provide expanded formatting options.

* **Bug Fixes**
  * Preserved consecutive spaces and indentation in microbiology memos when editing, saving, and viewing reports.
  * Improved spacing and separator formatting in antibiotic result displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->