### PR TITLE
fix(pharmacy): store search sale bill item UI and transferReceive font tweaks

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/hims</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/himsaudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,14 +2,14 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/hims</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/himsaudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issued_list.xhtml
@@ -43,7 +43,7 @@
                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                             rowsPerPageTemplate="5,10,15"
                             >                       
-                            <p:column headerText="Issue No" width="100px">                        
+                            <p:column headerText="Issue No" width="100px">
                                 <h:outputLabel value="#{p.deptId}"/>                          
                             </p:column>
                             <p:column headerText="Status" width="100px">                        

--- a/src/main/webapp/resources/pharmacy/transferReceive.xhtml
+++ b/src/main/webapp/resources/pharmacy/transferReceive.xhtml
@@ -16,39 +16,39 @@
         <h:outputStylesheet library="css" name="pharmacyA4.css"/>
         <div >
 
-            <table style="width: 100%; border-collapse: collapse; font-size: #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Headings in Pharmacy Disbursement Reports', '12pt')}!Important;">
+            <table style="width: 100%; border-collapse: collapse; font-size:2px #{configOptionApplicationController.getShortTextValueByKey('Report Font Size of Headings in Pharmacy Disbursement Reports', '12pt')}!Important;">
                 <!-- Institution Details -->
                 <tr>
-                    <td colspan="2" style="text-align: center; font-weight: bold;">
+                    <td colspan="2" style="text-align: center; font-weight: bold; font-size: 12px;">
                         <h:outputLabel value="#{cc.attrs.bill.creater.department.printingName}" />
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2" style="text-align: center;">
+                    <td colspan="2" style="text-align: center; font-size: 12px;">
                         <h:outputLabel value="#{cc.attrs.bill.creater.department.address}" />
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2" style="text-align: center;">
+                    <td colspan="2" style="text-align: center; font-size: 12px;">
                         <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone1}" />
                         <h:outputLabel value=" / " rendered="#{not empty cc.attrs.bill.creater.department.telephone2}" />
                         <h:outputLabel value="#{cc.attrs.bill.creater.department.telephone2}" />
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2" style="text-align: center;">
+                    <td colspan="2" style="text-align: center; font-size: 12px;">
                         <h:outputLabel value="Fax: #{cc.attrs.bill.creater.department.fax}" rendered="#{not empty cc.attrs.bill.creater.department.fax}" />
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2" style="text-align: center;">
+                    <td colspan="2" style="text-align: center; font-size: 12px;">
                         <h:outputLabel value="Email: #{cc.attrs.bill.creater.department.email}" rendered="#{not empty cc.attrs.bill.creater.department.email}" />
                     </td>
                 </tr>
 
                 <!-- Bill Heading -->
                 <tr>
-                    <td colspan="2" style="text-align: center; font-size: 1.2em; text-decoration: underline;">
+                    <td colspan="2" style="text-align: center; font-size: 12px; text-decoration: underline;">
                         <h:outputLabel value="Transfer Receive Note" />
                         <h:outputLabel value="**Cancelled**" style="color: red;" rendered="#{cc.attrs.bill.billedBill.cancelled eq true}" />
                     </td>
@@ -56,39 +56,39 @@
 
                 <!-- Bill Details -->
                 <tr>
-                    <td style="width: 50%; padding: 1px;">
+                    <td style="width: 50%; padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Location From: #{cc.attrs.bill.fromDepartment.name}" />
                     </td>
-                    <td style="width: 50%; padding: 1px;">
+                    <td style="width: 50%; padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Location To: #{cc.attrs.bill.department.name}" />
                     </td>
                 </tr>
                 <tr>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Received Person: #{cc.attrs.bill.creater.staff.code}" />
                     </td>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Issued Person: #{cc.attrs.bill.backwardReferenceBill.creater.staff.code}" />
                     </td>
                 </tr>
                 <tr>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Receive No: #{cc.attrs.bill.deptId}" />
                     </td>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Issue No: #{cc.attrs.bill.backwardReferenceBill.deptId}" />
                     </td>
                 </tr>
                 <tr>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Received Time: #{cc.attrs.bill.createdAt}" />
                     </td>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Issue Time: #{cc.attrs.bill.backwardReferenceBill.createdAt}" />
                     </td>
                 </tr>
                 <tr>
