### PR TITLE
Add configurable day-limit and approval workflow for pharmacy retail sale returns

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -597,6 +597,23 @@ double-negates them to positive — this is the "fee doubling after cancellation
 (which has no stored value). Verify by summing `bi.netValue` directly in SQL and matching
 the report's Grand Total.
 
+## 26. Editing a `ConfigOption` via raw SQL is invisible to the running app — use the admin UI
+
+`ConfigOptionApplicationController.getApplicationOption(key)` reads through EclipseLink's
+shared L2 entity cache. A direct `UPDATE configoption SET optionvalue=... WHERE optionkey=...`
+via the `mysql` CLI changes the DB row but the already-cached `ConfigOption` entity in the
+running Payara instance keeps serving the old value — `getLongValueByKey`/`getBooleanValueByKey`
+never see the change, with no error or log entry. This wasted a full test cycle while verifying
+a day-limit config for issue #22055 (two `UPDATE` statements had zero effect on rendered button
+state).
+
+**Fix:** edit config values through `admin/institutions/admin_mange_application_options.xhtml`
+(List Application Options → filter by Key → **Edit Option** → Save). That path goes through
+the entity manager and correctly invalidates the cache, and the change is visible on the very
+next page load — no redeploy or Payara restart needed. Reserve raw SQL for *reading* config
+state (e.g. confirming a key auto-created with the right default on first access), never for
+writing it mid-test.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -642,6 +642,7 @@ public class EnumController implements Serializable {
         rt.add(RequestType.DRAWER_ADJUSTMENT);
         rt.add(RequestType.PETTYCASH_APROVEL);
         rt.add(RequestType.PETTYCASH_CANCELLATION);
+        rt.add(RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
         //rt.add(RequestType.EDIT_REQUEST);
         //rt.add(RequestType.INFORMATION_UPDATE);
         //rt.add(RequestType.QUANTITY_CHANGE);

--- a/src/main/java/com/divudi/bean/common/RequestController.java
+++ b/src/main/java/com/divudi/bean/common/RequestController.java
@@ -594,9 +594,9 @@ public class RequestController implements Serializable {
             return;
         }
 
-        Request existing = requestService.findApprovedRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
+        Request existing = requestService.findActiveRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
         if (existing != null) {
-            JsfUtil.addErrorMessage("There is already an approved return request for this bill.");
+            JsfUtil.addErrorMessage("There is already a pending or approved return request for this bill.");
             return;
         }
 
@@ -847,13 +847,13 @@ public class RequestController implements Serializable {
             return;
         }
 
-        if (currentRequest.getStatus() == RequestStatus.APPROVED) {
-            JsfUtil.addErrorMessage("This Request is Already Approved");
+        if (currentRequest.getRequestType() != RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL) {
+            JsfUtil.addErrorMessage("Invalid request type for pharmacy retail sale return approval.");
             return;
         }
 
-        if (currentRequest.getStatus() == RequestStatus.REJECTED) {
-            JsfUtil.addErrorMessage("This Request is Already Rejected");
+        if (currentRequest.getStatus() != RequestStatus.PENDING && currentRequest.getStatus() != RequestStatus.UNDER_REVIEW) {
+            JsfUtil.addErrorMessage("Only pending or under-review requests can be approved.");
             return;
         }
 

--- a/src/main/java/com/divudi/bean/common/RequestController.java
+++ b/src/main/java/com/divudi/bean/common/RequestController.java
@@ -269,6 +269,12 @@ public class RequestController implements Serializable {
             case PETTYCASH_APROVEL:
                 pettyCashBillController.setCurrentRequest(currentRequest);
                 break;
+            case PHARMACY_RETAIL_SALE_RETURN_APPROVAL:
+                if (!webUserController.hasPrivilege("PharmacyRetailSaleReturnApproval")) {
+                    JsfUtil.addErrorMessage("You are not authorized to approve pharmacy retail sale return requests.");
+                    return "";
+                }
+                break;
             default:
                 JsfUtil.addErrorMessage("Approval is not supported for this request type.");
                 return "";
@@ -332,6 +338,15 @@ public class RequestController implements Serializable {
                 pettyCashPayeeType = resolvePettyCashPayeeType(currentRequest.getBill());
                 comment = null;
                 navigation = "/common/request/petty_cash_bill_cancellation_request?faces-redirect=true";
+                break;
+            case PHARMACY_RETAIL_SALE:
+            case PHARMACY_RETAIL_SALE_PRE:
+            case PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER:
+            case PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER:
+                bills.add(currentRequest.getBill());
+                patient = currentRequest.getBill().getPatient();
+                comment = null;
+                navigation = "/common/request/pharmacy_retail_sale_return_request_approvel?faces-redirect=true";
                 break;
             default:
                 navigation = "";
@@ -569,6 +584,54 @@ public class RequestController implements Serializable {
         printPreview = true;
     }
 
+    public void createRequestForPharmacyRetailSaleReturn(Bill saleBill) {
+        if (saleBill == null) {
+            JsfUtil.addErrorMessage("Bill not found for Create Request");
+            return;
+        }
+        if (comment == null || comment.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a comment explaining the return request.");
+            return;
+        }
+
+        Request existing = requestService.findApprovedRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
+        if (existing != null) {
+            JsfUtil.addErrorMessage("There is already an approved return request for this bill.");
+            return;
+        }
+
+        Request newlyRequest = new Request();
+
+        newlyRequest.setBill(saleBill);
+        newlyRequest.setRequester(sessionController.getLoggedUser());
+        newlyRequest.setRequestAt(new Date());
+        newlyRequest.setRequestReason(comment);
+        newlyRequest.setRequestType(RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
+        newlyRequest.setStatus(RequestStatus.PENDING);
+
+        newlyRequest.setInstitution(sessionController.getInstitution());
+        newlyRequest.setDepartment(sessionController.getDepartment());
+
+        String reqNo = billNumberGenerator.departmentRequestNumberGeneratorYearly(sessionController.getDepartment(), RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL);
+        newlyRequest.setRequestNo(reqNo);
+
+        requestService.save(newlyRequest, sessionController.getLoggedUser());
+
+        saleBill.setCurrentRequest(newlyRequest);
+        billFacade.edit(saleBill);
+
+        comment = null;
+        JsfUtil.addSuccessMessage("Approval request submitted.");
+    }
+
+    public void createRequestForPharmacyRetailSaleReturnById(Long saleBillId) {
+        if (saleBillId == null) {
+            JsfUtil.addErrorMessage("No Bill ID provided.");
+            return;
+        }
+        createRequestForPharmacyRetailSaleReturn(billFacade.find(saleBillId));
+    }
+
     public void createRequestforInpatientServiceBill() {
         if (batchBill == null) {
             JsfUtil.addErrorMessage("Bill not found for Create Request ");
@@ -778,6 +841,41 @@ public class RequestController implements Serializable {
 
     }
 
+    public void approvePharmacyRetailSaleReturnRequest() {
+        if (currentRequest == null) {
+            JsfUtil.addErrorMessage("Request not found for approval");
+            return;
+        }
+
+        if (currentRequest.getStatus() == RequestStatus.APPROVED) {
+            JsfUtil.addErrorMessage("This Request is Already Approved");
+            return;
+        }
+
+        if (currentRequest.getStatus() == RequestStatus.REJECTED) {
+            JsfUtil.addErrorMessage("This Request is Already Rejected");
+            return;
+        }
+
+        if (currentRequest.getBill() == null) {
+            JsfUtil.addErrorMessage("Bill not found for request");
+            return;
+        }
+
+        if (!webUserController.hasPrivilege("PharmacyRetailSaleReturnApproval")) {
+            JsfUtil.addErrorMessage("You are not authorized to approve this request.");
+            return;
+        }
+
+        currentRequest.setApproved(true);
+        currentRequest.setApprovedAt(new Date());
+        currentRequest.setApprovedBy(sessionController.getLoggedUser());
+        currentRequest.setStatus(RequestStatus.APPROVED);
+        requestService.save(currentRequest, sessionController.getLoggedUser());
+
+        JsfUtil.addSuccessMessage("Successfully Approved");
+    }
+
     public void approveDrawerAdjustmentRequest() {
         if (currentRequest == null) {
             JsfUtil.addErrorMessage("Request not found for approval");
@@ -902,6 +1000,8 @@ public class RequestController implements Serializable {
             canReject = true;
         } else if (currentRequest.getRequestType() == RequestType.PETTYCASH_CANCELLATION) {
             canReject = webUserController.hasPrivilege("PettyCashCancellationApproval");
+        } else if (currentRequest.getRequestType() == RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL) {
+            canReject = webUserController.hasPrivilege("PharmacyRetailSaleReturnApproval");
         } else {
             canReject = webUserController.hasPrivilege("BillCancelRequestApproval");
         }

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -930,6 +930,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode drawerAdjustmentRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentRequestApproval, "Drawer Adjustment Approval"), requestNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentDirect, "Drawer Adjustment Direct (No Approval)"), requestNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashCancellationApproval, "Petty-Cash Cancellation Approval"), requestNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyRetailSaleReturnApproval, "Pharmacy Retail Sale Return Approval"), requestNode);
 
         // Float Transfer Privileges
         TreeNode floatTransferNode = new DefaultTreeNode(new PrivilegeHolder(null, "Float Transfer"), allNode);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRefundForItemReturnsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRefundForItemReturnsController.java
@@ -760,6 +760,7 @@ public class PharmacyRefundForItemReturnsController implements Serializable, Con
         }
 
         Bill originalSaleBill = this.itemReturnBill.getReferenceBill();
+        // Day-limit/approval gate is enforced at the item-return step (SaleReturnController/PreReturnController), not here — intentional, see issue #22055.
 
         if (originalSaleBill == null) {
             JsfUtil.addErrorMessage("No Bill. Programmatic Error. Inform system administrator.");

--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -21,6 +21,7 @@ import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.ejb.PharmacyCalculation;
 import com.divudi.service.StaffService;
+import com.divudi.service.PharmacyRetailSaleReturnPolicyService;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.RefundBill;
@@ -77,6 +78,8 @@ public class PreReturnController implements Serializable {
     private BillItemFacade billItemFacade;
     @Inject
     PageMetadataRegistry pageMetadataRegistry;
+    @Inject
+    private PharmacyRetailSaleReturnPolicyService pharmacyRetailSaleReturnPolicyService;
 
     @PostConstruct
     public void init() {
@@ -147,6 +150,20 @@ public class PreReturnController implements Serializable {
             OptionScope.APPLICATION
         ));
 
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return - Days Allowed Without Approval",
+            "Number of days after the original sale a return is allowed without needing an approval request (default 3)",
+            "PharmacyRetailSaleReturnPolicyService.getNoApprovalDayLimit()",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return - Days Allowed With Approval",
+            "Number of days after the original sale a return remains possible with an approved request, beyond which it is hard-blocked (default 7)",
+            "PharmacyRetailSaleReturnPolicyService.getWithApprovalDayLimit()",
+            OptionScope.APPLICATION
+        ));
+
         // Privileges
         metadata.addPrivilege(new PrivilegeInfo(
             "Admin",
@@ -158,6 +175,12 @@ public class PreReturnController implements Serializable {
             "ChangeReceiptPrintingPaperTypes",
             "Ability to change receipt printing paper format settings",
             "Line 217 (XHTML): Settings button visibility for paper format configuration"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "PharmacyRetailSaleReturnApproval",
+            "Ability to approve or reject a pharmacy retail sale return approval request",
+            "RequestController.approvePharmacyRetailSaleReturnRequest() / navigateToApproveRequest()"
         ));
 
         // Register the metadata
@@ -174,6 +197,11 @@ public class PreReturnController implements Serializable {
         }
         if (!getSessionController().getDepartment().equals(bill.getDepartment())) {
             JsfUtil.addErrorMessage("You can't return another department's Issue. Please log to the billed department");
+            return null;
+        }
+        String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
+        if (returnBlockReason != null) {
+            JsfUtil.addErrorMessage(returnBlockReason);
             return null;
         }
         generateBillComponent(BillType.PharmacyPre);
@@ -208,6 +236,26 @@ public class PreReturnController implements Serializable {
 
     public void setPrintPreview(boolean printPreview) {
         this.printPreview = printPreview;
+    }
+
+    /**
+     * @param saleBill the original retail sale bill being returned
+     * @return true if the return is hard-blocked because the bill is older
+     * than the "with approval" day limit, with no possible override
+     */
+    public boolean isReturnBlockedByDayLimit(Bill saleBill) {
+        return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
+                && pharmacyRetailSaleReturnPolicyService.daysSinceBillCreation(saleBill) > pharmacyRetailSaleReturnPolicyService.getWithApprovalDayLimit();
+    }
+
+    /**
+     * @param saleBill the original retail sale bill being returned
+     * @return true if the return is still possible but requires an approved
+     * Request because the bill is older than the "no approval" day limit
+     */
+    public boolean needsReturnApproval(Bill saleBill) {
+        return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
+                && !isReturnBlockedByDayLimit(saleBill);
     }
 
     @Inject
@@ -339,6 +387,12 @@ public class PreReturnController implements Serializable {
     StaffService staffBean;
 
     public void settle() {
+        String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
+        if (returnBlockReason != null) {
+            JsfUtil.addErrorMessage(returnBlockReason);
+            return;
+        }
+
         // Check if credit has been partially or fully settled
         if (bill.getPaymentMethod() == PaymentMethod.Credit){
             if (bill != null && bill.getPaidAmount() > 0) {
@@ -346,7 +400,7 @@ public class PreReturnController implements Serializable {
                 return;
             }
         }
-        
+
         if (getReturnBill().getTotal() == 0) {
             JsfUtil.addErrorMessage("Total is Zero cant' return");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -255,7 +255,8 @@ public class PreReturnController implements Serializable {
      */
     public boolean needsReturnApproval(Bill saleBill) {
         return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
-                && !isReturnBlockedByDayLimit(saleBill);
+                && !isReturnBlockedByDayLimit(saleBill)
+                && !pharmacyRetailSaleReturnPolicyService.hasActiveReturnRequest(saleBill);
     }
 
     @Inject

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -24,6 +24,7 @@ import com.divudi.ejb.PharmacyBean;
 import com.divudi.ejb.PharmacyCalculation;
 import com.divudi.service.StaffService;
 import com.divudi.service.PaymentService;
+import com.divudi.service.PharmacyRetailSaleReturnPolicyService;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.BillFee;
@@ -104,6 +105,8 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     PaymentService paymentService;
     @Inject
     PageMetadataRegistry pageMetadataRegistry;
+    @Inject
+    private PharmacyRetailSaleReturnPolicyService pharmacyRetailSaleReturnPolicyService;
 
     PaymentMethodData paymentMethodData;
 
@@ -204,6 +207,20 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
             OptionScope.APPLICATION
         ));
 
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return - Days Allowed Without Approval",
+            "Number of days after the original sale a return is allowed without needing an approval request (default 3)",
+            "PharmacyRetailSaleReturnPolicyService.getNoApprovalDayLimit()",
+            OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Pharmacy Retail Sale Return - Days Allowed With Approval",
+            "Number of days after the original sale a return remains possible with an approved request, beyond which it is hard-blocked (default 7)",
+            "PharmacyRetailSaleReturnPolicyService.getWithApprovalDayLimit()",
+            OptionScope.APPLICATION
+        ));
+
         // Privileges
         metadata.addPrivilege(new PrivilegeInfo(
             "Admin",
@@ -215,6 +232,12 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
             "ChangeReceiptPrintingPaperTypes",
             "Ability to change receipt printing paper format settings",
             "Lines 332, 392 (XHTML): Settings button visibility for paper format configuration"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "PharmacyRetailSaleReturnApproval",
+            "Ability to approve or reject a pharmacy retail sale return approval request",
+            "RequestController.approvePharmacyRetailSaleReturnRequest() / navigateToApproveRequest()"
         ));
 
         // Register the metadata
@@ -237,7 +260,13 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
                 return null;
             }
         }
-        
+
+        String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
+        if (returnBlockReason != null) {
+            JsfUtil.addErrorMessage(returnBlockReason);
+            return null;
+        }
+
         returnBill = null;
         finalReturnBill = null;
         printPreview = false;
@@ -758,6 +787,12 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     }
 
     public void settle() {
+        String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
+        if (returnBlockReason != null) {
+            JsfUtil.addErrorMessage(returnBlockReason);
+            return;
+        }
+
         // Check if credit has been partially or fully settled
         if (bill.getPaymentMethod() == PaymentMethod.Credit){
             if (bill != null && bill.getPaidAmount() > 0) {
@@ -1405,6 +1440,26 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
             return false;
         }
         return paymentBill.getPaymentMethod() == PaymentMethod.Credit;
+    }
+
+    /**
+     * @param saleBill the original retail sale bill being returned
+     * @return true if the return is hard-blocked because the bill is older
+     * than the "with approval" day limit, with no possible override
+     */
+    public boolean isReturnBlockedByDayLimit(Bill saleBill) {
+        return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
+                && pharmacyRetailSaleReturnPolicyService.daysSinceBillCreation(saleBill) > pharmacyRetailSaleReturnPolicyService.getWithApprovalDayLimit();
+    }
+
+    /**
+     * @param saleBill the original retail sale bill being returned
+     * @return true if the return is still possible but requires an approved
+     * Request because the bill is older than the "no approval" day limit
+     */
+    public boolean needsReturnApproval(Bill saleBill) {
+        return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
+                && !isReturnBlockedByDayLimit(saleBill);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -1459,7 +1459,8 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
      */
     public boolean needsReturnApproval(Bill saleBill) {
         return pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(saleBill) != null
-                && !isReturnBlockedByDayLimit(saleBill);
+                && !isReturnBlockedByDayLimit(saleBill)
+                && !pharmacyRetailSaleReturnPolicyService.hasActiveReturnRequest(saleBill);
     }
 
     /**

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -755,6 +755,7 @@ public enum Privileges {
     DrawerAdjustmentRequestApproval("Drawer Adjustment Request Approval"),
     DrawerAdjustmentDirect("Drawer Adjustment Direct (No Approval)"),
     PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    PharmacyRetailSaleReturnApproval("Pharmacy Retail Sale Return Approval"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Float Transfer">
@@ -1138,6 +1139,7 @@ public enum Privileges {
             case DrawerAdjustmentRequestApproval:
             case DrawerAdjustmentDirect:
             case PettyCashCancellationApproval:
+            case PharmacyRetailSaleReturnApproval:
                 return "Approval";
 
             case CashierHandoverStatusReport:

--- a/src/main/java/com/divudi/core/data/RequestType.java
+++ b/src/main/java/com/divudi/core/data/RequestType.java
@@ -24,7 +24,8 @@ public enum RequestType {
     DRAWER_ADJUSTMENT("Drawer Adjustment", RequestCategory.ADJUSTMENT, "DRADJ"),
     
     PETTYCASH_APROVEL("Petty Cash Request" ,RequestCategory.APROVEL, "PTY-CH"),
-    PETTYCASH_CANCELLATION("Cancel Petty Cash" ,RequestCategory.APROVEL, "CAN-PTY-CH");
+    PETTYCASH_CANCELLATION("Cancel Petty Cash" ,RequestCategory.APROVEL, "CAN-PTY-CH"),
+    PHARMACY_RETAIL_SALE_RETURN_APPROVAL("Pharmacy Retail Sale Return Approval", RequestCategory.APROVEL, "PH-RET-APV");
     
     private final String displayName;
     private final RequestCategory category;

--- a/src/main/java/com/divudi/service/PharmacyRetailSaleReturnPolicyService.java
+++ b/src/main/java/com/divudi/service/PharmacyRetailSaleReturnPolicyService.java
@@ -25,12 +25,17 @@ public class PharmacyRetailSaleReturnPolicyService {
     @Inject
     RequestService requestService;
 
+    private static final long DEFAULT_NO_APPROVAL_DAY_LIMIT = 3L;
+    private static final long DEFAULT_WITH_APPROVAL_DAY_LIMIT = 7L;
+
     public Long getNoApprovalDayLimit() {
-        return configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed Without Approval", 3L);
+        Long value = configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed Without Approval", DEFAULT_NO_APPROVAL_DAY_LIMIT);
+        return value != null ? value : DEFAULT_NO_APPROVAL_DAY_LIMIT;
     }
 
     public Long getWithApprovalDayLimit() {
-        return configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed With Approval", 7L);
+        Long value = configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed With Approval", DEFAULT_WITH_APPROVAL_DAY_LIMIT);
+        return value != null ? value : DEFAULT_WITH_APPROVAL_DAY_LIMIT;
     }
 
     public long daysSinceBillCreation(Bill saleBill) {
@@ -42,6 +47,10 @@ public class PharmacyRetailSaleReturnPolicyService {
 
     public boolean hasApprovedReturnRequest(Bill saleBill) {
         return requestService.findApprovedRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL) != null;
+    }
+
+    public boolean hasActiveReturnRequest(Bill saleBill) {
+        return requestService.findActiveRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL) != null;
     }
 
     public String checkReturnAllowed(Bill saleBill) {

--- a/src/main/java/com/divudi/service/PharmacyRetailSaleReturnPolicyService.java
+++ b/src/main/java/com/divudi/service/PharmacyRetailSaleReturnPolicyService.java
@@ -1,0 +1,60 @@
+package com.divudi.service;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.RequestType;
+import com.divudi.core.entity.Bill;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+/**
+ * Enforces the configurable day-limit policy for pharmacy retail sale
+ * returns: allowed without approval up to N days after the original sale
+ * bill's creation, allowed with an approved Request between day N+1 and M,
+ * and hard-blocked beyond M days with no override.
+ *
+ * @author H.K. Damith Deshan | hkddrajapaksha@gmail.com
+ */
+@Stateless
+public class PharmacyRetailSaleReturnPolicyService {
+
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
+
+    @Inject
+    RequestService requestService;
+
+    public Long getNoApprovalDayLimit() {
+        return configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed Without Approval", 3L);
+    }
+
+    public Long getWithApprovalDayLimit() {
+        return configOptionApplicationController.getLongValueByKey("Pharmacy Retail Sale Return - Days Allowed With Approval", 7L);
+    }
+
+    public long daysSinceBillCreation(Bill saleBill) {
+        if (saleBill == null || saleBill.getCreatedAt() == null) {
+            return 0;
+        }
+        return ChronoUnit.DAYS.between(saleBill.getCreatedAt().toInstant(), Instant.now());
+    }
+
+    public boolean hasApprovedReturnRequest(Bill saleBill) {
+        return requestService.findApprovedRequestByBillAndType(saleBill, RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL) != null;
+    }
+
+    public String checkReturnAllowed(Bill saleBill) {
+        long days = daysSinceBillCreation(saleBill);
+        long withApprovalLimit = getWithApprovalDayLimit();
+        long noApprovalLimit = getNoApprovalDayLimit();
+        if (days > withApprovalLimit) {
+            return "This bill is " + days + " days old. Returns are not allowed after " + withApprovalLimit + " days.";
+        }
+        if (days > noApprovalLimit && !hasApprovedReturnRequest(saleBill)) {
+            return "This bill is " + days + " days old. Returns after " + noApprovalLimit + " days require an approved request. Please request approval.";
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/divudi/service/RequestService.java
+++ b/src/main/java/com/divudi/service/RequestService.java
@@ -64,6 +64,29 @@ public class RequestService {
         return req;
     }
 
+    public Request findApprovedRequestByBillAndType(Bill bill, RequestType type) {
+        if (bill == null || type == null) {
+            return null;
+        }
+
+        String jpql = "Select q from Request q "
+                + " where q.retired =:ret "
+                + " and q.bill =:bill "
+                + " and q.requestType =:type "
+                + " and q.status =:status "
+                + " order by q.id desc";
+
+        HashMap params = new HashMap();
+        params.put("ret", false);
+        params.put("bill", bill);
+        params.put("type", type);
+        params.put("status", RequestStatus.APPROVED);
+
+        Request req = requestFacade.findFirstByJpql(jpql, params);
+
+        return req;
+    }
+
     public boolean hasPendingDrawerAdjustmentRequest(WebUser requester) {
         if (requester == null) {
             return false;

--- a/src/main/java/com/divudi/service/RequestService.java
+++ b/src/main/java/com/divudi/service/RequestService.java
@@ -87,6 +87,34 @@ public class RequestService {
         return req;
     }
 
+    public Request findActiveRequestByBillAndType(Bill bill, RequestType type) {
+        if (bill == null || type == null) {
+            return null;
+        }
+
+        List<RequestStatus> availableStatus = new ArrayList<>();
+        availableStatus.add(RequestStatus.PENDING);
+        availableStatus.add(RequestStatus.UNDER_REVIEW);
+        availableStatus.add(RequestStatus.APPROVED);
+
+        String jpql = "Select q from Request q "
+                + " where q.retired =:ret "
+                + " and q.bill =:bill "
+                + " and q.requestType =:type "
+                + " and q.status in :status "
+                + " order by q.id desc";
+
+        HashMap params = new HashMap();
+        params.put("ret", false);
+        params.put("bill", bill);
+        params.put("type", type);
+        params.put("status", availableStatus);
+
+        Request req = requestFacade.findFirstByJpql(jpql, params);
+
+        return req;
+    }
+
     public boolean hasPendingDrawerAdjustmentRequest(WebUser requester) {
         if (requester == null) {
             return false;

--- a/src/main/webapp/common/request/pharmacy_retail_sale_return_request_approvel.xhtml
+++ b/src/main/webapp/common/request/pharmacy_retail_sale_return_request_approvel.xhtml
@@ -1,0 +1,216 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:na="http://xmlns.jcp.org/jsf/composite/template"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyRetailSaleReturnApproval')}">
+                        <na:not_authorize />
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{webUserController.hasPrivilege('PharmacyRetailSaleReturnApproval')}">
+                        <p:panel>
+                            <f:facet name="header">
+                                <h:outputText value="Pharmacy Retail Sale Return Approval" class="mt-5"/>
+                                <p:commandButton
+                                    id="btnBackToSearch"
+                                    ajax="false"
+                                    value="Back to Search"
+                                    icon="fa fa-arrow-left"
+                                    style="float: right;"
+                                    class="ui-button-warning"
+                                    action="#{requestController.navigateToBackSearchRequest()}">
+                                </p:commandButton>
+                            </f:facet>
+
+                            <div class="row mt-2 mb-3">
+                                <div class="d-flex justify-content-end gap-2">
+                                    <p:inputText
+                                        id="commentsMenu"
+                                        value="#{requestController.comment}"
+                                        style="width: 550px;"
+                                        rendered="#{!(requestController.currentRequest.status eq 'APPROVED')}"
+                                        readonly="#{(requestController.currentRequest.status eq 'REJECTED' or requestController.currentRequest.status eq 'COMPLETED' or requestController.currentRequest.status eq 'CANCELLED')}"
+                                        placeholder="Add Reason for Reject" >
+                                    </p:inputText>
+
+                                    <p:commandButton
+                                        id="btnApprove"
+                                        ajax="false"
+                                        value="Approve"
+                                        icon="fa fa-check"
+                                        onclick="if (!confirm('Are you sure you want to approve this pharmacy retail sale return request?'))
+                                                    return false;"
+                                        rendered="#{!(requestController.currentRequest.status eq 'APPROVED')}"
+                                        disabled="#{(requestController.currentRequest.status eq 'REJECTED' or requestController.currentRequest.status eq 'COMPLETED' or requestController.currentRequest.status eq 'CANCELLED')}"
+                                        class="ui-button-success"
+                                        action="#{requestController.approvePharmacyRetailSaleReturnRequest()}">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnReject"
+                                        ajax="false"
+                                        value="Reject"
+                                        icon="fa fa-times"
+                                        onclick="if (!confirm('Are you sure you want to reject this pharmacy retail sale return request?'))
+                                                    return false;"
+                                        rendered="#{!(requestController.currentRequest.status eq 'APPROVED')}"
+                                        disabled="#{(requestController.currentRequest.status eq 'REJECTED' or requestController.currentRequest.status eq 'COMPLETED' or requestController.currentRequest.status eq 'CANCELLED')}"
+                                        class="ui-button-danger"
+                                        action="#{requestController.rejectRequest()}">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+
+                            <!-- Patient, Bill and Request Details Panels -->
+                            <div class="row">
+                                <div class="col-4">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-id-card-alt"></h:outputText>
+                                            <h:outputLabel value="Patient Details" class="mx-2"></h:outputLabel>
+                                        </f:facet>
+
+                                        <h:panelGroup rendered="#{requestController.patient ne null}">
+                                            <common:patient patient="#{requestController.patient}" class="w-100"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{requestController.patient eq null}">
+                                            <h:outputLabel value="No Patient (Cash Sale)"></h:outputLabel>
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </div>
+                                <div class="col-4">
+                                    <p:panel id="billDetails">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa fa-file-invoice" />
+                                            <h:outputText value="Bill Details" class="mx-4"></h:outputText>
+                                        </f:facet>
+
+                                        <div style="line-height: 2.5">
+                                            <div class="row">
+                                                <div class="col-4"><h:outputLabel value="Bill No"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-7"><h:outputLabel value="#{requestController.currentRequest.bill.deptId}"></h:outputLabel></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-4"><h:outputLabel value="Bill Date"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-7">
+                                                    <h:outputLabel value="#{requestController.currentRequest.bill.createdAt}">
+                                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-4"><h:outputLabel value="Net Total"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-7">
+                                                    <h:outputLabel value="#{requestController.currentRequest.bill.netTotal}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                                <div class="col-4">
+                                    <p:panel id="requestDetails">
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fa fa-info-circle" />
+                                            <h:outputText value="Request Details" class="mx-4"></h:outputText>
+                                        </f:facet>
+
+                                        <div style="line-height: 2.5">
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request No" ></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.requestNo}" ></h:outputLabel></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request Type"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8">
+                                                    <p:badge rendered="#{requestController.currentRequest.requestType eq 'PHARMACY_RETAIL_SALE_RETURN_APPROVAL'}" value="#{requestController.currentRequest.requestType.displayName}" severity="info"></p:badge>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request Status"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><p:badge value="#{requestController.currentRequest.status.label}"></p:badge></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Requested Bill"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.bill.deptId}"></h:outputLabel></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request By"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.requester.webUserPerson.nameWithTitle}"></h:outputLabel></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request From"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.department.name}"></h:outputLabel></div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request At"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8">
+                                                    <h:outputLabel value="#{requestController.currentRequest.requestAt}">
+                                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-3"><h:outputLabel value="Request Reason"></h:outputLabel></div>
+                                                <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.requestReason}"></h:outputLabel></div>
+                                            </div>
+
+                                            <h:panelGroup rendered="#{requestController.currentRequest.rejected}">
+
+                                                <hr/>
+
+                                                <div class="row">
+                                                    <div class="col-3"><h:outputLabel value="Rejected Reason"></h:outputLabel></div>
+                                                    <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                    <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.rejectionReason}"></h:outputLabel></div>
+                                                </div>
+
+                                                <div class="row">
+                                                    <div class="col-3"><h:outputLabel value="Rejected By"></h:outputLabel></div>
+                                                    <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                    <div class="col-8"><h:outputLabel value="#{requestController.currentRequest.rejectedBy.webUserPerson.nameWithTitle}"></h:outputLabel></div>
+                                                </div>
+
+                                                <div class="row">
+                                                    <div class="col-3"><h:outputLabel value="Rejected At"></h:outputLabel></div>
+                                                    <div class="col-1"><h:outputLabel value=":" class="d-flex justify-content-center"></h:outputLabel></div>
+                                                    <div class="col-8">
+                                                        <h:outputLabel value="#{requestController.currentRequest.rejectedAt}">
+                                                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"></f:convertDateTime>
+                                                        </h:outputLabel>
+                                                    </div>
+                                                </div>
+                                            </h:panelGroup>
+                                        </div>
+
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </p:panel>
+                    </h:panelGroup>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/common/request/pharmacy_retail_sale_return_request_approvel.xhtml
+++ b/src/main/webapp/common/request/pharmacy_retail_sale_return_request_approvel.xhtml
@@ -11,7 +11,7 @@
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
-                <h:form>
+                <h:form onkeypress="if (event.keyCode === 13) { event.preventDefault(); return false; }">
                     <h:panelGroup rendered="#{!webUserController.hasPrivilege('PharmacyRetailSaleReturnApproval')}">
                         <na:not_authorize />
                     </h:panelGroup>

--- a/src/main/webapp/common/request/view_request.xhtml
+++ b/src/main/webapp/common/request/view_request.xhtml
@@ -179,6 +179,7 @@
                                             <p:badge rendered="#{r.requestType eq 'DRAWER_ADJUSTMENT'}" value="#{r.requestType.displayName}" severity="info" styleClass="mr-2"></p:badge>
                                             <p:badge rendered="#{r.requestType eq 'PETTYCASH_APROVEL'}" value="#{r.requestType.displayName}" severity="success" styleClass="mr-2"></p:badge>
                                             <p:badge rendered="#{r.requestType eq 'PETTYCASH_CANCELLATION'}" value="#{r.requestType.displayName}" severity="danger" styleClass="mr-2"></p:badge>
+                                            <p:badge rendered="#{r.requestType eq 'PHARMACY_RETAIL_SALE_RETURN_APPROVAL'}" value="#{r.requestType.displayName}" severity="info" styleClass="mr-2"></p:badge>
                                         </h:panelGroup>
                                     </p:column>
 

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
@@ -141,14 +141,59 @@
                                         </p:commandButton>
                                         <p:commandButton
                                             ajax="false"
+                                            id="btnAcceptReturn"
                                             class="m-1 ui-button-warning"
                                             value="Accept Return Items &amp; Refund"
                                             title="Return Items and Payments"
                                             icon="pi pi-undo"
                                             action="#{saleReturnController.navigateToReturnItemsAndPaymentsForPharmacyRetailSale()}"
-                                            disabled="#{billDto.cancelled eq true}">
+                                            disabled="#{billDto.cancelled eq true or saleReturnController.isReturnBlockedByDayLimit(searchController.loadBillById(billDto.id))}">
                                             <f:setPropertyActionListener value="#{searchController.loadBillById(billDto.id)}" target="#{saleReturnController.bill}"/>
                                         </p:commandButton>
+                                        <p:commandButton
+                                            id="btnRequestReturnApproval"
+                                            type="button"
+                                            class="m-1 ui-button-info"
+                                            value="Request Approval"
+                                            title="Request approval to return this bill beyond the no-approval window"
+                                            icon="pi pi-send"
+                                            onclick="PF('reqApprovalDlg#{billDto.id}').show();"
+                                            rendered="#{billDto.cancelled ne true and saleReturnController.needsReturnApproval(searchController.loadBillById(billDto.id))}">
+                                        </p:commandButton>
+
+                                        <p:dialog
+                                            id="reqApprovalDlg"
+                                            widgetVar="reqApprovalDlg#{billDto.id}"
+                                            header="Request Return Approval"
+                                            modal="true"
+                                            width="450px"
+                                            height="auto"
+                                            resizable="false"
+                                            rendered="#{billDto.cancelled ne true and saleReturnController.needsReturnApproval(searchController.loadBillById(billDto.id))}">
+                                            <div class="p-2">
+                                                <p:outputLabel for="reqApprovalComment" value="Reason for Return Approval Request" class="form-label"/>
+                                                <p:inputTextarea
+                                                    id="reqApprovalComment"
+                                                    value="#{requestController.comment}"
+                                                    rows="3"
+                                                    class="w-100"
+                                                    placeholder="Explain why this return needs approval" />
+                                                <div class="d-flex justify-content-end gap-2 mt-2">
+                                                    <p:commandButton
+                                                        value="Cancel"
+                                                        type="button"
+                                                        onclick="PF('reqApprovalDlg#{billDto.id}').hide();"
+                                                        class="ui-button-secondary" />
+                                                    <p:commandButton
+                                                        id="btnSubmitReturnApprovalRequest"
+                                                        value="Submit Request"
+                                                        ajax="false"
+                                                        icon="fa fa-paper-plane"
+                                                        class="ui-button-success"
+                                                        action="#{requestController.createRequestForPharmacyRetailSaleReturnById(billDto.id)}" />
+                                                </div>
+                                            </div>
+                                        </p:dialog>
                                     </p:column>
 
                                 </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_and_cash.xhtml
@@ -180,6 +180,7 @@
                                                     placeholder="Explain why this return needs approval" />
                                                 <div class="d-flex justify-content-end gap-2 mt-2">
                                                     <p:commandButton
+                                                        id="btnCancelReturnApproval"
                                                         value="Cancel"
                                                         type="button"
                                                         onclick="PF('reqApprovalDlg#{billDto.id}').hide();"

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
@@ -105,13 +105,58 @@
                                         </p:commandButton>
                                         <p:tooltip for="viewBill" value="View Bill"  showDelay="0" hideDelay="0"></p:tooltip>
                                         <p:commandButton
+                                            id="btnReturnItemOnly"
                                             ajax="false"
                                             value="Return Item Only "
                                             action="#{preReturnController.navigateToReturnRetailSaleItemsOnly}"
                                             class="mx-2"
-                                            disabled="#{bill.cancelled eq true}">
+                                            disabled="#{bill.cancelled eq true or preReturnController.isReturnBlockedByDayLimit(searchController.loadBillById(bill.id))}">
                                             <f:setPropertyActionListener value="#{searchController.loadBillById(bill.id)}" target="#{preReturnController.bill}"  />
                                         </p:commandButton>
+                                        <p:commandButton
+                                            id="btnRequestReturnApproval"
+                                            type="button"
+                                            value="Request Approval"
+                                            title="Request approval to return this bill beyond the no-approval window"
+                                            icon="pi pi-send"
+                                            class="mx-2"
+                                            onclick="PF('reqApprovalDlg#{bill.id}').show();"
+                                            rendered="#{bill.cancelled ne true and preReturnController.needsReturnApproval(searchController.loadBillById(bill.id))}">
+                                        </p:commandButton>
+
+                                        <p:dialog
+                                            id="reqApprovalDlg"
+                                            widgetVar="reqApprovalDlg#{bill.id}"
+                                            header="Request Return Approval"
+                                            modal="true"
+                                            width="450px"
+                                            height="auto"
+                                            resizable="false"
+                                            rendered="#{bill.cancelled ne true and preReturnController.needsReturnApproval(searchController.loadBillById(bill.id))}">
+                                            <div class="p-2">
+                                                <p:outputLabel for="reqApprovalComment" value="Reason for Return Approval Request" class="form-label"/>
+                                                <p:inputTextarea
+                                                    id="reqApprovalComment"
+                                                    value="#{requestController.comment}"
+                                                    rows="3"
+                                                    class="w-100"
+                                                    placeholder="Explain why this return needs approval" />
+                                                <div class="d-flex justify-content-end gap-2 mt-2">
+                                                    <p:commandButton
+                                                        value="Cancel"
+                                                        type="button"
+                                                        onclick="PF('reqApprovalDlg#{bill.id}').hide();"
+                                                        class="ui-button-secondary" />
+                                                    <p:commandButton
+                                                        id="btnSubmitReturnApprovalRequest"
+                                                        value="Submit Request"
+                                                        ajax="false"
+                                                        icon="fa fa-paper-plane"
+                                                        class="ui-button-success"
+                                                        action="#{requestController.createRequestForPharmacyRetailSaleReturnById(bill.id)}" />
+                                                </div>
+                                            </div>
+                                        </p:dialog>
                                     </p:column>
 
                                     <p:column width="300px" headerText="Return Bills">

--- a/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_pre_bill_for_return_item_only.xhtml
@@ -143,6 +143,7 @@
                                                     placeholder="Explain why this return needs approval" />
                                                 <div class="d-flex justify-content-end gap-2 mt-2">
                                                     <p:commandButton
+                                                        id="btnCancelReturnApproval"
                                                         value="Cancel"
                                                         type="button"
                                                         onclick="PF('reqApprovalDlg#{bill.id}').hide();"


### PR DESCRIPTION
## Summary

Adds a configurable day-limit on pharmacy retail sale returns, closing #22055:

- Returns are allowed without approval up to a configurable number of days after the original sale (default **3**).
- Between that limit and a second configurable outer limit (default **7**), returns require an **approved request**, submitted via a new "Request Approval" action and approved through the existing generic request/approval workflow (`view_request.xhtml`).
- Beyond the outer limit, returns are **hard-blocked** with no override.

Applies to all retail-sale return entry points (`SaleReturnController` and `PreReturnController`). In the two-step return flow, the check runs only at the **item-return** step — the later **cash-refund** step (`PharmacyRefundForItemReturnsController`) is intentionally left ungated so normal processing delay between pharmacist and cashier doesn't retroactively block a refund.

### Implementation

- New `PharmacyRetailSaleReturnPolicyService` (`@Stateless`) centralizes day-count math (`ChronoUnit.DAYS.between`), config lookups, and the approved-request check into a single `checkReturnAllowed(Bill)` gate reused at all call sites.
- Two new config keys (auto-created with defaults on first use): `"Pharmacy Retail Sale Return - Days Allowed Without Approval"` (3) and `"Pharmacy Retail Sale Return - Days Allowed With Approval"` (7).
- New `RequestType.PHARMACY_RETAIL_SALE_RETURN_APPROVAL` and `Privileges.PharmacyRetailSaleReturnApproval` (added to the enum, `getCategory()`, and the `UserPrivilageController` privilege tree per the 3-step privilege pattern).
- `RequestController` gained `createRequestForPharmacyRetailSaleReturn(By)Id`, `approvePharmacyRetailSaleReturnRequest()`, and new switch cases in `navigateToApproveRequest()`/`rejectRequest()`.
- New approval page `pharmacy_retail_sale_return_request_approvel.xhtml`, modeled on the existing petty-cash cancellation approval page.
- Both return search pages gained a "Request Approval" button/dialog, rendered only when a bill needs approval and none is yet approved.

### Testing

Verified end-to-end with Playwright against a local build (OPD Pharmacy department), using the admin config UI to temporarily widen the day-limit thresholds so a real historical bill could be exercised in each bucket without backdating data:

1. **Hard block** beyond the outer limit — Return button disabled, no bypass.
2. **Approval-required window** — Return blocked with the exact policy message; "Request Approval" submitted a `Request` (verified in DB: correct type/status/reason, `PH-RET-APV` numbering, `bill.currentRequest` linkage).
3. Approved the request as a user with the new `PharmacyRetailSaleReturnApproval` privilege via `view_request.xhtml` → new approval page.
4. Retried the return — succeeded, producing the item-return and cash-refund bills referencing the original sale (verified in DB).
5. Confirmed the same hard-block behavior on the two-step (item-only) flow independently.
6. Confirmed both config keys restore correctly to their defaults (3/7) via the admin config UI.

Full screenshots and details posted in [issue #22055 comment](https://github.com/hmislk/hmis/issues/22055#issuecomment-4953930123).

Also recorded a new Playwright testing gotcha (`ConfigOption` edits via raw SQL are invisible to the running app due to EclipseLink L2 caching — must use the admin UI) in `developer_docs/testing/playwright-e2e-workflow.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable time limits for pharmacy retail sale returns.
  - Returns beyond the standard period can now be submitted for approval.
  - Added approval and rejection workflows, including reasons and request status details.
  - Added a dedicated privilege for managing pharmacy retail return approvals.
  - Added clear return blocking when the maximum permitted period is exceeded.

- **Documentation**
  - Documented configuration-editing guidance for end-to-end testing and administration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->