### PR TITLE
fix(lab): correct Test Wise Count DTO report — apply filters and deduct cancellations/refunds

### DIFF
--- a/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
+++ b/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
@@ -971,15 +971,74 @@ public class LaborataryReportController implements Serializable {
         params.put("td", toDate);
         params.put("invType", Investigation.class);
 
-        List<BillTypeAtomic> bTypes = Arrays.asList(
+        // Positive (paid) bills
+        params.put("bType", Arrays.asList(
                 BillTypeAtomic.OPD_BILL_WITH_PAYMENT,
                 BillTypeAtomic.OPD_BILL_PAYMENT_COLLECTION_AT_CASHIER,
                 BillTypeAtomic.CC_BILL,
                 BillTypeAtomic.PACKAGE_OPD_BILL_WITH_PAYMENT,
-                BillTypeAtomic.INWARD_SERVICE_BILL);
-        params.put("bType", bTypes);
+                BillTypeAtomic.INWARD_SERVICE_BILL));
+        List<TestCountDTO> positiveResults = (List<TestCountDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
 
-        testWiseCountDtos = (List<TestCountDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+        // Cancellation bills
+        params.put("bType", Arrays.asList(
+                BillTypeAtomic.OPD_BILL_CANCELLATION,
+                BillTypeAtomic.OPD_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.PACKAGE_OPD_BILL_CANCELLATION,
+                BillTypeAtomic.PACKAGE_OPD_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION,
+                BillTypeAtomic.CC_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION,
+                BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION));
+        List<TestCountDTO> cancelResults = (List<TestCountDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+
+        // Refund bills
+        params.put("bType", Arrays.asList(
+                BillTypeAtomic.OPD_BILL_REFUND,
+                BillTypeAtomic.PACKAGE_OPD_BILL_REFUND,
+                BillTypeAtomic.CC_BILL_REFUND,
+                BillTypeAtomic.INWARD_SERVICE_BILL_REFUND));
+        List<TestCountDTO> refundResults = (List<TestCountDTO>) billItemFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+
+        // Index positive results by test id
+        Map<Long, TestCountDTO> resultMap = new HashMap<>();
+        if (positiveResults != null) {
+            for (TestCountDTO pos : positiveResults) {
+                resultMap.put(pos.getTestId(), pos);
+            }
+        }
+
+        // Subtract cancellations (count and all fees)
+        if (cancelResults != null) {
+            for (TestCountDTO cancel : cancelResults) {
+                TestCountDTO pos = resultMap.get(cancel.getTestId());
+                if (pos != null) {
+                    pos.setCount(pos.getCount() - Math.abs(cancel.getCount()));
+                    pos.setHosFee(safeDouble(pos.getHosFee()) - Math.abs(safeDouble(cancel.getHosFee())));
+                    pos.setCcFee(safeDouble(pos.getCcFee()) - Math.abs(safeDouble(cancel.getCcFee())));
+                    pos.setProFee(safeDouble(pos.getProFee()) - Math.abs(safeDouble(cancel.getProFee())));
+                    pos.setReagentFee(safeDouble(pos.getReagentFee()) - Math.abs(safeDouble(cancel.getReagentFee())));
+                    pos.setOtherFee(safeDouble(pos.getOtherFee()) - Math.abs(safeDouble(cancel.getOtherFee())));
+                    pos.setDiscount(safeDouble(pos.getDiscount()) - Math.abs(safeDouble(cancel.getDiscount())));
+                    pos.setTotal(safeDouble(pos.getTotal()) - Math.abs(safeDouble(cancel.getTotal())));
+                }
+            }
+        }
+
+        // Subtract refunds (fees only, count is not reduced by a refund)
+        if (refundResults != null) {
+            for (TestCountDTO refund : refundResults) {
+                TestCountDTO pos = resultMap.get(refund.getTestId());
+                if (pos != null) {
+                    pos.setHosFee(safeDouble(pos.getHosFee()) - Math.abs(safeDouble(refund.getHosFee())));
+                    pos.setCcFee(safeDouble(pos.getCcFee()) - Math.abs(safeDouble(refund.getCcFee())));
+                    pos.setProFee(safeDouble(pos.getProFee()) - Math.abs(safeDouble(refund.getProFee())));
+                    pos.setReagentFee(safeDouble(pos.getReagentFee()) - Math.abs(safeDouble(refund.getReagentFee())));
+                    pos.setOtherFee(safeDouble(pos.getOtherFee()) - Math.abs(safeDouble(refund.getOtherFee())));
+                    pos.setDiscount(safeDouble(pos.getDiscount()) - Math.abs(safeDouble(refund.getDiscount())));
+                    pos.setTotal(safeDouble(pos.getTotal()) - Math.abs(safeDouble(refund.getTotal())));
+                }
+            }
+        }
 
         totalCount = 0.0;
         totalHosFee = 0.0;
@@ -991,19 +1050,28 @@ public class LaborataryReportController implements Serializable {
         totalDiscount = 0.0;
         totalNetHosFee = 0.0;
 
-        if (testWiseCountDtos != null) {
-            for (TestCountDTO dto : testWiseCountDtos) {
+        // Keep only tests with a positive net count and accumulate totals
+        List<TestCountDTO> netResults = new ArrayList<>();
+        for (TestCountDTO dto : resultMap.values()) {
+            if (dto.getCount() != null && dto.getCount() > 0) {
+                netResults.add(dto);
                 totalCount += dto.getCount();
-                totalHosFee += dto.getHosFee();
-                totalCCFee += dto.getCcFee();
-                totalProFee += dto.getProFee();
-                totalReagentFee += dto.getReagentFee();
-                totalAdditionalFee += dto.getOtherFee();
-                totalNetTotal += dto.getTotal();
-                totalDiscount += dto.getDiscount();
-                totalNetHosFee += dto.getHosFee() - dto.getDiscount();
+                totalHosFee += safeDouble(dto.getHosFee());
+                totalCCFee += safeDouble(dto.getCcFee());
+                totalProFee += safeDouble(dto.getProFee());
+                totalReagentFee += safeDouble(dto.getReagentFee());
+                totalAdditionalFee += safeDouble(dto.getOtherFee());
+                totalNetTotal += safeDouble(dto.getTotal());
+                totalDiscount += safeDouble(dto.getDiscount());
+                totalNetHosFee += safeDouble(dto.getHosFee()) - safeDouble(dto.getDiscount());
             }
         }
+
+        testWiseCountDtos = setAlphabetList(netResults);
+    }
+
+    private double safeDouble(Double value) {
+        return value == null ? 0.0 : value;
     }
 
     public void processLabTestWiseReagentCostReportDto() {

--- a/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
+++ b/src/main/java/com/divudi/bean/lab/LaborataryReportController.java
@@ -939,6 +939,30 @@ public class LaborataryReportController implements Serializable {
             jpql += " and bi.bill.department.site=:site ";
             params.put("site", site);
         }
+        if (toInstitution != null) {
+            jpql += " and bi.bill.toInstitution=:toIns ";
+            params.put("toIns", toInstitution);
+        }
+        if (toDepartment != null) {
+            jpql += " and bi.bill.toDepartment=:toDep ";
+            params.put("toDep", toDepartment);
+        }
+        if (webUser != null) {
+            jpql += " and bi.bill.creater=:user ";
+            params.put("user", webUser);
+        }
+        if (admissionType != null) {
+            jpql += " and bi.bill.patientEncounter.admissionType=:admissionType ";
+            params.put("admissionType", admissionType);
+        }
+        if (paymentScheme != null) {
+            jpql += " and bi.bill.paymentScheme=:paymentScheme ";
+            params.put("paymentScheme", paymentScheme);
+        }
+        if (visitType != null && !visitType.trim().isEmpty()) {
+            jpql += " and bi.bill.ipOpOrCc = :type ";
+            params.put("type", visitType.trim());
+        }
 
         jpql += " group by bi.item.id, bi.item.code, bi.item.name";
 


### PR DESCRIPTION
## Merge to `development`

Closes #22098

Same fix as the coop-prod hotfix (#22099), cherry-picked onto `development`.

Corrects the **Laboratory Test Wise Count Report - DTO** (`reportLab/test_wise_count_dto.xhtml` → `LaborataryReportController.processLabTestWiseCountReportDto()`) so it matches the legacy Test Wise Count report.

## Problems fixed

### 1. Filter fields were ignored
Service Institution, Service Department, User, Admission Type, Discount Scheme and Visit Type were selectable in the UI (and Service Institution/Department were shown in the report header) but were **not applied** to the query. The report returned the same data regardless of these selections.

### 2. Cancellations and refunds were not deducted
The method ran a single query over paid bill types only. It never subtracted cancellation or refund bills, so when the period contained any cancelled/refunded lab bills the report **overstated** counts and fee totals (item rows and footer).

## Changes
Two commits, one per task:

1. **Apply all bound filters** — `toInstitution`, `toDepartment`, `webUser`, `admissionType`, `paymentScheme`, `visitType` now constrain the query.
2. **Deduct cancellations and refunds** — run positive / cancellation / refund queries and compute net figures the same way the legacy `processLabTestWiseCountReport()` does:
   - subtract cancellations (count + all fees)
   - subtract refunds (fees only; a refund does not reduce the count)
   - keep only rows with `count > 0`
   - match results by **test id** (more robust than test name)
   - null-safe fee handling to avoid NPEs on null reagent/other fees

## Result
The DTO report now produces the same net totals as the legacy report.

## Testing notes
- Java change — requires compile/deploy verification.
- Suggested check: same date range + Service Department = Main Laboratory on both the DTO and legacy reports; item-wise rows and footer totals should now match.

## Related
- coop-prod hotfix PR: #22099

## Files
- `src/main/java/com/divudi/bean/lab/LaborataryReportController.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved laboratory test-wise report filtering across institutions, departments, users, admission types, payment schemes, and visit types.
  * Corrected report calculations for paid tests, cancellations, and refunds.
  * Excluded tests with no remaining count and improved handling of missing fee values.
  * Updated totals to reflect only valid net results and sorted entries alphabetically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->