### PR TITLE
Relabel Pharmacy Disposal menu/pages as Consumption (#9346)

### DIFF
--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1271,7 +1271,7 @@
                 <!-- Pharmacy Disposal Direct Issue -->
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'pharmacy_disposal_issue' and webUserController.hasPrivilege('PharmacyDisposalIssue')}">
                     <h:form>
-                        <p:tooltip for="pharmacy_disposal_issue" value="Pharmacy Disposal Direct Issue"  showDelay="0" hideDelay="0"></p:tooltip>
+                        <p:tooltip for="pharmacy_disposal_issue" value="Pharmacy Consumption Direct Issue"  showDelay="0" hideDelay="0"></p:tooltip>
                         <p:commandLink
                             id="pharmacy_disposal_issue"
                             ajax="false"
@@ -1279,7 +1279,7 @@
                             actionListener="#{pharmacyIssueController.resetAll()}"
                             styleClass="svg-link" >
                             <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="pharmacy_disposal_issue.svg" style="cursor: pointer;" width="80" height="80"/>
-                            <h:outputText style="display: none;" value="Pharmacy Disposal - Direct Issue" />
+                            <h:outputText style="display: none;" value="Pharmacy Consumption - Direct Issue" />
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>

--- a/src/main/webapp/pharmacy/disposal_index.xhtml
+++ b/src/main/webapp/pharmacy/disposal_index.xhtml
@@ -22,7 +22,7 @@
                         <p:tab title="Issue">
                             <div class="d-grid gap-2">
                                 <p:commandButton
-                                    value="New Disposal Issue"
+                                    value="New Consumption Issue"
                                     ajax="false"
                                     action="/pharmacy/pharmacy_issue?faces-redirect=true"
                                     actionListener="#{pharmacyIssueController.resetAll()}"
@@ -120,19 +120,19 @@
             </div>
             <div class="col-10">
                 <ui:insert name="subcontent">
-                    <p:panel header="Disposal Management">
+                    <p:panel header="Consumption Management">
                         <div class="text-center p-5">
-                            <h3><h:outputText value="Welcome to Disposal Management"/></h3>
+                            <h3><h:outputText value="Welcome to Consumption Management"/></h3>
                             <p class="mt-3">
                                 <h:outputText value="Please select a function from the left menu to get started."/>
                             </p>
                             <div class="mt-4">
                                 <p:panelGrid columns="2" styleClass="mx-auto" style="max-width: 600px;">
                                     <h:outputText value="Issue" styleClass="font-weight-bold"/>
-                                    <h:outputText value="Create disposal issue bills and search existing bills"/>
+                                    <h:outputText value="Create consumption issue bills and search existing bills"/>
 
                                     <h:outputText value="Returns" styleClass="font-weight-bold"/>
-                                    <h:outputText value="Create, finalize, approve, and view completed disposal returns"/>
+                                    <h:outputText value="Create, finalize, approve, and view completed consumption returns"/>
                                 </p:panelGrid>
                             </div>
                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -554,7 +554,7 @@
                                         </div>
                                     </p:tab>
 
-                                    <p:tab title="Disposal Reports" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Pharmacy Analytics Disposal Reports Tab')}">
+                                    <p:tab title="Consumption Reports" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Pharmacy Analytics Disposal Reports Tab')}">
                                         <div class="d-grid gap-2">
                                             <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Unit Issue by bill')}" class="w-100 ui-button-warning" ajax="false"
                                                              value="Unit Issue by bill" 

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -50,7 +50,7 @@
                                             icon="fas fa-plus-circle"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                            title="Create a new Disposal Return Request">
+                                            title="Create a new Consumption Return Request">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="List Returns to Finalize"
@@ -59,7 +59,7 @@
                                             icon="fas fa-tasks"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                            title="Finalize Disposal Return Requests">
+                                            title="Finalize Consumption Return Requests">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="List Returns To Approve"
@@ -68,7 +68,7 @@
                                             icon="fas fa-check-circle"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                            title="Approve Disposal Return Requests">
+                                            title="Approve Consumption Return Requests">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="Completed Returns"
@@ -77,7 +77,7 @@
                                             icon="fas fa-check-double"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                            title="View Completed Disposal Returns">
+                                            title="View Completed Consumption Returns">
                                         </p:commandButton>
                                     </div>
 
@@ -97,7 +97,7 @@
                                             icon="fas fa-check-circle"
                                             styleClass="ui-button-success"
                                             value="Finalize"
-                                            onclick="return confirm('Are you sure you want to finalize this disposal issue? This action cannot be undone.');"
+                                            onclick="return confirm('Are you sure you want to finalize this consumption issue? This action cannot be undone.');"
                                             title="Finalize return bill"
                                             action="#{issueReturnController.finalizeDisposalIssueReturnBill()}"
                                             rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
@@ -108,7 +108,7 @@
                                             icon="fas fa-money-bill"
                                             styleClass="ui-button-warning"
                                             value="Approve Return"
-                                            onclick="return confirm('Are you sure you want to approve this disposal issue? This action cannot be undone.');"
+                                            onclick="return confirm('Are you sure you want to approve this consumption issue? This action cannot be undone.');"
                                             title="Approve and process the return"
                                             action="#{issueReturnController.settleDisposalIssueReturnBill}"
                                             rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
@@ -128,7 +128,7 @@
                             <div class="alert alert-danger d-flex align-items-center">
                                 <i class="fas fa-exclamation-triangle me-2"></i>
                                 <div>
