### PR TITLE
fix(pharmacy): stamp departmentType on transfer cancellation bills and add item-derived fallback (#22056)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
@@ -259,6 +259,7 @@ public class TransferIssueCancellationController implements Serializable {
         cancellationBill.setToDepartment(originalBill.getToDepartment());
         cancellationBill.setToInstitution(originalBill.getToInstitution());
         cancellationBill.setToStaff(originalBill.getToStaff());
+        cancellationBill.setDepartmentType(originalBill.getDepartmentType());
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
@@ -11,6 +11,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -260,6 +261,12 @@ public class TransferIssueCancellationController implements Serializable {
         cancellationBill.setToInstitution(originalBill.getToInstitution());
         cancellationBill.setToStaff(originalBill.getToStaff());
         cancellationBill.setDepartmentType(originalBill.getDepartmentType());
+        if (cancellationBill.getDepartmentType() == null) {
+            // Legacy issue bills predate departmentType stamping (#22056);
+            // derive from the original items so the cancellation stays visible
+            // in department-type-filtered reports.
+            cancellationBill.setDepartmentType(singleDepartmentTypeOfItems(originalBill.getBillItems()));
+        }
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());
@@ -275,6 +282,26 @@ public class TransferIssueCancellationController implements Serializable {
         // Initialize collections
         cancellationBill.setBillItems(new ArrayList<>());
         cancellationBill.setBilledBill(originalBill);
+    }
+
+    // Returns the department type shared by all non-null item types, or null
+    // when items are mixed/untyped — never guess from a partial match (#22056).
+    private DepartmentType singleDepartmentTypeOfItems(List<BillItem> items) {
+        if (items == null) {
+            return null;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : items) {
+            if (bi.isRetired() || bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return null;
+            }
+        }
+        return found;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -785,6 +785,11 @@ public class TransferIssueController implements Serializable {
             return;
         }
 
+        if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
+            getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
+        }
+        stampDepartmentTypeFromItemsIfMissing();
+
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
             BillItem originalOrderItem = billItemsInIssue.getReferanceBillItem();
@@ -1790,6 +1795,20 @@ public class TransferIssueController implements Serializable {
             getBillFacade().create(getIssuedBill());
         } else {
             getBillFacade().edit(getIssuedBill());
+        }
+    }
+
+    // Fallback when neither the request bill nor addToBill stamped a
+    // departmentType: department-type-filtered reports drop NULL bills (#22056).
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getIssuedBill().getDepartmentType() != null) {
+            return;
+        }
+        for (BillItem bi : getBillItems()) {
+            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
+                getIssuedBill().setDepartmentType(bi.getItem().getDepartmentType());
+                return;
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -1800,15 +1800,25 @@ public class TransferIssueController implements Serializable {
 
     // Fallback when neither the request bill nor addToBill stamped a
     // departmentType: department-type-filtered reports drop NULL bills (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
     private void stampDepartmentTypeFromItemsIfMissing() {
         if (getIssuedBill().getDepartmentType() != null) {
             return;
         }
+        DepartmentType found = null;
         for (BillItem bi : getBillItems()) {
-            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
-                getIssuedBill().setDepartmentType(bi.getItem().getDepartmentType());
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
                 return;
             }
+        }
+        if (found != null) {
+            getIssuedBill().setDepartmentType(found);
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -515,6 +515,7 @@ public class TransferIssueForRequestsController implements Serializable {
             getIssuedBill().setToDepartment(requestedBill.getFromDepartment());
             getIssuedBill().setDepartmentType(requestedBill.getDepartmentType());
         }
+        stampDepartmentTypeFromItemsIfMissing();
         getIssuedBill().setCreater(sessionController.getLoggedUser());
         getIssuedBill().setCreatedAt(Calendar.getInstance().getTime());
         getIssuedBill().setCompleted(false);
@@ -877,6 +878,7 @@ public class TransferIssueForRequestsController implements Serializable {
         if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
             getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
         }
+        stampDepartmentTypeFromItemsIfMissing();
 
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
@@ -1520,6 +1522,20 @@ public class TransferIssueForRequestsController implements Serializable {
             getBillFacade().create(getIssuedBill());
         } else {
             getBillFacade().edit(getIssuedBill());
+        }
+    }
+
+    // Fallback when the request bill carries no departmentType (e.g. legacy
+    // requests): department-type-filtered reports drop bills left NULL (#22056).
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getIssuedBill().getDepartmentType() != null) {
+            return;
+        }
+        for (BillItem bi : getBillItems()) {
+            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
+                getIssuedBill().setDepartmentType(bi.getItem().getDepartmentType());
+                return;
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -16,6 +16,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -515,7 +516,6 @@ public class TransferIssueForRequestsController implements Serializable {
             getIssuedBill().setToDepartment(requestedBill.getFromDepartment());
             getIssuedBill().setDepartmentType(requestedBill.getDepartmentType());
         }
-        stampDepartmentTypeFromItemsIfMissing();
         getIssuedBill().setCreater(sessionController.getLoggedUser());
         getIssuedBill().setCreatedAt(Calendar.getInstance().getTime());
         getIssuedBill().setCompleted(false);
@@ -531,6 +531,10 @@ public class TransferIssueForRequestsController implements Serializable {
             }
         }
         setBillItems(nonZeroItems);
+
+        // Stamp after zero-qty removal so dropped lines cannot decide the type;
+        // persisted by the final bill edit below.
+        stampDepartmentTypeFromItemsIfMissing();
 
         for (BillItem bi : getBillItems()) {
             updateBillItemRateAndValue(bi);
@@ -1527,15 +1531,25 @@ public class TransferIssueForRequestsController implements Serializable {
 
     // Fallback when the request bill carries no departmentType (e.g. legacy
     // requests): department-type-filtered reports drop bills left NULL (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
     private void stampDepartmentTypeFromItemsIfMissing() {
         if (getIssuedBill().getDepartmentType() != null) {
             return;
         }
+        DepartmentType found = null;
         for (BillItem bi : getBillItems()) {
-            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
-                getIssuedBill().setDepartmentType(bi.getItem().getDepartmentType());
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
                 return;
             }
+        }
+        if (found != null) {
+            getIssuedBill().setDepartmentType(found);
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
@@ -246,6 +246,7 @@ public class TransferReceiveCancellationController implements Serializable {
         cancellationBill.setFromInstitution(originalReceiveBill.getFromInstitution());
         cancellationBill.setToDepartment(originalReceiveBill.getToDepartment());
         cancellationBill.setToInstitution(originalReceiveBill.getToInstitution());
+        cancellationBill.setDepartmentType(originalReceiveBill.getDepartmentType());
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
@@ -11,6 +11,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -247,6 +248,12 @@ public class TransferReceiveCancellationController implements Serializable {
         cancellationBill.setToDepartment(originalReceiveBill.getToDepartment());
         cancellationBill.setToInstitution(originalReceiveBill.getToInstitution());
         cancellationBill.setDepartmentType(originalReceiveBill.getDepartmentType());
+        if (cancellationBill.getDepartmentType() == null) {
+            // Legacy receive bills predate departmentType stamping (#22056);
+            // derive from the original items so the cancellation stays visible
+            // in department-type-filtered reports.
+            cancellationBill.setDepartmentType(singleDepartmentTypeOfItems(originalReceiveBill.getBillItems()));
+        }
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());
@@ -265,6 +272,26 @@ public class TransferReceiveCancellationController implements Serializable {
 
         // Initialize collections
         cancellationBill.setBillItems(new ArrayList<>());
+    }
+
+    // Returns the department type shared by all non-null item types, or null
+    // when items are mixed/untyped — never guess from a partial match (#22056).
+    private DepartmentType singleDepartmentTypeOfItems(List<BillItem> items) {
+        if (items == null) {
+            return null;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : items) {
+            if (bi.isRetired() || bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return null;
+            }
+        }
+        return found;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1022,6 +1022,7 @@ public class TransferReceiveController implements Serializable {
         if (getIssuedBill().getDepartmentType() != null) {
             getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
         }
+        stampDepartmentTypeFromItemsIfMissing();
         List<BillItem> itemsToAdd = new ArrayList<>();
 
         for (BillItem i : getReceivedBill().getBillItems()) {
@@ -1149,6 +1150,7 @@ public class TransferReceiveController implements Serializable {
         if (getIssuedBill().getDepartmentType() != null) {
             getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
         }
+        stampDepartmentTypeFromItemsIfMissing();
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());
@@ -1165,6 +1167,20 @@ public class TransferReceiveController implements Serializable {
             }
         } else {
             getBillFacade().edit(getReceivedBill());
+        }
+    }
+
+    // Fallback when the issued bill carries no departmentType (legacy issues):
+    // department-type-filtered reports drop bills left NULL (#22056).
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getReceivedBill().getDepartmentType() != null) {
+            return;
+        }
+        for (BillItem bi : getReceivedBill().getBillItems()) {
+            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
+                getReceivedBill().setDepartmentType(bi.getItem().getDepartmentType());
+                return;
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import javax.persistence.TemporalType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.dataStructure.SearchKeyword;
 import com.divudi.ejb.BillNumberGenerator;
@@ -891,6 +892,10 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setFromStaff(getIssuedBill().getToStaff());
         getReceivedBill().setFromInstitution(getIssuedBill().getInstitution());
         getReceivedBill().setFromDepartment(getIssuedBill().getDepartment());
+        if (getIssuedBill().getDepartmentType() != null) {
+            getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
+        }
+        stampDepartmentTypeFromItemsIfMissing();
 
         if (getReceivedBill().getId() == null) {
             getBillFacade().create(getReceivedBill());
@@ -938,6 +943,10 @@ public class TransferReceiveController implements Serializable {
             getReceivedBill().setFromDepartment(getIssuedBill().getDepartment());
             getReceivedBill().setToInstitution(getSessionController().getInstitution());
             getReceivedBill().setToDepartment(getSessionController().getDepartment());
+            if (getIssuedBill().getDepartmentType() != null) {
+                getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
+            }
+            stampDepartmentTypeFromItemsIfMissing();
 
             if (getReceivedBill().getId() == null) {
                 getBillFacade().create(getReceivedBill());
@@ -1172,15 +1181,25 @@ public class TransferReceiveController implements Serializable {
 
     // Fallback when the issued bill carries no departmentType (legacy issues):
     // department-type-filtered reports drop bills left NULL (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
     private void stampDepartmentTypeFromItemsIfMissing() {
         if (getReceivedBill().getDepartmentType() != null) {
             return;
         }
+        DepartmentType found = null;
         for (BillItem bi : getReceivedBill().getBillItems()) {
-            if (bi.getItem() != null && bi.getItem().getDepartmentType() != null) {
-                getReceivedBill().setDepartmentType(bi.getItem().getDepartmentType());
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
                 return;
             }
+        }
+        if (found != null) {
+            getReceivedBill().setDepartmentType(found);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the Stock Transfer Report Department Type filter silently dropping transfer bills whose `DEPARTMENTTYPE` is NULL (`IN :departmentTypes` never matches NULL). The report JPQL was already correct — the bills were never stamped. See #22056 for the full root-cause analysis and regression timeline (regression window ~2026-05-30 → 2026-06-30 after PR #21328; partially fixed by PR #21754 which left cancellations and legacy-null fallbacks uncovered).

## Changes

- **TransferIssueCancellationController / TransferReceiveCancellationController** — copy `departmentType` from the original bill onto the cancellation bill. Previously never stamped, so every `PHARMACY_ISSUE_CANCELLED` / `PHARMACY_RECEIVE_CANCELLED` bill was NULL and escaped department-type-filtered reports (cancellations stopped offsetting their originals).
- **TransferIssueForRequestsController** (save + settle) — after copying from the request bill, fall back to the bill items' `item.departmentType` when still null (legacy requests carry no departmentType).
- **TransferIssueController** (legacy settle path, disbursement flow) — stamp from the request bill with the same item-derived fallback; this path previously never stamped at settle.
- **TransferReceiveController** (`settleApprove` + `saveBill`) — item-derived fallback when the issued bill carries no departmentType, so receives of legacy null-typed issues self-heal.

The item-derived fallback mirrors the existing single-type-per-bill rule already enforced in `addToBill` (mixed types are rejected at entry), so taking the first non-null item type is safe.

## Testing

- `mvn compile` passes.
- Backfill of existing NULL data is tracked separately: #22057 (Ruhunu production), #22058 (Ruhunu staging). Item-derived typing was validated against the staging copy: all 50 NULL transfer bills resolve to a single item department type (41 Store, 9 Pharmacy).

Closes #22056

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved department classification for pharmacy transfer issues and receipts, including legacy records.
  * Department information is now retained when creating cancellation records.
  * Reports and filters are less likely to show missing department types for transferred, received, or cancelled bills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->