### PR TITLE
Fix incorrect wholesale value calculation from unrounded batch rate

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/WholesaleSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WholesaleSaleNativeSqlController.java
@@ -785,9 +785,15 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
         bid.setFreeQty(0.0);
         // For wholesale sale, retailRate/batchRetailRate are kept as bookkeeping metadata
         // (from the batch lookup); the actual charged rate comes from wholesaleRate.
+        // The charged rate is rounded to currency precision (2dp) so the displayed Rate
+        // and the calculated Value always agree (ItemBatch.wholesaleRate is frequently
+        // stored with more than 2 decimal places, e.g. 8.4564 - issue #21912).
+        double lineWholesaleRate = CommonFunctions.round(
+                stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0);
+
         bid.setRetailRate(batchRetailRate);
         bid.setPurchaseRate(batchPurchaseRate);
-        bid.setWholesaleRate(stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0);
+        bid.setWholesaleRate(lineWholesaleRate);
         bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
         bid.setBatchRetailRate(batchRetailRate);
         bid.setBatchPurchaseRate(batchPurchaseRate);
@@ -798,7 +804,6 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
         bid.setCreatedAt(new Date());
         bid.setCreaterId(sessionController.getLoggedUser().getId());
 
-        double lineWholesaleRate = stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0;
         double grossValue = lineWholesaleRate * qty;
         double discountPct = 0.0;
         double discountValue = 0.0;
@@ -1081,10 +1086,13 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
         bid.setItemBatchId(sub.getItemBatchId());
         bid.setPbiQty(-Math.abs(qty));
         // For wholesale sale, retailRate/batchRetailRate are kept as bookkeeping metadata;
-        // the actual charged rate comes from the substitute's wholesaleRate.
+        // the actual charged rate comes from the substitute's wholesaleRate, rounded to
+        // currency precision so the displayed Rate and calculated Value agree (#21912).
+        double lineWholesaleRate = CommonFunctions.round(batchWholesaleRate);
+
         bid.setRetailRate(batchRetailRate);
         bid.setPurchaseRate(batchPurchaseRate);
-        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setWholesaleRate(lineWholesaleRate);
         bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
         bid.setBatchRetailRate(batchRetailRate);
         bid.setBatchPurchaseRate(batchPurchaseRate);
@@ -1093,7 +1101,6 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
         bid.setDoe(sub.getDateOfExpire());
         bid.setDescription(sub.getItemName());
 
-        double lineWholesaleRate = batchWholesaleRate;
         double grossValue = lineWholesaleRate * qty;
         double discountPct = 0.0;
         double discountValue = 0.0;
@@ -1189,7 +1196,8 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
 
     public void calculateBillItemListner() {
         if (stockDto != null && intQty != null) {
-            double rate = stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0;
+            double rate = CommonFunctions.round(
+                    stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0);
             getBillItem().setRate(rate);
             getBillItem().setNetRate(rate);
             getBillItem().setNetValue(rate * intQty);
@@ -1641,12 +1649,13 @@ public class WholesaleSaleNativeSqlController implements Serializable, Controlle
 
     public Double getPreviewRate() {
         if (stockDto == null) return null;
-        return stockDto.getWholesaleRate();
+        return stockDto.getWholesaleRate() != null ? CommonFunctions.round(stockDto.getWholesaleRate()) : null;
     }
 
     public Double getPreviewNetValue() {
         if (stockDto == null || intQty == null) return null;
-        double rate = stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0;
+        double rate = CommonFunctions.round(
+                stockDto.getWholesaleRate() != null ? stockDto.getWholesaleRate() : 0.0);
         return rate * intQty;
     }
 


### PR DESCRIPTION
## Summary
- Fixes #21912: on Pharmacy Wholesale Sale, a line's displayed **Value** could disagree with **Rate x Qty** (e.g. Rate 8.46, Qty 10 showed Value 84.56 instead of 84.60).
- Root cause: `ItemBatch.wholesaleRate` is frequently stored with more than 2 decimal places (e.g. `8.4564`), while the UI always displays rates rounded to 2dp. `WholesaleSaleNativeSqlController` was using the raw unrounded rate for all value/discount math, so the calculated Value didn't match what the user saw as the Rate. Confirmed against real data: the reported Amoxicillin 250mg (SPMC/SPC) batch has `WHOLESALERATE = 8.4564`, and `8.4564 x 10 = 84.564` rounds to display as 84.56 - matching the bug exactly. Other batches for the same item show the same pattern (e.g. `3.1418181818`), so this is systemic, not a one-off data error.
- Fix: round the wholesale rate to currency precision (2dp) at every point it's consumed for billing math - add item, substitute replacement, live preview (before "Add" is clicked), and the preview panel getters - using the existing `CommonFunctions.round()` helper, which is already the established convention for rounding wholesale rates elsewhere in the pharmacy module (`PharmacyPurchaseController`). Row-quantity edit and discount recalculation need no change since they already build on `bid.getRate()`, which now holds the rounded value from the moment a line is added.
- Scoped to the wholesale-sale billing path only. Root-causing this at the source (rounding `wholesaleRate` when it's computed/stored on `ItemBatch` during GRN/costing) would be a much larger change touching purchase-costing logic and historical data across the app, and is out of scope here.

## Test plan
- [x] `mvn compile` passes cleanly with the change.
- [ ] QA to verify on RMH (the environment where wholesale sale data with fractional wholesale rates exists): add the Amoxicillin 250mg (SPMC/SPC) batch with Qty 10 to a wholesale sale bill, confirm the preview and bill-items table both show Value = 84.60 (not 84.56), settle the bill, and confirm the persisted `bill_item_finance_details` net total/wholesale rate matches.
- [ ] Spot check an item whose batch already has a clean 2dp wholesale rate to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wholesale sale rates are now consistently rounded to two decimal places.
  * Gross and net amounts, line-item rates, and printed values now remain consistent when adding or replacing sale items.
  * Bill item previews display rounded rates and calculated net values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->