### PR TITLE
fix(inward): bypass stale L2 cache when resolving BHT direct-issue department

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -88,6 +88,8 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     private com.divudi.core.facade.BillItemFacade billItemFacade;
     @EJB
     private com.divudi.core.facade.InpatientPackageItemFacade inpatientPackageItemFacade;
+    @EJB
+    private com.divudi.core.facade.RoomFacilityChargeFacade roomFacilityChargeFacade;
 
     // ---- Working state ----
     private PatientEncounter patientEncounter;
@@ -247,7 +249,25 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
                 return sessionController.getDepartment();
             }
             if (patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge() != null) {
-                return patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge().getDepartment();
+                com.divudi.core.entity.inward.RoomFacilityCharge rfc = patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge();
+                Department dept = rfc.getDepartment();
+                if (dept == null) {
+                    // The shared L2 cache can hold a RoomFacilityCharge whose
+                    // department association was still unset when it was first
+                    // cached (e.g. the room-to-department link was added later,
+                    // via a path that didn't go through this persistence unit).
+                    // Force a fresh read before giving up.
+                    com.divudi.core.entity.inward.RoomFacilityCharge fresh = roomFacilityChargeFacade.findFreshByJpql(
+                            "select r from RoomFacilityCharge r where r.id = :id",
+                            java.util.Collections.singletonMap("id", rfc.getId()));
+                    dept = fresh != null ? fresh.getDepartment() : null;
+                    if (dept != null) {
+                        LOGGER.log(Level.WARNING, "RoomFacilityCharge id={0} had a stale null department in cache; "
+                                + "resolved to department id={1} after a fresh read.",
+                                new Object[]{rfc.getId(), dept.getId()});
+                    }
+                }
+                return dept;
             }
         } else if (matrixByIssuingDept) {
             return sessionController.getDepartment();

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -17,6 +17,7 @@ import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.facade.ItemBatchFacade;
 import com.divudi.core.facade.ItemFacade;
@@ -31,6 +32,7 @@ import com.divudi.core.util.CommonFunctions;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -249,7 +251,7 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
                 return sessionController.getDepartment();
             }
             if (patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge() != null) {
-                com.divudi.core.entity.inward.RoomFacilityCharge rfc = patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge();
+                RoomFacilityCharge rfc = patientEncounter.getCurrentPatientRoom().getRoomFacilityCharge();
                 Department dept = rfc.getDepartment();
                 if (dept == null) {
                     // The shared L2 cache can hold a RoomFacilityCharge whose
@@ -257,14 +259,18 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
                     // cached (e.g. the room-to-department link was added later,
                     // via a path that didn't go through this persistence unit).
                     // Force a fresh read before giving up.
-                    com.divudi.core.entity.inward.RoomFacilityCharge fresh = roomFacilityChargeFacade.findFreshByJpql(
+                    RoomFacilityCharge fresh = roomFacilityChargeFacade.findFreshByJpql(
                             "select r from RoomFacilityCharge r where r.id = :id",
-                            java.util.Collections.singletonMap("id", rfc.getId()));
+                            Collections.singletonMap("id", rfc.getId()));
                     dept = fresh != null ? fresh.getDepartment() : null;
                     if (dept != null) {
                         LOGGER.log(Level.WARNING, "RoomFacilityCharge id={0} had a stale null department in cache; "
                                 + "resolved to department id={1} after a fresh read.",
                                 new Object[]{rfc.getId(), dept.getId()});
+                    } else {
+                        LOGGER.log(Level.WARNING, "RoomFacilityCharge id={0} has no department even after a fresh, "
+                                + "cache-bypassing read; this room is genuinely unmapped to a department.",
+                                rfc.getId());
                     }
                 }
                 return dept;


### PR DESCRIPTION
## Summary
- `determineMatrixDepartment()` in `InpatientDirectIssueNativeSqlController` could return `null` for a valid, DB-correct room→department mapping because EclipseLink's shared L2 cache (explicitly enabled for reference data per `persistence.xml`) can hold a stale `RoomFacilityCharge.department = null` if that association was linked/fixed via a path bypassing this persistence unit.
- This silently blocked pharmacy BHT direct issues with *"Cannot issue: no department resolved for this BHT."* until the app was redeployed (which happens to clear the L2 cache).
- Fix: when the cached department is `null`, force one fresh, cache-bypassing read via the existing `RoomFacilityChargeFacade.findFreshByJpql()` helper (`cache.retrieveMode=BYPASS` / `storeMode=REFRESH`) before giving up. Logs a `WARNING` only when the fallback actually resolves something — silent on the normal path.

## Test plan
- [x] Reproduced the failure live against DB-correct data with a fresh JVM state (settle blocked, confirmed via server log + DB)
- [x] Rebuilt/redeployed, confirmed the same admission then settled correctly with the right department (`BILL.ID=4420450`, `FROMDEPARTMENT_ID=9191`)
- [x] Deliberately recreated the staleness live (loaded a room with `department=null` into cache, corrected `DEPARTMENT_ID` via direct SQL without restarting) — confirmed the fallback resolves it and settle succeeds (`BILL.ID=4420451`)
- [x] Confirmed the already-correct/normal path is unaffected (no regression)
- [x] `mvn clean package` — 138 tests pass

Closes #22106

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inpatient pharmacy issue processing by more reliably resolving the department when room facility charge details are missing or incomplete.
  * Now performs a fresh department lookup when cached department information is unavailable, while preserving the existing behavior when cached data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->