### PR TITLE
Add Inpatient Packages: fixed-price admission bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ pm/
 
 # AI prompt scratch files
 prompts/
+
+# Superpowers subagent-driven-development scratch state
+.superpowers/

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -236,6 +236,10 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDocumentUpload, "Document Upload"), inwardClinicalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientLetter, "Generate Inpatient Letters"), inwardClinicalNode);
 
+        TreeNode inwardPackageNode = new DefaultTreeNode(new PrivilegeHolder(null, "Packages"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdministration, "Manage Inpatient Packages"), inwardPackageNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdmission, "Package-Based Admission"), inwardPackageNode);
+
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillSearch, "Search Bills"), additionalPrivilegesNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2440,6 +2440,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     getFacade().edit(getCurrent());
 
                     JsfUtil.addErrorMessage("Package could not be applied to this admission and it has been cancelled. Please retry. (" + ex.getMessage() + ")");
+                    admittingProcessStarted = false;
                     return;
                 }
             }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2414,8 +2414,34 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             getCurrent().setCurrentPatientRoom(currentPatientRoom);
 
             if (getCurrent().getInpatientPackage() != null) {
-                getInpatientPackageApplicationBean().applyPackageToAdmission(
-                        getCurrent(), currentPatientRoom, getSessionController().getLoggedUser());
+                // The admission and room above were each already committed in their
+                // own EJB transaction (this controller is a CDI bean, not itself
+                // transactional). applyPackageToAdmission runs in a further, separate
+                // transaction, so a failure here cannot be rolled back by the
+                // container - it would otherwise leave a package-linked admission
+                // with none of its locked billing rows. Compensate explicitly by
+                // retiring what was just created and surfacing a clear error instead.
+                try {
+                    getInpatientPackageApplicationBean().applyPackageToAdmission(
+                            getCurrent(), currentPatientRoom, getSessionController().getLoggedUser());
+                } catch (RuntimeException ex) {
+                    logger.log(Level.SEVERE, "Package application failed for admission " + getCurrent().getBhtNo(), ex);
+                    Date now = new Date();
+                    currentPatientRoom.setRetired(true);
+                    currentPatientRoom.setRetireComments("Auto-retired: package application failed - " + ex.getMessage());
+                    currentPatientRoom.setRetirer(getSessionController().getLoggedUser());
+                    currentPatientRoom.setRetiredAt(now);
+                    patientRoomFacade.edit(currentPatientRoom);
+
+                    getCurrent().setRetired(true);
+                    getCurrent().setRetireComments("Auto-retired: package application failed - " + ex.getMessage());
+                    getCurrent().setRetirer(getSessionController().getLoggedUser());
+                    getCurrent().setRetiredAt(now);
+                    getFacade().edit(getCurrent());
+
+                    JsfUtil.addErrorMessage("Package could not be applied to this admission and it has been cancelled. Please retry. (" + ex.getMessage() + ")");
+                    return;
+                }
             }
 
             if (!getCurrent().isRoomAdmitted() && currentPatientRoom != null && currentPatientRoom.getRoomFacilityCharge() != null) {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -145,6 +145,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     ReservationFacade reservationFacade;
     @EJB
     private PatientTransferRequestFacade patientTransferRequestFacade;
+    @EJB
+    private com.divudi.ejb.InpatientPackageApplicationBean inpatientPackageApplicationBean;
+
+    public com.divudi.ejb.InpatientPackageApplicationBean getInpatientPackageApplicationBean() {
+        return inpatientPackageApplicationBean;
+    }
 
     @Inject
     BhtEditController bhtEditController;
@@ -2406,6 +2412,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             }
 
             getCurrent().setCurrentPatientRoom(currentPatientRoom);
+
+            if (getCurrent().getInpatientPackage() != null) {
+                getInpatientPackageApplicationBean().applyPackageToAdmission(
+                        getCurrent(), currentPatientRoom, getSessionController().getLoggedUser());
+            }
 
             if (!getCurrent().isRoomAdmitted() && currentPatientRoom != null && currentPatientRoom.getRoomFacilityCharge() != null) {
                 PatientTransferRequest handoverRequest = new PatientTransferRequest();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3318,6 +3318,14 @@ public class BhtSummeryController implements Serializable {
             return;
         }
 
+        if (p.isFromPackage() && !isPackageRoomDurationExceeded(p)) {
+            // Package-locked room: currentRoomCharge already holds the package's
+            // fixed total for the room, not a per-block rate — do not multiply
+            // it by elapsed TimedItemFee blocks while within the included duration.
+            p.setCalculatedRoomCharge(p.getCurrentRoomCharge() + p.getAddedRoomCharge());
+            return;
+        }
+
         double roomCharge = p.getCurrentRoomCharge();
         ////System.out.println("roomCharge = " + roomCharge);
         double calculated = getCharge(p, roomCharge) + p.getAddedRoomCharge();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3173,6 +3173,25 @@ public class BhtSummeryController implements Serializable {
     private void applyRoomChargeDiscounts(PatientRoom p,
             double roomPct, double maintainPct, double linenPct, double nursingPct,
             double moPct, double adminPct, double medicalCarePct) {
+        if (p.isFromPackage() && !isPackageRoomDurationExceeded(p)) {
+            // Package-locked room: the price is fixed by the package, not subject
+            // to PriceMatrix discount percentages while within the included duration.
+            p.setDiscountRoomCharge(0.0);
+            p.setDiscountMaintainCharge(0.0);
+            p.setDiscountLinenCharge(0.0);
+            p.setDiscountNursingCharge(0.0);
+            p.setDiscountMoCharge(0.0);
+            p.setDiscountAdministrationCharge(0.0);
+            p.setDiscountMedicalCareCharge(0.0);
+            p.setAdjustedRoomCharge(p.getCalculatedRoomCharge());
+            p.setAdjustedMaintainCharge(p.getCalculatedMaintainCharge());
+            p.setAjdustedLinenCharge(p.getCalculatedLinenCharge());
+            p.setAjdustedNursingCharge(p.getCalculatedNursingCharge());
+            p.setAdjustedMoCharge(p.getCalculatedMoCharge());
+            p.setAjdustedAdministrationCharge(p.getCalculatedAdministrationCharge());
+            p.setAjdustedMedicalCareCharge(p.getCalculatedMedicalCareCharge());
+            return;
+        }
         double roomDisc = (roomPct / 100.0) * p.getCalculatedRoomCharge();
         double maintainDisc = (maintainPct / 100.0) * p.getCalculatedMaintainCharge();
         double linenDisc = (linenPct / 100.0) * p.getCalculatedLinenCharge();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1535,6 +1535,12 @@ public class BhtSummeryController implements Serializable {
             JsfUtil.addErrorMessage("Room facility charge not set");
             return;
         }
+        if (pr.isFromPackage() && !isPackageRoomDurationExceeded(pr)) {
+            // Package-locked charge stays as set by InpatientPackageApplicationBean.
+            patientRooms = null;
+            createTables();
+            return;
+        }
         RoomFacilityCharge rfc = pr.getRoomFacilityCharge();
         pr.setCurrentRoomCharge(rfc.getRoomCharge() != null ? rfc.getRoomCharge() : 0.0);
         pr.setCurrentMaintananceCharge(rfc.getMaintananceCharge() != null ? rfc.getMaintananceCharge() : 0.0);
@@ -1591,6 +1597,38 @@ public class BhtSummeryController implements Serializable {
         charge = roomCharge * getInwardBean().calCount(timedFee, p.getAdmittedAt(), p.getDischargedAt());
 
         p.setCalculatedRoomCharge(charge);
+    }
+
+    private boolean isPackageRoomDurationExceeded(PatientRoom pr) {
+        if (pr.getIncludedRoomDurationHours() == null) {
+            return true;
+        }
+        Date to = pr.getDischargedAt() != null ? pr.getDischargedAt() : new Date();
+        if (pr.getAdmittedAt() == null) {
+            return false;
+        }
+        long stayedHours = java.time.Duration.between(
+                pr.getAdmittedAt().toInstant(), to.toInstant()).toHours();
+        return stayedHours > pr.getIncludedRoomDurationHours();
+    }
+
+    public double getPackageRoomVarianceCharge(PatientRoom pr) {
+        if (pr == null || !pr.isFromPackage() || !isPackageRoomDurationExceeded(pr) || pr.getRoomFacilityCharge() == null) {
+            return 0.0;
+        }
+        calCulateRoomCharge(pr);
+        double liveEquivalent = pr.getCalculatedRoomCharge();
+        // RoomFacilityCharge.roomCharge is a rate per TimedItemFee.durationHours block (see
+        // InwardBeanController.calCount: charge = roomCharge * count, where count is the number
+        // of durationHours-sized blocks between admittedAt/dischargedAt). Room-charge TimedItemFee
+        // configs are conventionally 24-hour ("per day") blocks, so we use the actual configured
+        // durationHours here (falling back to 24.0 if unset) rather than hardcoding 24.
+        TimedItemFee timedFee = pr.getRoomFacilityCharge().getTimedItemFee();
+        double blockHours = (timedFee != null && timedFee.getDurationHours() > 0) ? timedFee.getDurationHours() : 24.0;
+        double includedEquivalent = pr.getRoomFacilityCharge().getRoomCharge() != null
+                ? pr.getRoomFacilityCharge().getRoomCharge() * (pr.getIncludedRoomDurationHours() / blockHours)
+                : 0.0;
+        return Math.max(0.0, liveEquivalent - includedEquivalent);
     }
 
     private boolean checkDischargeTime() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1562,9 +1562,15 @@ public class BhtSummeryController implements Serializable {
             getPatientRoomFacade().create(patientRoom);
         }
 
-        patientRoom.setCurrentRoomCharge(patientRoom.getRoomFacilityCharge().getRoomCharge());
-
-        calCulateRoomCharge(patientRoom);
+        if (patientRoom.isFromPackage() && !isPackageRoomDurationExceeded(patientRoom)) {
+            // Package-locked room: currentRoomCharge already holds the package's fixed
+            // total, not a per-block rate - do not overwrite it with the facility rate
+            // while still within the included duration.
+            patientRoom.setCalculatedRoomCharge(patientRoom.getCurrentRoomCharge() + patientRoom.getAddedRoomCharge());
+        } else {
+            patientRoom.setCurrentRoomCharge(patientRoom.getRoomFacilityCharge().getRoomCharge());
+            calCulateRoomCharge(patientRoom);
+        }
 
         updatePaitentRoomAdjustedTotal();
     }
@@ -1616,18 +1622,24 @@ public class BhtSummeryController implements Serializable {
         if (pr == null || !pr.isFromPackage() || !isPackageRoomDurationExceeded(pr) || pr.getRoomFacilityCharge() == null) {
             return 0.0;
         }
-        calCulateRoomCharge(pr);
-        double liveEquivalent = pr.getCalculatedRoomCharge();
+        // currentRoomCharge holds the package's locked TOTAL for this room, not a
+        // per-block rate, so it must not be used as the multiplicand here (that was
+        // the bug: reusing calCulateRoomCharge(pr), which multiplies
+        // pr.getCurrentRoomCharge() by elapsed blocks). Both sides of this variance
+        // must be derived from the room's real per-block rate, RoomFacilityCharge.roomCharge.
+        Double facilityRoomCharge = pr.getRoomFacilityCharge().getRoomCharge();
+        if (facilityRoomCharge == null) {
+            return 0.0;
+        }
+        TimedItemFee timedFee = pr.getRoomFacilityCharge().getTimedItemFee();
+        double liveEquivalent = facilityRoomCharge * getInwardBean().calCount(timedFee, pr.getAdmittedAt(), pr.getDischargedAt());
         // RoomFacilityCharge.roomCharge is a rate per TimedItemFee.durationHours block (see
         // InwardBeanController.calCount: charge = roomCharge * count, where count is the number
         // of durationHours-sized blocks between admittedAt/dischargedAt). Room-charge TimedItemFee
         // configs are conventionally 24-hour ("per day") blocks, so we use the actual configured
         // durationHours here (falling back to 24.0 if unset) rather than hardcoding 24.
-        TimedItemFee timedFee = pr.getRoomFacilityCharge().getTimedItemFee();
         double blockHours = (timedFee != null && timedFee.getDurationHours() > 0) ? timedFee.getDurationHours() : 24.0;
-        double includedEquivalent = pr.getRoomFacilityCharge().getRoomCharge() != null
-                ? pr.getRoomFacilityCharge().getRoomCharge() * (pr.getIncludedRoomDurationHours() / blockHours)
-                : 0.0;
+        double includedEquivalent = facilityRoomCharge * (pr.getIncludedRoomDurationHours() / blockHours);
         return Math.max(0.0, liveEquivalent - includedEquivalent);
     }
 

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageAdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageAdmissionController.java
@@ -1,0 +1,115 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.entity.inward.InpatientPackage;
+import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.facade.InpatientPackageFacade;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class InpatientPackageAdmissionController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private AdmissionController admissionController;
+
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private InpatientPackageFacade inpatientPackageFacade;
+
+    private Patient patient;
+    private InpatientPackage inpatientPackage;
+
+    public List<Patient> completePatient(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<String, Object> m = new HashMap<>();
+        m.put("name", "%" + query.toUpperCase() + "%");
+        String jpql = "SELECT p FROM Patient p"
+                + " WHERE p.retired = false"
+                + " AND UPPER(p.person.name) LIKE :name"
+                + " ORDER BY p.person.name";
+        return patientFacade.findByJpql(jpql, m, 15);
+    }
+
+    public List<InpatientPackage> completeInpatientPackage(String query) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("name", "%" + (query == null ? "" : query.toUpperCase()) + "%");
+        String jpql = "SELECT p FROM InpatientPackage p"
+                + " WHERE p.retired = false"
+                + " AND UPPER(p.name) LIKE :name"
+                + " ORDER BY p.name";
+        return inpatientPackageFacade.findByJpql(jpql, m, 15);
+    }
+
+    public String navigatePackageAdmit() {
+        if (patient == null || patient.getId() == null) {
+            JsfUtil.addErrorMessage("Please select a Patient");
+            return "";
+        }
+        if (inpatientPackage == null || inpatientPackage.getId() == null) {
+            JsfUtil.addErrorMessage("Please select an Inpatient Package");
+            return "";
+        }
+
+        Admission ad = new Admission();
+        ad.setDateOfAdmission(CommonFunctions.getCurrentDateTime());
+        ad.setPatient(patient);
+        ad.setAdmissionType(inpatientPackage.getAdmissionType());
+        ad.setInpatientPackage(inpatientPackage);
+
+        admissionController.setCurrent(ad);
+        admissionController.setPrintPreview(false);
+        admissionController.setAdmittingProcessStarted(false);
+        admissionController.setPatientRoom(new PatientRoom());
+        admissionController.setPatientAllergies(null);
+        admissionController.setCurrentReservation(null);
+        admissionController.setBhtText("");
+
+        patient = null;
+        inpatientPackage = null;
+
+        return "/inward/inward_admission?faces-redirect=true";
+    }
+
+    public String navigateToPackageAdmitFromMenu() {
+        patient = null;
+        inpatientPackage = null;
+        return "/inward/package_admit?faces-redirect=true";
+    }
+
+    public Patient getPatient() {
+        return patient;
+    }
+
+    public void setPatient(Patient patient) {
+        this.patient = patient;
+    }
+
+    public InpatientPackage getInpatientPackage() {
+        return inpatientPackage;
+    }
+
+    public void setInpatientPackage(InpatientPackage inpatientPackage) {
+        this.inpatientPackage = inpatientPackage;
+    }
+}

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
@@ -1,12 +1,19 @@
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.entity.inward.InpatientPackage;
+import com.divudi.core.entity.inward.InpatientPackageItem;
 import com.divudi.core.facade.InpatientPackageFacade;