-                                    <h:outputText value="This disposal issue bill has been fully returned on " styleClass="fw-bold"/>
+                                    <h:outputText value="This consumption issue bill has been fully returned on " styleClass="fw-bold"/>
                                     <h:outputText value="#{issueReturnController.originalBill.fullReturnedAt}">
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
@@ -142,7 +142,7 @@
                             <div class="alert alert-success d-flex align-items-center">
                                 <i class="fas fa-check-circle me-2"></i>
                                 <div>
-                                    <h:outputText value="This disposal return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
+                                    <h:outputText value="This consumption return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
                                     <h:outputText value=" on " rendered="#{issueReturnController.returnBill.completedAt ne null}"/>
                                     <h:outputText value="#{issueReturnController.returnBill.completedAt}" rendered="#{issueReturnController.returnBill.completedAt ne null}">
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
@@ -158,7 +158,7 @@
                             <div class="alert alert-warning d-flex align-items-center">
                                 <i class="fas fa-ban me-2"></i>
                                 <div>
-                                    <h:outputText value="This disposal return has been closed. It can no longer be saved, finalized or approved - create a new return for this disposal issue if needed." styleClass="fw-bold"/>
+                                    <h:outputText value="This consumption return has been closed. It can no longer be saved, finalized or approved - create a new return for this consumption issue if needed." styleClass="fw-bold"/>
                                 </div>
                             </div>
                         </p:panel>
@@ -174,7 +174,7 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
                                     <h:outputText value=" and is awaiting approval. Items can no longer be edited." styleClass="fw-bold"/>
-                                    <h:outputText value=" You do not have the Approve Disposal Return privilege - please ask an authorized user to approve it."
+                                    <h:outputText value=" You do not have the Approve Consumption Return privilege - please ask an authorized user to approve it."
                                                   rendered="#{!webUserController.hasPrivilege('ApproveDisposalReturn')}"
                                                   styleClass="fw-bold text-danger ms-1"/>
                                 </div>
@@ -345,7 +345,7 @@
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <h:outputText value="Disposal Issue Return - Print Preview" styleClass="fw-bold"/>
+                                        <h:outputText value="Consumption Issue Return - Print Preview" styleClass="fw-bold"/>
                                     </div>
                                     <div class="d-flex gap-2">
                                         <p:commandButton
@@ -355,7 +355,7 @@
                                             icon="fas fa-plus-circle"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                            title="Create a new Disposal Return Request">
+                                            title="Create a new Consumption Return Request">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="List Returns to Finalize"
@@ -364,7 +364,7 @@
                                             icon="fas fa-tasks"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                            title="Finalize Disposal Return Requests">
+                                            title="Finalize Consumption Return Requests">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="List Returns To Approve"
@@ -373,7 +373,7 @@
                                             icon="fas fa-check-circle"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                            title="Approve Disposal Return Requests">
+                                            title="Approve Consumption Return Requests">
                                         </p:commandButton>
                                         <p:commandButton
                                             value="Completed Returns"
@@ -382,7 +382,7 @@
                                             icon="fas fa-check-double"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                            title="View Completed Disposal Returns">
+                                            title="View Completed Consumption Returns">
                                         </p:commandButton>
                                         <p:commandButton
                                             styleClass="ui-button-info"

--- a/src/main/webapp/pharmacy/pharmacy_cancel_bill_unit_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_cancel_bill_unit_issue.xhtml
@@ -94,7 +94,7 @@
 
                     <p:panel rendered="#{pharmacyBillSearch.printPreview}">
                         <f:facet name="header" >
-                            <h:outputLabel value="Disposal Issue Cancel" ></h:outputLabel>
+                            <h:outputLabel value="Consumption Issue Cancel" ></h:outputLabel>
                             <p:commandButton value="Print" ajax="false" style="float:right;" class="ui-button-info" icon="fas fa-print">
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
@@ -118,7 +118,7 @@
 
                     <!-- Disposal Issue Configuration Dialog -->
                     <p:dialog id="disposalCancelConfigDialog"
-                              header="Disposal Cancel Printer Configuration"
+                              header="Consumption Cancel Printer Configuration"
                               widgetVar="disposalCancelConfigDialog"
                               modal="true"
                               width="600"
@@ -134,7 +134,7 @@
                                 <div class="col-12">
                                     <div class="card config-section">
                                         <div class="card-header">
-                                            <h6><i class="fas fa-file-alt"></i> Disposal Cancel Paper Settings</h6>
+                                            <h6><i class="fas fa-file-alt"></i> Consumption Cancel Paper Settings</h6>
                                         </div>
                                         <div class="card-body">
                                             <div class="mb-3">
@@ -142,21 +142,21 @@
                                                     id="disposalCancelA4Paper"
                                                     value="#{pharmacyConfigController.disposalCancelA4Paper}" />
                                                 <p:outputLabel for="disposalCancelA4Paper" value="A4 Paper Format" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Standard A4 paper format for disposal cancel receipts</small>
+                                                <small class="form-text text-muted d-block">Standard A4 paper format for consumption cancel receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalCancelCustom1"
                                                     value="#{pharmacyConfigController.disposalCancelCustom1}" />
                                                 <p:outputLabel for="disposalCancelCustom1" value="Custom Format 1" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 1 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 1 for consumption issue receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalCancelCustom2"
                                                     value="#{pharmacyConfigController.disposalCancelCustom2}" />
                                                 <p:outputLabel for="disposalCancelCustom2" value="Custom Format 2" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 2 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 2 for consumption issue receipts</small>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_approve.xhtml
