### PR TITLE
fix(inward): add Service Charge column to Itemized Service Summary (OPD + Inward)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -2780,6 +2780,16 @@ public class SearchController implements Serializable {
                 .sum();
     }
 
+    public double getOpdSaleSummaryServiceChargeTotal() {
+        if (opdSaleSummaryDtos == null || opdSaleSummaryDtos.isEmpty()) {
+            return 0.0;
+        }
+        return opdSaleSummaryDtos.stream()
+                .filter(dto -> dto.getServiceCharge() != null)
+                .mapToDouble(OpdSaleSummaryDTO::getServiceCharge)
+                .sum();
+    }
+
     public int getOpdAnalyticsIndex() {
         return opdAnalyticsIndex;
     }

--- a/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
@@ -29,6 +29,10 @@ public class OpdSaleSummaryDTO implements Serializable {
     private String bhtNo;
     private String patientName;
 
+    // Service charge (issue #22050): inward margin (BillItem.marginValue) added on top
+    // of the gross amount. Net = Gross + Service Charge - Discount. Zero for OPD rows.
+    private Double serviceCharge;
+
     public OpdSaleSummaryDTO() {
     }
 
@@ -96,6 +100,23 @@ public class OpdSaleSummaryDTO implements Serializable {
         this.billedDate = billedDate;
         this.bhtNo = bhtNo;
         this.patientName = patientName;
+    }
+
+    // NEW (issue #22050): Per-billing-instance constructor with the service charge
+    // (inward margin). Delegates to the #21920 per-instance constructor.
+    public OpdSaleSummaryDTO(Long categoryId, String categoryName,
+                              Long itemId, String itemName,
+                              Long billItemId, Date billedDate,
+                              String bhtNo, String patientName,
+                              Long itemCount,
+                              Double hospitalFee, Double professionalFee,
+                              Double grossAmount, Double discountAmount,
+                              Double netTotal,
+                              Double serviceCharge) {
+        this(categoryId, categoryName, itemId, itemName, billItemId, billedDate,
+             bhtNo, patientName, itemCount,
+             hospitalFee, professionalFee, grossAmount, discountAmount, netTotal);
+        this.serviceCharge = serviceCharge;
     }
 
     public String getCategoryName() {
@@ -216,5 +237,13 @@ public class OpdSaleSummaryDTO implements Serializable {
 
     public void setPatientName(String patientName) {
         this.patientName = patientName;
+    }
+
+    public Double getServiceCharge() {
+        return serviceCharge;
+    }
+
+    public void setServiceCharge(Double serviceCharge) {
+        this.serviceCharge = serviceCharge;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/OpdSaleSummaryDTO.java
@@ -31,7 +31,7 @@ public class OpdSaleSummaryDTO implements Serializable {
 
     // Service charge (issue #22050): inward margin (BillItem.marginValue) added on top
     // of the gross amount. Net = Gross + Service Charge - Discount. Zero for OPD rows.
-    private Double serviceCharge;
+    private Double serviceCharge = 0.0;
 
     public OpdSaleSummaryDTO() {
     }
@@ -116,7 +116,7 @@ public class OpdSaleSummaryDTO implements Serializable {
         this(categoryId, categoryName, itemId, itemName, billItemId, billedDate,
              bhtNo, patientName, itemCount,
              hospitalFee, professionalFee, grossAmount, discountAmount, netTotal);
-        this.serviceCharge = serviceCharge;
+        this.serviceCharge = serviceCharge != null ? serviceCharge : 0.0;
     }
 
     public String getCategoryName() {

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -3297,7 +3297,8 @@ public class BillService {
                 + " bi.staffFee,"
                 + " bi.grossValue,"
                 + " bi.discount,"
-                + " bi.netValue"
+                + " bi.netValue,"
+                + " bi.marginValue" // Service charge (issue #22050) — inverted on cancellation items like the other values
                 + ") "
                 // All LEFT JOINs: item/category and patientEncounter/patient may be null on
                 // some rows. A path expression (e.g. bi.item.category.id or b.patientEncounter.bhtNo)

--- a/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
+++ b/src/main/webapp/inward/inward_itemized_service_summary_dto.xhtml
@@ -200,6 +200,17 @@
                         </h:outputText>
                     </p:column>
                     <p:column class="text-end">
+                        <f:facet name="header"><h:outputText value="Service Charge" /></f:facet>
+                        <f:facet name="footer">
+                            <h:outputText value="#{searchController.opdSaleSummaryServiceChargeTotal}" style="font-weight: bold;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </f:facet>
+                        <h:outputText value="#{row.serviceCharge}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </p:column>
+                    <p:column class="text-end">
                         <f:facet name="header"><h:outputText value="Discount" /></f:facet>
                         <f:facet name="footer">
                             <h:outputText value="#{searchController.opdSaleSummaryDiscountTotal}" style="font-weight: bold;">


### PR DESCRIPTION
## Summary

Fixes the two bugs reported in #22050 on the **Itemized Service Summary - OPD and Inward** report (`/inward/inward_itemized_service_summary_dto.xhtml`):

1. **Service Charge column was missing** — added it (the inward margin, `BillItem.marginValue`) between *Gross Amount* and *Discount*, with a footer grand total. The Excel export includes it automatically via the existing `p:dataExporter target="tbl"`.
2. **Cancelled bills added to the report instead of deducting** — root cause was double negation (inward cancellation `BillItem`s already store negative values and the old aggregated query negated them again). This was fixed by the merged PR #22051, which this branch builds on; verified end-to-end here.

Closes #22050

## What changed

- `OpdSaleSummaryDTO`: new `serviceCharge` field + one **new** delegating constructor (existing constructors untouched, per DTO guidelines)
- `BillService.fetchItemizedServiceInstanceDTOs`: selects `bi.marginValue` (stored sign used as-is — `BillItem.invertValue` inverts `marginValue` on cancellation, so cancellations deduct)
- `SearchController`: `getOpdSaleSummaryServiceChargeTotal()` mirroring the existing footer-total getters
- Report page: new **Service Charge** column with footer total

No schema change (no new persisted fields), so no DDL regeneration needed.

## Verification (local Payara + browser E2E + DB cross-check)

Exercised on the local `coop` DB, Inward department:

1. Added **Inward ETU ECG** to **BHT/56744** → bill `Inward//26/000466` (gross 400.00, service charge 56.00, net 456.00)
2. Report showed the row with **Service Charge 56.00**
3. Cancelled the bill (`Inward/INWCAN/36`) → report shows a separate negative row (Count −1, Gross −400.00, Service Charge **−56.00**, Net −456.00) and all grand totals net to **0.00**

![Report showing service charge column and cancellation deduction](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-22050-service-charge-and-cancellation.png)

DB cross-check — report rows match `BILLITEM` exactly:

```
DEPTID              BILLTYPEATOMIC                    GROSS  MARGIN  NET
Inward//26/000466   INWARD_SERVICE_BILL                 400      56   456
Inward/INWCAN/36    INWARD_SERVICE_BILL_CANCELLATION   -400     -56  -456
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Service Charge** column to itemized service summaries.
  * Service charges are displayed per row and totaled in the table footer.
  * Service charge handling is now consistent across regular sales and refund/cancellation rows.
* **Bug Fixes**
  * Corrected the itemized query-to-DTO mapping so service charge values use the stored sign consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->