+import com.divudi.core.facade.InpatientPackageItemFacade;
+import com.divudi.core.util.InpatientPackagePricing;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
@@ -25,8 +32,14 @@ public class InpatientPackageController implements Serializable {
     @Inject
     private SessionController sessionController;
 
+    @Inject
+    private WebUserController webUserController;
+
     @EJB
     private InpatientPackageFacade ejbFacade;
+
+    @EJB
+    private InpatientPackageItemFacade inpatientPackageItemFacade;
 
     private InpatientPackage current;
     private List<InpatientPackage> items;
@@ -37,6 +50,10 @@ public class InpatientPackageController implements Serializable {
     }
 
     public void delete() {
+        if (!webUserController.hasPrivilege("InwardPackageAdministration")) {
+            JsfUtil.addErrorMessage("You are not authorized to manage Inpatient Packages.");
+            return;
+        }
         if (current == null || current.getId() == null) {
             JsfUtil.addErrorMessage("Nothing to delete");
             return;
@@ -52,6 +69,10 @@ public class InpatientPackageController implements Serializable {
     }
 
     public void saveSelected() {
+        if (!webUserController.hasPrivilege("InwardPackageAdministration")) {
+            JsfUtil.addErrorMessage("You are not authorized to manage Inpatient Packages.");
+            return;
+        }
         if (current == null || current.getName() == null || current.getName().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please enter a package name");
             return;
@@ -64,6 +85,16 @@ public class InpatientPackageController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Room Category");
             return;
         }
+        double fixedRoomCharge = current.getFixedRoomCharge() != null ? current.getFixedRoomCharge() : 0.0;
+        List<InpatientPackageItem> components = new ArrayList<>();
+        if (current.getId() != null) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("pkg", current);
+            components = inpatientPackageItemFacade.findByJpql(
+                    "SELECT i FROM InpatientPackageItem i WHERE i.retired = false AND i.inpatientPackage = :pkg",
+                    params);
+        }
+        current.setTotalPrice(InpatientPackagePricing.calculateTotalPrice(fixedRoomCharge, components));
         if (current.getId() != null) {
             ejbFacade.edit(current);
             JsfUtil.addSuccessMessage("Updated Successfully.");

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
@@ -1,0 +1,102 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.inward.InpatientPackage;
+import com.divudi.core.facade.InpatientPackageFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class InpatientPackageController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SessionController sessionController;
+
+    @EJB
+    private InpatientPackageFacade ejbFacade;
+
+    private InpatientPackage current;
+    private List<InpatientPackage> items;
+
+    public void prepareAdd() {
+        current = new InpatientPackage();
+        items = null;
+    }
+
+    public void delete() {
+        if (current == null || current.getId() == null) {
+            JsfUtil.addErrorMessage("Nothing to delete");
+            return;
+        }
+        current.setRetired(true);
+        current.setRetirer(sessionController.getLoggedUser());
+        current.setRetiredAt(new Date());
+        current.setRetireComments("Deleted from Manage Inpatient Packages");
+        ejbFacade.edit(current);
+        items = null;
+        current = null;
+        JsfUtil.addSuccessMessage("Deleted Successfully");
+    }
+
+    public void saveSelected() {
+        if (current == null || current.getName() == null || current.getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter a package name");
+            return;
+        }
+        if (current.getAdmissionType() == null) {
+            JsfUtil.addErrorMessage("Please select an Admission Type");
+            return;
+        }
+        if (current.getRoomCategory() == null) {
+            JsfUtil.addErrorMessage("Please select a Room Category");
+            return;
+        }
+        if (current.getId() != null) {
+            ejbFacade.edit(current);
+            JsfUtil.addSuccessMessage("Updated Successfully.");
+        } else {
+            current.setCreatedAt(new Date());
+            current.setCreater(sessionController.getLoggedUser());
+            ejbFacade.create(current);
+            JsfUtil.addSuccessMessage("Saved Successfully");
+        }
+        items = null;
+    }
+
+    public List<InpatientPackage> getItems() {
+        if (items == null) {
+            items = ejbFacade.findByJpql("SELECT p FROM InpatientPackage p WHERE p.retired = false ORDER BY p.name");
+        }
+        return items;
+    }
+
+    public InpatientPackage getCurrent() {
+        if (current == null) {
+            current = new InpatientPackage();
+        }
+        return current;
+    }
+
+    public void setCurrent(InpatientPackage current) {
+        this.current = current;
+    }
+
+    public String navigateToManageInpatientPackagesFromMenu() {
+        current = null;
+        items = null;
+        return "/inward/inward_inpatient_package?faces-redirect=true";
+    }
+
+    public InpatientPackageFacade getEjbFacade() {
+        return ejbFacade;
+    }
+}

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageController.java
@@ -9,6 +9,10 @@ import java.util.Date;
 import java.util.List;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -98,5 +102,45 @@ public class InpatientPackageController implements Serializable {
 
     public InpatientPackageFacade getEjbFacade() {
         return ejbFacade;
+    }
+
+    @FacesConverter(forClass = InpatientPackage.class)
+    public static class InpatientPackageControllerConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.length() == 0) {
+                return null;
+            }
+            InpatientPackageController controller = (InpatientPackageController) facesContext.getApplication().getELResolver().
+                    getValue(facesContext.getELContext(), null, "inpatientPackageController");
+            return controller.getEjbFacade().find(getKey(value));
+        }
+
+        java.lang.Long getKey(String value) {
+            java.lang.Long key;
+            key = Long.valueOf(value);
+            return key;
+        }
+
+        String getStringKey(java.lang.Long value) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(value);
+            return sb.toString();
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return null;
+            }
+            if (object instanceof InpatientPackage) {
+                InpatientPackage o = (InpatientPackage) object;
+                return getStringKey(o.getId());
+            } else {
+                throw new IllegalArgumentException("object " + object + " is of type "
+                        + object.getClass().getName() + "; expected type: " + InpatientPackageController.class.getName());
+            }
+        }
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageItemController.java
@@ -1,0 +1,151 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.inward.InpatientPackageComponentType;
+import com.divudi.core.entity.inward.InpatientPackage;
+import com.divudi.core.entity.inward.InpatientPackageItem;
+import com.divudi.core.facade.InpatientPackageFacade;
+import com.divudi.core.facade.InpatientPackageItemFacade;
+import com.divudi.core.util.InpatientPackagePricing;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class InpatientPackageItemController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SessionController sessionController;
+
+    @EJB
+    private InpatientPackageItemFacade ejbFacade;
+
+    @EJB
+    private InpatientPackageFacade inpatientPackageFacade;
+
+    private InpatientPackage currentPackage;
+    private InpatientPackageItem current;
+    private List<InpatientPackageItem> items;
+
+    public String navigateToManageComponents(InpatientPackage pkg) {
+        currentPackage = pkg;
+        current = null;
+        items = null;
+        return "/inward/inward_inpatient_package_item?faces-redirect=true";
+    }
+
+    public void prepareAdd() {
+        current = new InpatientPackageItem();
+        current.setInpatientPackage(currentPackage);
+        current.setQty(1.0);
+    }
+
+    public List<InpatientPackageItem> getItems() {
+        if (currentPackage == null || currentPackage.getId() == null) {
+            items = new ArrayList<>();
+            return items;
+        }
+        Map<String, Object> m = new HashMap<>();
+        m.put("pkg", currentPackage);
+        items = ejbFacade.findByJpql(
+                "SELECT i FROM InpatientPackageItem i WHERE i.retired = false AND i.inpatientPackage = :pkg ORDER BY i.componentType, i.id",
+                m);
+        return items;
+    }
+
+    public void saveSelected() {
+        if (current == null || current.getComponentType() == null) {
+            JsfUtil.addErrorMessage("Please select a component type");
+            return;
+        }
+        if (current.getComponentType() == InpatientPackageComponentType.PROFESSIONAL_FEE_ROLE) {
+            if (current.getSpeciality() == null && (current.getRoleLabel() == null || current.getRoleLabel().trim().isEmpty())) {
+                JsfUtil.addErrorMessage("Please select a Speciality or enter a Role Label");
+                return;
+            }
+        } else if (current.getItem() == null) {
+            JsfUtil.addErrorMessage("Please select an Item");
+            return;
+        }
+        if (current.getQty() == null || current.getQty() <= 0) {
+            JsfUtil.addErrorMessage("Please enter a quantity greater than zero");
+            return;
+        }
+        if (current.getFixedPrice() == null || current.getFixedPrice() < 0) {
+            JsfUtil.addErrorMessage("Please enter a fixed price");
+            return;
+        }
+        current.setInpatientPackage(currentPackage);
+        if (current.getId() != null) {
+            ejbFacade.edit(current);
+            JsfUtil.addSuccessMessage("Updated Successfully.");
+        } else {
+            current.setCreatedAt(new Date());
+            current.setCreater(sessionController.getLoggedUser());
+            ejbFacade.create(current);
+            JsfUtil.addSuccessMessage("Component Added");
+        }
+        current = null;
+        items = null;
+        recalculateTotal();
+    }
+
+    public void delete() {
+        if (current == null || current.getId() == null) {
+            JsfUtil.addErrorMessage("Nothing to delete");
+            return;
+        }
+        current.setRetired(true);
+        current.setRetirer(sessionController.getLoggedUser());
+        current.setRetiredAt(new Date());
+        current.setRetireComments("Removed from package");
+        ejbFacade.edit(current);
+        current = null;
+        items = null;
+        recalculateTotal();
+    }
+
+    private void recalculateTotal() {
+        if (currentPackage == null || currentPackage.getId() == null) {
+            return;
+        }
+        double fixedRoomCharge = currentPackage.getFixedRoomCharge() != null ? currentPackage.getFixedRoomCharge() : 0.0;
+        double total = InpatientPackagePricing.calculateTotalPrice(fixedRoomCharge, getItems());
+        currentPackage.setTotalPrice(total);
+        inpatientPackageFacade.edit(currentPackage);
+    }
+
+    public InpatientPackage getCurrentPackage() {
+        return currentPackage;
+    }
+
+    public void setCurrentPackage(InpatientPackage currentPackage) {
+        this.currentPackage = currentPackage;
+    }
+
+    public InpatientPackageItem getCurrent() {
+        if (current == null) {
+            current = new InpatientPackageItem();
+        }
+        return current;
+    }
+
+    public void setCurrent(InpatientPackageItem current) {
+        this.current = current;
+    }
+
+    public InpatientPackageComponentType[] getComponentTypes() {
+        return InpatientPackageComponentType.values();
+    }
+}

--- a/src/main/java/com/divudi/bean/inward/InpatientPackageItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientPackageItemController.java
@@ -1,6 +1,7 @@
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.inward.InpatientPackageComponentType;
 import com.divudi.core.entity.inward.InpatientPackage;
 import com.divudi.core.entity.inward.InpatientPackageItem;
