### PR TITLE
feat(pharmacy): allow receiving free items not on the purchase order at GRN

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -657,6 +657,21 @@ button) surfaced these:
 - **html2canvas does not capture PrimeFaces overlay panels** (`*_panel` appended near body root render
   blank/absent) — capture page states instead, or read the panel's `innerText` as textual evidence.
 
+## 29. GRN costing Save→Finalize→Approve: `Difference` guard needs a real keyup on Invoice Total at EVERY step
+
+On `pharmacy_grn_costing_with_save_approve.xhtml` the controller field `difference` (checked by
+`Math.abs(difference) > 1` in the finalize/approve actions) is recomputed **only** by the
+`p:ajax event="keyup"` listener on the Invoice Total input (`insv`) — a DOM-set value applied by an
+`ajax="false"` full submit updates `insTotal` server-side but never recalculates `difference`, so the
+approve fails with "The invoice does not match..! Check again" even though the submitted total is
+correct. Worse, after the Finalize → "To Approve GRNs" → Approve navigation the page reloads with
+Invoice Total rendered as `0.00`, so a value that passed at Save/Finalize is gone at the Approve step.
+Fix in automation: on the approve pass, click into `insv`, `Control+a`, `browser_type` the total
+`slowly: true` (real keyups fire the AJAX), confirm the `diff` input reads `0.00`, then click Approve.
+Everything else on that page (row qty/free-qty/batch/expiry/retail-rate inputs, invoice number/date)
+CAN be set directly on the DOM inputs — the `ajax="false"` Save/Finalize buttons submit and apply them
+(verified while testing issue #22120).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -158,6 +158,7 @@ public class GrnCostingController implements Serializable {
     private Institution fromInstitution;
     private Institution referenceInstitution;
     BillItem currentExpense;
+    private Item freeItemToAdd;
 
     public double calDifference() {
         double netTotal = getGrnBill().getNetTotal();
@@ -271,6 +272,10 @@ public class GrnCostingController implements Serializable {
         if (originalBillItemToDuplicate == null) {
             return;
         }
+        if (originalBillItemToDuplicate.getReferanceBillItem() == null) {
+            JsfUtil.addInfoMessage("Cannot duplicate an ad-hoc free item line");
+            return;
+        }
         BigDecimal totalQuantityOfBillItemsRefernceToOriginalItem = BigDecimal.ZERO;
         BigDecimal totalFreeQuantityOfBillItemsRefernceToOriginalItem = BigDecimal.ZERO;
 
@@ -323,6 +328,69 @@ public class GrnCostingController implements Serializable {
         distributeProportionalBillValuesToItems(getBillItems(), getGrnBill());
         recalculateProfitMarginsForAllItems();
         calDifference();
+    }
+
+    public void addFreeItemNotInPo() {
+        if (!configOptionApplicationController.getBooleanValueByKey("GRN - Allow Free Items Not in Purchase Order", false)) {
+            JsfUtil.addErrorMessage("Adding free items not in the purchase order is not enabled.");
+            return;
+        }
+        if (freeItemToAdd == null) {
+            JsfUtil.addErrorMessage("Please select an item");
+            return;
+        }
+
+        List<Item> singleItemList = new ArrayList<>();
+        singleItemList.add(freeItemToAdd);
+        Map<Long, double[]> lastRatesMap = buildLastRatesMap(singleItemList);
+        double[] rates = lastRatesMap.get(freeItemToAdd.getId());
+        double lastPr = rates != null ? rates[0] : 0.0;
+        double lastRr = rates != null ? rates[1] : 0.0;
+
+        BillItem freeBillItem = new BillItem();
+        freeBillItem.setSearialNo(getBillItems().size());
+        freeBillItem.setItem(freeItemToAdd);
+        freeBillItem.setReferanceBillItem(null);
+        freeBillItem.setQty(0.0);
+        freeBillItem.setTmpQty(0.0);
+        freeBillItem.setTmpFreeQty(0.0);
+
+        PharmaceuticalBillItem freePbi = new PharmaceuticalBillItem();
+        freePbi.setBillItem(freeBillItem);
+        freePbi.setQty(0.0);
+        freePbi.setQtyInUnit(0.0);
+        freePbi.setFreeQty(0.0);
+        freePbi.setFreeQtyInUnit(0.0);
+        freePbi.setPurchaseRate(0.0);
+        freePbi.setRetailRate(lastRr);
+
+        freeBillItem.setPharmaceuticalBillItem(freePbi);
+
+        BillItemFinanceDetails fd = new BillItemFinanceDetails(freeBillItem);
+        fd.setQuantity(BigDecimal.ZERO);
+        fd.setFreeQuantity(BigDecimal.ZERO);
+        fd.setLineGrossRate(BigDecimal.ZERO);
+        fd.setLineDiscountRate(BigDecimal.ZERO);
+        fd.setLineNetRate(BigDecimal.ZERO);
+        fd.setRetailSaleRate(BigDecimal.valueOf(lastRr));
+
+        freeBillItem.setBillItemFinanceDetails(fd);
+        recalculateFinancialsBeforeAddingBillItem(fd);
+
+        freePbi.setLastPurchaseRate(lastPr);
+        freePbi.setLastPurchaseRateInUnit(lastPr);
+        freePbi.setLastPurchaseRatePack(lastPr * fd.getUnitsPerPack().doubleValue());
+
+        getBillItems().add(freeBillItem);
+
+        ensureBillDiscountSynchronization();
+        calculateBillTotalsFromItems();
+        distributeProportionalBillValuesToItems(getBillItems(), getGrnBill());
+        calDifference();
+        recalculateProfitMarginsForAllItems();
+
+        freeItemToAdd = null;
+        JsfUtil.addSuccessMessage("Free item added. Enter the received free quantity.");
     }
 
     public void removeSelected() {
@@ -1768,6 +1836,9 @@ public class GrnCostingController implements Serializable {
     }
 
     private double getRetailPrice(BillItem billItem) {
+        if (billItem == null || billItem.getReferanceBillItem() == null) {
+            return 0;
+        }
         String sql = "select (p.retailRate) from PharmaceuticalBillItem p where p.billItem=:b";
         HashMap hm = new HashMap();
         hm.put("b", billItem.getReferanceBillItem());
@@ -1902,11 +1973,13 @@ public class GrnCostingController implements Serializable {
         if (f == null) {
             return;
         }
-        double remains = getRemainingQty(tmp.getPharmaceuticalBillItem());
-        if (remains < f.getQuantity().doubleValue()) {
-            f.setQuantity(java.math.BigDecimal.valueOf(remains));
-            tmp.setTmpQty(remains);
-            JsfUtil.addErrorMessage("You cant Change Qty than Remaining qty");
+        if (tmp.getReferanceBillItem() != null) {
+            double remains = getRemainingQty(tmp.getPharmaceuticalBillItem());
+            if (remains < f.getQuantity().doubleValue()) {
+                f.setQuantity(java.math.BigDecimal.valueOf(remains));
+                tmp.setTmpQty(remains);
+                JsfUtil.addErrorMessage("You cant Change Qty than Remaining qty");
+            }
         }
 
         if (f.getLineGrossRate().compareTo(f.getRetailSaleRatePerUnit()) > 0) {
@@ -2574,6 +2647,14 @@ public class GrnCostingController implements Serializable {
         this.selectedBillItems = selectedBillItems;
     }
 
+    public Item getFreeItemToAdd() {
+        return freeItemToAdd;
+    }
+
+    public void setFreeItemToAdd(Item freeItemToAdd) {
+        this.freeItemToAdd = freeItemToAdd;
+    }
+
     public SearchKeyword getSearchKeyword() {
         if (searchKeyword == null) {
             searchKeyword = new SearchKeyword();
@@ -3130,14 +3211,13 @@ public class GrnCostingController implements Serializable {
             if (ph == null) {
                 continue;
             }
-            if (ph.getQty() != 0.0) {
-                if (ph.getDoe() == null || ph.getStringValue().trim().isEmpty()) {
+            if (ph.getQty() != 0.0 || ph.getFreeQty() != 0.0) {
+                if (ph.getDoe() == null || ph.getStringValue() == null || ph.getStringValue().trim().isEmpty()) {
                     return true;
                 }
-                if (ph.getPurchaseRate() > ph.getRetailRate()) {
-                    return true;
-                }
-
+            }
+            if (ph.getQty() != 0.0 && ph.getPurchaseRate() > ph.getRetailRate()) {
+                return true;
             }
 
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWithCostingController.java
@@ -22,6 +22,7 @@ import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillFeePayment;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.facade.BillFacade;
@@ -1572,8 +1573,17 @@ public class GrnReturnWithCostingController implements Serializable {
     // These should update bill item lelvel txtLineReturnValue and Bill Level panelReturnBillDetails
     // have to prefil 
     public void onEditItem(PharmacyItemData tmp) {
-        double pur = getPharmacyBean().getLastPurchaseRate(tmp.getPharmaceuticalBillItem().getBillItem().getItem(), tmp.getPharmaceuticalBillItem().getBillItem().getReferanceBillItem().getBill().getDepartment());
-        double ret = getPharmacyBean().getLastRetailRate(tmp.getPharmaceuticalBillItem().getBillItem().getItem(), tmp.getPharmaceuticalBillItem().getBillItem().getReferanceBillItem().getBill().getDepartment());
+        BillItem billItem = tmp.getPharmaceuticalBillItem().getBillItem();
+        BillItem referanceBillItem = billItem.getReferanceBillItem();
+        Department department = null;
+        if (referanceBillItem != null && referanceBillItem.getBill() != null) {
+            department = referanceBillItem.getBill().getDepartment();
+        } else if (billItem.getBill() != null) {
+            department = billItem.getBill().getDepartment();
+        }
+
+        double pur = getPharmacyBean().getLastPurchaseRate(billItem.getItem(), department);
+        double ret = getPharmacyBean().getLastRetailRate(billItem.getItem(), department);
 
         tmp.getPharmaceuticalBillItem().setPurchaseRateInUnit(pur);
         tmp.getPharmaceuticalBillItem().setRetailRateInUnit(ret);

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
@@ -154,6 +154,7 @@
                                         id="txtQty"
                                         onfocus="this.select();"
                                         autocomplete="off"
+                                        disabled="#{bi.referanceBillItem == null}"
                                         class="text-end text-primary w-100"
                                         value="#{bi.billItemFinanceDetails.quantity}" >
                                         <p:ajax
@@ -189,7 +190,7 @@
                                     styleClass="text-end #{bi.item.category.profitMargin > bi.billItemFinanceDetails.profitMargin ? 'ui-messages-fatal' : ''}">
                                     <p:inputText
                                         autocomplete="off"
-                                        disabled="#{not configOptionApplicationController.getBooleanValueByKey('Allow Editing the Purchase Rate during Goods Receipt', true)}"
+                                        disabled="#{not configOptionApplicationController.getBooleanValueByKey('Allow Editing the Purchase Rate during Goods Receipt', true) or bi.referanceBillItem == null}"
                                         class="text-end text-primary w-100"
                                         value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                         id="pRate" >
@@ -206,6 +207,7 @@
                                     styleClass="text-end #{bi.item.category.profitMargin > bi.billItemFinanceDetails.profitMargin ? 'ui-messages-fatal' : ''}">
                                     <p:inputText
                                         autocomplete="off"
+                                        disabled="#{bi.referanceBillItem == null}"
                                         class="text-end text-primary w-100"
                                         value="#{bi.billItemFinanceDetails.lineDiscountRate}"
                                         id="dRate"
@@ -317,11 +319,12 @@
                                     headerText="Actions"
                                     width="7em"
                                     styleClass="text-center #{bi.item.category.profitMargin > bi.billItemFinanceDetails.profitMargin ? 'ui-messages-fatal' : ''}">
-                                    <p:commandButton 
+                                    <p:commandButton
                                         process=":#{p:resolveFirstComponentWithId('itemList',view).clientId}"
                                         update=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} :#{p:resolveFirstComponentWithId('itemList',view).clientId} "
                                         icon="fas fa-plus"
                                         class="ui-button-warning mx-1"
+                                        disabled="#{bi.referanceBillItem == null}"
                                         action="#{grnCostingController.duplicateItem(bi)}"/>
                                     <p:commandButton
                                         id="btnRemoveItem"
@@ -336,6 +339,56 @@
                             </p:dataTable>
                         </div>
                     </div>
+
+                    <h:panelGroup
+                        layout="block"
+                        class="row"
+                        rendered="#{configOptionApplicationController.getBooleanValueByKey('GRN - Allow Free Items Not in Purchase Order', false)}">
+                        <div class="col-12">
+                            <p:panel header="Add Free Item (not in PO)" class="my-2">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-gift" />
+                                    <h:outputText class="mx-4" value="Add Free Item (not in PO)" />
+                                </f:facet>
+                                <div class="row w-100">
+                                    <div class="col-8">
+                                        <h:outputLabel
+                                            for="acFreeItem"
+                                            class="w-100 m-1"
+                                            value="Item"/><br/>
+                                        <p:autoComplete
+                                            id="acFreeItem"
+                                            class="w-100 m-1"
+                                            inputStyleClass="w-100"
+                                            value="#{grnCostingController.freeItemToAdd}"
+                                            forceSelection="true"
+                                            maxResults="50"
+                                            minQueryLength="3" queryDelay="300" completeMethod="#{itemController.completeAmpItem}" var="vt" itemLabel="#{vt.name}" itemValue="#{vt}">
+                                            <p:column headerText="Item" style="padding: 6px;">
+                                                <h:outputLabel value="#{vt.name}"></h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Code" style="padding: 6px;">
+                                                <h:outputLabel value="#{vt.code}"></h:outputLabel>
+                                            </p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                    <div class="col-4">
+                                        <h:outputLabel
+                                            class="w-100 m-1"
+                                            value="&nbsp;"/><br/>
+                                        <p:commandButton
+                                            id="btnAddFreeItem"
+                                            value="Add Free Item"
+                                            icon="fas fa-gift"
+                                            title="Add a free item that is not on the purchase order"
+                                            class="ui-button-success w-100"
+                                            action="#{grnCostingController.addFreeItemNotInPo()}"
+                                            ajax="false"/>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </div>
+                    </h:panelGroup>
 
                     <div class="row" >
                         <div class="col-9" >


### PR DESCRIPTION
## Summary

Implements #22120: at GRN (costing workflow), a supplier's free item that is a **different product from anything on the PO** (e.g., PO has Tooth Brush, supplier ships free Tooth Paste) can now be received. The free line carries a retail rate but **no purchase rate** — nothing is payable to the supplier for it.

### Changes

- **`pharmacy_grn_costing_with_save_approve.xhtml`** — new *Add Free Item (not in PO)* panel (item autocomplete + button, stable ids `acFreeItem`/`btnAddFreeItem`), rendered only when config `GRN - Allow Free Items Not in Purchase Order` is ON (**default OFF**). For ad-hoc free lines (`referanceBillItem == null`) the Receiving Qty, Purchase Rate, and Discount Rate inputs and the row-duplicate button are disabled.
- **`GrnCostingController`** — new `addFreeItemNotInPo()` builds the line with no PO reference, qty 0, purchase rate 0, retail rate defaulted from the item's last batch (`buildLastRatesMap`), and recalculates bill totals the same way the existing listeners do. `checkItemBatch` now requires batch + expiry for free-qty-only lines too (and null-guards `stringValue`). `onEdit`'s remaining-qty cap and `getRetailPrice` are guarded for null PO references; `duplicateItem` rejects ad-hoc lines.
- **`GrnReturnWithCostingController`** — `onEditItem` no longer dereferences the PO reference unguarded (falls back to the GRN bill's own department).
- **Docs** — added §29 to the Playwright E2E workflow guide (GRN costing `Difference`/keyup automation gotcha found during verification).

No schema changes. Existing constructors untouched.

## Verification (Playwright E2E + DB, local Payara / coop DB)

Full flow exercised on PO `MP/PO/26/035561` (Main Pharmacy) with ad-hoc free item **Toothpick pack**:

1. Config key auto-created `false` on first render; panel hidden until enabled via Application Options UI.
2. Free item added: qty/purchase-rate/discount locked at 0, retail defaulted to 30.00 from last batch, free qty 24 + batch + expiry entered.
3. Save → Finalize → Approve completed (invoice total = PO lines only; free line contributed nothing to the payable).
4. **DB checks** (GRN `MP/GRN/26/037907`): free `BillItem` has `REFERANCEBILLITEM_ID = NULL`, freeQty 24; `ItemBatch` created with purchase rate 0 / retail 30; `Stock` +24 in Main Pharmacy; bill `NETTOTAL` −23,013.30 unchanged; `SALEVALUE` 27,570 includes the free line; PO went `FULLYISSUED` normally.
5. Regression: with the config OFF (flipped back via admin UI), the GRN costing page renders with no new panel and the standard flow is untouched.

![Add Free Item panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22120_01_grn_page_add_free_item_panel.png)

![GRN saved with free line](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22120_02_grn_saved_with_free_line.png)

![GRN approved](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22120_03_grn_approved_free_line.png)

Closes #22120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