-                    <td style="padding: 1px;">
+                    <td style="padding: 1px; font-size: 12px;">
                         <h:outputLabel value="Transporter: #{cc.attrs.bill.fromStaff.person.nameWithTitle}" />
                     </td>
                     <td></td>
@@ -107,7 +107,7 @@
                     rowKey="#{bip.id}">
                     <p:column 
                         width="2em"
-                        style="padding: 0px; margin: 0px; "
+                        style="padding: 0px; margin: 0px; font-size: 12px;"
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Serial Number is required in Pharmacy Disbursement Reports', true)}">
                         <f:facet name="header">
                             <h:outputLabel value="No"/>
@@ -120,14 +120,14 @@
                     <p:column
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Code is required in Pharmacy Disbursement Reports', true)}"
                         width="2em"
-                        style="padding: 0px; margin: 0px; " >
+                        style="padding: 0px; margin: 0px; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Code"/>
                         </f:facet>
                         <h:outputLabel value="#{bip.item.code}"/>
                     </p:column>    
 
-                    <p:column   style="padding: 0px; margin: 0px; width: 15em" >
+                    <p:column   style="padding: 0px; margin: 0px; width: 15em; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Item"/>
                         </f:facet>
@@ -140,7 +140,7 @@
 
                     <p:column 
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Date of Expiary is required in Pharmacy Disbursement Reports', true)}"
-                        width="6em" style="padding: 0px; margin: 0px; text-align: right;" >
+                        width="6em" style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="D O E"/>
                         </f:facet>
@@ -149,7 +149,7 @@
                         </h:outputLabel>
                     </p:column>
 
-                    <p:column  width="6em" style="padding: 0px; margin: 0px; text-align: right;" >
+                    <p:column  width="6em" style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="QTY"/>
                         </f:facet>
@@ -160,7 +160,7 @@
 
                     <p:column  
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Purchase Rate is required in Pharmacy Disbursement Reports', true)}"
-                        width="5em" style="padding: 0px; margin: 0px; text-align: right;" >
+                        width="5em" style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Rate"/>
                         </f:facet>
@@ -171,7 +171,7 @@
 
                     <p:column
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Purchase Value is required in Pharmacy Disbursement Reports', true)}"
-                        width="6em" style="padding: 0px; margin: 0px; text-align: right;" >
+                        width="6em" style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Purchase Value"/>
                         </f:facet>
@@ -189,7 +189,7 @@
                     <p:column 
                         width="5em" 
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Retail Rate is required in Pharmacy Disbursement Reports', true)}"
-                        style="padding: 0px; margin: 0px; text-align: right;" >
+                        style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Retail Rate"/>
                         </f:facet>
@@ -201,7 +201,7 @@
                     <p:column 
                         width="5em" 
                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Report Columns - Retail Value is required in Pharmacy Disbursement Reports', true)}"
-                        style="padding: 0px; margin: 0px; text-align: right;" >
+                        style="padding: 0px; margin: 0px; text-align: right; font-size: 12px;" >
                         <f:facet name="header">
                             <h:outputLabel value="Retail Value"/>
                         </f:facet>
@@ -244,7 +244,7 @@
                 </h:outputScript>
             </div>
             <div class="w-100" style="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Receive Bill Footer CSS')}" >
-                <p:outputLabel value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Receive Bill Footer Text')}" escape="false" ></p:outputLabel>
+                <p:outputLabel value="#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Transfer Receive Bill Footer Text')}" escape="false" style="font-size: 12px;" ></p:outputLabel>
             </div>
 
         </div>

--- a/src/main/webapp/store/store_search_sale_bill_item_bht.xhtml
+++ b/src/main/webapp/store/store_search_sale_bill_item_bht.xhtml
@@ -6,132 +6,127 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 
-    <h:body>
-        <ui:composition template="/resources/template/template.xhtml">
-            <ui:define name="content">
-                <h:form>
-                    <p:panel>
-                        <f:facet name="header" >
-                            <h:outputLabel value="Search Store Bill Item"/>                                                          
-                        </f:facet>
+<h:body>
+    <ui:composition template="/resources/template/template.xhtml">
+        <ui:define name="content">
+            <h:form>
+                <p:panel>
+                    <f:facet name="header">
+                        <h:outputLabel value="Search Store Bill Item"/>
+                    </f:facet>
 
