### PR TITLE
fix(inward): BHT issue request navigation, refresh, settle-guard, and settle NPE

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -104,6 +104,9 @@ public class PharmacyBillSearch implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(PharmacyBillSearch.class.getName());
 
+    private static final String DEFAULT_INWARD_PHARMACY_REQUEST_REPRINT_RETURN_PAGE =
+            "/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true";
+
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
     private StaffService staffBean;
@@ -175,6 +178,13 @@ public class PharmacyBillSearch implements Serializable {
     private String comment;
     private String emailRecipient;
     private Bill bill;
+    /**
+     * The page to navigate to when the Back button on the inward pharmacy
+     * request reprint page is pressed. Callers set this via
+     * f:setPropertyActionListener before navigating to that page; defaults
+     * to the all-requests list if a caller does not set it.
+     */
+    private String returnPage;
     private PaymentMethod paymentMethod;
     private PaymentScheme paymentScheme;
     private RefundBill billForRefund;
@@ -638,6 +648,18 @@ public class PharmacyBillSearch implements Serializable {
     // </editor-fold>
     //////////////////
     ///////////////////
+    /**
+     * Navigates back from the inward pharmacy request reprint page to
+     * wherever the user came from (all-requests list, search results, or a
+     * single patient's request list), rather than always returning to the
+     * all-requests list (#22106 follow-up).
+     */
+    public String navigateBackFromInwardPharmacyRequestReprint() {
+        String dest = returnPage != null ? returnPage : DEFAULT_INWARD_PHARMACY_REQUEST_REPRINT_RETURN_PAGE;
+        returnPage = null;
+        return dest;
+    }
+
     public String editInwardPharmacyRequestBill() {
         if (bill == null) {
             JsfUtil.addErrorMessage("Not Bill Found !");
@@ -669,7 +691,7 @@ public class PharmacyBillSearch implements Serializable {
         bill.setCancelled(true);
         bill.setCancelledBill(cb);
         billFacade.edit(bill);
-        return "/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true";
+        return navigateBackFromInwardPharmacyRequestReprint();
     }
 
     /**
@@ -4174,6 +4196,13 @@ public class PharmacyBillSearch implements Serializable {
 
     }
 
+    public String getReturnPage() {
+        return returnPage;
+    }
+
+    public void setReturnPage(String returnPage) {
+        this.returnPage = returnPage;
+    }
 
     public List<BillEntry> getBillEntrys() {
         return billEntrys;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1142,7 +1142,39 @@ public class PharmacyRequestForBhtController implements Serializable {
         if (errorCheck()) {
             return;
         }
+        if (getPreBill() != null && getPreBill().getId() != null && hasNonCancelledIssuingAgainstRequest(getPreBill())) {
+            JsfUtil.addErrorMessage("This request has already been issued (partially or fully) from pharmacy and can no longer be edited.");
+            return;
+        }
         settleEditedBhtIssueRequest(BillType.InwardPharmacyRequest, getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), BillNumberSuffix.PHISSUEREQ);
+    }
+
+    /**
+     * XHTML-facing check so the Settle button can be disabled up front
+     * (server-side re-check on submit still applies via
+     * settleEditedPharmacyBhtIssueRequest()).
+     */
+    public boolean isPreBillAlreadyIssuedAgainstRequest() {
+        return preBill != null && preBill.getId() != null && hasNonCancelledIssuingAgainstRequest(preBill);
+    }
+
+    /**
+     * Mirrors PharmacyBillSearch.hasNonCancelledIssuingAgainstRequest - checks
+     * whether any non-cancelled, non-refunded PharmacyBhtPre bill still
+     * references this request, i.e. pharmacy has already issued (partially or
+     * fully) against it and it should no longer be editable/settleable.
+     */
+    private boolean hasNonCancelledIssuingAgainstRequest(Bill requestBill) {
+        String jpql = "SELECT COUNT(b) FROM Bill b WHERE b.retired = false "
+                + "AND b.billType = :btp "
+                + "AND b.referenceBill = :ref "
+                + "AND b.cancelled = false "
+                + "AND b.refunded = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillType.PharmacyBhtPre);
+        params.put("ref", requestBill);
+        Long count = billFacade.findLongByJpql(jpql, params);
+        return count != null && count > 0;
     }
 
     private void settleEditedBhtIssueRequest(BillType btp, Department matrixDepartment, BillNumberSuffix billNumberSuffix) {

--- a/src/main/java/com/divudi/core/facade/AbstractFacade.java
+++ b/src/main/java/com/divudi/core/facade/AbstractFacade.java
@@ -1768,7 +1768,8 @@ public abstract class AbstractFacade<T> {
             }
         }
         try {
-            return (Double) qry.getSingleResult();
+            Double result = (Double) qry.getSingleResult();
+            return result == null ? 0.0 : result;
         } catch (Exception e) {
             return 0.0;
         }

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -170,6 +170,7 @@
                                         icon="fa fa-eye"
                                         action="/ward/ward_pharmacy_reprint_bht_issue_request?faces-redirect=true">
                                         <f:setPropertyActionListener value="#{b}" target="#{pharmacyBillSearch.bill}"/>
+                                        <f:setPropertyActionListener value="/inward/reports/inpatient_pharmacy_requests_list?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
                                     </p:commandButton>
 
                                     <p:commandButton

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -30,6 +30,16 @@
                         </div>
                         <div class="d-flex gap-2">
                             <p:commandButton
+                                id="btnRefresh"
+                                title="Reload the latest pharmacy requests for this admission"
+                                value="Refresh"
+                                action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()}"
+                                ajax="false"
+                                icon="fa fa-sync-alt"
+                                styleClass="ui-button-secondary">
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnDownload"
                                 value="Download"
                                 ajax="false"
                                 icon="fa fa-download"
@@ -37,6 +47,7 @@
                                 <p:dataExporter fileName="Inpatient Pharmacy Requests" target="tbl1" type="xlsx"></p:dataExporter>
                             </p:commandButton>
                             <p:commandButton
+                                id="btnPrint"
                                 value="Print"
                                 ajax="false"
                                 icon="fa fa-print"

--- a/src/main/webapp/ward/issue_for_bht_request_list.xhtml
+++ b/src/main/webapp/ward/issue_for_bht_request_list.xhtml
@@ -73,6 +73,7 @@
                             <p:column>
                                 <p:commandButton ajax="false" value="View Request" action="ward_pharmacy_reprint_bht_issue_request">
                                     <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="/ward/issue_for_bht_request_list?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
                                 </p:commandButton>
                             </p:column>
                             <p:column >

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill_search.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill_search.xhtml
@@ -104,6 +104,7 @@
                                 <p:column>
                                     <p:commandButton ajax="false" value="View Request" action="/ward/ward_pharmacy_reprint_bht_issue_request?faces-redirect=true" class="ui-button-success">
                                         <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
+                                        <f:setPropertyActionListener value="/ward/ward_pharmacy_bht_issue_request_bill_search?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
                                     </p:commandButton>
                                 </p:column>
                                 <p:column headerText="Issued" width="39%">                   

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_edit.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_edit.xhtml
@@ -31,58 +31,71 @@
                             rendered="#{pharmacyRequestForBhtController.patientEncounter ne null and pharmacyRequestForBhtController.department ne null}"
                             >
                             <f:facet name="header" >
-                                <div class="d-flex justify-content-between">
-                                    <div class="d-flex mt-2">
-                                        <i class="fas fa-exclamation-circle mt-2" />
-                                        <p:spacer width="10" height="1" ></p:spacer>
-                                        <h:outputLabel value="BHT ISSUE REQUEST FOR - "/>
-                                        <h:outputLabel value="#{pharmacyRequestForBhtController.department.name}" class="mx-2" />
-                                    </div>
-                                    <div class="d-flex gap-2">
+                                <div class="d-flex justify-content-between align-items-center w-100">
 
+                                    <!-- LEFT: title -->
+                                    <div class="d-flex align-items-center gap-2">
+                                        <i class="fas fa-exclamation-circle" />
+                                        <h:outputLabel value="BHT ISSUE REQUEST FOR - "/>
+                                        <h:outputLabel value="#{pharmacyRequestForBhtController.department.name}" />
+                                    </div>
+
+                                    <!-- CENTER: entity navigation -->
+                                    <div class="d-flex gap-2">
                                         <p:commandButton
+                                            id="btnInpatientDashboard"
                                             ajax="false"
                                             icon="fa-solid fa-address-card"
-                                            class="ui-button-secondary "
+                                            styleClass="ui-button-info ui-button-outlined"
                                             value="Inpatient Dashboard"
                                             action="#{bhtSummeryController.navigateToInpatientProfile()}">
                                         </p:commandButton>
 
                                         <p:commandButton
+                                            id="btnLookup"
                                             value="Lookup"
                                             ajax="false"
                                             icon="fa fa-search"
-                                            class="ui-button-warning "
+                                            styleClass="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToSearchPatients()}"
                                             >
                                         </p:commandButton>
                                         <p:commandButton
+                                            id="btnProfile"
                                             value="Profile"
                                             ajax="false"
                                             icon="fa fa-user"
-                                            class="ui-button-warning"
+                                            styleClass="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToOpdPatientProfile()}"
                                             >
                                             <f:setPropertyActionListener
                                                 value="#{pharmacyRequestForBhtController.patientEncounter.patient}"
                                                 target="#{patientController.current}" ></f:setPropertyActionListener>
                                         </p:commandButton>
+                                    </div>
 
+                                    <!-- RIGHT: actions, left=least important -> right=primary -->
+                                    <div class="d-flex gap-2 align-items-center">
                                         <p:commandButton
+                                            id="btnNewBill"
                                             accesskey="n"
                                             value="New Bill"
                                             ajax="false"
                                             icon="fas fa-file-invoice"
-                                            class="ui-button-warning"
+                                            styleClass="ui-button-warning"
                                             action="pharmacy_bill_issue_bht"
                                             actionListener="#{pharmacyRequestForBhtController.resetAll}"  >
                                         </p:commandButton>
 
                                         <p:commandButton
+                                            id="btnSettle"
                                             value="Settle"
-                                            class="ui-button-success"
-                                            icon="fa fa-check"
+                                            styleClass="ui-button-success"
+                                            style="min-width:120px"
+                                            icon="fa fa-check-circle"
                                             ajax="false"
+                                            disabled="#{pharmacyRequestForBhtController.preBillAlreadyIssuedAgainstRequest}"
+                                            title="#{pharmacyRequestForBhtController.preBillAlreadyIssuedAgainstRequest ? 'This request has already been issued by pharmacy and can no longer be edited' : 'Settle'}"
                                             action="#{pharmacyRequestForBhtController.settleEditedPharmacyBhtIssueRequest}"
                                             actionListener="#{pharmacyRequestForBhtController.calculateAllRates}"  >
                                         </p:commandButton>
@@ -90,6 +103,11 @@
                                 </div>
 
                                 <h:panelGroup id="panelError" >
+                                    <h:panelGroup
+                                        rendered="#{pharmacyRequestForBhtController.preBillAlreadyIssuedAgainstRequest}"
+                                        style="background-color: yellow; color: red; display: block; margin: 2px; border: 1px solid red; padding: 3px; width: 95%;">
+                                        <p:outputLabel value="This request has already been issued (partially or fully) by pharmacy and can no longer be edited." ></p:outputLabel>
+                                    </h:panelGroup>
                                     <h:panelGroup
                                         rendered="#{pharmacyRequestForBhtController.errorMessage ne null and pharmacyRequestForBhtController.errorMessage ne ''}"
                                         style="background-color: yellow; color: red; display: block; margin: 2px; border: 1px solid red; padding: 3px; width: 95%;">
@@ -320,42 +338,30 @@
                 <h:form>
                     <p:panel  rendered="#{pharmacyRequestForBhtController.billPreview}" >
                         <f:facet name="header">
-                            <div class="d-flex justify-content-between">
-                                <div class="col-md-4">
-                                    <h:outputLabel value="View Bill" class="mt-2"/>
+                            <div class="d-flex justify-content-between align-items-center w-100">
+
+                                <!-- LEFT: title -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <h:outputLabel value="View Bill"/>
                                 </div>
+
+                                <!-- CENTER: entity navigation -->
                                 <div class="d-flex gap-2">
                                     <p:commandButton
-                                        accesskey="p"
-                                        id="btnPrint"
-                                        value="Print"
-                                        ajax="false"
-                                        class="ui-button-info"
-                                        icon="fa fa-print"> <!-- Font Awesome icon -->
-                                        <p:printer target="gpBillPreview" ></p:printer>
-                                    </p:commandButton>
-                                    <p:commandButton
-                                        accesskey="n"
-                                        value="New Medicine Request for BHT"
-                                        ajax="false"
-                                        class="ui-button-success"
-                                        action="pharmacy_bill_issue_request"
-                                        actionListener="#{pharmacyRequestForBhtController.resetAll()}"
-                                        icon="fa fa-plus-circle"> <!-- Font Awesome icon -->
-                                    </p:commandButton>
-                                    <p:commandButton
+                                        id="btnLookup"
                                         value="Lookup"
                                         ajax="false"
                                         icon="fa fa-search"
-                                        class="ui-button-warning "
+                                        styleClass="ui-button-info ui-button-outlined"
                                         action="#{patientController.navigateToSearchPatients()}"
                                         >
                                     </p:commandButton>
                                     <p:commandButton
+                                        id="btnPatientProfile"
                                         value="Patient Profile"
                                         ajax="false"
                                         icon="fa fa-user"
-                                        class="ui-button-warning"
+                                        styleClass="ui-button-info ui-button-outlined"
                                         action="#{patientController.navigateToOpdPatientProfile()}"
                                         >
                                         <f:setPropertyActionListener
@@ -363,14 +369,38 @@
                                             target="#{patientController.current}" ></f:setPropertyActionListener>
                                     </p:commandButton>
                                     <p:commandButton
+                                        id="btnInpatientDashboard"
                                         ajax="false"
                                         icon="fa-solid fa-address-card"
-                                        class="ui-button-secondary "
+                                        styleClass="ui-button-info ui-button-outlined"
                                         value="Inpatient Dashboard"
-                                        style="float: right;"
                                         action="#{admissionController.navigateToAdmissionProfilePage}"
                                         >
                                         <f:setPropertyActionListener value="#{pharmacyRequestForBhtController.patientEncounter}" target="#{admissionController.current}" />
+                                    </p:commandButton>
+                                </div>
+
+                                <!-- RIGHT: actions, left=least important -> right=primary -->
+                                <div class="d-flex gap-2 align-items-center">
+                                    <p:commandButton
+                                        accesskey="p"
+                                        id="btnPrint"
+                                        value="Print"
+                                        ajax="false"
+                                        styleClass="ui-button-secondary"
+                                        icon="fa fa-print">
+                                        <p:printer target="gpBillPreview" ></p:printer>
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        accesskey="n"
+                                        id="btnNewMedicineRequest"
+                                        value="New Medicine Request for BHT"
+                                        ajax="false"
+                                        styleClass="ui-button-success"
+                                        style="min-width:120px"
+                                        action="pharmacy_bill_issue_request"
+                                        actionListener="#{pharmacyRequestForBhtController.resetAll()}"
+                                        icon="fa fa-plus-circle">
                                     </p:commandButton>
                                 </div>
                             </div>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
@@ -150,6 +150,7 @@
                                     icon="fa fa-eye"
                                     action="ward_pharmacy_reprint_bht_issue_request?faces-redirect=true">
                                     <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
                                 </p:commandButton>
                                 
                                 <p:commandButton

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -12,48 +12,80 @@
         <h:form>
             <p:panel >
                 <f:facet name="header" >
-                    <h:outputLabel value="Inward Pharmacy Request Reprint" ></h:outputLabel>
-                    <p:commandButton class="ui-button-secondary mx-2" style="float: right;" icon="fas fa-arrow-left" ajax="false" action="/ward/ward_pharmacy_bht_issue_request_list_for_issue" value="Back"/>
+                    <div class="d-flex justify-content-between align-items-center w-100">
 
-                    <!--<p:commandButton ajax="false" action="/ward/ward_pharmacy_bht_issue_request_bill_search"  value="Requested List"/>-->
-                    <p:commandButton class="ui-button-info" style="float: right;" icon="fas fa-print" value="Reprint" ajax="false" >
-                        <p:printer target="gpBillPreview" ></p:printer>
-                    </p:commandButton>
+                        <!-- LEFT: title -->
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fas fa-file-invoice" />
+                            <h:outputLabel value="Inward Pharmacy Request Reprint" ></h:outputLabel>
+                        </div>
 
-                    <p:commandButton 
-                        class="ui-button-warning mx-1"
-                        style="float: right;"
-                        icon="fas fa-pen"
-                        value="Edit Request"
-                        disabled="#{configOptionApplicationController.getBooleanValueByKey('Disable Edit Button on Pharmacy Request Reprint',false) or (not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded)}"
-                        action="#{pharmacyBillSearch.editInwardPharmacyRequestBill()}"
-                        ajax="false">
-                    </p:commandButton>
+                        <!-- CENTER: navigation -->
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBack"
+                                title="Back to the previous list"
+                                icon="fas fa-arrow-left"
+                                ajax="false"
+                                action="#{pharmacyBillSearch.navigateBackFromInwardPharmacyRequestReprint()}"
+                                value="Back"
+                                styleClass="ui-button-info ui-button-outlined"/>
+                        </div>
 
-                    <p:commandButton 
-                        class="ui-button-danger mx-1"
-                        style="float: right;"
-                        disabled="#{not webUserController.hasPrivilege('InwardPharmacyIssueRequestCancel') or (not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded)}"
-                        icon="fas fa-cancel"
-                        value="Cancel Request" 
-                        onclick="PF('confirmationDialog').show();"
-                        >
-                    </p:commandButton>
+                        <!-- RIGHT: actions, left=least important -> right=primary -->
+                        <div class="d-flex gap-2 align-items-center">
+                            <p:commandButton
+                                id="btnCancelRequest"
+                                title="Cancel this request"
+                                styleClass="ui-button-secondary"
+                                disabled="#{not webUserController.hasPrivilege('InwardPharmacyIssueRequestCancel') or (not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded)}"
+                                icon="fas fa-cancel"
+                                value="Cancel Request"
+                                onclick="PF('confirmationDialog').show();"
+                                >
+                            </p:commandButton>
+
+                            <p:commandButton
+                                id="btnEditRequest"
+                                title="Edit this request"
+                                styleClass="ui-button-warning"
+                                icon="fas fa-pen"
+                                value="Edit Request"
+                                disabled="#{configOptionApplicationController.getBooleanValueByKey('Disable Edit Button on Pharmacy Request Reprint',false) or (not empty pharmacyBillSearch.bill.listOfBill or pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded)}"
+                                action="#{pharmacyBillSearch.editInwardPharmacyRequestBill()}"
+                                ajax="false">
+                            </p:commandButton>
+
+                            <p:commandButton
+                                id="btnReprint"
+                                title="Reprint this request"
+                                styleClass="ui-button-success"
+                                style="min-width:120px"
+                                icon="fas fa-print"
+                                value="Reprint"
+                                ajax="false" >
+                                <p:printer target="gpBillPreview" ></p:printer>
+                            </p:commandButton>
+                        </div>
+
+                    </div>
 
                     <p:dialog minHeight="100" width="800" header="Confirmation" widgetVar="confirmationDialog" modal="true" resizable="false">
                         <p>Are you sure you want to cancel the request?</p>
-                        <p:inputText class="w-100" 
+                        <p:inputText class="w-100"
                                      value="#{pharmacyBillSearch.comment}"
                                      placeholder="Please provide a comment for the cancel Request" />
 
                         <f:facet name="footer">
-                            <p:commandButton 
+                            <p:commandButton
+                                id="btnConfirmCancel"
                                 class="mx-2 ui-button-warning"
-                                ajax="false" 
+                                ajax="false"
                                 value="Yes"
-                                action="#{pharmacyBillSearch.cancelInwardPharmacyRequestBill()}" 
+                                action="#{pharmacyBillSearch.cancelInwardPharmacyRequestBill()}"
                                 onclick="PF('confirmationDialog').hide();" />
-                            <p:commandButton 
+                            <p:commandButton
+                                id="btnDismissCancel"
                                 value="No"
                                 onclick="PF('confirmationDialog').hide();" />
                         </f:facet>


### PR DESCRIPTION
## Summary

Fixes #22121 — follow-up QA on the "View Not Refresh - BHT Issue Requests" complaint
surfaced 5 related defects in the inward pharmacy BHT (bed-head-ticket) issue-request flow.

- **Reprint page navigation always returned to the all-requests list** regardless of where
  the user came from. Added `PharmacyBillSearch.returnPage` +
  `navigateBackFromInwardPharmacyRequestReprint()` (mirrors the existing
  `GrnNativeSqlController.returnPage` pattern); all 4 known callers now set it before
  navigating to the reprint page, and Cancel Request honours it too.
- **Missing Refresh button** on the patient's Pharmacy Requests list — added next to
  Download/Print.
- **Non-standard navigation buttons** on the BHT edit page — rebuilt both panel headers into
  the standard three-zone layout (title / centered entity-nav / right-aligned actions), with
  stable `id`s on every button.
- **Settle wasn't blocked once pharmacy had issued (partially or fully) against a request** —
  added `PharmacyRequestForBhtController.hasNonCancelledIssuingAgainstRequest()` /
  `isPreBillAlreadyIssuedAgainstRequest()`, same defect class as #21516 (already fixed for
  Cancel Request). Settle button disables client-side with an explanatory banner and
  re-checks server-side on submit.
- **NullPointerException when settling "Issue to BHT"** — `AbstractFacade.findAggregateDbl`
  returned a `null` `Double` when a SQL `SUM(...)` had zero matching rows; the caller
  (`PharmacyBean.getItemStockQty(Item, Institution)`) auto-unboxed that into a primitive
  `double`, throwing inside the settle transaction. Null-guarded `findAggregateDbl` the same
  way `findDoubleByJpql` already does, in the shared facade method so every caller benefits.

## Test plan

- [x] Admission Profile → Pharmacy Requests → View Request → Back returns to the same
      patient's Pharmacy Requests page (not the all-requests list) — verified via Playwright.
- [x] Refresh button reloads the patient's Pharmacy Requests list without error.
- [x] BHT edit page header renders the standard three-zone layout.
- [x] Settle button is disabled with an explanatory banner on a request that pharmacy has
      already issued against (partially or fully).
- [x] Reproduced the original settle NPE end-to-end (auto-substituted stock batch, settle via
      "Issue to BHT") — before the fix it failed silently; after the fix it completes and
      creates the issuing bill, request flips to fully-issued.
- [x] `mvn clean package` + local Payara redeploy clean, no new errors in `server.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)