### PR TITLE
feat(cc-payment): record and display CC payment voucher breakdown and date range

### DIFF
--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -570,6 +570,14 @@ public class CollectingCentrePaymentController implements Serializable {
         ccAgentPaymentBill.setTotal(payingBalanceAcodingToCCBalabce);
         ccAgentPaymentBill.setPaidAmount(payingBalanceAcodingToCCBalabce);
 
+        // Record the CC repayment voucher figures so the voucher can be reprinted later.
+        ccAgentPaymentBill.setCcBalanceBeforeTransaction(startingBalanseInCC);
+        ccAgentPaymentBill.setCcBalanceAfterTransaction(finalEndingBalanseInCC);
+        ccAgentPaymentBill.setCcTotalReceived(totalCCReceiveAmount);
+        ccAgentPaymentBill.setCcTransactionAmount(totalHospitalAmount);
+        ccAgentPaymentBill.setCcTotalCenterValue(totalCCAmount);
+        ccAgentPaymentBill.setCcExcessAmount(payingBalanceAcodingToCCBalabce);
+
         ccAgentPaymentBill.setFromDate(fromDate);
         ccAgentPaymentBill.setToDate(toDate);
 

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -519,6 +519,15 @@ public class Bill implements Serializable, RetirableEntity {
     @Enumerated(EnumType.STRING)
     private Priority priority;
 
+    // Collecting Centre repayment voucher values (recorded at settlement time so
+    // the CC payment voucher can be reprinted with the same figures later).
+    private double ccBalanceBeforeTransaction;
+    private double ccBalanceAfterTransaction;
+    private double ccTotalReceived;
+    private double ccTransactionAmount;
+    private double ccTotalCenterValue;
+    private double ccExcessAmount;
+
     public Bill() {
         if (status == null) {
             status = PatientInvestigationStatus.ORDERED;
@@ -3166,6 +3175,54 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setPriority(Priority priority) {
         this.priority = priority;
+    }
+
+    public double getCcBalanceBeforeTransaction() {
+        return ccBalanceBeforeTransaction;
+    }
+
+    public void setCcBalanceBeforeTransaction(double ccBalanceBeforeTransaction) {
+        this.ccBalanceBeforeTransaction = ccBalanceBeforeTransaction;
+    }
+
+    public double getCcBalanceAfterTransaction() {
+        return ccBalanceAfterTransaction;
+    }
+
+    public void setCcBalanceAfterTransaction(double ccBalanceAfterTransaction) {
+        this.ccBalanceAfterTransaction = ccBalanceAfterTransaction;
+    }
+
+    public double getCcTotalReceived() {
+        return ccTotalReceived;
+    }
+
+    public void setCcTotalReceived(double ccTotalReceived) {
+        this.ccTotalReceived = ccTotalReceived;
+    }
+
+    public double getCcTransactionAmount() {
+        return ccTransactionAmount;
+    }
+
+    public void setCcTransactionAmount(double ccTransactionAmount) {
+        this.ccTransactionAmount = ccTransactionAmount;
+    }
+
+    public double getCcTotalCenterValue() {
+        return ccTotalCenterValue;
+    }
+
+    public void setCcTotalCenterValue(double ccTotalCenterValue) {
+        this.ccTotalCenterValue = ccTotalCenterValue;
+    }
+
+    public double getCcExcessAmount() {
+        return ccExcessAmount;
+    }
+
+    public void setCcExcessAmount(double ccExcessAmount) {
+        this.ccExcessAmount = ccExcessAmount;
     }
 
 }

--- a/src/main/webapp/collecting_centre/sent_payment_to_collecting_centre.xhtml
+++ b/src/main/webapp/collecting_centre/sent_payment_to_collecting_centre.xhtml
@@ -273,7 +273,7 @@
                                 </h:panelGroup>
 
                                 <h:panelGroup rendered="#{collectingCentrePaymentController.printPriview eq true}">
-                                    <h:panelGroup id="gpBillPreview" class=" mt-3">
+                                    <h:panelGroup id="gpBillPreview" class="mt-3">
                                         <bi:A4PaperCCRepayment controller="#{collectingCentrePaymentController}" bill="#{collectingCentrePaymentController.currentPaymentBill}" dup="false"/>
                                     </h:panelGroup>
                                 </h:panelGroup>

--- a/src/main/webapp/resources/bill/A4PaperCCRepayment.xhtml
+++ b/src/main/webapp/resources/bill/A4PaperCCRepayment.xhtml
@@ -118,67 +118,93 @@
                         </tr>
                     </table>
                 </div>
+
                 <div class="billline">
                     <hr/>
                 </div>
+
+                <div class="d-flex justify-content-center gap-2" style="font-size: 18px; font-weight: 700;">
+                    <h:outputLabel value="Payment Date Range"/>
+                    <h:outputLabel value="#{cc.attrs.bill.fromDate}" >
+                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                    </h:outputLabel>
+                    <h:outputLabel value=" to " />
+                    <h:outputLabel value="#{cc.attrs.bill.toDate}">
+                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                    </h:outputLabel>
+                </div>
+
+                <div class="billline">
+                    <hr/>
+                </div>
+
                 <div class="billDetailsFiveFive" >
-                    <h:dataTable 
-                        value="#{billBeanController.fetchBillItems(cc.attrs.bill)}"
-                        var="bip" 
-                        style="margin: auto; padding: 1%; width: 100%; margin-right: 10%; " >
-
-                        <p:column style="text-align: center; margin-left: 10%" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="" ></h:outputLabel>
-                            </f:facet>
-                            <h:outputLabel 
-                                value="&emsp;"
-                                style="font-size:10px!important;" />
-                        </p:column>
-                        <p:column style="text-align: center;" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Bill No"  ></h:outputLabel>
-                            </f:facet>
-                            <h:outputLabel 
-                                value="#{bip.referenceBill.deptId}"
-                                style="font-size:10pt!important;" />
-                        </p:column>
-                        <p:column style="text-align: center;" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Ref. Number"  ></h:outputLabel>
-                            </f:facet>
-                            <h:outputLabel 
-                                value="#{bip.referenceBill.referenceNumber}"
-                                style="font-size:10pt!important;" />
-                        </p:column>
-
-                        <p:column style="text-align: center;" >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Patient"  ></h:outputLabel>
-                            </f:facet>
-                            <h:outputLabel 
-                                value="#{bip.referenceBill.patient.person.nameWithTitle}"
-                                style="font-size:10pt!important;" />
-                        </p:column>
-
-                        <h:column >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Value" class="d-flex justify-content-end mx-2"></h:outputLabel>
-                            </f:facet>
-                            <h:outputLabel 
-                                value="#{bip.netValue}" 
-                                class="d-flex justify-content-end mx-2"
-                                style="font-size: 10pt!important; text-align: right!important;" >
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </h:column>
-                    </h:dataTable>
+                    <table style="width: 95%!important; font-size: 11pt!important;" align="center" >
+                        <tr>
+                            <td><h:outputLabel value="Before Transaction Balance in Collcting Centre" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccBalanceBeforeTransaction}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h:outputLabel value="After Transaction Balance in Collcting Centre" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccBalanceAfterTransaction}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h:outputLabel value="Total Paying Amount ( Acoding to CC Balabce )" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr><td colspan="2">&nbsp;</td></tr>
+                        <tr>
+                            <td><h:outputLabel value="Total Receive from Collcting Centre" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccTotalReceived}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h:outputLabel value="Transaction Amount" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccTransactionAmount}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h:outputLabel value="Excees Amount" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccExcessAmount}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr><td colspan="2">&nbsp;</td></tr>
+                        <tr style="font-weight: bold;">
+                            <td><h:outputLabel value="Total Collection Center Value" /></td>
+                            <td style="text-align: right!important; padding-right: 15px;">
+                                <h:outputLabel value="#{cc.attrs.bill.ccTotalCenterValue}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
                 <div class="billline">
                     <hr/>
                 </div>
                 <div  >