@@ -6,7 +6,7 @@
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 <h:head>
-    <title>Disposal Issues — List to Approve</title>
+    <title>Consumption Issues — List to Approve</title>
 </h:head>
 <h:body>
     <ui:composition template="/resources/template/template.xhtml">
@@ -21,7 +21,7 @@
                 <f:facet name="header">
                     <div class="d-flex align-items-center">
                         <h:outputText styleClass="fas fa-check-double text-success me-2"/>
-                        <h:outputText value="Disposal Issues — List to Approve" styleClass="text-success"/>
+                        <h:outputText value="Consumption Issues — List to Approve" styleClass="text-success"/>
                     </div>
                 </f:facet>
                 <h:form>
@@ -65,7 +65,7 @@
                                 paginatorPosition="both"
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="10,15,25,50"
-                                emptyMessage="No finalized disposal issues found matching your criteria"
+                                emptyMessage="No finalized consumption issues found matching your criteria"
                                 sortMode="multiple"
                                 resizableColumns="true"
                                 reflow="true"
@@ -96,7 +96,7 @@
                                         styleClass="ui-button-stage-approve"
                                         icon="fas fa-check-double"
                                         value="View / Approve"
-                                        title="View and Approve Disposal Issue #{g.id}"
+                                        title="View and Approve Consumption Issue #{g.id}"
                                         ajax="false"
                                         action="#{pharmacyIssueController.loadFinalizedForApprove(g.id)}"/>
                                     <p:commandButton
@@ -104,9 +104,9 @@
                                         styleClass="ui-button-danger ui-button-outlined ms-1"
                                         icon="fas fa-times"
                                         value="Cancel"
-                                        title="Cancel this finalized disposal issue"
+                                        title="Cancel this finalized consumption issue"
                                         ajax="false"
-                                        onclick="return confirm('Cancel this finalized disposal issue? This cannot be undone.');"
+                                        onclick="return confirm('Cancel this finalized consumption issue? This cannot be undone.');"
                                         action="#{pharmacyIssueController.cancelFinalizedDisposalIssue(g.id)}"/>
                                 </p:column>
                             </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_issue_list_to_finalize.xhtml
@@ -6,7 +6,7 @@
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 <h:head>
-    <title>Disposal Issues — List to Finalize</title>
+    <title>Consumption Issues — List to Finalize</title>
 </h:head>
 <h:body>
     <ui:composition template="/resources/template/template.xhtml">
@@ -20,7 +20,7 @@
                 <f:facet name="header">
                     <div class="d-flex align-items-center">
                         <h:outputText styleClass="fas fa-tasks text-warning me-2"/>
-                        <h:outputText value="Disposal Issues — List to Finalize" styleClass="mb-0 text-warning"/>
+                        <h:outputText value="Consumption Issues — List to Finalize" styleClass="mb-0 text-warning"/>
                     </div>
                 </f:facet>
                 <h:form>
@@ -64,7 +64,7 @@
                                 paginatorPosition="both"
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="10,15,25,50"
-                                emptyMessage="No saved disposal issues found matching your criteria"
+                                emptyMessage="No saved consumption issues found matching your criteria"
                                 sortMode="multiple"
                                 resizableColumns="true"
                                 reflow="true"
@@ -92,18 +92,18 @@
                                         styleClass="ui-button-stage-finalize"
                                         icon="fas fa-lock"
                                         value="View / Finalize"
-                                        title="View and Finalize Disposal Issue #{g.id}"
+                                        title="View and Finalize Consumption Issue #{g.id}"
                                         ajax="false"
-                                        onclick="return confirm('Open disposal issue ##{g.id} for finalization?');"
+                                        onclick="return confirm('Open consumption issue ##{g.id} for finalization?');"
                                         action="#{pharmacyIssueController.loadDraftForEdit(g.id)}"/>
                                     <p:commandButton
                                         id="btnCancel"
                                         styleClass="ui-button-danger ui-button-outlined ms-1"
                                         icon="fas fa-times"
                                         value="Cancel"
-                                        title="Cancel this saved disposal issue"
+                                        title="Cancel this saved consumption issue"
                                         ajax="false"
-                                        onclick="return confirm('Cancel this disposal issue draft? This cannot be undone.');"
+                                        onclick="return confirm('Cancel this consumption issue draft? This cannot be undone.');"
                                         action="#{pharmacyIssueController.cancelPendingDisposalIssue(g.id)}"/>
                                 </p:column>
                             </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_return_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_return_approve.xhtml
@@ -17,7 +17,7 @@
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="d-flex align-items-center">
                             <i class="fas fa-check-circle text-success me-2"></i>
-                            <h:outputText value="Approve Disposal Return Requests" styleClass="mb-0 text-success" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
+                            <h:outputText value="Approve Consumption Return Requests" styleClass="mb-0 text-success" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
                         </div>
                         <div class="d-flex gap-2">
                             <p:commandButton
@@ -27,7 +27,7 @@
                                 icon="fas fa-plus-circle"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                title="Create a new Disposal Return Request">
+                                title="Create a new Consumption Return Request">
                             </p:commandButton>
                             <p:commandButton
                                 value="List Returns to Finalize"
@@ -36,7 +36,7 @@
                                 icon="fas fa-tasks"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                title="Finalize Disposal Return Requests">
+                                title="Finalize Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="List Returns To Approve"
@@ -45,7 +45,7 @@
                                 icon="fas fa-check-circle"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                title="Approve Disposal Return Requests">
+                                title="Approve Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="Completed Returns"
@@ -54,7 +54,7 @@
                                 icon="fas fa-check-double"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                title="View Completed Disposal Returns">
