### PR TITLE
fix(inward): attach uploaded document to admission document emails

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -260,8 +260,19 @@ public class InwardDocumentUploadController implements Serializable {
             return;
         }
 
+        Upload persisted = selectedDocument.getId() != null ? uploadFacade.find(selectedDocument.getId()) : null;
+        if (persisted == null || persisted.isRetired() || persisted.getBaImage() == null || persisted.getBaImage().length == 0) {
+            JsfUtil.addErrorMessage("Document content is not available to attach");
+            return;
+        }
+
         String subject = "Document: " + (selectedDocument.getFileName() != null ? selectedDocument.getFileName() : "Attachment");
         String body = buildDocumentEmailHtml();
+
+        com.divudi.core.data.EmailAttachment attachment = new com.divudi.core.data.EmailAttachment(
+                persisted.getFileName(),
+                persisted.getFileType(),
+                java.util.Base64.getEncoder().encodeToString(persisted.getBaImage()));
 
         com.divudi.core.entity.AppEmail email = new com.divudi.core.entity.AppEmail();
         email.setCreatedAt(new Date());
@@ -273,6 +284,7 @@ public class InwardDocumentUploadController implements Serializable {
         email.setInstitution(sessionController.getLoggedUser().getInstitution());
         email.setPatientEncounter(currentEncounter);
         email.setMessageType(com.divudi.core.data.MessageType.InpatientDocumentUpload);
+        email.setAttachment1(persisted.getFileName());
         email.setSentSuccessfully(false);
         email.setPending(true);
         emailFacade.create(email);
@@ -282,7 +294,8 @@ public class InwardDocumentUploadController implements Serializable {
                     java.util.Collections.singletonList(recipient),
                     body,
                     subject,
-                    true
+                    true,
+                    java.util.Collections.singletonList(attachment)
             );
             email.setSentSuccessfully(success);
             email.setPending(!success);
@@ -309,7 +322,7 @@ public class InwardDocumentUploadController implements Serializable {
             sb.append("<tr><td><b>Comments</b></td><td>").append(escapeHtml(selectedDocument.getComments())).append("</td></tr>");
         }
         sb.append("</table>");
-        sb.append("<p><i>Note: The file itself is not attached to this email. Please contact the hospital to obtain a copy of the document.</i></p>");
+        sb.append("<p><i>The document is attached to this email.</i></p>");
         sb.append("</body></html>");
         return sb.toString();
     }

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -307,6 +307,8 @@ public class InwardDocumentUploadController implements Serializable {
             }
             emailFacade.edit(email);
         } catch (Exception ex) {
+            java.util.logging.Logger.getLogger(InwardDocumentUploadController.class.getName())
+                    .log(java.util.logging.Level.SEVERE, "Failed to send document email", ex);
             JsfUtil.addErrorMessage("Sending Email Failed");
         }
     }

--- a/src/main/java/com/divudi/core/data/EmailAttachment.java
+++ b/src/main/java/com/divudi/core/data/EmailAttachment.java
@@ -1,0 +1,50 @@
+package com.divudi.core.data;
+
+import java.io.Serializable;
+
+/**
+ * A file attachment for outbound emails sent through the messenger REST
+ * gateway. Content is carried as a base64 string because the gateway
+ * contract is JSON.
+ */
+public class EmailAttachment implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String fileName;
+    private String contentType;
+    private String base64Content;
+
+    public EmailAttachment() {
+    }
+
+    public EmailAttachment(String fileName, String contentType, String base64Content) {
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.base64Content = base64Content;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getBase64Content() {
+        return base64Content;
+    }
+
+    public void setBase64Content(String base64Content) {
+        this.base64Content = base64Content;
+    }
+}

--- a/src/main/java/com/divudi/ejb/EmailManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/EmailManagerEjb.java
@@ -7,6 +7,7 @@ package com.divudi.ejb;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.lab.LabTestHistoryController;
+import com.divudi.core.data.EmailAttachment;
 import com.divudi.core.data.MessageType;
 import com.divudi.core.entity.AppEmail;
 import com.divudi.core.entity.Bill;
