### PR TITLE
fix(pharmacy): COGS variance for inward transactions + BHT issue qty-edit corruption

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -450,6 +450,7 @@ public class PharmacySaleBhtController implements Serializable {
         tmp.getPharmaceuticalBillItem().setQty(0 - editedQty);
         calculateRates(tmp);
         calCurrentBillItemTotal(getBillItems());
+        calTotal();
     }
 
     private void setZeroToQty(BillItem tmp) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -400,12 +400,14 @@ public class PharmacySaleBhtController implements Serializable {
         tmp.setQty(tmp.getPharmaceuticalBillItem().getQtyInUnit());
         if (tmp.getPharmaceuticalBillItem().getQtyInUnit() <= 0) {
             setZeroToQty(tmp);
+            recalculateEditedIssueRow(tmp);
             JsfUtil.addErrorMessage("Can not enter a minus value");
             return;
         }
         Stock fetchedStock = tmp.getPharmaceuticalBillItem().getStock();
         if (fetchedStock != null && tmp.getPharmaceuticalBillItem().getQtyInUnit() > fetchedStock.getStock()) {
             setZeroToQty(tmp);
+            recalculateEditedIssueRow(tmp);
             JsfUtil.addErrorMessage("No Sufficient Stocks?");
             return;
         }
@@ -421,6 +423,33 @@ public class PharmacySaleBhtController implements Serializable {
             }
         }
 