-                    <table style="width: 100%;">
+                    <table style="width: 98%;">
                         <tr>
                             <td  style="text-align: left; width: 60%; font-size: 20px!important;
                                  font-family:Verdana, Helvetica, sans-serif!important;

--- a/src/main/webapp/resources/bill/A4PaperCCRepayment.xhtml
+++ b/src/main/webapp/resources/bill/A4PaperCCRepayment.xhtml
@@ -124,14 +124,14 @@
                 </div>
 
                 <div class="d-flex justify-content-center gap-2" style="font-size: 18px; font-weight: 700;">
-                    <h:outputLabel value="Payment Date Range"/>
-                    <h:outputLabel value="#{cc.attrs.bill.fromDate}" >
+                    <h:outputText value="Payment Date Range"/>
+                    <h:outputText value="#{cc.attrs.bill.fromDate}" >
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                    </h:outputLabel>
-                    <h:outputLabel value=" to " />
-                    <h:outputLabel value="#{cc.attrs.bill.toDate}">
+                    </h:outputText>
+                    <h:outputText value=" to " />
+                    <h:outputText value="#{cc.attrs.bill.toDate}">
                         <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                    </h:outputLabel>
+                    </h:outputText>
                 </div>
 
                 <div class="billline">
@@ -141,61 +141,61 @@
                 <div class="billDetailsFiveFive" >
                     <table style="width: 95%!important; font-size: 11pt!important;" align="center" >
                         <tr>