+                                title="View Completed Consumption Returns">
                             </p:commandButton>
                         </div>
                     </div>
@@ -107,7 +107,7 @@
                                 <p:commandButton
                                     class="ui-button-success w-100"
                                     icon="fas fa-search"
-                                    value="Search Disposal Returns"
+                                    value="Search Consumption Returns"
                                     action="#{disposalReturnWorkflowController.fillDisposalReturnsToApprove()}"
                                     ajax="false"
                                     style="min-height: 45px;">
@@ -117,7 +117,7 @@
                         </p:panel>
                     </div>
                     <div class="col-lg-9 col-md-8">
-                        <p:panel header="Disposal Return Requests to Approve" styleClass="shadow-sm">
+                        <p:panel header="Consumption Return Requests to Approve" styleClass="shadow-sm">
                             <p:dataTable
                                 id="tbl"
                                 value="#{disposalReturnWorkflowController.disposalReturnsToApprove}"
@@ -128,7 +128,7 @@
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="5,10,15,25"
                                 styleClass="table-striped"
-                                emptyMessage="No disposal return requests found matching your criteria"
+                                emptyMessage="No consumption return requests found matching your criteria"
                                 filteredValue="#{disposalReturnWorkflowController.filteredDisposalReturnsToApprove}"
                                 sortMode="multiple"
                                 resizableColumns="true"
@@ -215,7 +215,7 @@
                                     <p:commandButton
                                         id="approve"
                                         ajax="false"
-                                        title="#{b.completed ? 'Already Approved' : (b.billClosed eq true ? 'Closed Return' : 'Review and Approve Disposal Return')}"
+                                        title="#{b.completed ? 'Already Approved' : (b.billClosed eq true ? 'Closed Return' : 'Review and Approve Consumption Return')}"
                                         icon="fas #{b.completed ? 'fa-check-circle' : 'fa-eye'}"
                                         class="#{b.completed ? 'ui-button-success ui-button-outlined' : (b.billClosed eq true ? 'ui-button-secondary ui-button-outlined' : 'ui-button-success')}"
                                         value="#{b.completed ? 'Approved' : 'Approve'}"
@@ -226,7 +226,7 @@
                                     <p:commandButton
                                         id="close"
                                         ajax="false"
-                                        title="Close this disposal return"
+                                        title="Close this consumption return"
                                         icon="fas fa-times"
                                         class="ui-button-danger ui-button-outlined"
                                         value="Close"
@@ -235,7 +235,7 @@
                                         rendered="#{b.billClosed ne true and b.completed ne true and b.checkedBy ne null}"
                                         style="min-width: 70px;">
                                         <p:confirm header="Confirm Close"
-                                                   message="Are you sure you want to close this finalized disposal return? This will allow creating a new return for the same bill."
+                                                   message="Are you sure you want to close this finalized consumption return? This will allow creating a new return for the same bill."
                                                    icon="pi pi-exclamation-triangle"/>
                                     </p:commandButton>
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_return_completed.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_return_completed.xhtml
@@ -17,7 +17,7 @@
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="d-flex align-items-center">
                             <i class="fas fa-check-double text-primary me-2"></i>
-                            <h:outputText value="Completed Disposal Return Requests" styleClass="mb-0 text-primary" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
+                            <h:outputText value="Completed Consumption Return Requests" styleClass="mb-0 text-primary" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
                         </div>
                         <div class="d-flex gap-2">
                             <p:commandButton
@@ -27,7 +27,7 @@
                                 icon="fas fa-tasks"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                title="Finalize Disposal Return Requests">
+                                title="Finalize Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="List Returns To Approve"
@@ -36,7 +36,7 @@
                                 icon="fas fa-check-circle"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                title="Approve Disposal Return Requests">
+                                title="Approve Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="Completed Returns"
@@ -45,7 +45,7 @@
                                 icon="fas fa-check-double"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                title="View Completed Disposal Returns">
+                                title="View Completed Consumption Returns">
                             </p:commandButton>
                         </div>
                     </div>
@@ -96,7 +96,7 @@
                         </p:panel>
                     </div>
                     <div class="col-lg-9 col-md-8">
-                        <p:panel header="Completed Disposal Return Requests" styleClass="shadow-sm">
+                        <p:panel header="Completed Consumption Return Requests" styleClass="shadow-sm">
                             <p:dataTable
                                 id="tbl"
                                 value="#{disposalReturnWorkflowController.completedDisposalReturns}"
@@ -107,7 +107,7 @@
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="5,10,15,25"
                                 styleClass="table-striped"
-                                emptyMessage="No completed disposal return requests found matching your criteria"
+                                emptyMessage="No completed consumption return requests found matching your criteria"
                                 filteredValue="#{disposalReturnWorkflowController.filteredCompletedDisposalReturns}"
                                 sortMode="multiple"
                                 resizableColumns="true"

--- a/src/main/webapp/pharmacy/pharmacy_disposal_return_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_return_finalize.xhtml
@@ -17,7 +17,7 @@
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="d-flex align-items-center">
                             <i class="fas fa-clipboard-list text-warning me-2"></i>
-                            <h:outputText value="Finalize Disposal Return Requests" styleClass="mb-0 text-warning" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
+                            <h:outputText value="Finalize Consumption Return Requests" styleClass="mb-0 text-warning" style="font-size: 1.5rem; font-weight: 500; margin: 0;" />
                         </div>
                         <div class="d-flex gap-2">
                             <p:commandButton
@@ -27,7 +27,7 @@
                                 icon="fas fa-plus-circle"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                title="Create a new Disposal Return Request">
