### PR TITLE
feat(api): bulk backfill endpoint for transfer bill departmentType with dry-run and audit trail (#22067)

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -5339,7 +5339,8 @@ public class AnthropicApiService implements Serializable {
                 githubUrl(branch, "developer_docs/API_PHARMACEUTICAL_MANAGEMENT.md"),
                 new String[][]{
                     {"POST", "/pharmacy/backfill_bfd",      "Backfill missing BFD records for historical pharmacy adjustment bills"},
-                    {"POST", "/pharmacy/backfill_grn_bifd", "Backfill missing BIFD/BFD records for historical Pharmacy GRN bills"}
+                    {"POST", "/pharmacy/backfill_grn_bifd", "Backfill missing BIFD/BFD records for historical Pharmacy GRN bills"},
+                    {"POST", "/pharmacy/backfill_transfer_department_type", "Backfill missing departmentType on historical pharmacy transfer bills (issue/receive/cancellations/returns). Dry-run by default (apply=false); resolution: unanimous item types, then backwardReferenceBill, then billedBill"}
                 });
 
         // ── Institution / Department / Sites ──────────────────────────────────

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -1,5 +1,6 @@
 package com.divudi.service;
 
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -49,7 +50,7 @@ public class BillDataCorrectionService {
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
 
-    private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments", "retired", "retireComments"));
+    private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments", "retired", "retireComments", "departmentType"));
     private static final Set<String> BILL_ITEM_FIELDS = new HashSet<>(Arrays.asList("qty", "rate", "grossValue", "netValue", "discount"));
     private static final Set<String> BILL_FINANCE_FIELDS = new HashSet<>(Arrays.asList("totalRetailSaleValue", "totalCostValue", "totalPurchaseValue", "netTotal", "grossTotal", "billExpensesConsideredForCosting", "billExpensesNotConsideredForCosting", "totalBillValue"));
     private static final Set<String> BILL_FEE_FIELDS = new HashSet<>(Arrays.asList("feeValue", "grossValue"));
@@ -152,6 +153,21 @@ public class BillDataCorrectionService {
             String value = toStringValue(fields.get("comments"));
             entity.setComments(value);
             newValues.put("comments", entity.getComments());
+        }
+        if (fields.containsKey("departmentType")) {
+            previousValues.put("departmentType", entity.getDepartmentType() != null ? entity.getDepartmentType().name() : null);
+            String value = toStringValue(fields.get("departmentType"));
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException("Field 'departmentType' cannot be empty");
+            }
+            DepartmentType departmentType;
+            try {
+                departmentType = DepartmentType.valueOf(value.trim());
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Field 'departmentType' must be one of " + Arrays.toString(DepartmentType.values()));
+            }
+            entity.setDepartmentType(departmentType);
+            newValues.put("departmentType", departmentType.name());
         }
         if (fields.containsKey("retired")) {
             boolean requestedRetire = toBooleanValue(fields.get("retired"), "retired");

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyTransferDeptTypeBackfillService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyTransferDeptTypeBackfillService.java
@@ -1,0 +1,214 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.util.CommonFunctions;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+
+/**
+ * EJB service that backfills the missing departmentType on historical pharmacy
+ * transfer bills (issue / receive / cancellations / returns).
+ *
+ * These bills were saved with departmentType = NULL during the capture
+ * regression fixed under issue #22056 (and by legacy flows that never stamped
+ * the field). Department-type-filtered reports drop NULL bills silently, so
+ * the historical rows must be corrected (#22057, #22058, #22067).
+ *
+ * Resolution order per bill:
+ *   1. ITEMS - the single department type shared unanimously by all non-null
+ *      item types on the bill (mixed-type bills are never guessed)
+ *   2. BACKWARD_REFERENCE_BILL - the referenced source bill's type
+ *      (issue for a receive, request for an issue)
+ *   3. BILLED_BILL - the original bill's type (for cancellation bills)
+ *   4. unresolved - reported for manual review, never written
+ */
+@Stateless
+public class PharmacyTransferDeptTypeBackfillService {
+
+    @EJB
+    private BillFacade billFacade;
+
+    @EJB
+    private BillItemFacade billItemFacade;
+
+    private static final List<BillTypeAtomic> TRANSFER_TYPES = Arrays.asList(
+            BillTypeAtomic.PHARMACY_ISSUE,
+            BillTypeAtomic.PHARMACY_ISSUE_PRE,
+            BillTypeAtomic.PHARMACY_RECEIVE,
+            BillTypeAtomic.PHARMACY_RECEIVE_PRE,
+            BillTypeAtomic.PHARMACY_ISSUE_CANCELLED,
+            BillTypeAtomic.PHARMACY_RECEIVE_CANCELLED,
+            BillTypeAtomic.PHARMACY_ISSUE_RETURN);
+
+    /**
+     * Finds transfer bills with departmentType IS NULL in the date range and
+     * resolves each one's type, in dry-run or apply mode.
+     *
+     * @param departmentId optional bill.department filter (null = all departments)
+     * @param fromDate     start date inclusive (normalised to start of day)
+     * @param toDate       end date inclusive (normalised to end of day)
+     * @param apply        false = return the resolution plan without writing
+     * @param auditComment audit trail comment (required by the API layer)
+     * @param approvedBy   approver name (required by the API layer)
+     * @param apiUser      the API user performing the backfill
+     * @return summary with per-source counts, the per-bill plan, unresolved
+     *         bill IDs and any per-bill errors
+     */
+    public Map<String, Object> backfillTransferDepartmentTypes(
+            Long departmentId,
+            Date fromDate,
+            Date toDate,
+            boolean apply,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        Date from = CommonFunctions.getStartOfDay(fromDate);
+        Date to = CommonFunctions.getEndOfDay(toDate);
+
+        String jpql = "SELECT b FROM Bill b"
+                + " WHERE b.retired = false"
+                + " AND b.billTypeAtomic IN :types"
+                + " AND b.departmentType IS NULL"
+                + " AND b.createdAt BETWEEN :from AND :to"
+                + (departmentId != null ? " AND b.department.id = :deptId" : "")
+                + " ORDER BY b.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("types", TRANSFER_TYPES);
+        params.put("from", from);
+        params.put("to", to);
+        if (departmentId != null) {
+            params.put("deptId", departmentId);
+        }
+
+        List<Bill> bills = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+
+        int fromItems = 0;
+        int fromBackwardReferenceBill = 0;
+        int fromBilledBill = 0;
+        int appliedCount = 0;
+        List<Long> unresolvedBillIds = new ArrayList<>();
+        List<Map<String, Object>> plan = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+
+        for (Bill bill : bills) {
+            try {
+                DepartmentType resolved = unanimousItemDepartmentType(bill);
+                String source;
+                if (resolved != null) {
+                    source = "ITEMS";
+                    fromItems++;
+                } else if (bill.getBackwardReferenceBill() != null
+                        && bill.getBackwardReferenceBill().getDepartmentType() != null) {
+                    resolved = bill.getBackwardReferenceBill().getDepartmentType();
+                    source = "BACKWARD_REFERENCE_BILL";
+                    fromBackwardReferenceBill++;
+                } else if (bill.getBilledBill() != null
+                        && bill.getBilledBill().getDepartmentType() != null) {
+                    resolved = bill.getBilledBill().getDepartmentType();
+                    source = "BILLED_BILL";
+                    fromBilledBill++;
+                } else {
+                    unresolvedBillIds.add(bill.getId());
+                    continue;
+                }
+
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("billId", bill.getId());
+                entry.put("deptId", bill.getDeptId());
+                entry.put("billTypeAtomic", bill.getBillTypeAtomic() != null ? bill.getBillTypeAtomic().name() : null);
+                entry.put("resolvedDepartmentType", resolved.name());
+                entry.put("source", source);
+                plan.add(entry);
+
+                if (apply) {
+                    bill.setDepartmentType(resolved);
+                    appendAuditLog(bill, resolved, source, auditComment, approvedBy, apiUser);
+                    billFacade.edit(bill);
+                    appliedCount++;
+                }
+            } catch (Exception ex) {
+                errors.add("Bill " + bill.getId() + ": " + ex.getMessage());
+            }
+        }
+
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("apply", apply);
+        summary.put("totalCandidates", bills.size());
+        summary.put("resolvedFromItems", fromItems);
+        summary.put("resolvedFromBackwardReferenceBill", fromBackwardReferenceBill);
+        summary.put("resolvedFromBilledBill", fromBilledBill);
+        summary.put("unresolved", unresolvedBillIds.size());
+        summary.put("appliedCount", appliedCount);
+        summary.put("unresolvedBillIds", unresolvedBillIds);
+        summary.put("plan", plan);
+        summary.put("errors", errors);
+        return summary;
+    }
+
+    /**
+     * Returns the department type shared unanimously by every non-null item
+     * type on the bill, or null when the items are mixed or untyped.
+     */
+    private DepartmentType unanimousItemDepartmentType(Bill bill) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("bill", bill);
+        List<BillItem> items = billItemFacade.findByJpql(
+                "SELECT bi FROM BillItem bi WHERE bi.bill = :bill AND bi.retired = false", params);
+        DepartmentType found = null;
+        for (BillItem bi : items) {
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return null;
+            }
+        }
+        return found;
+    }
+
+    private void appendAuditLog(Bill bill,
+            DepartmentType resolved,
+            String source,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        String existing = bill.getComments();
+        String correctedBy = apiUser != null ? apiUser.getName() : "Unknown API User";
+        String now = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        StringBuilder sb = new StringBuilder();
+        if (existing != null && !existing.trim().isEmpty()) {
+            sb.append(existing.trim()).append("\n\n");
+        }
+        sb.append("[Transfer DepartmentType Backfill]")
+                .append("\nTime: ").append(now)
+                .append("\nPreviousValue: null")
+                .append("\nNewValue: ").append(resolved.name())
+                .append("\nSource: ").append(source)
+                .append("\nCorrectedByApiUser: ").append(correctedBy)
+                .append("\nApprovedBy: ").append(approvedBy)
+                .append("\nAuditComment: ").append(auditComment);
+
+        bill.setComments(sb.toString());
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -89,6 +89,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.pharmacy.PharmacyGrnBifdBackfillApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacyItemApi.class);
         resources.add(com.divudi.ws.pharmacy.PharmacySearchApi.class);
+        resources.add(com.divudi.ws.pharmacy.PharmacyTransferDeptTypeBackfillApi.class);
         resources.add(com.divudi.ws.pharmacy.StockHistoryApi.class);
         resources.add(com.divudi.ws.pricing.CollectingCentreFeesApi.class);
         resources.add(com.divudi.ws.sap.SapBillingApi.class);

--- a/src/main/java/com/divudi/ws/pharmacy/PharmacyTransferDeptTypeBackfillApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmacyTransferDeptTypeBackfillApi.java
@@ -1,0 +1,265 @@
+package com.divudi.ws.pharmacy;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.pharmacy.PharmacyTransferDeptTypeBackfillService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * REST API for backfilling the missing departmentType on historical pharmacy
+ * transfer bills (issue / receive / cancellations / returns). See issues
+ * #22056 (capture regression), #22057 / #22058 (data corrections) and #22067
+ * (this endpoint).
+ *
+ * Endpoint: POST /api/pharmacy/backfill_transfer_department_type
+ * Auth:     Finance: &lt;api_key&gt; header
+ *
+ * Dry-run by default: with "apply": false (or omitted) the response contains
+ * the full resolution plan without writing anything. Re-run with
+ * "apply": true to persist it.
+ *
+ * Example request:
+ * <pre>
+ * {
+ *   "fromDate": "2026-05-01",
+ *   "toDate": "2026-06-30",
+ *   "departmentId": 485,
+ *   "apply": false,
+ *   "approvedBy": "Dr. Smith",
+ *   "auditComment": "Backfill departmentType missing during #22056 regression window"
+ * }
+ * </pre>
+ *
+ * Example response data:
+ * <pre>
+ * {
+ *   "apply": false,
+ *   "totalCandidates": 50,
+ *   "resolvedFromItems": 47,
+ *   "resolvedFromBackwardReferenceBill": 2,
+ *   "resolvedFromBilledBill": 1,
+ *   "unresolved": 0,
+ *   "appliedCount": 0,
+ *   "unresolvedBillIds": [],
+ *   "plan": [{"billId": 1, "deptId": "PH/TI/24/001", "billTypeAtomic": "PHARMACY_ISSUE",
+ *             "resolvedDepartmentType": "Store", "source": "ITEMS"}],
+ *   "errors": []
+ * }
+ * </pre>
+ */
+@Path("pharmacy/backfill_transfer_department_type")
+@RequestScoped
+public class PharmacyTransferDeptTypeBackfillApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private PharmacyTransferDeptTypeBackfillService backfillService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    /**
+     * Backfill departmentType for historical transfer bills.
+     *
+     * POST /api/pharmacy/backfill_transfer_department_type
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response backfillTransferDepartmentType(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            BackfillRequest request;
+            try {
+                request = gson.fromJson(requestBody, BackfillRequest.class);
+            } catch (JsonSyntaxException ex) {
+                return errorResponse("Invalid JSON format: " + ex.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            if (request.getFromDate() == null || request.getFromDate().trim().isEmpty()) {
+                return errorResponse("fromDate is required (format: yyyy-MM-dd)", 400);
+            }
+            if (request.getToDate() == null || request.getToDate().trim().isEmpty()) {
+                return errorResponse("toDate is required (format: yyyy-MM-dd)", 400);
+            }
+            if (request.getAuditComment() == null || request.getAuditComment().trim().isEmpty()) {
+                return errorResponse("auditComment is required", 400);
+            }
+            if (request.getApprovedBy() == null || request.getApprovedBy().trim().isEmpty()) {
+                return errorResponse("approvedBy is required", 400);
+            }
+
+            Date fromDate;
+            Date toDate;
+            try {
+                synchronized (DATE_FORMAT) {
+                    fromDate = DATE_FORMAT.parse(request.getFromDate().trim());
+                    toDate = DATE_FORMAT.parse(request.getToDate().trim());
+                }
+            } catch (ParseException ex) {
+                return errorResponse("Invalid date format. Use yyyy-MM-dd (e.g. 2026-05-30)", 400);
+            }
+
+            Map<String, Object> result = backfillService.backfillTransferDepartmentTypes(
+                    request.getDepartmentId(),
+                    fromDate,
+                    toDate,
+                    request.isApply(),
+                    request.getAuditComment().trim(),
+                    request.getApprovedBy().trim(),
+                    user);
+
+            return successResponse(result);
+
+        } catch (IllegalArgumentException ex) {
+            return errorResponse(ex.getMessage(), 400);
+        } catch (Exception ex) {
+            return errorResponse("An error occurred: " + ex.getMessage(), 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.getDateOfExpiary() == null
+                || apiKey.getDateOfExpiary().before(new Date())) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.ok(gson.toJson(response), MediaType.APPLICATION_JSON).build();
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response))
+                .type(MediaType.APPLICATION_JSON).build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Request DTO
+    // -------------------------------------------------------------------------
+
+    public static class BackfillRequest {
+
+        /** Optional bill.department ID filter. Null means all departments. */
+        private Long departmentId;
+
+        /** Start date inclusive, format yyyy-MM-dd. Required. */
+        private String fromDate;
+
+        /** End date inclusive, format yyyy-MM-dd. Required. */
+        private String toDate;
+
+        /** False (default) = dry run returning the plan; true = persist. */
+        private boolean apply;
+
+        /** Mandatory audit trail comment. */
+        private String auditComment;
+
+        /** Mandatory approver name. */
+        private String approvedBy;
+
+        public Long getDepartmentId() {
+            return departmentId;
+        }
+
+        public void setDepartmentId(Long departmentId) {
+            this.departmentId = departmentId;
+        }
+
+        public String getFromDate() {
+            return fromDate;
+        }
+
+        public void setFromDate(String fromDate) {
+            this.fromDate = fromDate;
+        }
+
+        public String getToDate() {
+            return toDate;
+        }
+
+        public void setToDate(String toDate) {
+            this.toDate = toDate;
+        }
+
+        public boolean isApply() {
+            return apply;
+        }
+
+        public void setApply(boolean apply) {
+            this.apply = apply;
+        }
+
+        public String getAuditComment() {
+            return auditComment;
+        }
+
+        public void setAuditComment(String auditComment) {
+            this.auditComment = auditComment;
+        }
+
+        public String getApprovedBy() {
+            return approvedBy;
+        }
+
+        public void setApprovedBy(String approvedBy) {
+            this.approvedBy = approvedBy;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #22067: a bulk, auditable, dry-run-first REST endpoint to backfill the missing `departmentType` on historical pharmacy transfer bills, so the Ruhunu staging (#22058) and production (#22057) data corrections can run through the API instead of direct SQL. Companion to PR #22060 (which stops new NULLs from being created).

## New endpoint

`POST /api/pharmacy/backfill_transfer_department_type` — `Finance: <api_key>` header

```json
{
  "fromDate": "2026-05-01",
  "toDate": "2026-06-30",
  "departmentId": null,
  "apply": false,
  "approvedBy": "Dr. Smith",
  "auditComment": "Backfill departmentType missing during #22056 regression window"
}
```

- Scope: `PHARMACY_ISSUE`, `PHARMACY_ISSUE_PRE`, `PHARMACY_RECEIVE`, `PHARMACY_RECEIVE_PRE`, `PHARMACY_ISSUE_CANCELLED`, `PHARMACY_RECEIVE_CANCELLED`, `PHARMACY_ISSUE_RETURN` with `departmentType IS NULL`, `retired = false`, in the date range (optional `departmentId` filter).
- **Dry-run by default**: `apply: false` returns the full per-bill resolution plan (bill ID, bill number, type, resolved value, source) without writing.
- Resolution order (never guesses): unanimous non-null item `departmentType` → `backwardReferenceBill` → `billedBill` → unresolved (reported, untouched).
- Apply mode appends a structured audit block to `bill.comments` (previous/new value, source, API user, approver, comment).
- Idempotent — corrected bills drop out of the `IS NULL` candidate query.

## Also included

- `PATCH /api/bill_data_correction` now accepts `departmentType` on the `BILL` target with enum validation, for one-off single-bill corrections.

## Registration

Follows the existing backfill precedent (`backfill_bfd`, `backfill_grn_bifd`): registered in `ApplicationConfig` and the AI system-prompt "Pharmacy - Backfill Operations" module listing; deliberately **not** listed in `/api/capabilities` (unauthenticated discovery) and **not** exposed as an AI chat tool — these are admin-only maintenance operations.

## Verification (local deployment, real data)

- Dry-run over March 2026: 94 candidates, all resolved unanimously from items, nothing written.
- Apply: 94/94 stamped; DB check confirms values and the audit block (existing comments preserved).
- Re-run dry-run: 0 candidates (idempotent).
- Single-bill PATCH via `bill_data_correction`: sets the value; invalid enum values rejected with the allowed list (surfaces as HTTP 500 due to pre-existing EJB exception wrapping — same behavior as existing "Bill not found" errors, not introduced here).

## Rollout

1. Merge → deploy to Ruhunu staging (also delivers PR #22060 capture fixes).
2. Staging: dry-run → review plan → `apply: true` → verify Stock Transfer Report (#22058).
3. Production after staging verification (#22057).

Closes #22067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