-                        <h:panelGroup class="d-flex gap-2">
-                            <h:panelGrid class="col-1 mx-1">
-                                <h:panelGrid columns="1" class="mt-1">
-                                    <h:outputLabel value="From Date"/>
-                                    <p:calendar 
-                                        styleClass="dateTimePicker" 
-                                        id="fromDate" 
-                                        value="#{searchController.fromDate}" 
-                                        navigator="false" 
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >      
-                                    </p:calendar>
-                                    <h:outputLabel value="To Date"/>
-                                    <p:calendar 
-                                        id="toDate" 
-                                        value="#{searchController.toDate}" 
-                                        navigator="false" 
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >                                                                              
-                                    </p:calendar>
-                                    <p:commandButton 
-                                        id="btnSearch" 
-                                        ajax="false" 
-                                        value="Search" 
-                                        class="mt-2  w-100"
-                                        action="#{searchController.createPharmacyBillItemTableBht()}"/>
-                                </h:panelGrid>
+                    <div class="d-flex gap-2">
 
-                                <h:panelGrid columns="1" class="mt-2">
-                                    <h:outputLabel value="Bill No"/>
-                                    <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
-                                    <h:outputLabel value="BHT No"/>
-                                    <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.bhtNo}" />
-                                    <h:outputLabel value="Item Name"/>   
-                                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}" />
-                                    <h:outputLabel value="Item Value"/>   
-                                    <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.total}" />
-                                    <h:outputLabel value="Patient"/>  
-                                    <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.patientName}" />
-                                    <h:outputLabel  value="Item Code"/>
-                                    <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
-                                </h:panelGrid>
+                        <div class="col-2">
+                            <h:panelGrid columns="1" class="w-100">
+                                <h:outputLabel value="From Date" for="fromDate"/>
+                                <p:calendar
+                                        id="fromDate"
+                                        value="#{searchController.fromDate}"
+                                        styleClass="w-100"
+                                        inputStyleClass="form-control"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                                <h:outputLabel value="To Date" for="toDate"/>
+                                <p:calendar
+                                        id="toDate"
+                                        value="#{searchController.toDate}"
+                                        styleClass="w-100"
+                                        inputStyleClass="form-control"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                                <p:commandButton
+                                        id="btnSearch"
+                                        ajax="false"
+                                        value="Search"
+                                        icon="fa fa-search"
+                                        class="mt-2 mb-3 w-100 ui-button-warning"
+                                        action="#{searchController.createStoreTableBht}"/>
+
+                                <h:outputLabel value="Bill No" for="billNo"/>
+                                <p:inputText id="billNo" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.billNo}"/>
+
+                                <h:outputLabel value="BHT No" for="bhtNo"/>
+                                <p:inputText id="bhtNo" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.bhtNo}"/>
+
+                                <h:outputLabel value="Item Name" for="itemName"/>
+                                <p:inputText id="itemName" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.itemName}"/>
+
+                                <h:outputLabel value="Item Value" for="itemValue"/>
+                                <p:inputText id="itemValue" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.total}"/>
+
+                                <h:outputLabel value="Patient" for="patientName"/>
+                                <p:inputText id="patientName" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.patientName}"/>
+
+                                <h:outputLabel value="Item Code" for="itemCode"/>
+                                <p:inputText id="itemCode" autocomplete="off" class="w-100"
+                                             value="#{searchController.searchKeyword.code}"/>
                             </h:panelGrid>
+                        </div>
 
-                            <p:panel>
-                                <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.billItems}" var="pi" >
-                                    <p:column headerText="No" styleClass="alignTop">
-                                        <h:outputLabel value="#{i+1}"/>
-                                    </p:column>
-                                    <p:column headerText="View">
-                                        <p:commandButton ajax="false" value="View Bill"
-                                                         action="/store/store_reprint_bill_sale">
-                                            <f:setPropertyActionListener value="#{pi.bill}"
-                                                                         target="#{storeBillSearch.bill}"/>                                     
-                                        </p:commandButton>
-                                    </p:column>
-                                    <p:column headerText="Bill No" styleClass="alignTop"  >
-                                        <h:outputLabel value="#{pi.bill.deptId}"/>
-                                    </p:column>
-                                    <p:column headerText="BHT No" styleClass="alignTop"  >
-                                        <h:outputLabel value="#{pi.bill.patientEncounter.bhtNo}"/>
-                                    </p:column>
-                                    <p:column headerText="Item Name"  styleClass="alignTop" >
-                                        <h:outputLabel value="#{pi.item.name}" />    
-                                    </p:column>
 