+                                title="Create a new Consumption Return Request">
                             </p:commandButton>
                             <p:commandButton
                                 value="List Returns to Finalize"
@@ -36,7 +36,7 @@
                                 icon="fas fa-tasks"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                title="Finalize Disposal Return Requests">
+                                title="Finalize Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="List Returns To Approve"
@@ -45,7 +45,7 @@
                                 icon="fas fa-check-circle"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                title="Approve Disposal Return Requests">
+                                title="Approve Consumption Return Requests">
                             </p:commandButton>
                             <p:commandButton
                                 value="Completed Returns"
@@ -54,7 +54,7 @@
                                 icon="fas fa-check-double"
                                 styleClass="ui-button-info ui-button-outlined"
                                 rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                title="View Completed Disposal Returns">
+                                title="View Completed Consumption Returns">
                             </p:commandButton>
                         </div>
                     </div>
@@ -107,7 +107,7 @@
                                 <p:commandButton
                                     class="ui-button-warning w-100"
                                     icon="fas fa-search"
-                                    value="Search Disposal Returns"
+                                    value="Search Consumption Returns"
                                     action="#{disposalReturnWorkflowController.fillDisposalReturnsToFinalize()}"
                                     ajax="false"
                                     style="min-height: 45px;">
@@ -116,7 +116,7 @@
                         </p:panel>
                     </div>
                     <div class="col-lg-9 col-md-8">
-                        <p:panel header="Disposal Return Requests to Finalize" styleClass="shadow-sm">
+                        <p:panel header="Consumption Return Requests to Finalize" styleClass="shadow-sm">
                             <p:dataTable
                                 id="tbl"
                                 value="#{disposalReturnWorkflowController.disposalReturnsToFinalize}"
@@ -127,7 +127,7 @@
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="5,10,15,25"
                                 styleClass="table-striped"
-                                emptyMessage="No disposal return requests found matching your criteria"
+                                emptyMessage="No consumption return requests found matching your criteria"
                                 filteredValue="#{disposalReturnWorkflowController.filteredDisposalReturnsToFinalize}"
                                 sortMode="multiple"
                                 resizableColumns="true"
@@ -214,7 +214,7 @@
                                     <p:commandButton
                                         id="finalize"
                                         ajax="false"
-                                        title="#{b.checkedBy ne null ? 'Already Finalized' : (b.billClosed eq true ? 'Closed Return' : 'Edit and Finalize Disposal Return')}"
+                                        title="#{b.checkedBy ne null ? 'Already Finalized' : (b.billClosed eq true ? 'Closed Return' : 'Edit and Finalize Consumption Return')}"
                                         icon="fas #{b.checkedBy ne null ? 'fa-check-double' : 'fa-edit'}"
                                         class="#{b.checkedBy ne null ? 'ui-button-success ui-button-outlined' : (b.billClosed eq true ? 'ui-button-secondary ui-button-outlined' : 'ui-button-warning')}"
                                         value="#{b.checkedBy ne null ? 'Finalized' : 'Finalize'}"
@@ -225,7 +225,7 @@
                                     <p:commandButton
                                         id="close"
                                         ajax="false"
-                                        title="Close this disposal return"
+                                        title="Close this consumption return"
                                         icon="fas fa-times"
                                         class="ui-button-danger ui-button-outlined"
                                         value="Close"
@@ -234,7 +234,7 @@
                                         rendered="#{b.billClosed ne true and b.checkedBy eq null}"
                                         style="min-width: 70px;">
                                         <p:confirm header="Confirm Close"
-                                                   message="Are you sure you want to close this disposal return? This will allow creating a new return for the same bill."
+                                                   message="Are you sure you want to close this consumption return? This will allow creating a new return for the same bill."
                                                    icon="pi pi-exclamation-triangle"/>
                                     </p:commandButton>
                                 </div>

--- a/src/main/webapp/pharmacy/pharmacy_disposal_return_reprint.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_disposal_return_reprint.xhtml
@@ -17,7 +17,7 @@
                         <f:facet name="header">
                             <div class="d-flex justify-content-between align-items-center">
                                 <div>
-                                    <h:outputText value="Disposal Issue Return - Reprint" styleClass="fw-bold"/>
+                                    <h:outputText value="Consumption Issue Return - Reprint" styleClass="fw-bold"/>
                                 </div>
                                 <div class="d-flex gap-2">
                                     <p:commandButton
@@ -27,7 +27,7 @@
                                         icon="fas fa-plus-circle"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                        title="Create a new Disposal Return Request">
+                                        title="Create a new Consumption Return Request">
                                     </p:commandButton>
                                     <p:commandButton
                                         value="List Returns to Finalize"
@@ -36,7 +36,7 @@
                                         icon="fas fa-tasks"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                        title="Finalize Disposal Return Requests">
+                                        title="Finalize Consumption Return Requests">
                                     </p:commandButton>
                                     <p:commandButton
                                         value="List Returns To Approve"
@@ -45,7 +45,7 @@
                                         icon="fas fa-check-circle"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                        title="Approve Disposal Return Requests">
+                                        title="Approve Consumption Return Requests">
                                     </p:commandButton>
                                     <p:commandButton
                                         value="Completed Returns"
@@ -54,7 +54,7 @@
                                         icon="fas fa-check-double"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                        title="View Completed Disposal Returns">
+                                        title="View Completed Consumption Returns">
                                     </p:commandButton>
                                     <p:commandButton
                                         styleClass="ui-button-info"

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -81,7 +81,7 @@
                                     <!-- LEFT: title + config -->
                                     <div class="d-flex align-items-center gap-2">
                                         <i class="fas fa-building"/>