@@ -27,6 +28,9 @@ public class InpatientPackageItemController implements Serializable {
 
     @Inject
     private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
 
     @EJB
     private InpatientPackageItemFacade ejbFacade;
@@ -65,6 +69,10 @@ public class InpatientPackageItemController implements Serializable {
     }
 
     public void saveSelected() {
+        if (!webUserController.hasPrivilege("InwardPackageAdministration")) {
+            JsfUtil.addErrorMessage("You are not authorized to manage Inpatient Packages.");
+            return;
+        }
         if (current == null || current.getComponentType() == null) {
             JsfUtil.addErrorMessage("Please select a component type");
             return;
@@ -102,6 +110,10 @@ public class InpatientPackageItemController implements Serializable {
     }
 
     public void delete() {
+        if (!webUserController.hasPrivilege("InwardPackageAdministration")) {
+            JsfUtil.addErrorMessage("You are not authorized to manage Inpatient Packages.");
+            return;
+        }
         if (current == null || current.getId() == null) {
             JsfUtil.addErrorMessage("Nothing to delete");
             return;

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -115,6 +115,7 @@ public class InwardProfessionalBillController implements Serializable {
     private String ageText;
     private Speciality speciality;
     private Staff staff;
+    private Staff pendingPackageStaff;
     private Bill current;
     private Institution institution;
     BillEntry removeBillEntry;
@@ -254,6 +255,11 @@ public class InwardProfessionalBillController implements Serializable {
 
         if (encounterComponent.getBillFee().getPaidValue() != 0) {
             JsfUtil.addErrorMessage("Staff Payment Already Paid U cant Remove");
+            return;
+        }
+
+        if (encounterComponent.getBillFee().isFromPackage()) {
+            JsfUtil.addErrorMessage("This fee is included in the admission's package and cannot be removed.");
             return;
         }
 
@@ -736,6 +742,23 @@ public class InwardProfessionalBillController implements Serializable {
         save();
         freeOfChargeProfessionalPayment = false;
         //   JsfUtil.addSuccessMessage("Fee Added");
+    }
+
+    public void assignStaffToPackageFee(BillFee billFee, Staff staff) {
+        if (billFee == null || !billFee.isFromPackage()) {
+            JsfUtil.addErrorMessage("This action is only for package-included professional fee roles.");
+            return;
+        }
+        if (staff == null) {
+            JsfUtil.addErrorMessage("Please select a Staff");
+            return;
+        }
+        double lockedFee = billFee.getOverriddenRate() != null ? billFee.getOverriddenRate() : billFee.getFeeValue();
+        billFee.setStaff(staff);
+        billFee.setFeeValue(lockedFee);
+        billFee.setFeeGrossValue(lockedFee);
+        getBillFeeFacade().edit(billFee);
+        JsfUtil.addSuccessMessage("Staff assigned. Fee amount unchanged.");
     }
 
     public void feeChanged(BillFee bf) {
@@ -1244,6 +1267,10 @@ public class InwardProfessionalBillController implements Serializable {
     }
 
     public void remove(BillFee bf) {
+        if (bf.isFromPackage()) {
+            JsfUtil.addErrorMessage("This fee is included in the admission's package and cannot be removed.");
+            return;
+        }
         bf.setRetiredAt(new Date());
         bf.setRetired(true);
         bf.setRetirer(getSessionController().getLoggedUser());
@@ -1338,6 +1365,14 @@ public class InwardProfessionalBillController implements Serializable {
 
     public void setStaff(Staff staff) {
         this.staff = staff;
+    }
+
+    public Staff getPendingPackageStaff() {
+        return pendingPackageStaff;
+    }
+
+    public void setPendingPackageStaff(Staff pendingPackageStaff) {
+        this.pendingPackageStaff = pendingPackageStaff;
     }
 
     public BillFee getCurrentBillFee() {

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -47,6 +47,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import com.divudi.bean.common.ConfigOptionController;
 import javax.ejb.EJB;
 import com.divudi.bean.inward.SurgeryBillController;
@@ -115,7 +116,7 @@ public class InwardProfessionalBillController implements Serializable {
     private String ageText;
     private Speciality speciality;
     private Staff staff;
-    private Staff pendingPackageStaff;
+    private Map<Long, Staff> pendingPackageStaffByFeeId = new HashMap<>();
     private Bill current;
     private Institution institution;
     BillEntry removeBillEntry;
@@ -753,6 +754,12 @@ public class InwardProfessionalBillController implements Serializable {
             JsfUtil.addErrorMessage("Please select a Staff");
             return;
         }
+        if (billFee.getSpeciality() != null
+                && (staff.getSpeciality() == null || !staff.getSpeciality().equals(billFee.getSpeciality()))) {
+            JsfUtil.addErrorMessage("Selected staff's speciality does not match this fee role's required speciality ("
+                    + billFee.getSpeciality().getName() + ").");
+            return;
+        }
         double lockedFee = billFee.getOverriddenRate() != null ? billFee.getOverriddenRate() : billFee.getFeeValue();
         billFee.setStaff(staff);
         billFee.setFeeValue(lockedFee);
@@ -1030,6 +1037,7 @@ public class InwardProfessionalBillController implements Serializable {
         totalProfessionalFeesForEncounter = 0.0;
         savedEstimatedProfessionalFees = null;
         totalSavedEstimatedProfessionalFeesForEncounter = 0.0;
+        pendingPackageStaffByFeeId.clear();
     }
 
     private void fetchEncounterProfessionalFees() {
@@ -1367,12 +1375,11 @@ public class InwardProfessionalBillController implements Serializable {
         this.staff = staff;
     }
 
-    public Staff getPendingPackageStaff() {
-        return pendingPackageStaff;
-    }
-
-    public void setPendingPackageStaff(Staff pendingPackageStaff) {
-        this.pendingPackageStaff = pendingPackageStaff;
+    public Map<Long, Staff> getPendingPackageStaffByFeeId() {
+        if (pendingPackageStaffByFeeId == null) {
+            pendingPackageStaffByFeeId = new HashMap<>();
+        }
+        return pendingPackageStaffByFeeId;
     }
 
     public BillFee getCurrentBillFee() {

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -645,6 +645,10 @@ public class InwardTimedItemController implements Serializable {
     }
 
     public void finalizeService(PatientItem pic) {
+        if (pic != null && pic.getBillItem() != null && pic.getBillItem().isFromPackage()) {
+            JsfUtil.addErrorMessage("This item is included in the admission's package and its charge cannot be changed.");
+            return;
+        }
         PatientItem temPi;
         if (pic.getToTime() != null && pic.getFromTime() != null) {
             if (pic.getToTime().before(pic.getFromTime())) {

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -350,6 +350,10 @@ public class InwardTimedItemController implements Serializable {
         if (generalChecking()) {
             return;
         }
+        if (encounterComponent.getBillItem() != null && encounterComponent.getBillItem().isFromPackage()) {
+            JsfUtil.addErrorMessage("This item is included in the admission's package and cannot be removed.");
+            return;
+        }
 
         retiredEncounterComponent(encounterComponent);
         retiredBillFee(encounterComponent.getBillFee());
@@ -381,6 +385,10 @@ public class InwardTimedItemController implements Serializable {
     }
 
     public void removePatientItem(PatientItem patientItem) {
+        if (patientItem != null && patientItem.getBillItem() != null && patientItem.getBillItem().isFromPackage()) {
+            JsfUtil.addErrorMessage("This item is included in the admission's package and cannot be removed.");
+            return;
+        }
         if (patientItem != null) {
             patientItem.setRetirer(getSessionController().getLoggedUser());
             patientItem.setRetiredAt(new Date());

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -84,6 +84,10 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     private InpatientDirectIssueNativeSqlService nativeSqlService;
     @EJB
     private PriceMatrixNativeSqlService priceMatrixNativeSqlService;
+    @EJB
+    private com.divudi.core.facade.BillItemFacade billItemFacade;
+    @EJB
+    private com.divudi.core.facade.InpatientPackageItemFacade inpatientPackageItemFacade;
 
     // ---- Working state ----
     private PatientEncounter patientEncounter;
@@ -290,6 +294,60 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     // Add item
     // -----------------------------------------------------------------------
 
+    /**
+     * Self-contained package-allocation check for the direct-issue flow
+     * (Task 16d) — mirrors the allocation lookup + persisted consumption +
+     * in-session consumption pattern used by the other two pharmacy issue
+     * paths (Task 16b/16c's resolvePackageOverrideRate), but duplicated here
+     * since this controller never receives a request-linked BillItem with
+     * useful override state to reuse.
+     */
+    private com.divudi.core.entity.inward.InpatientPackageItem resolvePackageAllocation(Long itemId, double requestedQty) {
+        if (patientEncounter == null || patientEncounter.getInpatientPackage() == null || itemId == null) {
+            return null;
+        }
+        java.util.Map<String, Object> m = new java.util.HashMap<>();
+        m.put("pkg", patientEncounter.getInpatientPackage());
+        m.put("itemId", itemId);
+        m.put("type", com.divudi.core.data.inward.InpatientPackageComponentType.PHARMACY_ITEM);
+        java.util.List<com.divudi.core.entity.inward.InpatientPackageItem> matches = inpatientPackageItemFacade.findByJpql(
+                "SELECT i FROM InpatientPackageItem i"
+                        + " WHERE i.retired = false"
+                        + " AND i.inpatientPackage = :pkg"
+                        + " AND i.item.id = :itemId"
+                        + " AND i.componentType = :type",
+                m);
+        if (matches.isEmpty()) {
+            return null;
+        }
+        com.divudi.core.entity.inward.InpatientPackageItem packageItem = matches.get(0);
+
+        java.util.Map<String, Object> qm = new java.util.HashMap<>();
+        qm.put("pe", patientEncounter);
+        qm.put("itemId", itemId);
+        Double alreadyIssued = billItemFacade.findDoubleByJpql(
+                "SELECT SUM(bi.qty) FROM BillItem bi"
+                        + " WHERE bi.retired = false"
+                        + " AND bi.fromPackage = true"
+                        + " AND bi.patientEncounter = :pe"
+                        + " AND bi.item.id = :itemId",
+                qm);
+        double consumed = alreadyIssued != null ? alreadyIssued : 0.0;
+
+        if (billItemDataList != null) {
+            for (BillItemData existing : billItemDataList) {
+                if (existing.isFromPackage() && itemId.equals(existing.getItemId())) {
+                    consumed += existing.getQty();
+                }
+            }
+        }
+
+        if (consumed + requestedQty > packageItem.getQty()) {
+            return null;
+        }
+        return packageItem;
+    }
+
     public void addBillItem() {
         if (patientEncounter == null) {
             JsfUtil.addErrorMessage("Please select a BHT first.");
@@ -367,32 +425,37 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
         bid.setCatId(null);
 
         // Rate / value for bill line — apply inward price matrix margin and discount
-        double lineRetailRate = selectedStockDto.getRetailRate() != null ? selectedStockDto.getRetailRate() : 0.0;
+        com.divudi.core.entity.inward.InpatientPackageItem packageAllocation = resolvePackageAllocation(selectedStockDto.getItemId(), qty);
+        boolean isPackageRate = packageAllocation != null;
+        double packageRate = isPackageRate ? packageAllocation.getFixedPrice() / packageAllocation.getQty() : 0.0;
+        double lineRetailRate = isPackageRate ? packageRate : (selectedStockDto.getRetailRate() != null ? selectedStockDto.getRetailRate() : 0.0);
         double absQty = Math.abs(qty);
         double grossValue = lineRetailRate * absQty;
         double marginRate = 0.0;
         double marginValue = 0.0;
         double discountPct = 0.0;
         double discountValue = 0.0;
-        try {
-            long itemId = selectedStockDto.getItemId();
-            Department matrixDept = determineMatrixDepartment();
-            if (matrixDept == null) matrixDept = sessionController.getDepartment();
-            long matrixDeptId = matrixDept.getId();
-            double marginPct = priceMatrixNativeSqlService.getInwardMarginPct(itemId, matrixDeptId, grossValue);
-            if (marginPct != 0.0) {
-                marginRate = (marginPct / 100.0) * lineRetailRate;
-                marginValue = marginRate * absQty;
+        if (!isPackageRate) {
+            try {
+                long itemId = selectedStockDto.getItemId();
+                Department matrixDept = determineMatrixDepartment();
+                if (matrixDept == null) matrixDept = sessionController.getDepartment();
+                long matrixDeptId = matrixDept.getId();
+                double marginPct = priceMatrixNativeSqlService.getInwardMarginPct(itemId, matrixDeptId, grossValue);
+                if (marginPct != 0.0) {
+                    marginRate = (marginPct / 100.0) * lineRetailRate;
+                    marginValue = marginRate * absQty;
+                }
+                if (priceMatrixNativeSqlService.isDiscountAllowed(itemId)) {
+                    Long schemeId = patientEncounter.getPaymentScheme() != null ? patientEncounter.getPaymentScheme().getId() : null;
+                    Long admTypeId = patientEncounter.getAdmissionType() != null ? patientEncounter.getAdmissionType().getId() : null;
+                    String pmName = patientEncounter.getPaymentMethod() != null ? patientEncounter.getPaymentMethod().name() : null;
+                    discountPct = priceMatrixNativeSqlService.getInwardDiscountPct(itemId, pmName, schemeId, admTypeId, matrixDeptId);
+                    discountValue = (discountPct / 100.0) * grossValue;
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "[addBillItem] margin/discount lookup failed, using retail rate only", e);
             }
-            if (priceMatrixNativeSqlService.isDiscountAllowed(itemId)) {
-                Long schemeId = patientEncounter.getPaymentScheme() != null ? patientEncounter.getPaymentScheme().getId() : null;
-                Long admTypeId = patientEncounter.getAdmissionType() != null ? patientEncounter.getAdmissionType().getId() : null;
-                String pmName = patientEncounter.getPaymentMethod() != null ? patientEncounter.getPaymentMethod().name() : null;
-                discountPct = priceMatrixNativeSqlService.getInwardDiscountPct(itemId, pmName, schemeId, admTypeId, matrixDeptId);
-                discountValue = (discountPct / 100.0) * grossValue;
-            }
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "[addBillItem] margin/discount lookup failed, using retail rate only", e);
         }
         double netRate = lineRetailRate + marginRate - (absQty > 0 ? discountValue / absQty : 0.0);
         double netValue = grossValue + marginValue - discountValue;
@@ -403,6 +466,11 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
         bid.setMarginValue(marginValue);
         bid.setNetValue(-netValue);
         bid.setGrossValue(-grossValue);
+        bid.setFromPackage(isPackageRate);
+        if (isPackageRate) {
+            bid.setOverriddenRate(packageRate);
+            bid.setSourcePackageItemId(packageAllocation.getId());
+        }
 
         if (billItemDataList == null) {
             billItemDataList = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1303,6 +1303,14 @@ public class PharmacyRequestForBhtController implements Serializable {
                 qm);
         double consumed = alreadyIssued != null ? alreadyIssued : 0.0;
 
+        if (getPreBill() != null && getPreBill().getBillItems() != null) {
+            for (BillItem existing : getPreBill().getBillItems()) {
+                if (existing.isFromPackage() && item.equals(existing.getItem())) {
+                    consumed += existing.getQty() != null ? existing.getQty() : 0.0;
+                }
+            }
+        }
+
         if (consumed + requestedQty > packageItem.getQty()) {
             return null; // Beyond allocation — bill remaining/extra qty at live rate.
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -120,6 +120,8 @@ public class PharmacyRequestForBhtController implements Serializable {
     com.divudi.ejb.PrescriptionToItemService prescriptionToItemService;
     @EJB
     private PharmacyService pharmacyService;
+    @EJB
+    private com.divudi.core.facade.InpatientPackageItemFacade inpatientPackageItemFacade;
 /////////////////////////
     Item selectedAlternative;
     private PreBill preBill;
@@ -1269,6 +1271,45 @@ public class PharmacyRequestForBhtController implements Serializable {
         return false;
     }
 
+    private Double resolvePackageOverrideRate(com.divudi.core.entity.Item item, double requestedQty) {
+        if (patientEncounter == null || patientEncounter.getInpatientPackage() == null || item == null) {
+            return null;
+        }
+        java.util.Map<String, Object> m = new java.util.HashMap<>();
+        m.put("pkg", patientEncounter.getInpatientPackage());
+        m.put("item", item);
+        m.put("type", com.divudi.core.data.inward.InpatientPackageComponentType.PHARMACY_ITEM);
+        java.util.List<com.divudi.core.entity.inward.InpatientPackageItem> matches = inpatientPackageItemFacade.findByJpql(
+                "SELECT i FROM InpatientPackageItem i"
+                        + " WHERE i.retired = false"
+                        + " AND i.inpatientPackage = :pkg"
+                        + " AND i.item = :item"
+                        + " AND i.componentType = :type",
+                m);
+        if (matches.isEmpty()) {
+            return null;
+        }
+        com.divudi.core.entity.inward.InpatientPackageItem packageItem = matches.get(0);
+
+        java.util.Map<String, Object> qm = new java.util.HashMap<>();
+        qm.put("pe", patientEncounter);
+        qm.put("item", item);
+        Double alreadyIssued = getBillItemFacade().findDoubleByJpql(
+                "SELECT SUM(bi.qty) FROM BillItem bi"
+                        + " WHERE bi.retired = false"
+                        + " AND bi.fromPackage = true"
+                        + " AND bi.patientEncounter = :pe"
+                        + " AND bi.item = :item",
+                qm);
+        double consumed = alreadyIssued != null ? alreadyIssued : 0.0;
+
+        if (consumed + requestedQty > packageItem.getQty()) {
+            return null; // Beyond allocation — bill remaining/extra qty at live rate.
+        }
+
+        return packageItem.getFixedPrice() / packageItem.getQty();
+    }
+
     public void addBillItem() {
 
         if (billItem == null) {
@@ -1314,6 +1355,9 @@ public class PharmacyRequestForBhtController implements Serializable {
         newBillItem.setQty(getQty());
         newBillItem.setInwardChargeType(InwardChargeType.Medicine);
         newBillItem.setBill(getPreBill());
+        // Required so resolvePackageOverrideRate()'s cumulative-quantity JPQL (bi.patientEncounter = :pe)
+        // can find this row on subsequent dispenses of the same package-listed item.
+        newBillItem.setPatientEncounter(patientEncounter);
 
         // Handle prescription only if prescription data is available
         boolean hasPrescriptionData = hasMeaningfulPrescriptionData(billItem.getPrescription());
@@ -1367,6 +1411,13 @@ public class PharmacyRequestForBhtController implements Serializable {
                     return;
                 }
             }
+        }
+
+        Double packageRate = resolvePackageOverrideRate(newBillItem.getItem(), getQty());
+        if (packageRate != null) {
+            newBillItem.setOverriddenRate(packageRate);
+            newBillItem.setRate(packageRate);
+            newBillItem.setFromPackage(true);
         }
 
         newBillItem.setSearialNo(getPreBill().getBillItems().size() + 1);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1305,7 +1305,7 @@ public class PharmacyRequestForBhtController implements Serializable {
 
         if (getPreBill() != null && getPreBill().getBillItems() != null) {
             for (BillItem existing : getPreBill().getBillItems()) {
-                if (existing.isFromPackage() && item.equals(existing.getItem())) {
+                if (existing.getId() == null && existing.isFromPackage() && item.equals(existing.getItem())) {
                     consumed += existing.getQty() != null ? existing.getQty() : 0.0;
                 }
             }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2578,6 +2578,20 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
 
+        if (bi.isFromPackage() && bi.getOverriddenRate() != null) {
+            double packageRate = bi.getOverriddenRate();
+            double quantity = bi.getQty() != null ? bi.getQty() : 0.0;
+            bi.setRate(packageRate);
+            bi.setGrossValue(packageRate * quantity);
+            bi.setMarginValue(0.0);
+            bi.setNetValue(packageRate * quantity);
+            bi.setMarginRate(0.0);
+            bi.setNetRate(packageRate);
+            bi.setAdjustedValue(packageRate * quantity);
+            bi.setDiscount(0);
+            return;
+        }
+
         if (selectedStockDto != null
                 && bi.getPharmaceuticalBillItem().getStock() != null
                 && Objects.equals(selectedStockDto.getId(), bi.getPharmaceuticalBillItem().getStock().getId())) {
@@ -2936,6 +2950,11 @@ public class PharmacySaleBhtController implements Serializable {
                     billItem.setInwardChargeType(InwardChargeType.Medicine);
                     billItem.getPharmaceuticalBillItem().setBillItem(billItem);
                     billItem.setReferanceBillItem(i);
+                    if (i.isFromPackage()) {
+                        billItem.setFromPackage(true);
+                        billItem.setOverriddenRate(i.getOverriddenRate());
+                        billItem.setSourcePackageItem(i.getSourcePackageItem());
+                    }
                     billItem.setSearialNo(getBillItems().size() + 1);
                     if (isSubstitute) {
                         billItem.setAutoSubstituted(true);
@@ -2957,6 +2976,11 @@ public class PharmacySaleBhtController implements Serializable {
                 billItem.setDescreption(i.getDescreption());
                 billItem.setInwardChargeType(InwardChargeType.Medicine);
                 billItem.setReferanceBillItem(i);
+                if (i.isFromPackage()) {
+                    billItem.setFromPackage(true);
+                    billItem.setOverriddenRate(i.getOverriddenRate());
+                    billItem.setSourcePackageItem(i.getSourcePackageItem());
+                }
                 billItem.setSearialNo(getBillItems().size() + 1);
                 billItem.getPharmaceuticalBillItem().setBillItem(billItem);
                 calculateRates(billItem);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -138,6 +138,8 @@ public enum Privileges {
     InwardPhysicalDischarge("Inward Physical Discharge"),
     InwardDocumentUpload("Inward Document Upload"),
     InpatientLetter("Inpatient Letter"),
+    InwardPackageAdministration("Inward Package Administration"),
+    InwardPackageAdmission("Inward Package Admission"),
     //</editor-fold>
     
     //<editor-fold defaultstate="collapsed" desc="Nurse">
@@ -1175,6 +1177,8 @@ public enum Privileges {
             case InwardAddChargesAfterNursingDischarge:
             case InwardDocumentUpload:
             case InpatientLetter:
+            case InwardPackageAdministration:
+            case InwardPackageAdmission:
             case InwardFormTemplateAdmin:
             case InwardFormFill:
             case InwardSettleFinalBill:

--- a/src/main/java/com/divudi/core/data/dto/BillItemData.java
+++ b/src/main/java/com/divudi/core/data/dto/BillItemData.java
@@ -64,6 +64,11 @@ public class BillItemData implements Serializable {
     // ---- Linkage back to an originating ItemRequest line (issue #21793 redesign) ----
     private Long sourceRequestBillItemId;
 
+    // ---- Package rate override (Task 16d — inpatient package pricing) ----
+    private Double overriddenRate;
+    private boolean fromPackage;
+    private Long sourcePackageItemId;
+
     public BillItemData() {
     }
 
@@ -329,5 +334,29 @@ public class BillItemData implements Serializable {
 
     public void setSourceRequestBillItemId(Long sourceRequestBillItemId) {
         this.sourceRequestBillItemId = sourceRequestBillItemId;
+    }
+
+    public Double getOverriddenRate() {
+        return overriddenRate;
+    }
+
+    public void setOverriddenRate(Double overriddenRate) {
+        this.overriddenRate = overriddenRate;
+    }
+
+    public boolean isFromPackage() {
+        return fromPackage;
+    }
+
+    public void setFromPackage(boolean fromPackage) {
+        this.fromPackage = fromPackage;
+    }
+
+    public Long getSourcePackageItemId() {
+        return sourcePackageItemId;
+    }
+
+    public void setSourcePackageItemId(Long sourcePackageItemId) {
+        this.sourcePackageItemId = sourcePackageItemId;
     }
 }

--- a/src/main/java/com/divudi/core/data/inward/InpatientPackageComponentType.java
+++ b/src/main/java/com/divudi/core/data/inward/InpatientPackageComponentType.java
@@ -1,0 +1,9 @@
+package com.divudi.core.data.inward;
+
+public enum InpatientPackageComponentType {
+    SERVICE,
+    TIMED_ITEM,
+    PROFESSIONAL_FEE_ROLE,
+    OUTSIDE_CHARGE,
+    PHARMACY_ITEM
+}

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -5,6 +5,7 @@
 package com.divudi.core.entity;
 
 import com.divudi.core.data.FeeType;
+import com.divudi.core.entity.inward.InpatientPackageItem;
 import com.divudi.core.entity.inward.PatientRoom;
 import java.io.Serializable;
 import java.util.Date;
@@ -122,6 +123,11 @@ public class BillFee implements Serializable, RetirableEntity {
     private BillItem referenceBillItem;
     int orderNo;
 
+    private Double overriddenRate;
+    private boolean fromPackage;
+    @ManyToOne
+    private InpatientPackageItem sourcePackageItem;
+
     private boolean returned;
 
     @Transient
@@ -170,6 +176,30 @@ public class BillFee implements Serializable, RetirableEntity {
         this.orderNo = orderNo;
     }
 
+    public Double getOverriddenRate() {
+        return overriddenRate;
+    }
+
+    public void setOverriddenRate(Double overriddenRate) {
+        this.overriddenRate = overriddenRate;
+    }
+
+    public boolean isFromPackage() {
+        return fromPackage;
+    }
+
+    public void setFromPackage(boolean fromPackage) {
+        this.fromPackage = fromPackage;
+    }
+
+    public InpatientPackageItem getSourcePackageItem() {
+        return sourcePackageItem;
+    }
+
+    public void setSourcePackageItem(InpatientPackageItem sourcePackageItem) {
+        this.sourcePackageItem = sourcePackageItem;
+    }
+
     public double getTransNetValue() {
         transNetValue = (feeValue + feeMargin) - feeDiscount + feeVat;
         return transNetValue;
@@ -203,6 +233,9 @@ public class BillFee implements Serializable, RetirableEntity {
         feeUnitValue = billFee.getFeeUnitValue();
         feeUnitMargin = billFee.getFeeUnitMargin();
         feeUnitDiscount = billFee.getFeeUnitDiscount();
+        overriddenRate = billFee.getOverriddenRate();
+        fromPackage = billFee.isFromPackage();
+        sourcePackageItem = billFee.getSourcePackageItem();
     }
 
     public void copyWithoutFinancialData(BillFee billFee) {
@@ -215,6 +248,8 @@ public class BillFee implements Serializable, RetirableEntity {
         department = billFee.getDepartment();
         speciality = billFee.getSpeciality();
         FeeAt = billFee.getFeeAt();
+        fromPackage = billFee.isFromPackage();
+        sourcePackageItem = billFee.getSourcePackageItem();
     }
 
     public double getFeeVatPlusValue() {

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -8,6 +8,7 @@ import com.divudi.core.data.BillItemStatus;
 import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.data.lab.Priority;
 import com.divudi.core.entity.clinical.Prescription;
+import com.divudi.core.entity.inward.InpatientPackageItem;
 import com.divudi.core.entity.lab.PatientInvestigation;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -143,6 +144,10 @@ public class BillItem implements Serializable, RetirableEntity {
     Bill referenceBill;
     @Enumerated(EnumType.STRING)
     InwardChargeType inwardChargeType;
+    private Double overriddenRate;
+    private boolean fromPackage;
+    @ManyToOne
+    private InpatientPackageItem sourcePackageItem;
     String agentRefNo;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date billTime;
@@ -295,6 +300,9 @@ public class BillItem implements Serializable, RetirableEntity {
         collectingCentreFee = billItem.getCollectingCentreFee();
         consideredForCosting = billItem.isConsideredForCosting();
         primaryStaff = billItem.getPrimaryStaff();
+        overriddenRate = billItem.getOverriddenRate();
+        fromPackage = billItem.isFromPackage();
+        sourcePackageItem = billItem.getSourcePackageItem();
         //  referanceBillItem=billItem.getReferanceBillItem();
         // Copy BillItemFinanceDetails if present (access field directly to avoid auto-creation)
         if (billItem.billItemFinanceDetails != null) {
@@ -338,6 +346,9 @@ public class BillItem implements Serializable, RetirableEntity {
         collectingCentreFee = billItem.getCollectingCentreFee();
         consideredForCosting = billItem.isConsideredForCosting();
         primaryStaff = billItem.getPrimaryStaff();
+        overriddenRate = billItem.getOverriddenRate();
+        fromPackage = billItem.isFromPackage();
+        sourcePackageItem = billItem.getSourcePackageItem();
 
         // Access field directly to avoid auto-creation, then use getter for cloning
         if (billItem.billItemFinanceDetails != null) {
@@ -371,6 +382,8 @@ public class BillItem implements Serializable, RetirableEntity {
         agentRefNo = billItem.getAgentRefNo();
         consideredForCosting = billItem.isConsideredForCosting();
         primaryStaff = billItem.getPrimaryStaff();
+        fromPackage = billItem.isFromPackage();
+        sourcePackageItem = billItem.getSourcePackageItem();
     }
 
     public void resetValue() {
@@ -785,6 +798,30 @@ public class BillItem implements Serializable, RetirableEntity {
 
     public void setInwardChargeType(InwardChargeType inwardChargeType) {
         this.inwardChargeType = inwardChargeType;
+    }
+
+    public Double getOverriddenRate() {
+        return overriddenRate;
+    }
+
+    public void setOverriddenRate(Double overriddenRate) {
+        this.overriddenRate = overriddenRate;
+    }
+
+    public boolean isFromPackage() {
+        return fromPackage;
+    }
+
+    public void setFromPackage(boolean fromPackage) {
+        this.fromPackage = fromPackage;
+    }
+
+    public InpatientPackageItem getSourcePackageItem() {
+        return sourcePackageItem;
+    }
+
+    public void setSourcePackageItem(InpatientPackageItem sourcePackageItem) {
+        this.sourcePackageItem = sourcePackageItem;
     }
 
     public String getAgentRefNo() {

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -102,6 +102,8 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     Date timeOfAdmission;
     @ManyToOne
     AdmissionType admissionType;
+    @javax.persistence.ManyToOne
+    private com.divudi.core.entity.inward.InpatientPackage inpatientPackage;
     Boolean discharged = false;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date timeOfDischarge;
@@ -713,6 +715,14 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setAdmissionType(AdmissionType admissionType) {
         this.admissionType = admissionType;
+    }
+
+    public com.divudi.core.entity.inward.InpatientPackage getInpatientPackage() {
+        return inpatientPackage;
+    }
+
+    public void setInpatientPackage(com.divudi.core.entity.inward.InpatientPackage inpatientPackage) {
+        this.inpatientPackage = inpatientPackage;
     }
 
     public Boolean isDischarged() {

--- a/src/main/java/com/divudi/core/entity/inward/InpatientPackage.java
+++ b/src/main/java/com/divudi/core/entity/inward/InpatientPackage.java
@@ -1,0 +1,182 @@
+package com.divudi.core.entity.inward;
+
+import com.divudi.core.entity.RetirableEntity;
+import com.divudi.core.entity.WebUser;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+public class InpatientPackage implements Serializable, RetirableEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    private AdmissionType admissionType;
+
+    @ManyToOne
+    private RoomCategory roomCategory;
+
+    private Double includedRoomDurationHours = 0.0;
+
+    private Double fixedRoomCharge = 0.0;
+
+    private Double totalPrice = 0.0;
+
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    public RoomCategory getRoomCategory() {
+        return roomCategory;
+    }
+
+    public void setRoomCategory(RoomCategory roomCategory) {
+        this.roomCategory = roomCategory;
+    }
+
+    public Double getIncludedRoomDurationHours() {
+        return includedRoomDurationHours;
+    }
+
+    public void setIncludedRoomDurationHours(Double includedRoomDurationHours) {
+        this.includedRoomDurationHours = includedRoomDurationHours;
+    }
+
+    public Double getFixedRoomCharge() {
+        return fixedRoomCharge;
+    }
+
+    public void setFixedRoomCharge(Double fixedRoomCharge) {
+        this.fixedRoomCharge = fixedRoomCharge;
+    }
+
+    public Double getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(Double totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public boolean isRetired() {
+        return retired;
+    }
+
+    @Override
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    @Override
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    @Override
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    @Override
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    @Override
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    @Override
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    @Override
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof InpatientPackage)) {
+            return false;
+        }
+        InpatientPackage other = (InpatientPackage) object;
+        return (this.id != null || other.id == null) && (this.id == null || this.id.equals(other.id));
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.inward.InpatientPackage[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/entity/inward/InpatientPackageItem.java
+++ b/src/main/java/com/divudi/core/entity/inward/InpatientPackageItem.java
@@ -1,0 +1,199 @@
+package com.divudi.core.entity.inward;
+
+import com.divudi.core.data.inward.InpatientPackageComponentType;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Speciality;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.RetirableEntity;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+public class InpatientPackageItem implements Serializable, RetirableEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private InpatientPackage inpatientPackage;
+
+    @Enumerated(EnumType.STRING)
+    private InpatientPackageComponentType componentType;
+
+    @ManyToOne
+    private Item item;
+
+    @ManyToOne
+    private Speciality speciality;
+
+    private String roleLabel;
+
+    private Double qty = 1.0;
+
+    private Double fixedPrice = 0.0;
+
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public InpatientPackage getInpatientPackage() {
+        return inpatientPackage;
+    }
+
+    public void setInpatientPackage(InpatientPackage inpatientPackage) {
+        this.inpatientPackage = inpatientPackage;
+    }
+
+    public InpatientPackageComponentType getComponentType() {
+        return componentType;
+    }
+
+    public void setComponentType(InpatientPackageComponentType componentType) {
+        this.componentType = componentType;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public Speciality getSpeciality() {
+        return speciality;
+    }
+
+    public void setSpeciality(Speciality speciality) {
+        this.speciality = speciality;
+    }
+
+    public String getRoleLabel() {
+        return roleLabel;
+    }
+
+    public void setRoleLabel(String roleLabel) {
+        this.roleLabel = roleLabel;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getFixedPrice() {
+        return fixedPrice;
+    }
+
+    public void setFixedPrice(Double fixedPrice) {
+        this.fixedPrice = fixedPrice;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public boolean isRetired() {
+        return retired;
+    }
+
+    @Override
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    @Override
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    @Override
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    @Override
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    @Override
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    @Override
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    @Override
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof InpatientPackageItem)) {
+            return false;
+        }
+        InpatientPackageItem other = (InpatientPackageItem) object;
+        return (this.id != null || other.id == null) && (this.id == null || this.id.equals(other.id));
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.inward.InpatientPackageItem[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
@@ -101,6 +101,10 @@ public class PatientRoom implements Serializable, RetirableEntity {
     double calculatedLinenCharge = 0;
     double calculatedAdministrationCharge = 0;
     double calculatedMedicalCareCharge = 0;
+
+    private boolean fromPackage;
+    private Double includedRoomDurationHours;
+
 //Discount
     private double discountRoomCharge;
     private double discountMaintainCharge;
@@ -703,6 +707,22 @@ public class PatientRoom implements Serializable, RetirableEntity {
 
     public void setAdmitted(boolean admitted) {
         this.admitted = admitted;
+    }
+
+    public boolean isFromPackage() {
+        return fromPackage;
+    }
+
+    public void setFromPackage(boolean fromPackage) {
+        this.fromPackage = fromPackage;
+    }
+
+    public Double getIncludedRoomDurationHours() {
+        return includedRoomDurationHours;
+    }
+
+    public void setIncludedRoomDurationHours(Double includedRoomDurationHours) {
+        this.includedRoomDurationHours = includedRoomDurationHours;
     }
 
     @OneToMany(mappedBy = "patientRoom", cascade = CascadeType.ALL)

--- a/src/main/java/com/divudi/core/facade/InpatientPackageFacade.java
+++ b/src/main/java/com/divudi/core/facade/InpatientPackageFacade.java
@@ -1,0 +1,22 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.inward.InpatientPackage;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class InpatientPackageFacade extends AbstractFacade<InpatientPackage> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public InpatientPackageFacade() {
+        super(InpatientPackage.class);
+    }
+}

--- a/src/main/java/com/divudi/core/facade/InpatientPackageItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/InpatientPackageItemFacade.java
@@ -1,0 +1,22 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.inward.InpatientPackageItem;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class InpatientPackageItemFacade extends AbstractFacade<InpatientPackageItem> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public InpatientPackageItemFacade() {
+        super(InpatientPackageItem.class);
+    }
+}

--- a/src/main/java/com/divudi/core/util/InpatientPackagePricing.java
+++ b/src/main/java/com/divudi/core/util/InpatientPackagePricing.java
@@ -1,0 +1,26 @@
+package com.divudi.core.util;
+
+import com.divudi.core.entity.inward.InpatientPackageItem;
+import java.util.List;
+
+public class InpatientPackagePricing {
+
+    private InpatientPackagePricing() {
+    }
+
+    public static double calculateTotalPrice(double fixedRoomCharge, List<InpatientPackageItem> components) {
+        double total = fixedRoomCharge;
+        if (components == null) {
+            return total;
+        }
+        for (InpatientPackageItem component : components) {
+            if (component == null || component.isRetired()) {
+                continue;
+            }
+            if (component.getFixedPrice() != null) {
+                total += component.getFixedPrice();
+            }
+        }
+        return total;
+    }
+}

--- a/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
+++ b/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
@@ -7,6 +7,7 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Department;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.Admission;
@@ -113,7 +114,7 @@ public class InpatientPackageApplicationBean {
         patientRoomFacade.edit(patientRoom);
     }
 
-    private BilledBill createLockedBill(Admission admission, BillType billType, BillTypeAtomic billTypeAtomic, BillNumberSuffix suffix, WebUser loggedUser) {
+    private BilledBill createLockedBill(Admission admission, BillType billType, BillTypeAtomic billTypeAtomic, BillNumberSuffix suffix, Department toDepartment, WebUser loggedUser) {
         BilledBill bill = new BilledBill();
         bill.setBillType(billType);
         bill.setBillTypeAtomic(billTypeAtomic);
@@ -127,6 +128,10 @@ public class InpatientPackageApplicationBean {
         bill.setBillTime(new Date());
         bill.setCreatedAt(new Date());
         bill.setCreater(loggedUser);
+        if (toDepartment != null) {
+            bill.setToDepartment(toDepartment);
+            bill.setToInstitution(toDepartment.getInstitution());
+        }
         bill.setDeptId(billNumberBean.departmentBillNumberGenerator(bill.getDepartment(), billType, BillClassType.BilledBill, suffix));
         bill.setInsId(billNumberBean.institutionBillNumberGenerator(bill.getInstitution(), billType, BillClassType.BilledBill, suffix));
         billFacade.create(bill);
@@ -134,7 +139,8 @@ public class InpatientPackageApplicationBean {
     }
 
     private void createLockedServiceBillItem(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
-        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, loggedUser);
+        Department toDepartment = component.getItem() != null ? component.getItem().getDepartment() : null;
+        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, toDepartment, loggedUser);
         BillItem billItem = new BillItem();
         billItem.setBill(bill);
         billItem.setItem(component.getItem());
@@ -152,7 +158,8 @@ public class InpatientPackageApplicationBean {
     }
 
     private void createLockedTimedItem(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
-        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, loggedUser);
+        Department toDepartment = component.getItem() != null ? component.getItem().getDepartment() : null;
+        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, toDepartment, loggedUser);
         BillItem billItem = new BillItem();
         billItem.setBill(bill);
         billItem.setItem(component.getItem());
@@ -181,7 +188,7 @@ public class InpatientPackageApplicationBean {
     }
 
     private void createLockedProfessionalFee(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
-        BilledBill bill = createLockedBill(admission, BillType.InwardProfessional, BillTypeAtomic.INWARD_PROFESSIONAL_FEE_BILL, BillNumberSuffix.NONE, loggedUser);
+        BilledBill bill = createLockedBill(admission, BillType.InwardProfessional, BillTypeAtomic.INWARD_PROFESSIONAL_FEE_BILL, BillNumberSuffix.NONE, null, loggedUser);
         BillFee billFee = new BillFee();
         billFee.setBill(bill);
         billFee.setPatienEncounter(admission);
@@ -199,7 +206,7 @@ public class InpatientPackageApplicationBean {
     }
 
     private void createLockedOutsideCharge(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
-        BilledBill bill = createLockedBill(admission, BillType.InwardOutSideBill, BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL, BillNumberSuffix.NONE, loggedUser);
+        BilledBill bill = createLockedBill(admission, BillType.InwardOutSideBill, BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL, BillNumberSuffix.NONE, null, loggedUser);
         BillItem billItem = new BillItem();
         billItem.setBill(bill);
         billItem.setItem(component.getItem());

--- a/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
+++ b/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
@@ -164,6 +164,7 @@ public class InpatientPackageApplicationBean {
         billItem.setBill(bill);
         billItem.setItem(component.getItem());
         billItem.setQty(component.getQty());
+        billItem.setInwardChargeType(component.getItem() != null ? component.getItem().getInwardChargeType() : null);
         billItem.setPatientEncounter(admission);
         billItem.setGrossValue(component.getFixedPrice());
         billItem.setNetValue(component.getFixedPrice());

--- a/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
+++ b/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
@@ -210,6 +210,7 @@ public class InpatientPackageApplicationBean {
         BillItem billItem = new BillItem();
         billItem.setBill(bill);
         billItem.setItem(component.getItem());
+        billItem.setInwardChargeType(component.getItem() != null ? component.getItem().getInwardChargeType() : null);
         billItem.setPatientEncounter(admission);
         billItem.setDescreption(component.getItem() != null ? component.getItem().getName() : component.getRoleLabel());
         billItem.setGrossValue(component.getFixedPrice());

--- a/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
+++ b/src/main/java/com/divudi/ejb/InpatientPackageApplicationBean.java
@@ -1,0 +1,217 @@
+package com.divudi.ejb;
+
+import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.BillNumberSuffix;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.PatientItem;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.entity.inward.InpatientPackage;
+import com.divudi.core.entity.inward.InpatientPackageItem;
+import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.InpatientPackageItemFacade;
+import com.divudi.core.facade.PatientItemFacade;
+import com.divudi.core.facade.PatientRoomFacade;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+/**
+ * Creates the locked, package-derived billing rows (service, timed item,
+ * professional-fee role, outside charge) as soon as a package-linked
+ * admission is saved, and locks the room charge on the newly created
+ * PatientRoom. Pharmacy-item components are intentionally NOT created here
+ * — they are consumed progressively via pharmacy issue (see Task 16).
+ *
+ * Bill numbering for all four locked-bill categories uses a single,
+ * simplified BillNumberGenerator call pattern (departmentBillNumberGenerator
+ * / institutionBillNumberGenerator taking Department/Institution, BillType,
+ * BillClassType, BillNumberSuffix) rather than replicating each category's
+ * more elaborate, differing numbering strategy used elsewhere
+ * (BillBhtController, InwardAdditionalChargeController,
+ * InwardProfessionalBillController). This was a deliberate v1 simplification.
+ */
+@Stateless
+public class InpatientPackageApplicationBean {
+
+    @EJB
+    private InpatientPackageItemFacade inpatientPackageItemFacade;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private BillFeeFacade billFeeFacade;
+    @EJB
+    private PatientItemFacade patientItemFacade;
+    @EJB
+    private PatientRoomFacade patientRoomFacade;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+
+    public void applyPackageToAdmission(Admission admission, PatientRoom patientRoom, WebUser loggedUser) {
+        InpatientPackage inpatientPackage = admission.getInpatientPackage();
+        if (inpatientPackage == null) {
+            return;
+        }
+
+        lockRoomCharge(inpatientPackage, patientRoom);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("pkg", inpatientPackage);
+        List<InpatientPackageItem> components = inpatientPackageItemFacade.findByJpql(
+                "SELECT i FROM InpatientPackageItem i WHERE i.retired = false AND i.inpatientPackage = :pkg",
+                params);
+
+        for (InpatientPackageItem component : components) {
+            switch (component.getComponentType()) {
+                case SERVICE:
+                    createLockedServiceBillItem(admission, component, loggedUser);
+                    break;
+                case TIMED_ITEM:
+                    createLockedTimedItem(admission, component, loggedUser);
+                    break;
+                case PROFESSIONAL_FEE_ROLE:
+                    createLockedProfessionalFee(admission, component, loggedUser);
+                    break;
+                case OUTSIDE_CHARGE:
+                    createLockedOutsideCharge(admission, component, loggedUser);
+                    break;
+                case PHARMACY_ITEM:
+                    // Not pre-created — consumed progressively via pharmacy issue, see Task 16.
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private void lockRoomCharge(InpatientPackage inpatientPackage, PatientRoom patientRoom) {
+        if (patientRoom == null || patientRoom.getId() == null) {
+            return;
+        }
+        patientRoom.setFromPackage(true);
+        patientRoom.setIncludedRoomDurationHours(inpatientPackage.getIncludedRoomDurationHours());
+        patientRoom.setCurrentRoomCharge(inpatientPackage.getFixedRoomCharge() != null ? inpatientPackage.getFixedRoomCharge() : 0.0);
+        patientRoom.setCurrentMaintananceCharge(0.0);
+        patientRoom.setCurrentNursingCharge(0.0);
+        patientRoom.setCurrentMoCharge(0.0);
+        patientRoom.setCurrentMoChargeForAfterDuration(0.0);
+        patientRoom.setCurrentLinenCharge(0.0);
+        patientRoom.setCurrentAdministrationCharge(0.0);
+        patientRoom.setCurrentMedicalCareCharge(0.0);
+        patientRoomFacade.edit(patientRoom);
+    }
+
+    private BilledBill createLockedBill(Admission admission, BillType billType, BillTypeAtomic billTypeAtomic, BillNumberSuffix suffix, WebUser loggedUser) {
+        BilledBill bill = new BilledBill();
+        bill.setBillType(billType);
+        bill.setBillTypeAtomic(billTypeAtomic);
+        bill.setDepartment(admission.getDepartment());
+        bill.setInstitution(admission.getInstitution());
+        bill.setPatient(admission.getPatient());
+        bill.setPatientEncounter(admission);
+        bill.setPaymentScheme(admission.getPaymentScheme());
+        bill.setPaymentMethod(admission.getPaymentMethod());
+        bill.setBillDate(new Date());
+        bill.setBillTime(new Date());
+        bill.setCreatedAt(new Date());
+        bill.setCreater(loggedUser);
+        bill.setDeptId(billNumberBean.departmentBillNumberGenerator(bill.getDepartment(), billType, BillClassType.BilledBill, suffix));
+        bill.setInsId(billNumberBean.institutionBillNumberGenerator(bill.getInstitution(), billType, BillClassType.BilledBill, suffix));
+        billFacade.create(bill);
+        return bill;
+    }
+
+    private void createLockedServiceBillItem(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
+        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, loggedUser);
+        BillItem billItem = new BillItem();
+        billItem.setBill(bill);
+        billItem.setItem(component.getItem());
+        billItem.setQty(component.getQty());
+        billItem.setInwardChargeType(component.getItem() != null ? component.getItem().getInwardChargeType() : null);
+        billItem.setPatientEncounter(admission);
+        billItem.setGrossValue(component.getFixedPrice());
+        billItem.setNetValue(component.getFixedPrice());
+        billItem.setOverriddenRate(component.getFixedPrice());
+        billItem.setFromPackage(true);
+        billItem.setSourcePackageItem(component);
+        billItem.setCreatedAt(new Date());
+        billItem.setCreater(loggedUser);
+        billItemFacade.create(billItem);
+    }
+
+    private void createLockedTimedItem(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
+        BilledBill bill = createLockedBill(admission, BillType.InwardBill, BillTypeAtomic.INWARD_SERVICE_BILL, BillNumberSuffix.INWSER, loggedUser);
+        BillItem billItem = new BillItem();
+        billItem.setBill(bill);
+        billItem.setItem(component.getItem());
+        billItem.setQty(component.getQty());
+        billItem.setPatientEncounter(admission);
+        billItem.setGrossValue(component.getFixedPrice());
+        billItem.setNetValue(component.getFixedPrice());
+        billItem.setOverriddenRate(component.getFixedPrice());
+        billItem.setFromPackage(true);
+        billItem.setSourcePackageItem(component);
+        billItem.setCreatedAt(new Date());
+        billItem.setCreater(loggedUser);
+        billItemFacade.create(billItem);
+
+        PatientItem patientItem = new PatientItem();
+        patientItem.setPatient(admission.getPatient());
+        patientItem.setPatientEncounter(admission);
+        patientItem.setBill(bill);
+        patientItem.setBillItem(billItem);
+        patientItem.setItem(component.getItem());
+        patientItem.setServiceValue(component.getFixedPrice());
+        patientItem.setDiscount(0.0);
+        patientItem.setCreatedAt(new Date());
+        patientItem.setCreater(loggedUser);
+        patientItemFacade.create(patientItem);
+    }
+
+    private void createLockedProfessionalFee(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
+        BilledBill bill = createLockedBill(admission, BillType.InwardProfessional, BillTypeAtomic.INWARD_PROFESSIONAL_FEE_BILL, BillNumberSuffix.NONE, loggedUser);
+        BillFee billFee = new BillFee();
+        billFee.setBill(bill);
+        billFee.setPatienEncounter(admission);
+        billFee.setSpeciality(component.getSpeciality());
+        billFee.setStaff(null); // Assigned later — see Task 15
+        billFee.setFeeValue(component.getFixedPrice());
+        billFee.setFeeGrossValue(component.getFixedPrice());
+        billFee.setOverriddenRate(component.getFixedPrice());
+        billFee.setFromPackage(true);
+        billFee.setSourcePackageItem(component);
+        billFee.setFeeAt(new Date());
+        billFee.setCreatedAt(new Date());
+        billFee.setCreater(loggedUser);
+        billFeeFacade.create(billFee);
+    }
+
+    private void createLockedOutsideCharge(Admission admission, InpatientPackageItem component, WebUser loggedUser) {
+        BilledBill bill = createLockedBill(admission, BillType.InwardOutSideBill, BillTypeAtomic.INWARD_OUTSIDE_CHARGES_BILL, BillNumberSuffix.NONE, loggedUser);
+        BillItem billItem = new BillItem();
+        billItem.setBill(bill);
+        billItem.setItem(component.getItem());
+        billItem.setPatientEncounter(admission);
+        billItem.setDescreption(component.getItem() != null ? component.getItem().getName() : component.getRoleLabel());
+        billItem.setGrossValue(component.getFixedPrice());
+        billItem.setNetValue(component.getFixedPrice());
+        billItem.setOverriddenRate(component.getFixedPrice());
+        billItem.setFromPackage(true);
+        billItem.setSourcePackageItem(component);
+        billItem.setCreatedAt(new Date());
+        billItem.setCreater(loggedUser);
+        billItemFacade.create(billItem);
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/InpatientDirectIssueNativeSqlService.java
@@ -111,8 +111,9 @@ public class InpatientDirectIssueNativeSqlService {
                 + " (bill_ID, item_ID, qty, descreption, netValue, grossValue, netRate,"
                 + " rate, marginValue, discount, discountRate,"
                 + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
-                + " consideredForCosting, inwardChargeType, referanceBillItem_ID)"
-                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+                + " consideredForCosting, inwardChargeType, referanceBillItem_ID,"
+                + " overriddenRate, fromPackage, sourcePackageItem_ID)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?,?,?,?)")
                 .setParameter(1, billId)
                 .setParameter(2, d.getItemId())
                 .setParameter(3, absQty)
@@ -127,6 +128,9 @@ public class InpatientDirectIssueNativeSqlService {
                 .setParameter(12, new Timestamp(createdAt.getTime()))
                 .setParameter(13, d.getCreaterId())
                 .setParameter(14, d.getSourceRequestBillItemId())
+                .setParameter(15, d.getOverriddenRate())
+                .setParameter(16, d.isFromPackage() ? 1 : 0)
+                .setParameter(17, d.getSourcePackageItemId())
                 .executeUpdate();
             biIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
 

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -446,7 +446,7 @@
                                                         id="acAssignPackageStaff"
                                                         styleClass="w-100"
                                                         inputStyleClass="w-100"
-                                                        value="#{inwardProfessionalBillController.pendingPackageStaff}"
+                                                        value="#{inwardProfessionalBillController.pendingPackageStaffByFeeId[bif.id]}"
                                                         completeMethod="#{inwardProfessionalBillController.completeStaff}"
                                                         var="st"
                                                         maxResults="20"
@@ -459,11 +459,12 @@
                                                         </p:column>
                                                     </p:autoComplete>
                                                     <p:commandButton
+                                                        id="btnAssignPackageStaff"
                                                         title="Assign staff for package fee role #{bif.id}"
                                                         value="Assign"
                                                         icon="fa fa-user-check"
                                                         styleClass="mt-1 ui-button-secondary"
-                                                        actionListener="#{inwardProfessionalBillController.assignStaffToPackageFee(bif, inwardProfessionalBillController.pendingPackageStaff)}"
+                                                        actionListener="#{inwardProfessionalBillController.assignStaffToPackageFee(bif, inwardProfessionalBillController.pendingPackageStaffByFeeId[bif.id])}"
                                                         process="@this acAssignPackageStaff"
                                                         update="@form" />
                                                 </h:panelGroup>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -600,6 +600,34 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </p:column>
+                                        <p:column headerText="Assign Staff">
+                                            <h:panelGroup rendered="#{bif.fromPackage}" layout="block">
+                                                <p:autoComplete
+                                                    id="acAssignPackageStaff"
+                                                    styleClass="w-100"
+                                                    inputStyleClass="w-100"
+                                                    value="#{inwardProfessionalBillController.pendingPackageStaff}"
+                                                    completeMethod="#{inwardProfessionalBillController.completeStaff}"
+                                                    var="st"
+                                                    maxResults="20"
+                                                    itemLabel="#{st.person.nameWithTitle}"
+                                                    itemValue="#{st}"
+                                                    placeholder="Search Doctor..."
+                                                    forceSelection="true">
+                                                    <p:column headerText="Doctor Name" style="padding: 5px;">
+                                                        <h:outputLabel value="#{st.person.nameWithTitle}" styleClass="fw-bold" />
+                                                    </p:column>
+                                                </p:autoComplete>
+                                                <p:commandButton
+                                                    title="Assign staff for package fee role #{bif.id}"
+                                                    value="Assign"
+                                                    icon="fa fa-user-check"
+                                                    styleClass="mt-1 ui-button-secondary"
+                                                    actionListener="#{inwardProfessionalBillController.assignStaffToPackageFee(bif, inwardProfessionalBillController.pendingPackageStaff)}"
+                                                    process="@this acAssignPackageStaff"
+                                                    update="@form" />
+                                            </h:panelGroup>
+                                        </p:column>
                                     </p:dataTable>
                                 </div>
                             </h:panelGroup>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -440,6 +440,34 @@
                                                     <f:convertNumber pattern="#,##0.00" />
                                                 </h:outputLabel>
                                             </p:column>
+                                            <p:column headerText="Assign Staff">
+                                                <h:panelGroup rendered="#{bif.fromPackage}" layout="block">
+                                                    <p:autoComplete
+                                                        id="acAssignPackageStaff"
+                                                        styleClass="w-100"
+                                                        inputStyleClass="w-100"
+                                                        value="#{inwardProfessionalBillController.pendingPackageStaff}"
+                                                        completeMethod="#{inwardProfessionalBillController.completeStaff}"
+                                                        var="st"
+                                                        maxResults="20"
+                                                        itemLabel="#{st.person.nameWithTitle}"
+                                                        itemValue="#{st}"
+                                                        placeholder="Search Doctor..."
+                                                        forceSelection="true">
+                                                        <p:column headerText="Doctor Name" style="padding: 5px;">
+                                                            <h:outputLabel value="#{st.person.nameWithTitle}" styleClass="fw-bold" />
+                                                        </p:column>
+                                                    </p:autoComplete>
+                                                    <p:commandButton
+                                                        title="Assign staff for package fee role #{bif.id}"
+                                                        value="Assign"
+                                                        icon="fa fa-user-check"
+                                                        styleClass="mt-1 ui-button-secondary"
+                                                        actionListener="#{inwardProfessionalBillController.assignStaffToPackageFee(bif, inwardProfessionalBillController.pendingPackageStaff)}"
+                                                        process="@this acAssignPackageStaff"
+                                                        update="@form" />
+                                                </h:panelGroup>
+                                            </p:column>
                                         </p:dataTable>
                                     </p:panel>
                                 </h:panelGroup>
@@ -599,34 +627,6 @@
                                             <h:outputLabel value="#{bif.feeValue}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
-                                        </p:column>
-                                        <p:column headerText="Assign Staff">
-                                            <h:panelGroup rendered="#{bif.fromPackage}" layout="block">
-                                                <p:autoComplete
-                                                    id="acAssignPackageStaff"
-                                                    styleClass="w-100"
-                                                    inputStyleClass="w-100"
-                                                    value="#{inwardProfessionalBillController.pendingPackageStaff}"
-                                                    completeMethod="#{inwardProfessionalBillController.completeStaff}"
-                                                    var="st"
-                                                    maxResults="20"
-                                                    itemLabel="#{st.person.nameWithTitle}"
-                                                    itemValue="#{st}"
-                                                    placeholder="Search Doctor..."
-                                                    forceSelection="true">
-                                                    <p:column headerText="Doctor Name" style="padding: 5px;">
-                                                        <h:outputLabel value="#{st.person.nameWithTitle}" styleClass="fw-bold" />
-                                                    </p:column>
-                                                </p:autoComplete>
-                                                <p:commandButton
-                                                    title="Assign staff for package fee role #{bif.id}"
-                                                    value="Assign"
-                                                    icon="fa fa-user-check"
-                                                    styleClass="mt-1 ui-button-secondary"
-                                                    actionListener="#{inwardProfessionalBillController.assignStaffToPackageFee(bif, inwardProfessionalBillController.pendingPackageStaff)}"
-                                                    process="@this acAssignPackageStaff"
-                                                    update="@form" />
-                                            </h:panelGroup>
                                         </p:column>
                                     </p:dataTable>
                                 </div>

--- a/src/main/webapp/inward/inward_inpatient_package.xhtml
+++ b/src/main/webapp/inward/inward_inpatient_package.xhtml
@@ -1,0 +1,133 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/inward/inward_administration.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="subcontent">
+
+        <h:form id="formInpatientPackage">
+            <p:growl/>
+            <p:focus id="selectFocus" for="lstSelectPackage"/>
+            <p:focus id="detailFocus" for="txtPackageName"/>
+
+            <p:panel class="mx-1">
+                <f:facet name="header">
+                    <i class="fa-solid fa-box-archive"></i>
+                    <p:outputLabel value="Manage Inpatient Packages" class="mx-2"/>
+                </f:facet>
+
+                <div class="row">
+                    <div class="col-md-5">
+                        <div class="row">
+                            <div class="col-12">
+                                <p:commandButton
+                                    id="btnAddPackage"
+                                    value="Add"
+                                    icon="fa fa-plus"
+                                    action="#{inpatientPackageController.prepareAdd()}"
+                                    class="w-25 ui-button-success"
+                                    process="btnAddPackage"
+                                    update="lstSelectPackage gpPackageDetail">
+                                </p:commandButton>
+                                <p:commandButton
+                                    id="btnDeletePackage"
+                                    onclick="if (!confirm('Are you sure you want to delete this record?')) return false;"
+                                    class="w-25 mx-2 ui-button-danger"
+                                    action="#{inpatientPackageController.delete()}"
+                                    value="Delete"
+                                    icon="fa fa-trash"
+                                    process="btnDeletePackage"
+                                    update="lstSelectPackage gpPackageDetail">
+                                </p:commandButton>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                <div class="form-group">
+                                    <p:selectOneListbox
+                                        id="lstSelectPackage"
+                                        value="#{inpatientPackageController.current}"
+                                        class="w-100 mt-2 overflow-auto"
+                                        filter="true">
+                                        <f:selectItems
+                                            value="#{inpatientPackageController.items}"
+                                            var="myPackage"
+                                            itemValue="#{myPackage}"
+                                            itemLabel="#{myPackage.name}">
+                                        </f:selectItems>
+                                        <p:ajax process="lstSelectPackage" update="gpPackageDetail"></p:ajax>
+                                    </p:selectOneListbox>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-md-7">
+                        <p:panel class="mx-1" id="gpPackageDetail">
+                            <f:facet name="header">
+                                <p:outputLabel value="Package Details" class="mt-2"/>
+                                <p:commandButton
+                                    id="btnSavePackage"
+                                    value="Save"
+                                    icon="fa fa-save"
+                                    action="#{inpatientPackageController.saveSelected()}"
+                                    class="ui-button-warning"
+                                    process="btnSavePackage gpPackageDetail"
+                                    style="float: right"
+                                    update="lstSelectPackage">
+                                </p:commandButton>
+                                <p:defaultCommand target="btnSavePackage"/>
+                            </f:facet>
+                            <h:panelGrid columns="3" class="w-100">
+                                <h:outputText value="Name"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:inputText class="mx-2 w-100" autocomplete="off" id="txtPackageName" value="#{inpatientPackageController.current.name}"></p:inputText>
+
+                                <h:outputText value="Admission Type"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:selectOneMenu id="selPackageAdmissionType" value="#{inpatientPackageController.current.admissionType}" class="w-100">
+                                    <f:selectItem itemLabel="Select One" itemValue="#{null}"/>
+                                    <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                                </p:selectOneMenu>
+
+                                <h:outputText value="Room Category"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:selectOneMenu id="selPackageRoomCategory" value="#{inpatientPackageController.current.roomCategory}" class="w-100">
+                                    <f:selectItem itemLabel="Select One" itemValue="#{null}"/>
+                                    <f:selectItems value="#{roomCategoryController.items}" var="rc" itemValue="#{rc}" itemLabel="#{rc.name}"/>
+                                </p:selectOneMenu>
+
+                                <h:outputText value="Included Room Duration (Hours)"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:inputNumber id="txtIncludedDuration" value="#{inpatientPackageController.current.includedRoomDurationHours}" class="w-100"/>
+
+                                <h:outputText value="Fixed Room Charge"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:inputNumber id="txtFixedRoomCharge" value="#{inpatientPackageController.current.fixedRoomCharge}" class="w-100"/>
+
+                                <h:outputText value="Total Package Price"></h:outputText>
+                                <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
+                                <p:outputLabel id="lblTotalPrice" value="#{inpatientPackageController.current.totalPrice}"/>
+                            </h:panelGrid>
+
+                            <h:panelGroup rendered="#{inpatientPackageController.current.id ne null}">
+                                <p:commandButton
+                                    id="btnManageComponents"
+                                    value="Manage Components"
+                                    icon="fa fa-list"
+                                    ajax="false"
+                                    action="#{inpatientPackageItemController.navigateToManageComponents(inpatientPackageController.current)}"
+                                    class="ui-button-info mt-2">
+                                </p:commandButton>
+                            </h:panelGroup>
+                        </p:panel>
+                    </div>
+                </div>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/inward_inpatient_package.xhtml
+++ b/src/main/webapp/inward/inward_inpatient_package.xhtml
@@ -5,9 +5,16 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
 
     <ui:define name="subcontent">
+
+        <h:panelGroup rendered="#{not webUserController.hasPrivilege('InwardPackageAdministration')}">
+            <na:not_authorize />
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardPackageAdministration')}" layout="block">
 
         <h:form id="formInpatientPackage">
             <p:growl/>
@@ -103,11 +110,11 @@
 
                                 <h:outputText value="Included Room Duration (Hours)"></h:outputText>
                                 <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
-                                <p:inputNumber id="txtIncludedDuration" value="#{inpatientPackageController.current.includedRoomDurationHours}" class="w-100"/>
+                                <p:inputNumber id="txtIncludedDuration" value="#{inpatientPackageController.current.includedRoomDurationHours}" class="w-100" minValue="0"/>
 
                                 <h:outputText value="Fixed Room Charge"></h:outputText>
                                 <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
-                                <p:inputNumber id="txtFixedRoomCharge" value="#{inpatientPackageController.current.fixedRoomCharge}" class="w-100"/>
+                                <p:inputNumber id="txtFixedRoomCharge" value="#{inpatientPackageController.current.fixedRoomCharge}" class="w-100" minValue="0"/>
 
                                 <h:outputText value="Total Package Price"></h:outputText>
                                 <p:outputLabel value=": " style="width: 30px; text-align: center;"></p:outputLabel>
@@ -129,5 +136,7 @@
                 </div>
             </p:panel>
         </h:form>
+
+        </h:panelGroup>
     </ui:define>
 </ui:composition>

--- a/src/main/webapp/inward/inward_inpatient_package_item.xhtml
+++ b/src/main/webapp/inward/inward_inpatient_package_item.xhtml
@@ -5,9 +5,17 @@
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
 
     <ui:define name="subcontent">
+
+        <h:panelGroup rendered="#{not webUserController.hasPrivilege('InwardPackageAdministration')}">
+            <na:not_authorize />
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardPackageAdministration')}" layout="block">
+
         <h:form id="formPackageItems">
             <p:growl/>
 
@@ -103,5 +111,7 @@
                 </p:panel>
             </p:panel>
         </h:form>
+
+        </h:panelGroup>
     </ui:define>
 </ui:composition>

--- a/src/main/webapp/inward/inward_inpatient_package_item.xhtml
+++ b/src/main/webapp/inward/inward_inpatient_package_item.xhtml
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/inward/inward_administration.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="subcontent">
+        <h:form id="formPackageItems">
+            <p:growl/>
+
+            <p:panel class="mx-1">
+                <f:facet name="header">
+                    <i class="fa-solid fa-list"></i>
+                    <p:outputLabel value="Package Components: #{inpatientPackageItemController.currentPackage.name}" class="mx-2"/>
+                </f:facet>
+
+                <p:dataTable id="tblComponents" var="row" value="#{inpatientPackageItemController.items}" widgetVar="wTblComponents" rowKey="#{row.id}" styleClass="p-datatable-sm" stickyHeader="true">
+                    <p:column headerText="Type">#{row.componentType}</p:column>
+                    <p:column headerText="Item / Role">#{row.item != null ? row.item.name : row.roleLabel}</p:column>
+                    <p:column headerText="Qty">#{row.qty}</p:column>
+                    <p:column headerText="Fixed Price">#{row.fixedPrice}</p:column>
+                    <p:column headerText="Action">
+                        <p:commandButton
+                            id="btnEditComponent"
+                            title="Edit component #{row.id}"
+                            icon="fa fa-pen"
+                            actionListener="#{inpatientPackageItemController.setCurrent(row)}"
+                            update=":formPackageItems:gpComponentDetail"
+                            process="@this">
+                        </p:commandButton>
+                    </p:column>
+                </p:dataTable>
+
+                <p:panel id="gpComponentDetail" class="mt-3">
+                    <f:facet name="header">
+                        <p:outputLabel value="Add / Edit Component"/>
+                        <p:commandButton
+                            id="btnSaveComponent"
+                            value="Save"
+                            icon="fa fa-save"
+                            action="#{inpatientPackageItemController.saveSelected()}"
+                            process="btnSaveComponent gpComponentDetail"
+                            update="tblComponents gpComponentDetail"
+                            style="float: right">
+                        </p:commandButton>
+                        <p:commandButton
+                            id="btnAddComponent"
+                            value="New"
+                            icon="fa fa-plus"
+                            action="#{inpatientPackageItemController.prepareAdd()}"
+                            process="btnAddComponent"
+                            update="gpComponentDetail"
+                            style="float: right"
+                            class="mx-2">
+                        </p:commandButton>
+                        <p:commandButton
+                            id="btnDeleteComponent"
+                            value="Delete"
+                            icon="fa fa-trash"
+                            onclick="if (!confirm('Remove this component?')) return false;"
+                            action="#{inpatientPackageItemController.delete()}"
+                            process="btnDeleteComponent"
+                            update="tblComponents gpComponentDetail"
+                            style="float: right"
+                            class="mx-2 ui-button-danger">
+                        </p:commandButton>
+                    </f:facet>
+
+                    <h:panelGrid columns="3" class="w-100">
+                        <h:outputText value="Component Type"/>
+                        <p:outputLabel value=": "/>
+                        <p:selectOneMenu id="selComponentType" value="#{inpatientPackageItemController.current.componentType}" class="w-100">
+                            <f:selectItem itemLabel="Select One" itemValue="#{null}"/>
+                            <f:selectItems value="#{inpatientPackageItemController.componentTypes}" var="ct" itemValue="#{ct}" itemLabel="#{ct}"/>
+                        </p:selectOneMenu>
+
+                        <h:outputText value="Item (Service / Timed Item / Pharmacy Item)"/>
+                        <p:outputLabel value=": "/>
+                        <p:autoComplete id="acComponentItem" value="#{inpatientPackageItemController.current.item}" completeMethod="#{itemController.completeItem}" var="itm" itemLabel="#{itm.name}" itemValue="#{itm}" forceSelection="true" maxResults="20" class="w-100"/>
+
+                        <h:outputText value="Speciality (for Professional Fee Role)"/>
+                        <p:outputLabel value=": "/>
+                        <p:selectOneMenu id="selComponentSpeciality" value="#{inpatientPackageItemController.current.speciality}" class="w-100">
+                            <f:selectItem itemLabel="None" itemValue="#{null}"/>
+                            <f:selectItems value="#{specialityController.items}" var="sp" itemValue="#{sp}" itemLabel="#{sp.name}"/>
+                        </p:selectOneMenu>
+
+                        <h:outputText value="Role Label (if no Speciality)"/>
+                        <p:outputLabel value=": "/>
+                        <p:inputText id="txtRoleLabel" value="#{inpatientPackageItemController.current.roleLabel}" class="w-100"/>
+
+                        <h:outputText value="Qty"/>
+                        <p:outputLabel value=": "/>
+                        <p:inputNumber id="txtComponentQty" value="#{inpatientPackageItemController.current.qty}" class="w-100"/>
+
+                        <h:outputText value="Fixed Price"/>
+                        <p:outputLabel value=": "/>
+                        <p:inputNumber id="txtComponentFixedPrice" value="#{inpatientPackageItemController.current.fixedPrice}" class="w-100"/>
+                    </h:panelGrid>
+                </p:panel>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
@@ -129,7 +129,8 @@
                                             <p:autoComplete value="#{bip.staff}"
                                                             disabled="#{bip.paidValue!=0 or bip.fromPackage or !webUserController.hasPrivilege('ChangeProfessionalFee')}"
                                                             completeMethod="#{inwardProfessionalBillController.completeStaff}"
-                                                            var="bifs" itemLabel="#{bifs.person.name}" itemValue="#{bifs}" 
+                                                            var="bifs" itemLabel="#{bifs.person.name}" itemValue="#{bifs}"
+                                                            maxResults="20"
                                                             forceSelection="true"/>
 
                                         </f:facet>  

--- a/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
@@ -126,8 +126,8 @@
                                             <h:outputLabel value="#{bip.staff.person.name}"  ></h:outputLabel>
                                         </f:facet>  
                                         <f:facet name="input">  
-                                            <p:autoComplete value="#{bip.staff}" 
-                                                            disabled="#{bip.paidValue!=0 or !webUserController.hasPrivilege('ChangeProfessionalFee')}"
+                                            <p:autoComplete value="#{bip.staff}"
+                                                            disabled="#{bip.paidValue!=0 or bip.fromPackage or !webUserController.hasPrivilege('ChangeProfessionalFee')}"
                                                             completeMethod="#{inwardProfessionalBillController.completeStaff}"
                                                             var="bifs" itemLabel="#{bifs.person.name}" itemValue="#{bifs}" 
                                                             forceSelection="true"/>

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -311,7 +311,8 @@
                                     ajax="false"
                                     value="Remove"
                                     action="#{inwardTimedItemController.removePatientItem(ti)}"
-                                    disabled="#{inwardTimedItemController.current.patientEncounter.paymentFinalized}" >
+                                    disabled="#{inwardTimedItemController.current.patientEncounter.paymentFinalized}"
+                                    rendered="#{not ti.billItem.fromPackage}" >
                                 </p:commandButton>
                             </div>
 

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -266,21 +266,23 @@
                             #{ti.item.name}
                         </p:column>
                         <p:column headerText="Start Time">
-                            <p:datePicker 
+                            <p:datePicker
                                 showTime="true"
-                                timeInput="true" 
-                                value="#{ti.fromTime}" 
+                                timeInput="true"
+                                value="#{ti.fromTime}"
+                                disabled="#{ti.billItem.fromPackage}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
-                            </p:datePicker>      
+                            </p:datePicker>
 
-                        </p:column>                               
+                        </p:column>
                         <p:column headerText="Stopped Time">
-                            <p:datePicker 
+                            <p:datePicker
                                 showTime="true"
-                                timeInput="true"  
-                                value="#{ti.toTime}" 
+                                timeInput="true"
+                                value="#{ti.toTime}"
+                                disabled="#{ti.billItem.fromPackage}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
-                            </p:datePicker> 
+                            </p:datePicker>
                         </p:column>
                         <p:column headerText="Total" styleClass="averageNumericColumn" rendered="#{webUserController.hasPrivilege('ShowTimeServiceCharges')}">
                             <h:outputLabel  value="#{ti.serviceValue}">
@@ -298,12 +300,13 @@
                         </p:column>     
                         <p:column headerText="Action" >
                             <div class="d-flex gap-2">
-                                <p:commandButton 
-                                    value="Update" 
+                                <p:commandButton
+                                    value="Update"
                                     class="ui-button-warning"
                                     icon="fa fa-pencil"
-                                    ajax="false" 
-                                    action="#{inwardTimedItemController.finalizeService(ti)}" >                                                                    
+                                    ajax="false"
+                                    action="#{inwardTimedItemController.finalizeService(ti)}"
+                                    rendered="#{not ti.billItem.fromPackage}" >
                                 </p:commandButton>
                                 <p:commandButton
                                     icon="fa-solid fa-trash"

--- a/src/main/webapp/inward/package_admit.xhtml
+++ b/src/main/webapp/inward/package_admit.xhtml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
+
+    <ui:define name="content">
+        <h:form id="formPackageAdmit">
+            <h:panelGroup rendered="#{not webUserController.hasPrivilege('InwardPackageAdmission')}">
+                <na:not_authorize />
+            </h:panelGroup>
+
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardPackageAdmission')}">
+                <p:panel>
+                    <f:facet name="header">
+                        <h:outputText styleClass="fa-solid fa-box-archive" />
+                        <h:outputLabel class="mx-4" value="Package Admit"/>
+                    </f:facet>
+
+                    <h:panelGroup class="row" layout="block">
+                        <div class="col-md-3">
+                            <p:outputLabel class="mt-1" value="Select Patient"></p:outputLabel>
+                        </div>
+                        <div class="col-md-6">
+                            <p:autoComplete
+                                value="#{inpatientPackageAdmissionController.patient}"
+                                forceSelection="true"
+                                id="acPatient"
+                                completeMethod="#{inpatientPackageAdmissionController.completePatient}"
+                                var="pt"
+                                itemLabel="#{pt.person.name}"
+                                itemValue="#{pt}"
+                                maxResults="15"
+                                class="w-100 mb-1"
+                                required="true"
+                                requiredMessage="Patient is Required"
+                                placeholder="Search by patient name"
+                                inputStyleClass="form-control">
+                                <p:column headerText="Patient Name" style="padding: 6px;">#{pt.person.name}</p:column>
+                            </p:autoComplete>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup class="row" layout="block">
+                        <div class="col-md-3">
+                            <p:outputLabel class="mt-1" value="Select Inpatient Package"></p:outputLabel>
+                        </div>
+                        <div class="col-md-6">
+                            <p:autoComplete
+                                value="#{inpatientPackageAdmissionController.inpatientPackage}"
+                                forceSelection="true"
+                                id="acInpatientPackage"
+                                completeMethod="#{inpatientPackageAdmissionController.completeInpatientPackage}"
+                                var="pkg"
+                                itemLabel="#{pkg.name}"
+                                itemValue="#{pkg}"
+                                maxResults="15"
+                                class="w-100 mb-1"
+                                required="true"
+                                requiredMessage="Package is Required"
+                                placeholder="Search by package name"
+                                inputStyleClass="form-control">
+                                <p:column headerText="Package Name" style="padding: 6px;">#{pkg.name}</p:column>
+                                <p:column headerText="Admission Type" style="padding: 6px;">#{pkg.admissionType.name}</p:column>
+                                <p:column headerText="Total Price" style="padding: 6px;">#{pkg.totalPrice}</p:column>
+                            </p:autoComplete>
+                        </div>
+                        <div class="col-md-3">
+                            <p:commandButton
+                                id="btnSelectPackage"
+                                ajax="false"
+                                value="Select"
+                                action="#{inpatientPackageAdmissionController.navigatePackageAdmit()}">
+                            </p:commandButton>
+                        </div>
+                    </h:panelGroup>
+                </p:panel>
+            </h:panelGroup>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -2058,15 +2058,22 @@
                         icon="fa fa-list"
                         rendered="#{webUserController.hasPrivilege('AdminItems')}" >
                     </p:menuitem>
-                    <p:menuitem  
+                    <p:menuitem
                         rendered="#{webUserController.hasPrivilege('InwardAdministration')}"
-                        ajax="false"  
-                        action="/inward/inward_administration?faces-redirect=true" 
-                        value="Manage Inpatient Services" 
+                        ajax="false"
+                        action="/inward/inward_administration?faces-redirect=true"
+                        value="Manage Inpatient Services"
                         icon="fa fa-bed" >
                     </p:menuitem>
+                    <p:menuitem
+                        ajax="false"
+                        value="Manage Inpatient Packages"
+                        action="#{inpatientPackageController.navigateToManageInpatientPackagesFromMenu()}"
+                        icon="fa fa-box-archive"
+                        rendered="#{webUserController.hasPrivilege('InwardPackageAdministration')}">
+                    </p:menuitem>
 
-                    <p:menuitem  
+                    <p:menuitem
                         ajax="false"  
                         action="#{pharmacyController.navigateToManagePharmaceuticals}" 
                         value="Pharmaceutical Management" 

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -437,6 +437,13 @@
                         </p:menuitem>
                         <p:menuitem
                             ajax="false"
+                            value="Package Admission"
+                            action="#{inpatientPackageAdmissionController.navigateToPackageAdmitFromMenu()}"
+                            icon="fa fa-box-archive"
+                            rendered="#{webUserController.hasPrivilege('InwardPackageAdmission')}">
+                        </p:menuitem>
+                        <p:menuitem
+                            ajax="false"
                             value="Manage Appointment"
                             actionListener="#{appointmentController.makeNull()}" 
                             action="#{appointmentController.navigateToSearchAppointmentsListFromMenu()}"

--- a/src/test/java/com/divudi/core/util/InpatientPackagePricingTest.java
+++ b/src/test/java/com/divudi/core/util/InpatientPackagePricingTest.java
@@ -1,0 +1,53 @@
+package com.divudi.core.util;
+
+import com.divudi.core.data.inward.InpatientPackageComponentType;
+import com.divudi.core.entity.inward.InpatientPackageItem;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InpatientPackagePricingTest {
+
+    private InpatientPackageItem component(double fixedPrice, boolean retired) {
+        InpatientPackageItem item = new InpatientPackageItem();
+        item.setComponentType(InpatientPackageComponentType.SERVICE);
+        item.setFixedPrice(fixedPrice);
+        item.setRetired(retired);
+        return item;
+    }
+
+    @Test
+    void sumsRoomChargeAndAllActiveComponents() {
+        List<InpatientPackageItem> components = new ArrayList<>();
+        components.add(component(5000.0, false));
+        components.add(component(2500.0, false));
+
+        double total = InpatientPackagePricing.calculateTotalPrice(50000.0, components);
+
+        assertEquals(57500.0, total, 0.001);
+    }
+
+    @Test
+    void excludesRetiredComponents() {
+        List<InpatientPackageItem> components = new ArrayList<>();
+        components.add(component(5000.0, false));
+        components.add(component(9999.0, true));
+
+        double total = InpatientPackagePricing.calculateTotalPrice(50000.0, components);
+
+        assertEquals(55000.0, total, 0.001);
+    }
+
+    @Test
+    void handlesNullComponentListAndNullFixedPrice() {
+        assertEquals(50000.0, InpatientPackagePricing.calculateTotalPrice(50000.0, null), 0.001);
+
+        List<InpatientPackageItem> components = new ArrayList<>();
+        InpatientPackageItem noPrice = component(0.0, false);
+        noPrice.setFixedPrice(null);
+        components.add(noPrice);
+
+        assertEquals(50000.0, InpatientPackagePricing.calculateTotalPrice(50000.0, components), 0.001);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Inpatient Packages** — fixed-price bundles for inpatient admissions covering admission type, room (with an included duration), services, timed-item fees, professional-fee roles, and outside charges, admitted through a flow analogous to the existing appointment-admission path. The resulting interim bill stays at the package's fixed price unless the included room duration is exceeded or extra items are added beyond what the package covers. Pharmacy items included in a package search from department stock (respecting expiry) but bill at the package-defined rate rather than the live stock rate.

- New entities: `InpatientPackage`, `InpatientPackageItem` (component types: SERVICE, TIMED_ITEM, PROFESSIONAL_FEE_ROLE, OUTSIDE_CHARGE, PHARMACY_ITEM)
- New admin CRUD pages for package headers + components, with live total-price recalculation
- New "Package Admit" entry point (patient + package search → admission form), mirroring `appointment_admit.xhtml`
- `InpatientPackageApplicationBean` auto-creates locked billing rows (service, timed item, professional fee, outside charge) at admission time; pharmacy items are consumed progressively at issue time instead
- Room charge locking reuses `PatientRoom`'s existing `current*Charge`/`calculated*Charge` split — package rooms carry a fixed total in `currentRoomCharge` rather than a per-block rate
- Package-sourced billing rows (BillItem/BillFee) carry `overriddenRate`, `fromPackage`, `sourcePackageItem` for provenance and are locked against edit/removal in the UI until the room's included duration is exceeded
- Pharmacy rate override propagates through all 3 issue paths: nurse-request, ward-issue-against-request, and direct-issue (native SQL)
- New privileges: `InwardPackageAdministration`, `InwardPackageAdmission` (registered in the enum, `getCategory()`, and the admin privilege tree)

Built with Subagent-Driven Development (18 planned tasks + follow-ups), each task reviewed individually, plus a final whole-branch review. The final review found 2 Critical bugs at "seams" between the new feature and pre-existing, unmodified billing code (a room-charge multiplication bug and a missing `inwardChargeType` on locked outside-charge rows); both were fixed and live-verified against a real deployment. A follow-up review of that fix caught a third instance of the same defect (missing `inwardChargeType` on locked timed-item rows), also fixed and live-verified.

## Test plan

- [x] `InpatientPackagePricingTest` (unit tests for total-price calculation) passing
- [x] Full `mvn test` passing
- [x] Live E2E via Playwright against a real deployment + MySQL: package CRUD, component CRUD with price recalc, package admission, locked room/service/outside-charge/timed-item BillItem rows created with correct `overriddenRate`/`fromPackage`/`sourcePackageItem`/`inwardChargeType`
- [x] Verified package room charge stays at the fixed locked price (not multiplied by elapsed duration blocks) while within the included duration
- [x] Verified PriceMatrix discounts do not silently undercut a locked package room price
- [ ] Not yet exercised live in this session: room-duration-exceeded variance billing (`getPackageRoomVarianceCharge` — currently unwired, tracked as a follow-up), professional-fee staff-assignment timing, pharmacy package-rate override across all 3 issue paths (each code-reviewed but not run end-to-end live)

Related: hmislk/hmis#9843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inpatient package management, including package details, component setup, soft retirement, and total pricing.
  * Added a “Package Admit” workflow for selecting a patient and package, plus new menu navigation.
  * Package admissions now auto-generate package-locked billing items (including package-aware pharmacy pricing) and disable edits where applicable.
  * Added staff assignment for package-included professional fees.
* **Bug Fixes**
  * Enforced package-locked room charges and prevented modifications/removals for package-included billing/charge items, including timed service start/stop controls.
* **Permissions**
  * Introduced separate privileges for package administration and package admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->