### PR TITLE
feat(lab): Analyzer vise Investigation Counts report (COOP hotfix)

### DIFF
--- a/src/main/java/com/divudi/bean/report/AnalyzerInvestigationCountController.java
+++ b/src/main/java/com/divudi/bean/report/AnalyzerInvestigationCountController.java
@@ -1,0 +1,302 @@
+/*
+ * Open Hospital Management Information System
+ */
+package com.divudi.bean.report;
+
+import com.divudi.bean.lab.LaborataryReportController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.dataStructure.AnalyzerInvestigationCountRow;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.entity.lab.Machine;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+/**
+ * Controller for the "Analyzer vise Investigation Counts" report.
+ *
+ * Lists the number of times each investigation was performed within a date
+ * range, grouped by investigation and its analyzer (machine). Uses a direct
+ * DTO JPQL query ({@link AnalyzerInvestigationCountRow}) instead of the
+ * per-item counting used by the legacy report.
+ */
+@Named
+@SessionScoped
+public class AnalyzerInvestigationCountController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private InvestigationFacade investigationFacade;
+
+    @Inject
+    private LaborataryReportController laborataryReportController;
+
+    private Date fromDate;
+    private Date toDate;
+    private Machine machine;
+
+    private List<AnalyzerInvestigationCountRow> items;
+    private Long totalCount;
+
+    public AnalyzerInvestigationCountController() {
+    }
+
+    public void createAnalyzerInvestigationCounts() {
+        items = new ArrayList<>();
+        totalCount = 0L;
+
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT new com.divudi.core.data.dataStructure.AnalyzerInvestigationCountRow("
+                + "ix.id, ix.code, ix.name, d.name, m.name, count(bi)) ");
+        jpql.append("FROM BillItem bi ");
+        jpql.append("JOIN bi.item ix ");
+        jpql.append("LEFT JOIN ix.department d ");
+        jpql.append("JOIN ix.machine m ");
+        jpql.append("WHERE type(ix) = :ixtype ");
+        jpql.append("AND type(bi.bill) = :billClass ");
+        jpql.append("AND bi.bill.billType in :bts ");
+        jpql.append("AND bi.retired = false ");
+        jpql.append("AND bi.bill.retired = false ");
+        jpql.append("AND bi.bill.cancelled = false ");
+        jpql.append("AND (bi.refunded is null or bi.refunded = false) ");
+        jpql.append("AND bi.bill.createdAt between :fd and :td ");
+
+        if (machine != null) {
+            jpql.append("AND ix.machine = :mac ");
+            m.put("mac", machine);
+        }
+
+        jpql.append("GROUP BY ix, m ");
+        jpql.append("ORDER BY ix.name");
+
+        m.put("ixtype", Investigation.class);
+        m.put("billClass", BilledBill.class);
+        m.put("bts", Arrays.asList(BillType.OpdBill, BillType.LabBill, BillType.InwardBill, BillType.CollectingCentreBill));
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+
+        items = (List<AnalyzerInvestigationCountRow>) (Object) billItemFacade.findLightsByJpqlWithoutCache(jpql.toString(), m, TemporalType.TIMESTAMP);
+
+        for (AnalyzerInvestigationCountRow row : items) {
+            if (row.getCount() != null) {
+                totalCount += row.getCount();
+            }
+        }
+    }
+
+    /**
+     * Navigate to the investigation bill-item list for the selected test,
+     * pre-filtered by this report's date range and the chosen investigation.
+     */
+    public String navigateToBillItemList(Long investigationId) {
+        if (investigationId == null) {
+            JsfUtil.addErrorMessage("Investigation not found.");
+            return null;
+        }
+        Investigation ix = investigationFacade.find(investigationId);
+        if (ix == null) {
+            JsfUtil.addErrorMessage("Investigation not found.");
+            return null;
+        }
+        laborataryReportController.resetAllFiltersExceptDateRange();
+        laborataryReportController.setFromDate(fromDate);
+        laborataryReportController.setToDate(toDate);
+        laborataryReportController.setInvestigation(ix);
+        laborataryReportController.processLaborataryBillItemReportDto();
+        return "/reportLab/bill_item_list?faces-redirect=true";
+    }
+
+    public void downloadExcel() {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpServletResponse response =
+                (HttpServletResponse) facesContext.getExternalContext().getResponse();
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            XSSFSheet sheet = workbook.createSheet("Investigation Counts");
+
+            final int colCount = 6;
+
+            // Styles
+            Font titleFont = workbook.createFont();
+            titleFont.setBold(true);
+            titleFont.setFontHeightInPoints((short) 14);
+            CellStyle titleStyle = workbook.createCellStyle();
+            titleStyle.setFont(titleFont);
+            titleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            CellStyle subtitleStyle = workbook.createCellStyle();
+            subtitleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerFont.setColor(IndexedColors.WHITE.getIndex());
+            CellStyle headerStyle = workbook.createCellStyle();
+            headerStyle.setFont(headerFont);
+            headerStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.getIndex());
+            headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+            headerStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            Font totalFont = workbook.createFont();
+            totalFont.setBold(true);
+            CellStyle totalStyle = workbook.createCellStyle();
+            totalStyle.setFont(totalFont);
+            totalStyle.setFillForegroundColor(IndexedColors.LIGHT_YELLOW.getIndex());
+            totalStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy MMMM dd hh:mm a");
+            int rowIdx = 0;
+
+            // Title
+            Row titleRow = sheet.createRow(rowIdx++);
+            Cell titleCell = titleRow.createCell(0);
+            titleCell.setCellValue("Analyzer vise Investigation Counts");
+            titleCell.setCellStyle(titleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, colCount - 1));
+
+            // Analyzer filter
+            Row analyzerRow = sheet.createRow(rowIdx++);
+            Cell analyzerCell = analyzerRow.createCell(0);
+            analyzerCell.setCellValue("Analyzer: " + (machine != null ? machine.getName() : "All Analyzers"));
+            analyzerCell.setCellStyle(subtitleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(1, 1, 0, colCount - 1));
+
+            // Date range
+            Row dateRow = sheet.createRow(rowIdx++);
+            Cell dateCell = dateRow.createCell(0);
+            dateCell.setCellValue(sdf.format(fromDate) + "  to  " + sdf.format(toDate));
+            dateCell.setCellStyle(subtitleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(2, 2, 0, colCount - 1));
+
+            rowIdx++; // blank row
+
+            // Column headers
+            String[] headers = {"No", "Code", "Test", "Department", "Analyzer", "Count"};
+            Row headerRow = sheet.createRow(rowIdx++);
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            // Data rows
+            int no = 1;
+            for (AnalyzerInvestigationCountRow r : items) {
+                Row row = sheet.createRow(rowIdx++);
+                row.createCell(0).setCellValue(no++);
+                row.createCell(1).setCellValue(r.getCode() != null ? r.getCode() : "");
+                row.createCell(2).setCellValue(r.getTestName() != null ? r.getTestName() : "");
+                row.createCell(3).setCellValue(r.getDepartmentName() != null ? r.getDepartmentName() : "");
+                row.createCell(4).setCellValue(r.getAnalyzerName() != null ? r.getAnalyzerName() : "");
+                row.createCell(5).setCellValue(r.getCount() != null ? r.getCount() : 0);
+            }
+
+            // Grand total
+            Row totalRow = sheet.createRow(rowIdx++);
+            Cell totalLabel = totalRow.createCell(2);
+            totalLabel.setCellValue("Total");
+            totalLabel.setCellStyle(totalStyle);
+            Cell totalValue = totalRow.createCell(5);
+            totalValue.setCellValue(totalCount != null ? totalCount : 0);
+            totalValue.setCellStyle(totalStyle);
+
+            for (int i = 0; i < colCount; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            String filename = "Analyzer_Investigation_Counts_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".xlsx";
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            try (OutputStream out = response.getOutputStream()) {
+                workbook.write(out);
+            }
+            facesContext.responseComplete();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Date getFromDate() {
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfMonth();
+        }
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        if (toDate == null) {
+            toDate = CommonFunctions.getEndOfDay();
+        }
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Machine getMachine() {
+        return machine;
+    }
+
+    public void setMachine(Machine machine) {
+        this.machine = machine;
+    }
+
+    public List<AnalyzerInvestigationCountRow> getItems() {
+        return items;
+    }
+
+    public void setItems(List<AnalyzerInvestigationCountRow> items) {
+        this.items = items;
+    }
+
+    public Long getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
+    }
+
+}