+        recalculateEditedIssueRow(tmp);
+    }
+
+    /**
+     * After a row-edit on the BHT issue page, restore the issue sign convention
+     * (unit qty is stored NEGATIVE for issues, exactly as
+     * generateIssueBillComponentsForBhtRequest builds the rows) and recalculate
+     * this row's financials (rate/margin/gross/net) plus the running bill total
+     * for the edited quantity.
+     *
+     * Without this, a partially-issued row settled after a qty edit keeps the
+     * ORIGINAL requested-quantity gross/margin/net values while stock moves by
+     * the edited quantity, and the positive unit qty flips the sign of the
+     * movement in the Cost Of Goods Sold report (found via COGS E2E
+     * verification: request 20, issue 10 → bill said 458.70, stock moved 10,
+     * COGS saw +10 instead of -10).
+     */
+    private void recalculateEditedIssueRow(BillItem tmp) {
+        if (tmp == null || tmp.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQtyInUnit());
+        tmp.setQty(editedQty);
+        tmp.getPharmaceuticalBillItem().setQtyInUnit((float) (0 - editedQty));
+        tmp.getPharmaceuticalBillItem().setQty(0 - editedQty);
+        calculateRates(tmp);
+        calCurrentBillItemTotal(getBillItems());
     }
 
     private void setZeroToQty(BillItem tmp) {

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13716,13 +13716,35 @@ public class PharmacyReportController implements Serializable {
 
     private void calculateBhtIssueValue() {
         try {
+            // The BHT Issue row is the NET stock effect of the inward medicine
+            // cycle (same pattern as the retail Sale row, where refunds/cancels
+            // net against sales inside one row):
+            //   - pharmacy issue to BHT ................ stock OUT (qty stored negative)
+            //   - ward receiving the issued medicines ... stock IN at ward (qty stored positive)
+            //   - pharmacy accepting a ward return ...... stock IN at pharmacy (qty stored positive)
+            // All three groups sum correctly with their stored signs in one query.
             List<BillTypeAtomic> billTypes = Arrays.asList(
                     BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD,
                     BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE,
-                    BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE
+                    BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE,
+                    BillTypeAtomic.ACCEPT_ISSUED_MEDICINE_INWARD,
+                    BillTypeAtomic.ACCEPT_RETURN_MEDICINE_INWARD
             );
 
             Map<String, Double> bhtIssues = retrievePurchaseAndCostValues(" bi.bill.billTypeAtomic ", billTypes);
+
+            // The ward-return leg (RETURN_MEDICINE_INWARD) removes stock from the
+            // ward but its bills store a POSITIVE quantity, so it must be queried
+            // separately and DEDUCTED from the row total. Without these ward legs
+            // every ward receive/return shows up as a spurious COGS variance
+            // (found via COGS E2E verification).
+            Map<String, Double> wardReturns = retrievePurchaseAndCostValues(" bi.bill.billTypeAtomic ",
+                    Collections.singletonList(BillTypeAtomic.RETURN_MEDICINE_INWARD));
+            for (Map.Entry<String, Double> e : wardReturns.entrySet()) {
+                double v = e.getValue() == null ? 0.0 : Math.abs(e.getValue());
+                bhtIssues.merge(e.getKey(), -v, Double::sum);
+            }
+
             cogsRows.put("BHT Issue", bhtIssues);
 
         } catch (Exception e) {

--- a/src/main/webapp/reports/inventoryReports/bht_issue.xhtml
+++ b/src/main/webapp/reports/inventoryReports/bht_issue.xhtml
@@ -275,7 +275,10 @@
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputText>
                                 <f:facet name="footer">
-                                    <h:outputText value="#{pharmacyReportController.costValueTotal}" >
+                                    <!-- Issue totals are stored with negative unit quantities; the
+                                         rows above display positive values, so display the total's
+                                         magnitude (display only). -->
+                                    <h:outputText value="#{pharmacyReportController.costValueTotal lt 0 ? -pharmacyReportController.costValueTotal : pharmacyReportController.costValueTotal}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </f:facet>


### PR DESCRIPTION
Closes #22109

## Fixes

### 1. BHT issue page qty edit corrupted the bill (billing + COGS)
`PharmacySaleBhtController.onEditing` left the pharmaceutical quantity **positive** (issues store negative unit qty) and never recalculated the row financials, so a partial issue settled with the original requested-quantity value (patient overbilled) and the movement's sign flipped in COGS.

New `recalculateEditedIssueRow(BillItem)` runs on every `onEditing` exit path: restores the negative unit-qty sign convention (matching `generateIssueBillComponentsForBhtRequest`), reruns `calculateRates()` and the running bill total.

### 2. COGS BHT Issue row now nets the full inward medicine cycle
`ACCEPT_ISSUED_MEDICINE_INWARD` (ward receives → ward stock in), `RETURN_MEDICINE_INWARD` (ward → pharmacy return) and `ACCEPT_RETURN_MEDICINE_INWARD` (pharmacy accepts return) were in no COGS row while their stock movements land in closing stock, so every ward receive produced a spurious variance equal to the received value.

Following the retail Sale row pattern (returns net against sales inside one row), `calculateBhtIssueValue()` now sums issues + ward accepts + pharmacy accept-of-return in one query (stored signs are already correct) and **deducts** the `RETURN_MEDICINE_INWARD` leg, which stores a positive quantity although ward stock decreases. No new report rows.

### 3. Cosmetic: BHT Issue report Cost Value footer
Rows display positive cost values but the footer total rendered with a minus sign. Display-only EL change (a `DecimalFormat` negative subpattern identical to the positive one does **not** suppress the sign — verified).

## Verification (local coop instance, Playwright E2E)

Full cycle exercised: 3 direct issues → partial return → cancellation → 2 ward requests → full / partial / later-fill issues (partial via the **fixed** qty-edit path) → 3 ward receives → ward return → pharmacy accept.

- Before fix 1: variance 284.48/284.48/330.00 (= 2 × the edited 10 Panadeine); partial bill net 458.70 instead of 229.35.
- Before fix 2: variance -744.84/-671.53/-858.70 (= exactly the three ward receives).
- After both: **variance 0.00/0.00/0.00**, Calculated Closing == Closing Stock, BHT Issue row -284.20/-284.65/-328.40 matches hand-calculated net movement; BHT Issue report rows match the DB; footer shows 956.19 (positive).

Not covered: discharge-medicine issues, theatre issues, ward-return cancellation (`RETURN_MEDICINE_INWARD_CANCELLATION`), substitution issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pharmacy issue row recalculations immediately after edited quantities are reset for invalid values (zero/negative) or when exceeding available stock, ensuring signs and financials remain consistent.
  * Corrected BHT issue report totals by including all relevant inward/discharge/accept/issue-related bill types.
  * Adjusted ward-return handling to deduct their values properly, preventing false cost-of-goods variance.
* **Improvements**
  * Updated the BHT issue report “Cost Value” footer to show the total as a positive magnitude, matching the table display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->