### PR TITLE
fix(inward): remove dead rendered guards on primitive boolean fields in admission details (#21878)

### DIFF
--- a/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/admission_details.xhtml
@@ -41,22 +41,18 @@
                         </div>
                     </h:panelGroup>
 
-                    <h:panelGroup rendered="#{cc.attrs.admission.foriegner ne null}">
-                        <div class="row">
-                            <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
-                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                            <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
-                        </div>
-                    </h:panelGroup>
+                    <div class="row">
+                        <div class="col-md-5"><p:outputLabel value="Citizenship" /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                        <div class="col-md-6"> <h:outputLabel value="#{cc.attrs.admission.foriegner ? 'Foreigner' : 'Local'}" /></div>
+                    </div>
 
-                    <h:panelGroup rendered="#{cc.attrs.admission.claimable ne null}">
-                        <div class="row">
-                            <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
-                            <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                            <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
-                            </div>
+                    <div class="row">
+                        <div class="col-md-5"><p:outputLabel value="Claimable/Non-Claimable" /></div>
+                        <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                        <div class="col-md-6"><h:outputText value="#{cc.attrs.admission.claimable ? 'Claimable' : 'Non-Claimable'}" />
                         </div>
-                    </h:panelGroup>
+                    </div>
 
                     <h:panelGroup rendered="#{cc.attrs.admission.referringDoctor ne null or cc.attrs.admission.referringConsultant ne null}">
                         <div class="row">


### PR DESCRIPTION
Cleanup PR opened to bring an existing feature branch that was ahead of `development` into review.

Branch: `21878-admission-details-hide-empty-labels`
Relates to #21878

This PR was created as part of a branch-cleanup pass. Commits already existed on the branch; this simply opens them for review against `development`. Please review for relevance — if the work is stale or superseded, close and delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)