### PR TITLE
fix(opd): show persistent validation error on OPD bill settle failure (#22118)

### DIFF
--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -19,6 +19,9 @@
                 <h:form id="form" rendered="#{webUserController.hasPrivilege('OpdBilling') or webUserController.hasPrivilege('LabCashier')}" >
 
                     <p:growl id="msg"  />
+                    <p:messages id="messages" showDetail="true" closable="true" redisplay="true" >
+                        <p:autoUpdate />
+                    </p:messages>
                     <p:panel class="m-0 p-0" >
                         <f:facet name="header" >
                             <div class="d-flex justify-content-between align-items-center">
@@ -49,11 +52,6 @@
                         </f:facet>
 
 
-                        <!--                        <div class="row" >
-                                                    <div class="col-md-12 text-center p-1" >
-                                                        <p:messages id="messages" ></p:messages>
-                                                    </div>
-                                                </div>-->
                         <div class="row" >
                             <div class="col-md-8" >
                                 <p:focus  context="txtQuickSearchPhoneNumber" ></p:focus>


### PR DESCRIPTION
## Summary
Fixes #22118 — clicking **Settle** on the OPD billing page could silently do nothing: the form reloaded with no bill created and no visible reason, leaving the cashier unsure whether the bill saved.

## Root cause
`OpdBillController.errorCheck()` correctly aborts the settle and adds a `FacesMessage` for each missing required field (phone number, referral doctor/institution, tendered amount, etc.). But the **only message sink on `opd_bill.xhtml` was an auto-fading `<p:growl>`** — the persistent `<p:messages>` panel was **commented out**. Because the Settle button is `ajax="false"` (full-page POST + reload), the growl flashed once during the reload and then faded, so the cashier saw a cleared form with no explanation.

## Fix
Re-enable a persistent messages panel at the top of the form:

```xhtml
<p:messages id="messages" showDetail="true" closable="true" redisplay="true">
    <p:autoUpdate/>
</p:messages>
```

- `redisplay="true"` + no auto-fade → the validation reason stays visible until the cashier reads or closes it.
- `<p:autoUpdate/>` keeps it refreshed on subsequent AJAX interactions.
- Removed the stale commented-out `<p:messages>` block.

Entered patient/item state is already preserved (the action returns to the same view without clearing), so the cashier can correct the field and re-Settle.

## Verification (Playwright, local `coop` deployment)
Reproduced the reported behavior against the currently deployed page:
- Triggered a settle validation failure → the error appeared **only** in a `.ui-growl-item`; **`.ui-messages` panel count = 0**.
- After ~6s the growl faded → **zero visible feedback** remained, matching the "silent failure" report.

The rendered fix could not be observed live because the local Payara runs `PROJECT_STAGE=Production` (facelets cached; a full redeploy is needed to see it). This is a **JSF-only change** using a standard, syntactically-valid PrimeFaces `<p:messages>` component.

Closes #22118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added visible, closable notifications to the OPD billing page for validation, system, and other form messages.
  * Messages now refresh automatically and can be redisplayed with additional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->