-                                    <p:column headerText="Item Code">
-                                        <f:facet name="header">
-                                            <h:outputLabel value="Code"/>
-                                        </f:facet>
-                                        <h:outputLabel value="#{pi.item.code}"
-                                                       style="width: 100px!important;" ></h:outputLabel>
-                                    </p:column>
+                        <div class="col-10">
+                            <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.billItems}" var="pi"
+                                         styleClass="equal-columns-table" style="width: 100%"
+                                         paginator="true" rows="10"
+                                         paginatorPosition="bottom"
+                                         paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="10,20,50">
 
-                                    <p:column headerText="Billed At"  >
-                                        <h:outputLabel value="Billed at " />
-                                        <h:outputLabel value="#{pi.bill.createdAt}" >
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                        </h:outputLabel>
-                                        <br/>
-                                        <h:panelGroup rendered="#{pi.bill.referenceBill.cancelled}" >
-                                            <h:outputLabel style="color: red;" value="Cancelled at " />
-                                            <h:outputLabel style="color: red;" 
-                                                           rendered="#{pi.bill.referenceBill.cancelled}" 
-                                                           value="#{pi.bill.referenceBill.cancelledBill.createdAt}" >
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{pi.bill.referenceBill.refunded}" >
-                                            <h:outputLabel style="color: red;" value="Refunded at " />
-                                            <h:outputLabel style="color: red;" 
-                                                           rendered="#{pi.bill.referenceBill.refunded}" 
-                                                           value="#{pi.referanceBillItem.bill.createdAt}" >
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </h:panelGroup>
-                                    </p:column>     
-                                    <p:column headerText="Qty" >
-                                        <h:outputLabel value="#{pi.qty}" >
-                                            <f:convertNumber pattern="#0.00"/>
-                                        </h:outputLabel>
-                                    </p:column>   
 
-                                    <p:column headerText="Bill item Value">
-                                        <h:outputLabel value="#{pi.netValue}" >
-                                            <f:convertNumber pattern="#,##0.00"/>
-                                        </h:outputLabel>
-                                    </p:column>
+                                <p:column headerText="No" width="4%" styleClass="align-top">
+                                    <h:outputLabel value="#{i+1}"/>
+                                </p:column>
 
-                                    <p:column headerText="Patient"  styleClass="alignTop" >
-                                        <h:outputLabel value="#{pi.bill.patient.person.nameWithTitle}" >
-                                        </h:outputLabel>                             
-                                    </p:column>
-                                </p:dataTable>
-                            </p:panel>
-                        </h:panelGroup>
-                    </p:panel>
-                </h:form>
-            </ui:define>
-        </ui:composition>
-    </h:body>
+                                <p:column headerText="View" width="8%" styleClass="align-top">
+                                    <p:commandButton ajax="false" value="View Bill"
+                                                     styleClass="view-button"
+                                                     action="/store/store_reprint_bill_sale">
+                                        <f:setPropertyActionListener value="#{pi.bill}"
+                                                                     target="#{storeBillSearch.bill}"/>
+                                    </p:commandButton>
+                                </p:column>
+
+                                <p:column headerText="Bill No" width="10%" styleClass="align-top">
+                                    <h:outputLabel value="#{pi.bill.deptId}"/>
+                                </p:column>
+
+                                <p:column headerText="BHT No" width="10%" styleClass="align-top">
+                                    <h:outputLabel value="#{pi.bill.patientEncounter.bhtNo}"/>
+                                </p:column>
+
+                                <p:column headerText="Item Name" width="15%" styleClass="align-top">
+                                    <h:outputLabel value="#{pi.item.name}"/>
+                                </p:column>
+
+                                <p:column headerText="Item Code" width="10%" styleClass="align-top">
+                                    <h:outputLabel value="#{pi.item.code}"/>
+                                </p:column>
+
+                                <p:column headerText="Billed At" width="14%" styleClass="align-top">
+                                </p:column>
+
+                                <p:column headerText="Qty" width="8%" styleClass="align-top">
+                                </p:column>
+
+                                <p:column headerText="Bill Item Value" width="12%" styleClass="align-top">
+                                </p:column>
+
+                                <p:column headerText="Patient" width="14%" styleClass="align-top">
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                    </div>
+                </p:panel>
+            </h:form>
+        </ui:define>
+    </ui:composition>
+</h:body>
 </html>