--- a/src/main/java/com/divudi/core/data/dataStructure/AnalyzerInvestigationCountRow.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/AnalyzerInvestigationCountRow.java
@@ -1,0 +1,82 @@
+package com.divudi.core.data.dataStructure;
+
+import java.io.Serializable;
+
+/**
+ * @author H.K. Damith Deshan | hkddrajapaksha@gmail.com
+ */
+
+public class AnalyzerInvestigationCountRow implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long investigationId;
+    private String code;
+    private String testName;
+    private String departmentName;
+    private String analyzerName;
+    private Long count;
+
+    public AnalyzerInvestigationCountRow() {
+    }
+
+    // Used by JPQL constructor query in
+    // com.divudi.bean.report.AnalyzerInvestigationCountController#createAnalyzerInvestigationCounts()
+    public AnalyzerInvestigationCountRow(Long investigationId, String code, String testName, String departmentName, String analyzerName, Long count) {
+        this.investigationId = investigationId;
+        this.code = code;
+        this.testName = testName;
+        this.departmentName = departmentName;
+        this.analyzerName = analyzerName;
+        this.count = count;
+    }
+
+    public Long getInvestigationId() {
+        return investigationId;
+    }
+
+    public void setInvestigationId(Long investigationId) {
+        this.investigationId = investigationId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public String getAnalyzerName() {
+        return analyzerName;
+    }
+
+    public void setAnalyzerName(String analyzerName) {
+        this.analyzerName = analyzerName;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+
+}

--- a/src/main/webapp/reportLab/investigation_counts.xhtml
+++ b/src/main/webapp/reportLab/investigation_counts.xhtml
@@ -16,154 +16,251 @@
             <h:form id="frm" >
 
 
-                <p:panel header="Investigation Counts">
+                <p:panel styleClass="mb-3">
                     <f:facet name="header" >
-                        <h:outputText styleClass="fa-solid fa-vials" />
-                        <p:outputLabel value="Investigation Counts" 
-                                       styleClass="noPrintButton mx-2"/>
-                    </f:facet> 
+                        <h:outputText styleClass="fa-solid fa-vials mx-2" />
+                        <h:outputText value="Analyzer vise Investigation Counts"
+                                      styleClass="noPrintButton"/>
+                    </f:facet>
 
+                    <!-- Search / Filter section -->
+                    <div class="border rounded p-3 mb-3 bg-body-tertiary noPrintButton">
+                        <div class="d-flex align-items-center mb-3">
+                            <h:outputText styleClass="fa-solid fa-filter me-2 text-primary" />
+                            <h:outputText value="Search Filters" style="font-weight: 600;"/>
+                        </div>
+                        <div class="row g-3 align-items-end">
+                            <div class="col-12 col-sm-6 col-md-3">
+                                <p:outputLabel for="frmDate" value="From" styleClass="form-label fw-semibold mb-1"/>
+                                <p:calendar styleClass="dateTimePicker w-100" navigator="true" id="frmDate"
+                                            value="#{analyzerInvestigationCountController.fromDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+                            <div class="col-12 col-sm-6 col-md-3">
+                                <p:outputLabel for="toDate" value="To" styleClass="form-label fw-semibold mb-1"/>
+                                <p:calendar styleClass="dateTimePicker w-100" navigator="true" id="toDate"
+                                            value="#{analyzerInvestigationCountController.toDate}"
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </div>
+                            <div class="col-12 col-sm-6 col-md-3">
+                                <p:outputLabel for="cmbMachine" value="Analyzer" styleClass="form-label fw-semibold mb-1"/>
+                                <p:selectOneMenu id="cmbMachine" styleClass="w-100" filter="true" filterMatchMode="contains"
+                                                 value="#{analyzerInvestigationCountController.machine}">
+                                    <f:selectItem itemLabel="All Analyzers" itemValue="#{null}" noSelectionOption="true"/>
+                                    <f:selectItems value="#{machineController.items}" var="mac" itemLabel="#{mac.name}" itemValue="#{mac}" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="col-12 col-sm-6 col-md-3">
+                                <p:commandButton ajax="false"
+                                                 value="Process"
+                                                 icon="fa-solid fa-magnifying-glass"
+                                                 styleClass="ui-button-success"
+                                                 title="Generate the report for the selected date range and analyzer"
+                                                 action="#{analyzerInvestigationCountController.createAnalyzerInvestigationCounts}" />
+                            </div>
+                        </div>
+                    </div>
 
-                    <table class="mt-2">
-                        <tr>
-                            <td>
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-6">
-                                        <h:outputLabel value="From"/>
+                    <!-- Action toolbar -->
+                    <div class="d-flex justify-content-end mb-2 noPrintButton">
+                        <p:commandButton id="print" value="Print"
+                                         icon="fa-solid fa-print"
+                                         styleClass="ui-button-info ui-button-outlined me-2"
+                                         title="Print the report">
+                            <p:printer target="reportPrint" />
+                        </p:commandButton>
+                        <p:commandButton value="Excel" ajax="false"
+                                         icon="fa-solid fa-file-excel"
+                                         styleClass="ui-button-secondary"
+                                         title="Download the report as an Excel file"
+                                         actionListener="#{analyzerInvestigationCountController.downloadExcel}" >
+                        </p:commandButton>
+                    </div>
+
+                    <style>
+                        @media screen {
+                            .paper {
+                                position: static !important;
+                                width: 210mm !important;
+                                zoom: 1.6;
+                            }
+                            .paper table {
+                                border-collapse: collapse;
+                                width: 100%;
+                                font-size: 13px !important;
+                                margin-top: 3mm !important;
+                            }
+                            .paper th, .paper td {
+                                border: 1px solid #000;
+                                padding: 1px !important;
+                                text-align: left;
+                            }
+                        }
+
+                        @media print {
+                            @page {
+                                @bottom-right {
+                                    content: "Page " counter(page) " of " counter(pages);
+                                    font-family: Arial, sans-serif;
+                                    font-size: 10pt;
+                                }
+                            }
+                            body {
+                                counter-reset: page;
+                            }
+                            .paper {
+                                position: static !important;
+                                width: 210mm !important;
+                                size: A4 portrait !important;
+                            }
+                            .header {
+                                line-height: 1.1;
+                                margin: 0mm !important;
+                            }
+                            .paper table {
+                                border-collapse: collapse;
+                                width: 99.9%;
+                                font-size: 13px !important;
+                                margin-top: 3mm !important;
+                            }
+                            .paper th, .paper td {
+                                border: 1px solid #000;
+                                padding: 1px !important;
+                                text-align: left;
+                            }
+                            .noPrintButton {
+                                display: none !important;
+                            }
+                        }
+                    </style>
+
+                    <h:panelGroup layout="block" id="reportPrint" styleClass="d-flex justify-content-center">
+                        <div class="paper">
+                            <!-- Report header -->
+                            <div class="header">
+                                <div class="d-flex justify-content-center" style="font-weight: 700; font-size: 22px;">
+                                    <h:outputText value="#{sessionController.institution.name}"/>
+                                </div>
+                                <div class="d-flex justify-content-center gap-2" style="font-weight: 700; font-size: 18px;">
+                                    <h:outputText value="Analyzer vise Investigation Counts"/>
+                                    <h:panelGroup rendered="#{analyzerInvestigationCountController.machine ne null}">
+                                        <div class="d-flex gap-2">
+                                            <h:outputText value="-" class="text-center" style="width: 1em !important;"/>
+                                            <h:outputText value="#{analyzerInvestigationCountController.machine.name}"/>
+                                        </div>
+                                    </h:panelGroup>
+                                </div>
+                                <div class="d-flex justify-content-center mt-2" style="font-size: 12px;">
+                                    <div class="d-flex gap-3">
+                                        <h:outputText value="From Date" style="width: 6em !important; font-weight: 600;"/>
+                                        <h:outputText value="#{analyzerInvestigationCountController.fromDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputText>
                                     </div>
-                                    <div class="col-6">
-                                        <p:calendar styleClass="dateTimePicker" navigator="true" id="frmDate" value="#{investigationMonthSummeryOwnControllerSession.fromDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
-                                        </p:calendar>
+                                    <h:outputText value="" style="width: 5mm !important;"/>
+                                    <div class="d-flex gap-3">
+                                        <h:outputText value="To Date" style="width: 4em !important; font-weight: 600;"/>
+                                        <h:outputText value="#{analyzerInvestigationCountController.toDate}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                        </h:outputText>
                                     </div>
                                 </div>
-                                <div class="row d-flex align-items-center my-2">
-                                    <div class="col-6">
-                                        <h:outputLabel value="To"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <p:calendar styleClass="dateTimePicker" navigator="true" id="toDate" value="#{investigationMonthSummeryOwnControllerSession.toDate}" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
-                                        </p:calendar>
-                                    </div>
-                                </div>
-                            </td>
-                            <td rowspan="2" >
-                                <p:fieldset styleClass="noPrintButton my-1" style="max-width: 70%; float: right; text-align: justify; height: 25%; overflow-y: scroll; overflow-x: auto; "  >
-                                    <p>
-                                        This report lists the counts of all the investigation performed using the application. It includes results from all institutions and their departments. This also includes OPD requests, inward requests and collecting centre requests. Investigations requested using any payment method is listed here.
-                                    </p>
-                                    <p>
-                                        You can search by Investigation Name. You can sort by Investigation Name and the Count.
-                                    </p>
-                                </p:fieldset>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <h:panelGrid columns="6" styleClass="noPrintButton">
-                                    <p:spacer height="1" width="30"/>
-                                    <p:commandButton ajax="false"  value="Process" 
-                                                     icon="fa-solid fa-arrows-rotate"
-                                                     class="ui-button-Warning"
-                                                     action="#{investigationMonthSummeryOwnControllerSession.createInvestigationMonthEndSummeryCounts}"
-                                                     style="float: right;" />
-                                    <p:commandButton id="print" value="Print"
-                                                     icon="fa-solid fa-print"
-                                                     class="mx-1 ui-button-info">
-                                        <p:printer target="reportPrint" />
-                                    </p:commandButton>
-                                    <p:commandButton value="Excel" ajax="false" 
-                                                     icon="fa-solid fa-file-excel"
-                                                     class="mx-1 ui-button-success" style="float: right;" >
-                                        <p:dataExporter type="xlsx" target="tbl" fileName="Investigation Counts"
+                            </div>
 
+                            <!-- Report table -->
+                            <div>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th style="width: 8mm; font-weight: 700;">
+                                                <h:outputText value="No" style="margin-left: 2mm;"/>
+                                            </th>
+                                            <th style="width: 20mm; font-weight: 700;">
+                                                <h:outputText value="Code" style="margin-left: 3mm;"/>
+                                            </th>
+                                            <th style="font-weight: 700;">
+                                                <h:outputText value="Test" style="margin-left: 3mm;"/>
+                                            </th>
+                                            <th style="font-weight: 700;">
+                                                <h:outputText value="Department" style="margin-left: 3mm;"/>
+                                            </th>
+                                            <th style="font-weight: 700;">
+                                                <h:outputText value="Analyzer" style="margin-left: 3mm;"/>
+                                            </th>
+                                            <th style="width: 20mm; font-weight: 700; text-align: right;">
+                                                <h:outputText value="Count" style="margin-right: 3mm;"/>
+                                            </th>
+                                            <th class="noPrintButton" style="width: 20mm; font-weight: 700; text-align: center;">
+                                                <h:outputText value="Bills"/>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <ui:repeat value="#{analyzerInvestigationCountController.items}" var="c" varStatus="i">
+                                            <tr>
+                                                <td style="width: 8mm;">
+                                                    <h:outputText value="#{i.index + 1}" style="margin-left: 2mm;"/>
+                                                </td>
+                                                <td>
+                                                    <h:outputText value="#{c.code}" style="margin-left: 3mm;"/>
+                                                </td>
+                                                <td>
+                                                    <h:outputText value="#{c.testName}" style="margin-left: 3mm;"/>
+                                                </td>
+                                                <td>
+                                                    <h:outputText value="#{c.departmentName}" style="margin-left: 3mm;"/>
+                                                </td>
+                                                <td>
+                                                    <h:outputText value="#{c.analyzerName}" style="margin-left: 3mm;"/>
+                                                </td>
+                                                <td style="width: 20mm; text-align: right;">
+                                                    <h:outputText value="#{c.count}" style="margin-right: 3mm;">
+                                                        <f:convertNumber pattern="#,##0" />
+                                                    </h:outputText>
+                                                </td>
+                                                <td class="noPrintButton" style="width: 22mm; text-align: center; white-space: nowrap;">
+                                                    <p:commandButton
+                                                        ajax="false"
+                                                        icon="fa-solid fa-file-invoice"
+                                                        value="View"
+                                                        title="View bills for this test"
+                                                        class="ui-button-info"
+                                                        style="width: auto; display: inline-flex; padding: 1px 1px; font-size: 11px;"
+                                                        action="#{analyzerInvestigationCountController.navigateToBillItemList(c.investigationId)}" >
+                                                    </p:commandButton>
+                                                </td>
+                                            </tr>
+                                        </ui:repeat>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr>
+                                            <td style="width: 8mm;"></td>
+                                            <td></td>
+                                            <td></td>
+                                            <td></td>
+                                            <th style="font-weight: 700; text-align: right;">
+                                                <h:outputText value="Total" style="margin-right: 3mm;"/>
+                                            </th>
+                                            <th style="width: 20mm; font-weight: 700; text-align: right;">
+                                                <h:outputText value="#{analyzerInvestigationCountController.totalCount}" style="margin-right: 3mm;">
+                                                    <f:convertNumber pattern="#,##0" />
+                                                </h:outputText>
+                                            </th>
+                                            <td class="noPrintButton"></td>
+                                        </tr>
+                                    </tfoot>
+                                </table>
+                            </div>
+                        </div>
+                    </h:panelGroup>
 
-                                                        />
-                                    </p:commandButton> 
+                    <h:panelGroup rendered="#{empty analyzerInvestigationCountController.items}">
+                        <div class="text-center text-muted p-3">
+                            <h:outputText value="No investigations found. Adjust the filters and click Process." />
+                        </div>
+                    </h:panelGroup>
 
-                                </h:panelGrid>
-                            </td>
-                        </tr>
-                    </table>
-
-
-                    <p:panel id="reportPrint">
-                        <p:dataTable id="tbl"  value="#{investigationMonthSummeryOwnControllerSession.items}" var="c"
-                                     rowKey="#{c.investigation}"
-                                     rowIndexVar="i"
-                                     class="w-100">
-                            <f:facet name="header" >
-                                <h:outputLabel value="Investigation Counts"/>
-                                <br></br>
-                                <h:outputLabel value="From  "/>                     
-                                <h:outputLabel value="#{investigationMonthSummeryOwnControllerSession.fromDate}" >
-                                    <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
-                                </h:outputLabel>
-                                <h:outputLabel value="- To "/>                       
-                                <h:outputLabel value="#{investigationMonthSummeryOwnControllerSession.toDate}" >
-                                    <f:convertDateTime pattern="yyyy MMMM dd hh:mm:ss a" />
-                                </h:outputLabel>
-                            </f:facet>
-                            <p:column>
-                                <f:facet name="header">
-                                    <h:outputLabel value="No"/>
-                                </f:facet>
-                                <h:outputLabel value="#{i+1}"  />
-                            </p:column>
-
-                            <p:column headerText="Test" 
-                                      sortBy="#{c.investigation.name}" 
-                                      filterBy="#{c.investigation.name}"
-                                      filterMatchMode="contains">
-                                <f:facet name="header">
-                                    <h:outputLabel value="Test"/>
-                                </f:facet>
-                                <h:outputLabel value="#{c.investigation.name}"  />
-                                <f:facet name="footer">
-                                    <h:outputLabel value="Total">
-                                    </h:outputLabel>
-                                </f:facet>
-                            </p:column>
-                            <p:column headerText="Analyzer" rendered="#{webUserController.hasPrivilege('Developers')}"
-                                      sortBy="#{c.investigation.machine.name}" 
-                                      filterBy="#{c.investigation.machine.name}"
-                                      filterMatchMode="contains">
-                                <f:facet name="header">
-                                    <h:outputLabel value="Analyzer"/>
-                                </f:facet>
-                                <h:outputLabel value="#{c.investigation.machine.name}"  />
-                            </p:column>
-                            <p:column headerText="Count" style="text-align:center" 
-                                      sortBy="#{c.count}">
-                                <f:facet name="header">
-                                    <h:outputLabel value="Count"/>
-                                </f:facet>
-                                <h:outputLabel value="#{c.count}" />
-                                <f:facet name="footer">
-                                    <h:outputLabel value="#{investigationMonthSummeryOwnControllerSession.totalCount}">
-                                    </h:outputLabel>
-                                </f:facet>
-                            </p:column>
-<!--                            <p:column exportable="false" headerText="Test ID" rendered="#{webUserController.hasPrivilege('Developers')}"
-                                      sortBy="#{c.investigation.id}"
-                                      filterBy="#{c.investigation.id}"
-                                      filterMatchMode="contains">
-                                <f:facet name="header">
-                                    <h:outputLabel value="Test ID"/>
-                                </f:facet>
-                                <p:commandButton value="Edit" ajax="false" 
-                                                 action="/lab/investigation"
-                                                 icon="fa-solid fa-pen"
-                                                 class="mx-1 ui-button-success"
-                                                 onclick="this.form.target = '_blank'">
-                                    <f:setPropertyActionListener value="#{c.investigation}" target="#{investigationController.current}" ></f:setPropertyActionListener>
-                                </p:commandButton>
-                            </p:column>-->
-
-                        </p:dataTable>
-                    </p:panel>
-
-
-                </p:panel>        
+                </p:panel>
             </h:form>
         </h:panelGroup>
     </ui:define>

--- a/src/main/webapp/reportLab/lab_summeries_index.xhtml
+++ b/src/main/webapp/reportLab/lab_summeries_index.xhtml
@@ -18,8 +18,18 @@
                                     <h:form>
 
                                         <div class="d-grid gap-2">
-                                            <p:commandButton ajax="false" value="Investigation List" action="investigation_counts?faces-redirect=true"/>
-                                            <p:commandButton ajax="false" value="Bill List" action="/reportLab/bill_list?faces-redirect=true"/> 
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                class="w-100 ui-button-success"
+                                                value="Investigation List" 
+                                                action="investigation_counts?faces-redirect=true">
+                                            </p:commandButton>
+                                            
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Bill List" 
+                                                action="/reportLab/bill_list?faces-redirect=true">
+                                            </p:commandButton>
                                             
                                             <p:commandButton 
                                                 ajax="false"


### PR DESCRIPTION
## Summary

Adds a new **Analyzer vise Investigation Counts** report (reworked from the legacy `reportLab/investigation_counts.xhtml`). It lists how many times each investigation was performed within a date range, grouped by its analyzer (machine), using a dedicated DTO-based query, with an analyzer filter, a print-optimised A4 view, Excel export, and drill-down to a test's bills.

Closes #22093

## Changes (commit by commit)

1. **`feat(lab): add AnalyzerInvestigationCountRow DTO`** — new DTO (`investigationId`, `code`, `testName`, `departmentName`, `analyzerName`, `count`).
2. **`feat(lab): add AnalyzerInvestigationCountController`** — dedicated `@SessionScoped` controller:
   - single direct DTO JPQL query via `findLightsByJpql` (no per-item N+1 counting);
   - counts only genuine billed bills (`type = BilledBill`, `billType IN OpdBill/LabBill/InwardBill/CollectingCentreBill`), excluding cancelled bills and refunded items;
   - `INNER JOIN` on `investigation.machine` (only tests with an analyzer), `LEFT JOIN` on `investigation.department` for display;
   - optional analyzer (`Machine`) filter;
   - Excel export via Apache POI to `HttpServletResponse` (`downloadExcel()`);
   - `navigateToBillItemList(investigationId)` drill-down to the bill-item list.
3. **`feat(lab): redesign … report page`** — filters card; columns No/Code/Test/Department/Analyzer/Count + total; A4 "paper" print layout matching `test_wise_count_print`; pure-HTML table (no DataTable filters); Print + Excel actions; per-row View button (hidden in print).
4. **`style(lab): highlight the Investigation List button`** — lab summaries index menu styling.

## Counting semantics
- Included bill types: OPD, Lab, Inward, Collecting Centre (billed bills only).
- **Cancelled** bills and **refunded** items are excluded from the count.
- Only investigations with an assigned analyzer are shown.

## Notes / follow-ups
- The count query uses the coarse `BillType`, while the drill-down bill list (`LaborataryReportController`) filters by `BillTypeAtomic`. Counts and the listed bills can therefore differ slightly — a follow-up can align the count query to the same atomic set if exact parity is required.
- `src/main/resources/META-INF/persistence.xml` local dev changes were intentionally **not** committed.

## Testing
- [ ] Process with/without an analyzer filter over a date range.
- [ ] Verify cancelled/refunded items are excluded.
- [ ] Print renders the A4 layout without on-screen controls / View column.
- [ ] Excel export downloads with title, filters, data and grand total.
- [ ] View opens the bill list filtered to the test and date range.

## Target
Hotfix for the **`coop-prod`** production branch.