### PR TITLE
Show per-billing rows with billed date in Itemized Service Summary (#21920)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -572,6 +572,31 @@ privilege check for that department under the PO branch's code. Fix: delete (or 
 the rows for privileges that don't exist on the currently deployed branch, re-grant only
 what the current branch's `Privileges.java` actually declares, then re-login.
 
+## 25. A JPQL path expression through a nullable relationship silently INNER-JOINs and drops rows
+
+Writing `b.patientEncounter.bhtNo` or `b.patient.person.name` directly in a `SELECT`/`WHERE`
+generates an **implicit INNER JOIN** on that relationship. If the relationship is null for
+some rows (e.g. `patientEncounter`/`patient` are null on OPD bills), **every one of those
+rows silently disappears** from the result — no error, no log entry. The report just looks
+"wrong" (too few rows), and it's easy to blame filters/dates first.
+
+Tell: a combined OPD+Inward report showed only the 2 Inward rows (which have a
+`patientEncounter`) and dropped all 20 OPD rows for the same item/date range. DB count
+didn't match the report count. Fix: use explicit `left join b.patientEncounter pe` /
+`left join b.patient pat left join pat.person per` and reference the aliases (`pe.bhtNo`,
+`per.name`) in the projection. Verified on issue #21920 (`fetchItemizedServiceInstanceDTOs`
+in `BillService`). Always cross-check report row count against a direct
+`SELECT ... FROM billitem bi JOIN bill b ...` when a report projects fields from an
+optional relationship.
+
+Related sign gotcha found the same pass: cancellation/refund `BillItem` fee columns
+(`netValue`, `hospitalFee`, …) are **already stored negative** in the DB. A
+`case when billClassType in (cancel, refund) then -bi.netValue else bi.netValue end`
+double-negates them to positive — this is the "fee doubling after cancellation" symptom
+(issue #21918). Use the stored values as-is; only synthesize a sign for the row **count**
+(which has no stored value). Verify by summing `bi.netValue` directly in SQL and matching
+the report's Grand Total.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -17206,7 +17206,10 @@ public class SearchController implements Serializable {
         btas.add(BillTypeAtomic.INWARD_SERVICE_BILL_REFUND);
         btas.add(BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
         btas.add(BillTypeAtomic.INWARD_SERVICE_BATCH_BILL_REFUND);
-        opdSaleSummaryDtos = billService.fetchOpdSaleSummaryDTOs(
+        // Issue #21920: one row per billing instance (not aggregated by item) with a
+        // billed date, so re-billed/cancelled/refunded services are preserved as
+        // separate rows instead of overwriting the same record.
+        opdSaleSummaryDtos = billService.fetchItemizedServiceInstanceDTOs(
                 fromDate, toDate, institution, site, department, category, item, btas);
     }
 

--- a/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
@@ -1,6 +1,7 @@
 package com.divudi.core.data.dto;
 
 import java.io.Serializable;
+import java.util.Date;
 
 public class OpdSaleSummaryDTO implements Serializable {
     // Display fields
@@ -19,6 +20,14 @@ public class OpdSaleSummaryDTO implements Serializable {
 
     // Doctor/staff assigned to this item
     private String staffName;
+
+    // Per-billing-instance fields (issue #21920): one row per BillItem so re-billing,
+    // cancellation and refund events are preserved as separate rows instead of being
+    // aggregated/overwritten. Populated only by the itemized service instance query.
+    private Long billItemId;
+    private Date billedDate;
+    private String bhtNo;
+    private String patientName;
 
     public OpdSaleSummaryDTO() {
     }
@@ -68,6 +77,25 @@ public class OpdSaleSummaryDTO implements Serializable {
         this(categoryId, categoryName, itemId, itemName, itemCount,
              hospitalFee, professionalFee, grossAmount, discountAmount, netTotal);
         this.staffName = staffName;
+    }
+
+    // NEW (issue #21920): Per-billing-instance constructor. One row per BillItem, with
+    // billed date and patient (BHT + name) so inpatient billing history is preserved
+    // and traceable. Used by the Itemized Service Summary (combined OPD + Inward) report.
+    public OpdSaleSummaryDTO(Long categoryId, String categoryName,
+                              Long itemId, String itemName,
+                              Long billItemId, Date billedDate,
+                              String bhtNo, String patientName,
+                              Long itemCount,
+                              Double hospitalFee, Double professionalFee,
+                              Double grossAmount, Double discountAmount,
+                              Double netTotal) {
+        this(categoryId, categoryName, itemId, itemName, itemCount,
+             hospitalFee, professionalFee, grossAmount, discountAmount, netTotal);
+        this.billItemId = billItemId;
+        this.billedDate = billedDate;
+        this.bhtNo = bhtNo;
+        this.patientName = patientName;
     }
 
     public String getCategoryName() {
@@ -156,5 +184,37 @@ public class OpdSaleSummaryDTO implements Serializable {
 
     public void setStaffName(String staffName) {
         this.staffName = staffName;
+    }
+
+    public Long getBillItemId() {
+        return billItemId;
+    }
+
+    public void setBillItemId(Long billItemId) {
+        this.billItemId = billItemId;
+    }
+
+    public Date getBilledDate() {
+        return billedDate;
+    }
+
+    public void setBilledDate(Date billedDate) {
+        this.billedDate = billedDate;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
     }
 }

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -3256,6 +3256,150 @@ public class BillService {
         return dtos;
     }
 
+    /**
+     * Itemized Service Summary (combined OPD + Inward) — issue #21920.
+     *
+     * Unlike {@link #fetchOpdSaleSummaryDTOs}, this returns ONE ROW PER BillItem
+     * (no group-by aggregation), so re-billing the same service, cancellations and
+     * refunds are preserved as separate rows instead of being overwritten. Each row
+     * carries its bill's date (billed date) and the patient (BHT + name) when the bill
+     * is an inpatient (Inward) bill. Cancellation/refund bill items are negated so
+     * they show as negative rows and net out correctly in the totals.
+     *
+     * The staff (Doctor/Technician) name is populated best-effort per item (staff is
+     * assigned per item, not per billing instance) reusing the same second query as
+     * {@link #fetchOpdSaleSummaryDTOs}, to keep the existing Doctor column non-empty.
+     */
+    public List<OpdSaleSummaryDTO> fetchItemizedServiceInstanceDTOs(Date fromDate,
+            Date toDate,
+            Institution institution,
+            Institution site,
+            Department department,
+            Category category,
+            Item item,
+            List<BillTypeAtomic> billTypeAtomics) {
+
+        // Step 1: One row per BillItem — no group by, so nothing is aggregated/overwritten.
+        String jpql = "select new com.divudi.core.data.dto.OpdSaleSummaryDTO("
+                + " bi.item.category.id," // Category ID for navigation
+                + " coalesce(bi.item.category.name, 'No Category')," // Category name for display
+                + " bi.item.id," // Item ID for navigation
+                + " coalesce(bi.item.name, 'No Item')," // Item name for display
+                + " bi.id," // BillItem ID — stable per-row key
+                + " b.createdAt," // Billed date
+                + " pe.bhtNo," // BHT (null for OPD bills — LEFT JOIN so OPD rows are kept)
+                + " per.name," // Patient name (null for anonymous/OPD bills — LEFT JOIN)
+                + " case when b.billClassType in (:cancel, :refund) then -1L else 1L end," // Count (no stored sign)
+                // Fee/value columns are ALREADY stored negative on cancellation/refund bill
+                // items, so they are used as-is. Negating them here would double-negate and
+                // make cancellations show as positive (the fee-doubling bug of issue #21918).
+                + " bi.hospitalFee,"
+                + " bi.staffFee,"
+                + " bi.grossValue,"
+                + " bi.discount,"
+                + " bi.netValue"
+                + ") "
+                // LEFT JOINs: patientEncounter/patient are null for OPD bills. Using a path
+                // expression (b.patientEncounter.bhtNo) would generate an implicit INNER JOIN
+                // that silently drops every OPD row. Explicit LEFT JOINs keep OPD rows.
+                + " from BillItem bi join bi.bill b "
+                + " left join b.patientEncounter pe "
+                + " left join b.patient pat "
+                + " left join pat.person per "
+                + " where b.retired=:ret "
+                + " and b.billTypeAtomic in :bts "
+                + " and b.createdAt between :fd and :td ";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("ret", false);
+        params.put("bts", billTypeAtomics);
+        params.put("fd", fromDate);
+        params.put("td", toDate);
+        params.put("cancel", BillClassType.CancelledBill);
+        params.put("refund", BillClassType.RefundBill);
+
+        if (institution != null) {
+            jpql += " and b.department.institution=:ins";
+            params.put("ins", institution);
+        }
+        if (department != null) {
+            jpql += " and b.department=:dep";
+            params.put("dep", department);
+        }
+        if (site != null) {
+            jpql += " and b.department.site=:site";
+            params.put("site", site);
+        }
+        if (category != null) {
+            jpql += " and bi.item.category=:cat";
+            params.put("cat", category);
+        }
+        if (item != null) {
+            jpql += " and bi.item=:itm";
+            params.put("itm", item);
+        }
+
+        // Chronological billing history
+        jpql += " order by b.createdAt, bi.id";
+
+        List<OpdSaleSummaryDTO> dtos = (List<OpdSaleSummaryDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+
+        // Step 2: Per-item staff (doctor/technician) name — same approach as
+        // fetchOpdSaleSummaryDTOs. Staff is assigned per item, so this is a best-effort
+        // fill to keep the existing Doctor column populated.
+        String staffJpql = "select bi2.item.id, stf.person.name"
+                + " from BillFee bf"
+                + " join bf.billItem bi2"
+                + " join bi2.bill b2"
+                + " join bf.staff stf"
+                + " where b2.retired = false"
+                + " and b2.billTypeAtomic in :bts"
+                + " and b2.createdAt between :fd and :td"
+                + " and bf.retired = false";
+
+        Map<String, Object> staffParams = new HashMap<>();
+        staffParams.put("bts", billTypeAtomics);
+        staffParams.put("fd", fromDate);
+        staffParams.put("td", toDate);
+
+        if (institution != null) {
+            staffJpql += " and b2.department.institution=:ins";
+            staffParams.put("ins", institution);
+        }
+        if (department != null) {
+            staffJpql += " and b2.department=:dep";
+            staffParams.put("dep", department);
+        }
+        if (site != null) {
+            staffJpql += " and b2.department.site=:site";
+            staffParams.put("site", site);
+        }
+        if (category != null) {
+            staffJpql += " and bi2.item.category=:cat";
+            staffParams.put("cat", category);
+        }
+        if (item != null) {
+            staffJpql += " and bi2.item=:itm";
+            staffParams.put("itm", item);
+        }
+
+        staffJpql += " group by bi2.item.id, stf.id, stf.person.name";
+
+        List<Object[]> staffRows = billItemFacade.findObjectArrayByJpql(staffJpql, staffParams, TemporalType.TIMESTAMP);
+
+        Map<Long, String> staffByItem = new HashMap<>();
+        for (Object[] row : staffRows) {
+            Long rowItemId = (Long) row[0];
+            String staffName = row[1] != null ? (String) row[1] : "";
+            staffByItem.putIfAbsent(rowItemId, staffName);
+        }
+        for (OpdSaleSummaryDTO dto : dtos) {
+            dto.setStaffName(staffByItem.getOrDefault(dto.getItemId(), ""));
+        }
+
+        return dtos;
+    }
+
     public List<Bill> fetchBillsWithToInstitution(Date fromDate,
             Date toDate,
             Institution institution,

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -3281,10 +3281,10 @@ public class BillService {
 
         // Step 1: One row per BillItem — no group by, so nothing is aggregated/overwritten.
         String jpql = "select new com.divudi.core.data.dto.OpdSaleSummaryDTO("
-                + " bi.item.category.id," // Category ID for navigation
-                + " coalesce(bi.item.category.name, 'No Category')," // Category name for display
-                + " bi.item.id," // Item ID for navigation
-                + " coalesce(bi.item.name, 'No Item')," // Item name for display
+                + " cat.id," // Category ID for navigation
+                + " coalesce(cat.name, 'No Category')," // Category name for display
+                + " itm.id," // Item ID for navigation
+                + " coalesce(itm.name, 'No Item')," // Item name for display
                 + " bi.id," // BillItem ID — stable per-row key
                 + " b.createdAt," // Billed date
                 + " pe.bhtNo," // BHT (null for OPD bills — LEFT JOIN so OPD rows are kept)
@@ -3299,14 +3299,18 @@ public class BillService {
                 + " bi.discount,"
                 + " bi.netValue"
                 + ") "
-                // LEFT JOINs: patientEncounter/patient are null for OPD bills. Using a path
-                // expression (b.patientEncounter.bhtNo) would generate an implicit INNER JOIN
-                // that silently drops every OPD row. Explicit LEFT JOINs keep OPD rows.
+                // All LEFT JOINs: item/category and patientEncounter/patient may be null on
+                // some rows. A path expression (e.g. bi.item.category.id or b.patientEncounter.bhtNo)
+                // would generate an implicit INNER JOIN that silently drops those BillItem rows
+                // before coalesce() runs — the opposite of this report's "keep every billing" intent.
                 + " from BillItem bi join bi.bill b "
+                + " left join bi.item itm "
+                + " left join itm.category cat "
                 + " left join b.patientEncounter pe "
                 + " left join b.patient pat "
                 + " left join pat.person per "
                 + " where b.retired=:ret "
+                + " and (bi.retired is null or bi.retired=false) " // exclude voided bill items
                 + " and b.billTypeAtomic in :bts "
                 + " and b.createdAt between :fd and :td ";
 
@@ -3331,11 +3335,11 @@ public class BillService {
             params.put("site", site);
         }
         if (category != null) {
-            jpql += " and bi.item.category=:cat";
+            jpql += " and cat=:cat";
             params.put("cat", category);
         }
         if (item != null) {
-            jpql += " and bi.item=:itm";
+            jpql += " and itm=:itm";
             params.put("itm", item);
         }
 
@@ -3346,13 +3350,16 @@ public class BillService {
 
         // Step 2: Per-item staff (doctor/technician) name — same approach as
         // fetchOpdSaleSummaryDTOs. Staff is assigned per item, so this is a best-effort
-        // fill to keep the existing Doctor column populated.
-        String staffJpql = "select bi2.item.id, stf.person.name"
+        // fill to keep the existing Doctor column populated. Explicit join on the item and
+        // a bi2.retired guard, mirroring the main query above.
+        String staffJpql = "select itm2.id, stf.person.name"
                 + " from BillFee bf"
                 + " join bf.billItem bi2"
                 + " join bi2.bill b2"
+                + " join bi2.item itm2"
                 + " join bf.staff stf"
                 + " where b2.retired = false"
+                + " and (bi2.retired is null or bi2.retired=false)"
                 + " and b2.billTypeAtomic in :bts"
                 + " and b2.createdAt between :fd and :td"
                 + " and bf.retired = false";
@@ -3375,15 +3382,15 @@ public class BillService {
             staffParams.put("site", site);
         }
         if (category != null) {
-            staffJpql += " and bi2.item.category=:cat";
+            staffJpql += " and itm2.category=:cat";
             staffParams.put("cat", category);
         }
         if (item != null) {
-            staffJpql += " and bi2.item=:itm";
+            staffJpql += " and itm2=:itm";
             staffParams.put("itm", item);
         }
 
-        staffJpql += " group by bi2.item.id, stf.id, stf.person.name";
+        staffJpql += " group by itm2.id, stf.id, stf.person.name";
 
         List<Object[]> staffRows = billItemFacade.findObjectArrayByJpql(staffJpql, staffParams, TemporalType.TIMESTAMP);
 

--- a/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
+++ b/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
@@ -129,13 +129,27 @@
                              rows="20"
                              paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                              rowsPerPageTemplate="10,20,50"
-                             rowKey="#{row.itemId}_#{row.staffName}">
+                             rowKey="#{row.billItemId}">
                     <f:facet name="header">
                         <h:outputText value="Itemized Service Summary - OPD and Inward (DTO - Optimized)" />
                     </f:facet>
                     <p:column>
-                        <f:facet name="header"><h:outputText value="Category" /></f:facet>
+                        <f:facet name="header"><h:outputText value="Billed Date" /></f:facet>
                         <f:facet name="footer"><h:outputText value="Grand Total" style="font-weight: bold;" /></f:facet>
+                        <h:outputText value="#{row.billedDate}">
+                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </h:outputText>
+                    </p:column>
+                    <p:column>
+                        <f:facet name="header"><h:outputText value="BHT" /></f:facet>
+                        <h:outputText value="#{row.bhtNo}" />
+                    </p:column>
+                    <p:column>
+                        <f:facet name="header"><h:outputText value="Patient" /></f:facet>
+                        <h:outputText value="#{row.patientName}" />
+                    </p:column>
+                    <p:column>
+                        <f:facet name="header"><h:outputText value="Category" /></f:facet>
                         <h:outputText value="#{row.categoryName}" />
                     </p:column>
                     <p:column>


### PR DESCRIPTION
## Summary

Fixes the **Itemized Service Summary - OPD and Inward (Fast - DTO-Based)** report (`/inward/inward_itemized_service_summary_dto.xhtml`), which grouped every billing of a service into a single row. Re-billing, cancelling or refunding the same service overwrote the existing record, and there was no way to see when each service was billed.

Closes #21920 (builds on the cancellation/fee concerns raised in #21918).

## What changed

- New `BillService.fetchItemizedServiceInstanceDTOs(...)` returns **one row per `BillItem`** (no group-by), so every billing/cancellation/refund is preserved as its own row.
- Added **Billed Date**, **BHT** and **Patient** columns; `rowKey` is now the `BillItem` id (previously `itemId_staffName`, which collided across instances).
- Cancellation/refund bill items are **already stored negative**, so their fee/value columns are used as-is — only the row **count** gets a synthesized sign. This shows cancellations as separate negative rows and avoids the fee-doubling that the aggregated report exhibits (#21918).
- Used explicit **LEFT JOINs** for `patientEncounter`/`patient` so OPD rows (no encounter) aren't dropped by an implicit inner join.
- `OpdSaleSummaryDTO` gains 4 fields + one **new** constructor (existing constructors untouched, per the DTO guidelines).

Scope is isolated: the OPD-only *Itemized Sales Summary* page (`/opd/analytics/itemized_sale_summary_dto.xhtml`) still uses the original aggregated `fetchOpdSaleSummaryDTOs` and is unchanged. No schema change (no new persisted fields), so no DDL regeneration needed.

## Verification (local Payara + Playwright + DB cross-check)

Exercised on the local `coop` DB against real data.

**Per-instance rows + Billed Date + Patient** — filtering one service (MRI - ABDOMEN) now returns **22 separate rows** instead of a single aggregated row:

![Per-instance rows](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-21920-per-instance-rows.png)

**Cancellation is a separate negative row (not overwritten)** — for BHT/53223 (patient G K DANAWATHI), FBC billed at 07:25:54 (**+456.00**) and cancelled at 07:56:03 (**Count −1, Net −456.00**) appear as two separate rows. Grand Total (2,000.00) matches a direct `SUM(bi.netValue)` over the same window:

![Cancellation separate negative row](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-21920-cancellation-separate-negative-row.png)

**DB cross-check** confirmed the report rows (dates, BHT, patient, signs) match the underlying `billitem`/`bill` data exactly. The OPD *Itemized Sales Summary* page was regression-checked and still aggregates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Inpatient service summaries now list one row per billing instance, including billed date, BHT, and patient details.
  - Staff names are included when available.
  - The inward itemized service summary table is updated to key rows by billing item and to reorder the initial columns to highlight billing and patient information.

- **Bug Fixes**
  - Fixed missing rows caused by nullable patient relationships in JPQL.
  - Prevented fee doubling by relying on stored negative/refund values correctly.

- **Documentation**
  - Added guidance on JPQL nullable-join pitfalls and proper fee sign handling for cancellations/refunds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->