-                                        <h:outputText value="Department Disposal — Issue to #{pharmacyIssueController.toDepartment.name}"/>
+                                        <h:outputText value="Department Consumption — Issue to #{pharmacyIssueController.toDepartment.name}"/>
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
                                             <p:commandButton
                                                 id="btnConfig"
@@ -98,22 +98,22 @@
                                     <div class="d-flex gap-2">
                                         <p:commandButton
                                             id="btnNavFinalize"
-                                            value="Disposal Issues to Finalize"
+                                            value="Consumption Issues to Finalize"
                                             icon="fas fa-lock"
                                             ajax="false"
                                             action="/pharmacy/pharmacy_disposal_issue_list_to_finalize?faces-redirect=true"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
-                                            title="View disposal issues waiting to be finalized"/>
+                                            title="View consumption issues waiting to be finalized"/>
                                         <p:commandButton
                                             id="btnNavApprove"
-                                            value="Disposal Issues to Approve"
+                                            value="Consumption Issues to Approve"
                                             icon="fas fa-check-double"
                                             ajax="false"
                                             action="/pharmacy/pharmacy_disposal_issue_list_to_approve?faces-redirect=true"
                                             styleClass="ui-button-info ui-button-outlined"
                                             rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
-                                            title="View disposal issues waiting for approval"/>
+                                            title="View consumption issues waiting for approval"/>
                                     </div>
 
                                     <!-- RIGHT: actions (left=least important → right=primary) -->
@@ -121,7 +121,7 @@
                                         <p:commandButton
                                             id="btnNew"
                                             accesskey="n"
-                                            value="New Disposal Issue Bill"
+                                            value="New Consumption Issue Bill"
                                             icon="fas fa-plus-circle"
                                             styleClass="ui-button-stage-save"
                                             ajax="false"
@@ -146,7 +146,7 @@
                                             styleClass="ui-button-stage-finalize"
                                             ajax="false"
                                             action="#{pharmacyIssueController.finalizeCurrentDraft()}"
-                                            onclick="return confirm('Finalize this disposal issue? It will be queued for approval.');"
+                                            onclick="return confirm('Finalize this consumption issue? It will be queued for approval.');"
                                             rendered="#{pharmacyIssueController.preBill.checkedBy eq null}"
                                             disabled="#{not webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
                                             style="min-width:120px"/>
@@ -158,7 +158,7 @@
                                             styleClass="ui-button-stage-approve"
                                             ajax="false"
                                             action="#{pharmacyIssueController.approveDisposalIssue(pharmacyIssueController.preBill.id)}"
-                                            onclick="return confirm('Approve this disposal issue? Stock will be deducted.');"
+                                            onclick="return confirm('Approve this consumption issue? Stock will be deducted.');"
                                             rendered="#{pharmacyIssueController.preBill.checkedBy ne null and !pharmacyIssueController.preBill.completed}"
                                             disabled="#{not webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
                                             style="min-width:120px"/>
@@ -654,22 +654,22 @@
                                 <div class="d-flex gap-2">
                                     <p:commandButton
                                         id="btnPrintNavFinalize"
-                                        value="Disposal Issues to Finalize"
+                                        value="Consumption Issues to Finalize"
                                         icon="fas fa-lock"
                                         ajax="false"
                                         action="/pharmacy/pharmacy_disposal_issue_list_to_finalize?faces-redirect=true"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueFinalize')}"
-                                        title="View disposal issues waiting to be finalized"/>
+                                        title="View consumption issues waiting to be finalized"/>
                                     <p:commandButton
                                         id="btnPrintNavApprove"
-                                        value="Disposal Issues to Approve"
+                                        value="Consumption Issues to Approve"
                                         icon="fas fa-check-double"
                                         ajax="false"
                                         action="/pharmacy/pharmacy_disposal_issue_list_to_approve?faces-redirect=true"
                                         styleClass="ui-button-info ui-button-outlined"
                                         rendered="#{webUserController.hasPrivilege('PharmacyDisposalIssueApprove')}"
-                                        title="View disposal issues waiting for approval"/>
+                                        title="View consumption issues waiting for approval"/>
                                 </div>
 
                                 <!-- RIGHT: New bill -->
@@ -677,7 +677,7 @@
                                     <p:commandButton
                                         id="btnPrintNew"
                                         accesskey="n"
-                                        value="New Disposal Issue Bill"
+                                        value="New Consumption Issue Bill"
                                         icon="fas fa-plus-circle"
                                         styleClass="ui-button-stage-save"
                                         ajax="false"
@@ -703,7 +703,7 @@
 
                     <!-- Disposal Issue Configuration Dialog -->
                     <p:dialog id="disposalIssueConfigDialog"
-                              header="Disposal Issue Printer Configuration"
+                              header="Consumption Issue Printer Configuration"
                               widgetVar="disposalIssueConfigDialog"
                               modal="true"
                               width="600"
@@ -719,7 +719,7 @@
                                 <div class="col-12">
                                     <div class="card config-section">
                                         <div class="card-header">
-                                            <h6><i class="fas fa-file-alt"></i> Disposal Issue Paper Settings</h6>
+                                            <h6><i class="fas fa-file-alt"></i> Consumption Issue Paper Settings</h6>
                                         </div>
                                         <div class="card-body">
                                             <div class="mb-3">