--- a/src/main/webapp/store/store_search_sale_bill_item_bht.xhtml
+++ b/src/main/webapp/store/store_search_sale_bill_item_bht.xhtml
@@ -11,32 +11,28 @@
         <ui:define name="content">
             <h:form>
                 <p:panel>
-                    <f:facet name="header">
+                    <f:facet name="header" >
                         <h:outputLabel value="Search Store Bill Item"/>
                     </f:facet>
 
-                    <div class="d-flex gap-2">
-
-                        <div class="col-2">
-                            <h:panelGrid columns="1" class="w-100">
-                                <h:outputLabel value="From Date" for="fromDate"/>
+                    <h:panelGroup class="d-flex gap-2">
+                        <h:panelGrid class="col-1 mx-1">
+                            <h:panelGrid columns="1" class="mt-1">
+                                <h:outputLabel value="From Date"/>
                                 <p:calendar
+                                        styleClass="dateTimePicker"
                                         id="fromDate"
                                         value="#{searchController.fromDate}"
-                                        styleClass="w-100"
-                                        inputStyleClass="form-control"
                                         navigator="false"
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-
-                                <h:outputLabel value="To Date" for="toDate"/>
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >
+                                </p:calendar>
+                                <h:outputLabel value="To Date"/>
                                 <p:calendar
                                         id="toDate"
                                         value="#{searchController.toDate}"
-                                        styleClass="w-100"
-                                        inputStyleClass="form-control"
                                         navigator="false"
-                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >
+                                </p:calendar>
                                 <p:commandButton
                                         id="btnSearch"
                                         ajax="false"
@@ -44,86 +40,96 @@
                                         icon="fa fa-search"
                                         class="mt-2 mb-3 w-100 ui-button-warning"
                                         action="#{searchController.createStoreTableBht}"/>
-
-                                <h:outputLabel value="Bill No" for="billNo"/>
-                                <p:inputText id="billNo" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.billNo}"/>
-
-                                <h:outputLabel value="BHT No" for="bhtNo"/>
-                                <p:inputText id="bhtNo" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.bhtNo}"/>
-
-                                <h:outputLabel value="Item Name" for="itemName"/>
-                                <p:inputText id="itemName" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.itemName}"/>
-
-                                <h:outputLabel value="Item Value" for="itemValue"/>
-                                <p:inputText id="itemValue" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.total}"/>
-
-                                <h:outputLabel value="Patient" for="patientName"/>
-                                <p:inputText id="patientName" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.patientName}"/>
-
-                                <h:outputLabel value="Item Code" for="itemCode"/>
-                                <p:inputText id="itemCode" autocomplete="off" class="w-100"
-                                             value="#{searchController.searchKeyword.code}"/>
                             </h:panelGrid>
-                        </div>
 
+                            <h:panelGrid columns="1" class="mt-2">
+                                <h:outputLabel value="Bill No"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" />
+                                <h:outputLabel value="BHT No"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.bhtNo}" />
+                                <h:outputLabel value="Item Name"/>
+                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.itemName}" />
+                                <h:outputLabel value="Item Value"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.total}" />
+                                <h:outputLabel value="Patient"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.patientName}" />
+                                <h:outputLabel  value="Item Code"/>
+                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.code}"/>
+                            </h:panelGrid>
+                        </h:panelGrid>
 
-                        <div class="col-10">
-                            <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.billItems}" var="pi"
-                                         styleClass="equal-columns-table" style="width: 100%"
-                                         paginator="true" rows="10"
-                                         paginatorPosition="bottom"
-                                         paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                         rowsPerPageTemplate="10,20,50">
-
-
-                                <p:column headerText="No" width="4%" styleClass="align-top">
+                        <p:panel>
+                            <p:dataTable rowIndexVar="i" id="tblBills" value="#{searchController.billItems}" var="pi" >
+                                <p:column headerText="No" styleClass="alignTop">
                                     <h:outputLabel value="#{i+1}"/>
                                 </p:column>