-                            <td><h:outputLabel value="Before Transaction Balance in Collcting Centre" /></td>
+                            <td><h:outputText value="Before Transaction Balance in Collecting Centre" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccBalanceBeforeTransaction}" >
+                                <h:outputText value="#{cc.attrs.bill.ccBalanceBeforeTransaction}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
-                            <td><h:outputLabel value="After Transaction Balance in Collcting Centre" /></td>
+                            <td><h:outputText value="After Transaction Balance in Collecting Centre" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccBalanceAfterTransaction}" >
+                                <h:outputText value="#{cc.attrs.bill.ccBalanceAfterTransaction}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
-                            <td><h:outputLabel value="Total Paying Amount ( Acoding to CC Balabce )" /></td>
+                            <td><h:outputText value="Total Paying Amount ( According to CC Balance )" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" >
+                                <h:outputText value="#{cc.attrs.bill.netTotal}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr><td colspan="2">&nbsp;</td></tr>
                         <tr>
-                            <td><h:outputLabel value="Total Receive from Collcting Centre" /></td>
+                            <td><h:outputText value="Total Received from Collecting Centre" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccTotalReceived}" >
+                                <h:outputText value="#{cc.attrs.bill.ccTotalReceived}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
-                            <td><h:outputLabel value="Transaction Amount" /></td>
+                            <td><h:outputText value="Transaction Amount" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccTransactionAmount}" >
+                                <h:outputText value="#{cc.attrs.bill.ccTransactionAmount}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
-                            <td><h:outputLabel value="Excees Amount" /></td>
+                            <td><h:outputText value="Excess Amount" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccExcessAmount}" >
+                                <h:outputText value="#{cc.attrs.bill.ccExcessAmount}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr><td colspan="2">&nbsp;</td></tr>
                         <tr style="font-weight: bold;">
-                            <td><h:outputLabel value="Total Collection Center Value" /></td>
+                            <td><h:outputText value="Total Collection Centre Value" /></td>
                             <td style="text-align: right!important; padding-right: 15px;">
-                                <h:outputLabel value="#{cc.attrs.bill.ccTotalCenterValue}" >
+                                <h:outputText value="#{cc.attrs.bill.ccTotalCenterValue}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
## Description
Adds the full payment-calculation breakdown and the payment date range to the **Collecting Centre Payment Voucher**, and persists those figures on the payment `Bill` so they remain available when a voucher is reprinted later.

Previously the breakdown existed only as transient values on `CollectingCentrePaymentController` (shown on the on-screen "Payment Details" panel) and was never stored — so `cc_repayment_bill_reprint.xhtml` could not reproduce it.

## Changes (commit by commit)
1. **Entity** — `Bill.java`: add persisted fields `ccBalanceBeforeTransaction`, `ccBalanceAfterTransaction`, `ccTotalReceived`, `ccTransactionAmount`, `ccTotalCenterValue`, `ccExcessAmount` (with getters/setters).
2. **Controller** — `CollectingCentrePaymentController.saveBill()`: record the computed figures on the payment bill at settlement time.
3. **UI** — `A4PaperCCRepayment.xhtml`: render the breakdown + Payment Date Range (reads from the persisted Bill, so it works at settlement and on reprint). Minor whitespace tidy in `sent_payment_to_collecting_centre.xhtml`.

## Voucher now shows
- Before Transaction Balance in Collecting Centre
- After Transaction Balance in Collecting Centre
- Total Paying Amount (According to CC Balance)
- Total Receive from Collecting Centre
- Transaction Amount
- Excess Amount
- Total Collection Center Value
- Payment Date Range (From – To)

## Notes / Impact
- Adds 6 new columns to the `bill` table.
- `fromDate`/`toDate` already existed on `Bill` and were already persisted — only display was added for the date range.
- Vouchers settled **before** this change will show `0.00` for the new figures; only new settlements populate them.

## Testing
- `mvn compile` passes.
- Manual: settle a CC payment → voucher shows the full breakdown and date range; reprint shows the same stored values.

Closes #22138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collecting centre repayment vouchers now show a payment date range along with a detailed CC summary, including balances before/after transaction, total received, transaction amount, excess amount, and total collection centre value.
  * Repayment records now retain the required CC voucher figures to support accurate voucher reprints.

* **Style**
  * Cleaned up spacing in the collecting centre payment preview.
  * Updated the repayment voucher layout sizing and alignment for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->