@@ -727,21 +727,21 @@
                                                     id="disposalIssueA4"
                                                     value="#{pharmacyConfigController.disposalIssueA4Paper}" />
                                                 <p:outputLabel for="disposalIssueA4" value="A4 Paper Format" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Standard A4 paper format for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Standard A4 paper format for consumption issue receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalIssueCustom1"
                                                     value="#{pharmacyConfigController.disposalIssueCustom1}" />
                                                 <p:outputLabel for="disposalIssueCustom1" value="Custom Format 1" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 1 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 1 for consumption issue receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalIssueCustom2"
                                                     value="#{pharmacyConfigController.disposalIssueCustom2}" />
                                                 <p:outputLabel for="disposalIssueCustom2" value="Custom Format 2" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 2 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 2 for consumption issue receipts</small>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
@@ -37,7 +37,7 @@
                                     </h:panelGroup>
                                     <p:commandButton
                                         accesskey="n"
-                                        value="New Disposal Issue Bill"
+                                        value="New Consumption Issue Bill"
                                         icon="pi pi-plus"
                                         class="ui-button-warning mx-1"
                                         ajax="false"
@@ -76,7 +76,7 @@
                             <div class="col-12">
                                 <h:panelGroup 
                                     rendered="#{not configOptionApplicationController.getBooleanValueByKey('Pharmacy Disposal Cancellation is allowed', false)}" >
-                                    <p:outputLabel value="Disposal Cancellation is Disabled by Configuration - Pharmacy Disposal Cancellation is allowed" ></p:outputLabel>
+                                    <p:outputLabel value="Consumption Cancellation is Disabled by Configuration - Pharmacy Disposal Cancellation is allowed" ></p:outputLabel>
                                 </h:panelGroup>
                             </div>
                         </div>
@@ -84,7 +84,7 @@
 
                     <!-- Disposal Issue Configuration Dialog -->
                     <p:dialog id="disposalIssueConfigDialog"
-                              header="Disposal Issue Printer Configuration"
+                              header="Consumption Issue Printer Configuration"
                               widgetVar="disposalIssueConfigDialog"
                               modal="true"
                               width="600"
@@ -100,7 +100,7 @@
                                 <div class="col-12">
                                     <div class="card config-section">
                                         <div class="card-header">
-                                            <h6><i class="fas fa-file-alt"></i> Disposal Issue Paper Settings</h6>
+                                            <h6><i class="fas fa-file-alt"></i> Consumption Issue Paper Settings</h6>
                                         </div>
                                         <div class="card-body">
                                             <div class="mb-3">
@@ -108,21 +108,21 @@
                                                     id="disposalIssueA4"
                                                     value="#{pharmacyConfigController.disposalIssueA4Paper}" />
                                                 <p:outputLabel for="disposalIssueA4" value="A4 Paper Format" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Standard A4 paper format for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Standard A4 paper format for consumption issue receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalIssueCustom1"
                                                     value="#{pharmacyConfigController.disposalIssueCustom1}" />
                                                 <p:outputLabel for="disposalIssueCustom1" value="Custom Format 1" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 1 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 1 for consumption issue receipts</small>
                                             </div>
                                             <div class="mb-3">
                                                 <p:selectBooleanCheckbox
                                                     id="disposalIssueCustom2"
                                                     value="#{pharmacyConfigController.disposalIssueCustom2}" />
                                                 <p:outputLabel for="disposalIssueCustom2" value="Custom Format 2" class="ms-2" />
-                                                <small class="form-text text-muted d-block">Custom format 2 for disposal issue receipts</small>
+                                                <small class="form-text text-muted d-block">Custom format 2 for consumption issue receipts</small>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/webapp/pharmacy/pharmacy_search_issue_bill_for_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_issue_bill_for_return.xhtml
@@ -19,7 +19,7 @@
                     <f:facet name="header">
                         <div class="d-flex justify-content-between align-items-center">
                             <div>
-                                <h:outputText value="Select Disposal Issue Bill for Return"/>
+                                <h:outputText value="Select Consumption Issue Bill for Return"/>
                             </div>
                             <div class="d-flex gap-2">
                                 <p:commandButton
@@ -29,7 +29,7 @@
                                     icon="fas fa-plus-circle"
                                     styleClass="ui-button-info ui-button-outlined"
                                     rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}"
-                                    title="Create a new Disposal Return Request">
+                                    title="Create a new Consumption Return Request">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="List Returns to Finalize"
@@ -38,7 +38,7 @@
                                     icon="fas fa-tasks"
                                     styleClass="ui-button-info ui-button-outlined"
                                     rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}"
-                                    title="Finalize Disposal Return Requests">
+                                    title="Finalize Consumption Return Requests">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="List Returns To Approve"
@@ -47,7 +47,7 @@
                                     icon="fas fa-check-circle"
                                     styleClass="ui-button-info ui-button-outlined"
                                     rendered="#{webUserController.hasPrivilege('ApproveDisposalReturn')}"
-                                    title="Approve Disposal Return Requests">
+                                    title="Approve Consumption Return Requests">
                                 </p:commandButton>
                                 <p:commandButton
                                     value="Completed Returns"
@@ -56,7 +56,7 @@
                                     icon="fas fa-check-double"
                                     styleClass="ui-button-info ui-button-outlined"
                                     rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                    title="View Completed Disposal Returns">
+                                    title="View Completed Consumption Returns">
                                 </p:commandButton>
                             </div>
                         </div>
@@ -104,7 +104,7 @@
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="5,10,15,25"
                                 styleClass="w-100 table-striped"
