### PR TITLE
fix(pharmacy): port PO approve/navigate double-click guards to development

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -159,7 +159,17 @@ public class PurchaseOrderController implements Serializable {
         return fromDate;
     }
 
-    public String navigateToPurchaseOrderApproval() {
+    // synchronized: the Approve button on the PO-list-to-approve page has no
+    // confirm() or double-click guard and posts here (not to approve()) before
+    // the review screen is even shown. A double-click raced two calls through
+    // clearList()+generateBillComponent() on this session-scoped bean: both
+    // nulled billItems, then both re-populated it from the same PO Request,
+    // leaving billItems holding every line twice. approve() then faithfully
+    // persisted the doubled list in a single call, producing one approved
+    // Bill with every item duplicated once - the GRN duplication reported by
+    // Ruhunu on PO/RH/GSK/26/01093, a recurrence of the same bug class as the
+    // approve() fix (PR #21815/#22101) one step earlier in the workflow.
+    public synchronized String navigateToPurchaseOrderApproval() {
         Bill temRequestedBill = requestedBill;
 
         // Check if the requested bill is already approved
@@ -207,7 +217,15 @@ public class PurchaseOrderController implements Serializable {
         return true;
     }
 
-    public String approve() {
+    // synchronized: a double-submit on the Approve button (slow ajax="false"
+    // postback re-clicked, or a resubmitted form) let two requests race through
+    // the same in-memory billItems list before either had persisted, so both
+    // saw BillItem.id == null and created every line twice. The "already
+    // approved" guard below only protects against a second call once the first
+    // has actually finished; synchronized serializes concurrent/racing calls
+    // on this session-scoped bean so the guard is effective (issue: GRN item
+    // duplication reported by Ruhunu, same pattern as #21417)
+    public synchronized String approve() {
         if (!isAuthorized("APPROVE", "PurchaseOrdersApprovel")) {
             return "";
         }


### PR DESCRIPTION
## Summary
- Ports two double-click guards from ruhunu-prod hotfix branches that were never merged into `development`, closing #21821 and part of #22102.
- `PurchaseOrderController.approve()` — `synchronized` (PR #21815). Without it, a double-submit on the Approve button races two requests through the same in-memory `billItems` list, duplicating every line.
- `PurchaseOrderController.navigateToPurchaseOrderApproval()` — `synchronized` (PR #22101). The Approve button on the PO-list-to-approve page has no `confirm()`/double-click guard and posts here before the review screen is shown; a double-click races `clearList()` + `generateBillComponent()`, leaving `billItems` holding every line twice before `approve()` persists it.

Both are the root cause of GRN item duplication reported twice in production by Ruhunu (PO/RH/GSK/26/01053, then PO/RH/GSK/26/01093 two days after the first hotfix).

## Test plan
- [x] `mvn compile` succeeds
- [ ] Manually double-click the Approve button on the PO-list-to-approve page and on the PO-approving page for a multi-item PO, confirm no duplicate items
- [ ] Confirm normal single-click PO Request → Approve → GRN flow still works

Closes #21821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase order approval reliability by preventing overlapping approval actions.
  * Helps avoid duplicate bill items and repeated approval results when requests occur concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->