### PR TITLE
fix(pharmacy): fix invalid JPQL in short-expiry-by-AMP-period report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -1640,8 +1640,8 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             jpql.append("left join s.itemBatch.item.dosageForm df ");
             jpql.append("where s.stock > 0");
             jpql.append(" and type(s.itemBatch.item) = Amp");
-            jpql.append(" and cast(s.itemBatch.item as Amp).numberOfDaysToMarkAsShortExpiary > 0");
-            jpql.append(" and (s.itemBatch.dateOfExpire - CURRENT_DATE) <= CAST(cast(s.itemBatch.item as Amp).numberOfDaysToMarkAsShortExpiary AS long)");
+            jpql.append(" and treat(s.itemBatch.item as Amp).numberOfDaysToMarkAsShortExpiary > 0");
+            jpql.append(" and FUNCTION('DATEDIFF', s.itemBatch.dateOfExpire, CURRENT_DATE) <= treat(s.itemBatch.item as Amp).numberOfDaysToMarkAsShortExpiary");
 
             if (department != null) {
                 jpql.append(" and s.department=:d");


### PR DESCRIPTION
## Summary
- The short-expiry-by-AMP-period stock report (added in #22141/#22143) never returned data because its JPQL failed to parse on every execution — `cast(x as Amp)` was used for entity downcasting (JPQL requires `treat(x as Amp)`), and the expiry-day comparison used raw date subtraction with an invalid `CAST(... AS long)`.
- `ReportTimerController.trackReportExecution()` catches and logs all exceptions rather than surfacing them, so the UI silently showed "No records found" instead of an error.
- Fixed the downcast to use `treat()` and replaced the invalid date arithmetic with `FUNCTION('DATEDIFF', ...)`, matching the existing pattern already used in `InwardReportController`.

## Test plan
- [x] Rebuilt and redeployed locally, reproduced the silent JPQL parse failure in `server.log`
- [x] Applied fix, redeployed, confirmed via Playwright that `Pharmacy Analytics > Stock Reports > Stock Report by Short Expiry (AMP Period)` now returns matching rows (5 pages, correct purchase/cost/retail value totals) instead of "No records found"
- [x] Confirmed the shared print view (`pharmacy_report_short_expiry_by_amp_period_print.xhtml`) reuses the same `reportsStock.stockDtos`, so it is fixed by the same change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the short-expiry stock report to more accurately identify pharmacy items approaching their expiry date.
  * Updated expiry calculations to provide more reliable results based on the number of days configured for short-expiry warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->