-                                emptyMessage="No disposal issue bills found matching your criteria. Use the search filters to find bills."
+                                emptyMessage="No consumption issue bills found matching your criteria. Use the search filters to find bills."
                                 sortMode="multiple"
                                 resizableColumns="true"
                                 reflow="true">

--- a/src/main/webapp/pharmacy/returns_and_cancellations_index.xhtml
+++ b/src/main/webapp/pharmacy/returns_and_cancellations_index.xhtml
@@ -75,17 +75,17 @@
                                     rendered="#{webUserController.hasPrivilege('ApproveDirectPurchaseReturn')}" />
                             </p:panelGrid>
                         </p:tab>
-                        <p:tab title="Disposal Returns" >
+                        <p:tab title="Consumption Returns" >
                             <p:panelGrid columns="1" >
                                 <p:commandButton
-                                    value="Create Disposal Return"
+                                    value="Create Consumption Return"
                                     ajax="false"
                                     action="#{disposalReturnWorkflowController.navigateToCreateDisposalReturn()}"
                                     class="ui-button-success w-100"
                                     icon="fas fa-plus-circle"
                                     rendered="#{webUserController.hasPrivilege('CreateDisposalReturn')}" />
                                 <p:commandButton
-                                    value="Finalize Disposal Return"
+                                    value="Finalize Consumption Return"
                                     ajax="false"
                                     action="#{disposalReturnWorkflowController.navigateToFinalizeDisposalReturn()}"
                                     actionListener="#{disposalReturnWorkflowController.makeNull()}"
@@ -93,7 +93,7 @@
                                     icon="fas fa-tasks"
                                     rendered="#{webUserController.hasPrivilege('FinalizeDisposalReturn')}" />
                                 <p:commandButton
-                                    value="Approve Disposal Return"
+                                    value="Approve Consumption Return"
                                     ajax="false"
                                     action="#{disposalReturnWorkflowController.navigateToApproveDisposalReturn()}"
                                     class="ui-button-info w-100"
@@ -106,7 +106,7 @@
                                     icon="fas fa-check-double"
                                     styleClass="ui-button-secondary  w-100"
                                     rendered="#{webUserController.hasPrivilege('ViewDisposalReturn')}"
-                                    title="View Completed Disposal Returns">
+                                    title="View Completed Consumption Returns">
                                 </p:commandButton>
                             </p:panelGrid>
                         </p:tab>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1232,7 +1232,7 @@
                     <p:menuitem
                         ajax="false"
                         action="/pharmacy/disposal_index?faces-redirect=true"
-                        value="Disposal"
+                        value="Consumption"
                         rendered="#{webUserController.hasPrivilege('PharmacyDisposalMenue')}"
                         icon="fas fa-trash-alt" />
 


### PR DESCRIPTION
## Summary
- Renames the user-facing **labels** in the Pharmacy Disposal module from "Disposal" to "Consumption" — main menu item, page headings, panel headers, button captions, tooltips, dialog titles, and confirm-dialog text.
- Scope is entry points (main menu, `disposal_index.xhtml`, `returns_and_cancellations_index.xhtml`, home dashboard tile) plus the main workflow pages reached from them (`pharmacy_issue.xhtml`, finalize/approve list pages, disposal-return finalize/approve/completed/reprint pages, cancel/reprint pages, and the Pharmacy Analytics "Disposal Reports" tab).
- **No file names, backend methods, JSF page names, privilege names, or DB config keys were changed** — those all still say "Disposal" internally (e.g. `pharmacy_disposal_issue_list_to_finalize.xhtml`, `PharmacyDisposalIssue` privilege). A full terminology rename is explicitly a future task per the issue discussion.
- Deliberately excluded: `reports/index.xhtml`'s "Asset Disposal Report" (a different, fixed-asset domain, not pharmacy stock consumption), print/receipt templates, and `dataAdmin/admin_functions.xhtml` informational text.
- Updated the corresponding end-user wiki pages (`Disposal.md`, `Pharmacy-Issue.md`, `Disposal-Reports.md`, `Pharmacy-Configuration-and-Privileges.md`, `Pharmacy/Disposal-Issue-Returns.md`, `Pharmacy/Pharmacy-Navigation-Guide.md`, `Pharmacy.md`, `Pharmacy-Analytics.md`, and the two `Disposal-Issue-Search.md` copies) so navigation instructions and quoted UI labels match what a user now sees, while leaving general "disposal" business terminology and developer docs untouched.

## Verification
- This is a JSF/XHTML-only, label-text-only change (no Java, no schema) — per project convention such changes don't require compilation/build.
- Verified every one of the 16 changed XHTML files is still well-formed XML after editing (`xml.etree.ElementTree` parse check, all pass).
- Manually swept all 16 files to confirm no remaining visible "Disposal" label text was missed, and that only `value=`/`header=`/`title=`/`emptyMessage=`/`<title>`/confirm-dialog strings were touched — `action=`, `actionListener=`, `rendered=`, `id=`, `widgetVar=`, and `getBooleanValueByKey('...')` config-key literals were left untouched by design (changing those would break privilege gating or DB-stored config lookups).
- Local Payara `rh` domain wasn't running at the time of this change, so no live browser pass was done for this PR — reviewers can visually confirm by loading the Pharmacy menu after deploy; the diff is intentionally narrow and mechanical (string swaps only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated pharmacy navigation, menus, page titles, buttons, reports, alerts, confirmations, and empty-state messages to use “Consumption” terminology instead of “Disposal.”
  * Renamed issue, return, cancellation, printer configuration, and reporting labels throughout the pharmacy workflows.
  * Updated print-preview and receipt-setting descriptions to reflect consumption issues and returns.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->