### PR TITLE
fix(pharmacy): guard PO approval navigation against double-click item duplication

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -152,7 +152,18 @@ public class PurchaseOrderController implements Serializable {
         return fromDate;
     }
 
-    public String navigateToPurchaseOrderApproval() {
+    // synchronized: the Approve button on the PO-list-to-approve page has no
+    // confirm() or double-click guard and posts here (not to approve()) before
+    // the review screen is even shown. A double-click raced two calls through
+    // clearList()+generateBillComponent() on this session-scoped bean: both
+    // nulled billItems, then both re-populated it from the same PO Request,
+    // leaving billItems holding every line twice. The (already synchronized)
+    // approve() then faithfully persisted the doubled list in a single call,
+    // producing one approved Bill with every item duplicated once - the GRN
+    // duplication reported by Ruhunu on PO/RH/GSK/26/01093, a recurrence of
+    // the same bug class as the approve() fix (PR #21815) one step earlier
+    // in the workflow.
+    public synchronized String navigateToPurchaseOrderApproval() {
         Bill temRequestedBill = requestedBill;
 
         // Check if the requested bill is already approved


### PR DESCRIPTION
## Summary
- Fixes a recurrence of the GRN item duplication bug reported by Ruhunu (PO/RH/GSK/26/01093, 2026-07-05), after the prior hotfix (#21815).
- `navigateToPurchaseOrderApproval()` — invoked by the **Approve** button on the PO-list-to-approve page, which has no `confirm()` or double-click guard — calls `clearList()` + `generateBillComponent()` without synchronization. A double-click races two calls: both null the session-scoped `billItems` list and both re-populate it from the same PO Request, leaving every line duplicated *before* the user ever reaches the (already synchronized) `approve()` step.
- `approve()` then faithfully persists whatever is in `billItems` — a single approve() call producing one Bill with every item duplicated once, exactly matching what was found in production (bill 5194104: one Bill row, 2 duplicate BillItem rows, same timestamp, same creator).
- Added `synchronized` to `navigateToPurchaseOrderApproval()`, mirroring the existing guard on `approve()`.

## Root cause context
Same bug class as #21417 (PO Request double-submit) and #21815 (PO Approve double-submit) — an unsynchronized "clear-then-repopulate" method reachable from a double-clickable `ajax="false"` button. This is one step earlier in the same workflow that #21815 didn't cover.

## Test plan
- [x] `mvn compile` succeeds
- [ ] Manually double-click the Approve button on the PO-list-to-approve page for a multi-item PO Request and confirm only one set of items appears on the approved PO
- [ ] Confirm existing single-click approval flow still works end-to-end (Request → Approve → GRN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)