-
-                                <p:column headerText="View" width="8%" styleClass="align-top">
+                                <p:column headerText="View">
                                     <p:commandButton ajax="false" value="View Bill"
-                                                     styleClass="view-button"
                                                      action="/store/store_reprint_bill_sale">
                                         <f:setPropertyActionListener value="#{pi.bill}"
                                                                      target="#{storeBillSearch.bill}"/>
                                     </p:commandButton>
                                 </p:column>
-
-                                <p:column headerText="Bill No" width="10%" styleClass="align-top">
+                                <p:column headerText="Bill No" styleClass="alignTop"  >
                                     <h:outputLabel value="#{pi.bill.deptId}"/>
                                 </p:column>
-
-                                <p:column headerText="BHT No" width="10%" styleClass="align-top">
+                                <p:column headerText="BHT No" styleClass="alignTop"  >
                                     <h:outputLabel value="#{pi.bill.patientEncounter.bhtNo}"/>
                                 </p:column>
-
-                                <p:column headerText="Item Name" width="15%" styleClass="align-top">
-                                    <h:outputLabel value="#{pi.item.name}"/>
+                                <p:column headerText="Item Name"  styleClass="alignTop" >
+                                    <h:outputLabel value="#{pi.item.name}" />
                                 </p:column>
 
-                                <p:column headerText="Item Code" width="10%" styleClass="align-top">
-                                    <h:outputLabel value="#{pi.item.code}"/>
+                                <p:column headerText="Item Code">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Code"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{pi.item.code}"
+                                                   style="width: 100px!important;" ></h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Billed At" width="14%" styleClass="align-top">
+                                <p:column headerText="Billed At"  >
+                                    <h:outputLabel value="Billed at " />
+                                    <h:outputLabel value="#{pi.bill.createdAt}" >
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                    </h:outputLabel>
+                                    <br/>
+                                    <h:panelGroup rendered="#{pi.bill.referenceBill.cancelled}" >
+                                        <h:outputLabel style="color: red;" value="Cancelled at " />
+                                        <h:outputLabel style="color: red;"
+                                                       rendered="#{pi.bill.referenceBill.cancelled}"
+                                                       value="#{pi.bill.referenceBill.cancelledBill.createdAt}" >
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputLabel>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{pi.bill.referenceBill.refunded}" >
+                                        <h:outputLabel style="color: red;" value="Refunded at " />
+                                        <h:outputLabel style="color: red;"
+                                                       rendered="#{pi.bill.referenceBill.refunded}"
+                                                       value="#{pi.referanceBillItem.bill.createdAt}" >
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputLabel>
+                                    </h:panelGroup>
+                                </p:column>
+                                <p:column headerText="Qty" >
+                                    <h:outputLabel value="#{pi.qty}" >
+                                        <f:convertNumber pattern="#0.00"/>
+                                    </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Qty" width="8%" styleClass="align-top">
+                                <p:column headerText="Bill Item Value">
+                                    <h:outputLabel value="#{pi.netValue}" >
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
                                 </p:column>
 
-                                <p:column headerText="Bill Item Value" width="12%" styleClass="align-top">
-                                </p:column>
-
-                                <p:column headerText="Patient" width="14%" styleClass="align-top">
+                                <p:column headerText="Patient"  styleClass="alignTop" >
+                                    <h:outputLabel value="#{pi.bill.patient.person.nameWithTitle}" >
+                                    </h:outputLabel>
                                 </p:column>
                             </p:dataTable>
-                        </div>
-                    </div>
+                        </p:panel>
+                    </h:panelGroup>
                 </p:panel>
             </h:form>
         </ui:define>


### PR DESCRIPTION
Cleanup PR opened to bring an existing feature branch that was ahead of `development` into review.

Branch: `store_ui`


This PR was created as part of a branch-cleanup pass. Commits already existed on the branch; this simply opens them for review against `development`. Please review for relevance — if the work is stale or superseded, close and delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated store bill item search behavior to use the appropriate search workflow.
* **Style**
  * Standardized typography across transfer receipt printouts with consistent 12px text sizing.
  * Improved formatting and presentation of transfer details, totals, and bill item headings.
  * Refined search button styling and minor table label formatting.
* **Bug Fixes**
  * Preserved correct display of reference dates for cancelled and refunded bills in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->