### PR TITLE
feat(pharmacy): add edit/update option for item rows in Direct Purchase (#18583)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -80,6 +80,7 @@ public class PharmacyDirectPurchaseController implements Serializable {
     private BilledBill bill;
     private List<BillItem> billItems;
     private BillItem currentBillItem;
+    private BillItem editingBillItem;
     private boolean printPreview;
     private boolean showAllBillFormats = false;
     private BillItem currentExpense;
@@ -1094,6 +1095,35 @@ public class PharmacyDirectPurchaseController implements Serializable {
         currentBillItem = null;
     }
 
+    public void prepareEditBillItem(BillItem bi) {
+        this.editingBillItem = bi;
+    }
+
+    public void updateBillItem() {
+        if (editingBillItem == null) {
+            JsfUtil.addErrorMessage("No item selected for editing");
+            return;
+        }
+        BillItemFinanceDetails f = editingBillItem.getBillItemFinanceDetails();
+        if (f != null) {
+            // Sync retailSaleRatePerUnit from retailSaleRate (same logic as onRetailSaleRateChange)
+            if (f.getRetailSaleRate() != null) {
+                Item item = editingBillItem.getItem();
+                if (item instanceof Ampp) {
+                    double dblVal = item.getDblValue();
+                    BigDecimal unitsPerPack = dblVal > 0.0 ? BigDecimal.valueOf(dblVal) : BigDecimal.ONE;
+                    f.setRetailSaleRatePerUnit(f.getRetailSaleRate().divide(unitsPerPack, MathContext.DECIMAL64));
+                } else {
+                    f.setRetailSaleRatePerUnit(f.getRetailSaleRate());
+                }
+            }
+        }
+        calculateItemTotals(editingBillItem);
+        calculateBillTotalsFromItems();
+        recalculateProfitMarginsForAllItems();
+        editingBillItem = null;
+    }
+
     /**
      * Autocomplete method for items filtered by department type
      * When department type is set on the bill, only items of that type are returned
@@ -2011,6 +2041,14 @@ public class PharmacyDirectPurchaseController implements Serializable {
 
     public void setCurrentBillItem(BillItem currentBillItem) {
         this.currentBillItem = currentBillItem;
+    }
+
+    public BillItem getEditingBillItem() {
+        return editingBillItem;
+    }
+
+    public void setEditingBillItem(BillItem editingBillItem) {
+        this.editingBillItem = editingBillItem;
     }
 
     public List<BillItem> getBillItems() {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdcb/coop</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/coopAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdcb/coop</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -10,7 +10,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/coopAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>


### PR DESCRIPTION
Cleanup PR opened to bring an existing feature branch that was ahead of `development` into review.

Branch: `#18583-better-if-added-an-edit-option-for-item-rows-in-direct-purchase`
Relates to #18583

Adds an update button to Direct Purchase to allow editing item rows after they are added. Persistence.xml was reset to CI/CD JNDI placeholders so validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)