@@ -167,6 +168,11 @@ public class EmailManagerEjb {
 //
 //    }
     private boolean sendEmailViaRestGateway(String subject, String body, List<String> recipients, boolean isHtml) {
+        return sendEmailViaRestGateway(subject, body, recipients, isHtml, null);
+    }
+
+    private boolean sendEmailViaRestGateway(String subject, String body, List<String> recipients, boolean isHtml,
+            List<EmailAttachment> attachments) {
         String messengerServiceURL = configOptionApplicationController.getShortTextValueByKey("Email Gateway - URL", "");
 
         if (messengerServiceURL == null || messengerServiceURL.trim().isEmpty()) {
@@ -176,7 +182,7 @@ public class EmailManagerEjb {
 
         HttpURLConnection connection = null;
         try {
-            JSONObject payload = buildEmailJsonPayload(subject, body, recipients, isHtml);
+            JSONObject payload = buildEmailJsonPayload(subject, body, recipients, isHtml, attachments);
 
             URL url = new URL(messengerServiceURL);
             connection = (HttpURLConnection) url.openConnection();
@@ -228,6 +234,11 @@ public class EmailManagerEjb {
     }
 
     private JSONObject buildEmailJsonPayload(String subject, String body, List<String> recipients, boolean isHtml) {
+        return buildEmailJsonPayload(subject, body, recipients, isHtml, null);
+    }
+
+    private JSONObject buildEmailJsonPayload(String subject, String body, List<String> recipients, boolean isHtml,
+            List<EmailAttachment> attachments) {
         final String username = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Username", "");
         final String password = configOptionApplicationController.getShortTextValueByKey("Email Gateway - Password", "");
         final String smtpHost = configOptionApplicationController.getShortTextValueByKey("Email Gateway - SMTP Host", "");
@@ -244,6 +255,20 @@ public class EmailManagerEjb {
             recipientArray.put(recipient);
         }
         payload.put("recipients", recipientArray);
+
+        // Only include the key when attachments exist so older messenger
+        // deployments keep accepting attachment-less payloads unchanged.
+        if (attachments != null && !attachments.isEmpty()) {
+            JSONArray attachmentArray = new JSONArray();
+            for (EmailAttachment attachment : attachments) {
+                JSONObject attachmentJson = new JSONObject();
+                attachmentJson.put("fileName", attachment.getFileName());
+                attachmentJson.put("contentType", attachment.getContentType());
+                attachmentJson.put("base64Content", attachment.getBase64Content());
+                attachmentArray.put(attachmentJson);
+            }
+            payload.put("attachments", attachmentArray);
+        }
 
         JSONObject smtpConfig = new JSONObject();
         smtpConfig.put("username", username);
@@ -369,6 +394,21 @@ public class EmailManagerEjb {
     public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml) {
         try {
             return sendEmailViaRestGateway(subject, body, recipients, isHtml);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Sends an email with file attachments through the messenger REST
+     * gateway. Requires a messenger deployment that supports the
+     * "attachments" field in the payload.
+     */
+    public boolean sendEmail(final List<String> recipients, final String body, final String subject, final boolean isHtml,
+            final List<EmailAttachment> attachments) {
+        try {
+            return sendEmailViaRestGateway(subject, body, recipients, isHtml, attachments);
         } catch (Exception e) {
             Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.SEVERE, "Failed to send email: " + e.getMessage(), e);
             return false;

--- a/src/main/webapp/inward/admission_documents.xhtml
+++ b/src/main/webapp/inward/admission_documents.xhtml
@@ -198,7 +198,7 @@
                                              required="true" requiredMessage="Email address is required"/>
                             </div>
                             <div class="mb-3">
-                                <small class="text-muted">Note: The file is not attached. The recipient will be sent a cover note with the document details.</small>
+                                <small class="text-muted">The document will be attached to the email along with a cover note.</small>
                             </div>
                             <div class="d-flex justify-content-end gap-2">
                                 <p:commandButton id="btnCancelDocEmail" value="Cancel" onclick="PF('emailDocDialog').hide();"


### PR DESCRIPTION
## Summary
Fixes #21945 — on `inward/admission_documents.xhtml`, "Send by Email" sent only a cover note; the uploaded document was never attached (the old body text even said the file is not attached). Attachment support did not exist in the REST email path, so this fix spans both repos:

- **hmislk/carecode-messenger#28** (must be deployed first): adds an optional `attachments` array to the email gateway API and multipart MIME building.
- **This PR**:
  - New `com.divudi.core.data.EmailAttachment` DTO (fileName, contentType, base64Content)
  - New `EmailManagerEjb.sendEmail(recipients, body, subject, isHtml, attachments)` overload; the `attachments` key is only included in the gateway payload when non-empty, so older messenger deployments keep working for all existing attachment-less emails
  - `InwardDocumentUploadController.sendDocumentEmail()` re-fetches the persisted `Upload`, guards against missing content, sends the file bytes as a base64 attachment, and records the file name on the `AppEmail` audit row (`attachment1`)
  - Email body + send-dialog note updated to say the document is attached

No entity/schema changes; no existing method signatures changed (new overloads only).

## Verification (local E2E)
Local Payara (`rh` domain) + updated messenger on Payara Micro 6 (:8081) + capture SMTP server (:1025):

1. Uploaded `test_doc_21945.pdf` (Referral Letter) on admission BHT/56744's documents page:

![Documents page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21945-documents-page.png)

2. Sent by email via the dialog (note text updated):

![Email dialog](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21945-email-dialog.png)

3. Captured SMTP message is `multipart/mixed`: HTML cover note + `application/pdf` attachment whose bytes are **sha256-identical** to the uploaded file.
4. DB: `APPEMAIL` row has `ATTACHMENT1=test_doc_21945.pdf`, `SENTSUCCESSFULLY=1`, `PENDING=0`, `SENTAT` set.
5. Regression: attachment-less messenger payloads still produce the previous single-part `text/html` message.

Full evidence in the [issue comment](https://github.com/hmislk/hmis/issues/21945#issuecomment-4950384466).

## Deployment order
Deploy **carecode-messenger#28 first** (or together). Until then, sending a document email from this page would fail (messenger rejects the unknown `attachments` field), same as the feature never having worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inward admission documents can now be emailed with the uploaded file attached (optional attachments).
  * Attachments preserve the original file name and content type.
  * Email content now consistently reflects that the document is attached.

* **Bug Fixes**
  * Prevented sending document emails when the uploaded file’s stored content is missing or empty.
  * Improved error handling by logging failures at a higher severity level.
  * Updated email dialog/helper text to accurately describe the attachment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->