### PR TITLE
PO Approval item locking & double-click prevention

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -114,11 +114,8 @@ public class PurchaseOrderController implements Serializable {
             return "";
         }
 
-        for (BillItem b : selectedItems) {
-            getBillItems().remove(b.getSearialNo());
-            calTotal();
-        }
-
+        getBillItems().removeAll(selectedItems);
+        calTotal();
         selectedItems = null;
         return "";
     }
@@ -128,11 +125,11 @@ public class PurchaseOrderController implements Serializable {
     }
 
     public synchronized String removeItem(BillItem billItem) {
-        if (billItem == null || !billItems.contains(billItem)) {
+        if (billItem == null || !getBillItems().contains(billItem)) {
             JsfUtil.addErrorMessage("Item not found or already removed");
             return "";
         }
-        getBillItems().remove(billItem.getSearialNo());
+        getBillItems().remove(billItem);
         calTotal();
         return "";
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -108,30 +108,33 @@ public class PurchaseOrderController implements Serializable {
 
     private String emailRecipient;
 
-    public void removeSelected() {
-        //  //System.err.println("1");
-        if (selectedItems == null) {
-            JsfUtil.addErrorMessage("Please select items");
-            return;
+    public synchronized String removeSelected() {
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            JsfUtil.addErrorMessage("No items selected to remove");
+            return "";
         }
 
-        //System.err.println("3");
         for (BillItem b : selectedItems) {
-            //  //System.err.println("4");
             getBillItems().remove(b.getSearialNo());
             calTotal();
         }
 
         selectedItems = null;
+        return "";
     }
 
     public void displayItemDetails(BillItem bi) {
         getPharmacyController().fillItemDetails(bi.getItem());
     }
 
-    public void removeItem(BillItem billItem) {
+    public synchronized String removeItem(BillItem billItem) {
+        if (billItem == null || !billItems.contains(billItem)) {
+            JsfUtil.addErrorMessage("Item not found or already removed");
+            return "";
+        }
         getBillItems().remove(billItem.getSearialNo());
         calTotal();
+        return "";
     }
 
     private int maxResult = 50;

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -51,7 +51,7 @@
                                     <f:facet name="header">  
                                         <div class="d-flex justify-content-between">
                                             <h:outputLabel  value="Pharmacy Bill Item"/>
-                                            <p:commandButton process="itemList @this" update=":#{p:resolveFirstComponentWithId('itemList',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId}" value="Remove All" class="ui-button-Danger" style="float: right" onclick="return confirm('Remove all selected items? This action cannot be undone.');" action="#{purchaseOrderController.removeSelected()}"/>                            
+                                            <p:commandButton id="btnRemoveAll" process="itemList @this" update=":#{p:resolveFirstComponentWithId('itemList',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId}" value="Remove All" class="ui-button-danger" style="float: right" onclick="return confirm('Remove all selected items? This action cannot be undone.');" action="#{purchaseOrderController.removeSelected()}"/>                            
                                         </div>
                                     </f:facet>
                                     <p:dataTable scrollable="true" styleClass="noBorder" scrollHeight="250"
@@ -152,7 +152,7 @@
                                             </h:outputText>
                                         </p:column>  
                                         <p:column  class="text-end px-1"  width="4em" >
-                                            <p:commandButton process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash" class="ui-button-Danger" onclick="return confirm('Remove this item? This action cannot be undone.');" action="#{purchaseOrderController.removeItem(bi)}"/>
+                                            <p:commandButton id="btnRemoveItem" process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash" class="ui-button-danger" onclick="return confirm('Remove this item? This action cannot be undone.');" action="#{purchaseOrderController.removeItem(bi)}"/>
                                         </p:column>
                                     </p:dataTable> 
 

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -51,7 +51,7 @@
                                     <f:facet name="header">  
                                         <div class="d-flex justify-content-between">
                                             <h:outputLabel  value="Pharmacy Bill Item"/>
-                                            <p:commandButton process="itemList @this" update=":#{p:resolveFirstComponentWithId('itemList',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId}" value="Remove All" class="ui-button-Danger" style="float: right" action="#{purchaseOrderController.removeSelected()}"/>                            
+                                            <p:commandButton process="itemList @this" update=":#{p:resolveFirstComponentWithId('itemList',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId}" value="Remove All" class="ui-button-Danger" style="float: right" onclick="return confirm('Remove all selected items? This action cannot be undone.');" action="#{purchaseOrderController.removeSelected()}"/>                            
                                         </div>
                                     </f:facet>
                                     <p:dataTable scrollable="true" styleClass="noBorder" scrollHeight="250"
@@ -152,7 +152,7 @@
                                             </h:outputText>
                                         </p:column>  
                                         <p:column  class="text-end px-1"  width="4em" >
-                                            <p:commandButton  process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash"  class="ui-button-Danger" action="#{purchaseOrderController.removeItem(bi)}"/>
+                                            <p:commandButton process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash" class="ui-button-Danger" onclick="return confirm('Remove this item? This action cannot be undone.');" action="#{purchaseOrderController.removeItem(bi)}"/>
                                         </p:column>
                                     </p:dataTable> 
 


### PR DESCRIPTION
## Summary

Prevent accidental item removal and double-click submission errors during PO approval by:
- Adding client-side confirm() dialogs to Remove All and per-item remove buttons
- Making removeSelected() and removeItem() synchronized to prevent concurrent execution  
- Adding idempotency checks to detect and abort duplicate removals

## Test plan

- [ ] Build: `mvn clean package -DskipTests=true` ✅ (passed in implementation)
- [ ] Navigate to Menu > Pharmacy > Procurement > Approve Purchase Orders
- [ ] Open a PO for approval
- [ ] Verify Remove All button shows confirm dialog
- [ ] Verify per-item trash button shows confirm dialog
- [ ] Test double-click safety on both buttons — no duplicate removals
- [ ] Verify Approve button still works with existing confirm dialog

## Technical Details

**Files changed:**
- `src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml` — Added `onclick` confirm guards to buttons
- `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java` — Synchronized removeSelected() and removeItem() with idempotency checks

**Pattern reference:** Follows existing double-click guard patterns from PR #22101 and #21815 (PO approval navigation and approval method synchronization)

Closes #14846

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before removing all pharmacy bill items or a single item from a purchase order.

* **Bug Fixes**
  * Improved item removal validation so attempting to remove with nothing selected (or with an invalid item) shows an error instead of failing silently.
  * Ensures totals are recalculated only after successful removals to prevent inconsistent totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->