### PR TITLE
fix(hr): link createPerson audit events to their record, fix create-event diff display

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConsultantController.java
+++ b/src/main/java/com/divudi/bean/common/ConsultantController.java
@@ -226,7 +226,7 @@ public class ConsultantController implements Serializable {
         personService.personToAuditMap(editedPerson, current.getPerson());
         
         if (current.getPerson().getId() == null || current.getPerson().getId() == 0) {
-            getPersonFacade().create(current.getPerson());
+            getPersonFacade().createAndFlush(current.getPerson());
 
             // Refresh the map now that the Person has been assigned an ID
             personService.personToAuditMap(editedPerson, current.getPerson());

--- a/src/main/java/com/divudi/bean/common/ConsultantController.java
+++ b/src/main/java/com/divudi/bean/common/ConsultantController.java
@@ -227,9 +227,12 @@ public class ConsultantController implements Serializable {
         
         if (current.getPerson().getId() == null || current.getPerson().getId() == 0) {
             getPersonFacade().create(current.getPerson());
-            
+
+            // Refresh the map now that the Person has been assigned an ID
+            personService.personToAuditMap(editedPerson, current.getPerson());
+
             // Person created, log the creation event
-            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", null);
+            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", current.getPerson().getId());
             // For editing staff just created
             initialPerson = new HashMap<>();
         } else {

--- a/src/main/java/com/divudi/bean/common/DoctorController.java
+++ b/src/main/java/com/divudi/bean/common/DoctorController.java
@@ -356,7 +356,7 @@ public class DoctorController implements Serializable {
         personService.personToAuditMap(editedPerson, current.getPerson());
         
         if (current.getPerson().getId() == null || current.getPerson().getId() == 0) {
-            getPersonFacade().create(current.getPerson());
+            getPersonFacade().createAndFlush(current.getPerson());
 
             // Refresh the map now that the Person has been assigned an ID
             personService.personToAuditMap(editedPerson, current.getPerson());

--- a/src/main/java/com/divudi/bean/common/DoctorController.java
+++ b/src/main/java/com/divudi/bean/common/DoctorController.java
@@ -357,9 +357,12 @@ public class DoctorController implements Serializable {
         
         if (current.getPerson().getId() == null || current.getPerson().getId() == 0) {
             getPersonFacade().create(current.getPerson());
-            
+
+            // Refresh the map now that the Person has been assigned an ID
+            personService.personToAuditMap(editedPerson, current.getPerson());
+
             // Person created, log the creation event
-            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", null);
+            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", current.getPerson().getId());
         } else {
             getPersonFacade().edit(current.getPerson());
             

--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -265,11 +265,14 @@ public class StaffController implements Serializable {
         } else {
             current.getPerson().setCreatedAt(new Date());
             current.getPerson().setCreater(sessionController.getLoggedUser());
-            personFacade.edit(current.getPerson());
+            personFacade.createAndFlush(current.getPerson());
+
+            // Refresh the map now that the Person has been assigned an ID
+            personService.personToAuditMap(editedPerson, current.getPerson());
 
             // Person created, log the creation event
-            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", null);
-            
+            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", current.getPerson().getId());
+
             // For editing staff just created
             initialPerson = new HashMap<>();
         }
@@ -1339,9 +1342,12 @@ public class StaffController implements Serializable {
             current.getPerson().setCreatedAt(new Date());
             current.getPerson().setCreater(getSessionController().getLoggedUser());
             getPersonFacade().createAndFlush(current.getPerson());
-            
+
+            // Refresh the map now that the Person has been assigned an ID
+            personService.personToAuditMap(editedPerson, current.getPerson());
+
             // Person created, log the creation event
-            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", null);
+            auditService.logAudit(null, editedPerson, sessionController.getLoggedUser(), "Person", "createPerson", current.getPerson().getId());
             JsfUtil.addSuccessMessage("New Person Created");
             
             // For editing staff just created

--- a/src/main/java/com/divudi/core/entity/AuditEvent.java
+++ b/src/main/java/com/divudi/core/entity/AuditEvent.java
@@ -97,8 +97,16 @@ public class AuditEvent implements Serializable {
     
     
     public void calculateDifference() {
-        if (beforeJson == null || afterJson == null) {
-            this.difference = "One or both JSON values are null.";
+        if (beforeJson == null && afterJson == null) {
+            this.difference = "No data recorded for this event.";
+            return;
+        }
+        if (beforeJson == null) {
+            this.difference = formatSingleSide("Created with", afterJson);
+            return;
+        }
+        if (afterJson == null) {
+            this.difference = formatSingleSide("Removed", beforeJson);
             return;
         }
         // If either value is not a JSON object (e.g. a plain toString() string
@@ -151,6 +159,38 @@ public class AuditEvent implements Serializable {
         StringBuilder sb = new StringBuilder();
         diff.forEach((key, value) -> sb.append(key).append(": ").append(value).append("\n"));
         return sb.toString();
+    }
+
+    /**
+     * Formats a create ("Created with") or delete ("Removed") event where
+     * only one side of the JSON snapshot exists, listing the recorded
+     * field values instead of the generic null-JSON message.
+     */
+    private String formatSingleSide(String label, String json) {
+        if (!json.trim().startsWith("{")) {
+            return label + ": " + json;
+        }
+        try {
+            Gson gson = new Gson();
+            Type type = new TypeToken<Map<String, Object>>() {
+            }.getType();
+            Map<String, Object> map = gson.fromJson(json, type);
+            if (map == null || map.isEmpty()) {
+                return label + ": (no fields recorded)";
+            }
+            StringBuilder sb = new StringBuilder();
+            map.forEach((key, value) -> {
+                if (value != null) {
+                    sb.append(key).append(": ").append(value).append("\n");
+                }
+            });
+            if (sb.length() == 0) {
+                return label + ": (no fields recorded)";
+            }
+            return label + ":\n" + sb.toString();
+        } catch (Exception e) {
+            return label + ": " + json;
+        }
     }
 
     public String getDifference() {


### PR DESCRIPTION
## Summary

Two follow-up fixes from QA of the merged Person audit-event PR (#22072), addressing gaps found while verifying create flows for Doctor/Consultant/Staff.

- **Closes #22108** — `createPerson` audit events previously logged `objectId` as `null` and omitted `personId` from the after-JSON, because the audit snapshot was taken *before* the Person's IDENTITY-generated ID existed. Now re-snapshots the audit map after `create()`/`createAndFlush()` and passes the real `objectId`, in `DoctorController.saveSelected()`, `ConsultantController.saveSelected()`, and `StaffController.saveSelected()`/`saveCurrentStaff()`. `saveCurrentStaff()`'s create branch also switched from `edit()`/`merge()` to `createAndFlush()`/`persist()`, since `merge()` on a transient entity does not reliably populate the ID on the original object reference — this was the actual cause of the missing ID.
- **Closes #22112** — `AuditEvent.calculateDifference()` showed a generic "One or both JSON values are null" message for every create event (before-JSON is legitimately null for a create) instead of the field values that were set. It now formats a "Created with: ..." list (or "Removed: ..." for a symmetrical delete case) from whichever side is populated. This applies to any entity using the shared `AuditEvent` mechanism, not just Person.

## Verification performed

Built with `mvn clean package` (JDK 11) — all 138 existing unit tests pass. Redeployed locally and verified end-to-end via the running app + direct DB queries:

- Created a new Consultant ("Fix Verification Consultant") → `AUDITEVENT` row now shows `OBJECTID` populated (previously always `NULL`) and `personId` present in `AFTERJSON`.
- Audit Event History viewer's Differences column now reads `Created with: address: ... name: Fix Verification Consultant personId: 503014.0 ...` instead of "One or both JSON values are null." — confirmed for both a brand-new create event and retroactively for an older create event already in the database (the diff is computed on read, not stored, so existing rows benefit immediately).
- Updated the same consultant afterward and confirmed the normal before/after diff path (both JSON sides present) still renders correctly, unaffected by the change.
- Test data cleaned up (soft-deleted) after verification.

## Note for reviewers

While verifying the update path on the Consultant screen, editing a just-created consultant (without navigating away first) appeared to create a second `Person` row and re-point the `Staff` row to it, orphaning the original `Person`. Confirmed this is **not** caused by this change — the diff here only touches the create branches, and the update/edit branch is untouched. Flagging in case it's worth a separate issue; happy to investigate further if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit logging for newly created people so audit entries reference the correct newly persisted record ID instead of a missing/null value.
  * Improved audit difference messaging to correctly reflect created, removed, or unavailable data for null/empty before/after snapshots.
  * Enhanced audit detail formatting to generate clearer field-level output and safer fallback messages when snapshots are incomplete or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->