### PR TITLE
fix(pharmacy): re-entrancy guard on Transfer Request approval (port from ruhunu-prod hotfix)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -333,7 +333,10 @@ public class TransferRequestController implements Serializable {
 
     }
 
-    public void approveTransferRequestBill() {
+    // synchronized: defense in depth alongside navigateToApproveRequest() — serializes
+    // the final persist step on this session-scoped bean so a racing double-submit
+    // can't write the (already duplicated) billItems list twice.
+    public synchronized void approveTransferRequestBill() {
         if (!isAuthorized("APPROVE_REQUEST", "PharmacyDisbursementRequestApproval")) {
             return;
         }
@@ -350,7 +353,9 @@ public class TransferRequestController implements Serializable {
         printPreview = true;
     }
 
-    public Bill createNewApprovedTransferRequestBill(Bill preBillToCreateApprovedBill, List<BillItem> transferRequestPreBillItems, Bill newApprovedBill) {
+    // synchronized: same re-entrancy guard as approveTransferRequestBill()/
+    // navigateToApproveRequest() above, applied at the actual persist step.
+    public synchronized Bill createNewApprovedTransferRequestBill(Bill preBillToCreateApprovedBill, List<BillItem> transferRequestPreBillItems, Bill newApprovedBill) {
         if (transferRequestPreBillItems == null || transferRequestPreBillItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return null;
@@ -683,7 +688,13 @@ public class TransferRequestController implements Serializable {
     
     
 
-    public String navigateToApproveRequest() {
+    // synchronized: the Approve Request button on the transfer-request-list-to-approve
+    // page has no double-click guard. This method clears and repopulates the
+    // session-scoped billItems field from the pre-bill's items; a double-click raced
+    // two concurrent calls through this clear-then-repopulate step, leaving billItems
+    // holding every line twice (issue: duplicate items on TREQ/RH/GRO/26/00074, same
+    // bug class as #21417/#21815/PR #22101, tracked generically under #22102).
+    public synchronized String navigateToApproveRequest() {
         Bill transferRequestBillTemp = transferRequestBillPre;
         recreate();
         transferRequestBillPre = transferRequestBillTemp;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -340,6 +340,13 @@ public class TransferRequestController implements Serializable {
         if (!isAuthorized("APPROVE_REQUEST", "PharmacyDisbursementRequestApproval")) {
             return;
         }
+        // Check if the pre-bill is already approved to prevent a queued double-submit
+        // (blocked on the synchronized lock above) from creating a second approved bill
+        // once the first call has finished.
+        if (transferRequestBillPre != null && transferRequestBillPre.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This transfer request is already approved");
+            return;
+        }
         if (billItems == null || billItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return;

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
@@ -113,8 +113,9 @@
                                     icon="fas fa-check-circle"
                                     class="ui-button-success m-1"
                                     disabled="#{p.checkedBy eq null or p.approveUser ne null or p.cancelled eq true or not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
-                                    action="#{transferRequestController.navigateToApproveRequest()}">
-                                    <f:setPropertyActionListener 
+                                    action="#{transferRequestController.navigateToApproveRequest()}"
+                                    onclick="return confirm('Proceed to review and approve this transfer request?');">
+                                    <f:setPropertyActionListener
                                         target="#{transferRequestController.transferRequestBillPre}"
                                         value="#{p}"/>
                                 </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -76,6 +76,7 @@
                                     title="Approve Request"
                                     icon="fas fa-check-double" styleClass="ui-button-stage-approve mx-2"
                                     action="#{transferRequestController.navigateToApproveRequest}"
+                                    onclick="return confirm('Proceed to review and approve this transfer request?');"
                                     disabled="#{b.cancelled eq true}">
                                     <f:setPropertyActionListener target="#{transferRequestController.transferRequestBillPre}" value="#{b}"/>
                                 </p:commandButton>


### PR DESCRIPTION
## Summary
- Ports the `ruhunu-prod` hotfix (#22128) to `development`. Ruhunu Hospital transfer request `TREQ/RH/GRO/26/00074` had every line item duplicated on approval (24 items for 12 real lines, bill total exactly doubled); production data already corrected, root cause fixed there and here.
- `TransferRequestController` is `@SessionScoped`. `navigateToApproveRequest()`, `approveTransferRequestBill()`, and `createNewApprovedTransferRequestBill()` had no `synchronized` guard, and the "Approve Request" button (`ajax="false"`, on both the approval list and the search-for-approval pages) had no double-click protection at all.
- Adds `synchronized` to all three methods, plus a `confirm()` dialog on both "Approve Request" buttons — worded as a review step since `navigateToApproveRequest()` only navigates to the approval screen; the actual approval happens on the next page.
- Same bug class as #21417 / #21815 / PR #22101, tracked generically under the audit issue #22102 (adds Transfer Request Approval as a covered entry point).
- Cherry-picked from `duplicate-transfer-request-approval-guard-hotfix` (39fa4d1857) with minor conflict resolution to preserve `development`'s existing `isAuthorized(...)` checks (not present on `ruhunu-prod`) and its existing `disabled` attribute logic in `pharmacy_transfer_request_list_search_for_approval.xhtml`.

Related: #22127, PR #22128

## Test plan
- [x] `mvn compile` passes
- [ ] Manual: double-click "Approve Request" on a transfer request with several items, confirm only one set of items is created and totals match the pre-bill
- [ ] Confirm the `confirm()` dialog appears and cancelling it aborts navigation without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate transfer-request bill items caused by rapid repeated approval submissions.
  * Improved stability across the approval navigation and bill-creation steps.
* **User Experience**
  * Added a confirmation dialog when choosing to approve a transfer request.
  * Users can cancel the approval action if they do not wish to proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->