### PR TITLE
feat: implement department-scoped configuration preferences

### DIFF
--- a/src/main/java/com/divudi/bean/admin/DepartmentPreferencesController.java
+++ b/src/main/java/com/divudi/bean/admin/DepartmentPreferencesController.java
@@ -7,12 +7,12 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.SessionScoped;
+import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 /**
- * Session-scoped controller for managing department-level preferences backed
+ * View-scoped controller for managing department-level preferences backed
  * by department-scoped ConfigOption entries (OptionScope.DEPARTMENT).
  *
  * Starts with a single preference: "Pharmacy - Allow Issue to Same Department".
@@ -20,7 +20,7 @@ import javax.inject.Named;
  * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
  */
 @Named
-@SessionScoped
+@ViewScoped
 public class DepartmentPreferencesController implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/bean/admin/DepartmentPreferencesController.java
+++ b/src/main/java/com/divudi/bean/admin/DepartmentPreferencesController.java
@@ -1,0 +1,121 @@
+package com.divudi.bean.admin;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.entity.Department;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Session-scoped controller for managing department-level preferences backed
+ * by department-scoped ConfigOption entries (OptionScope.DEPARTMENT).
+ *
+ * Starts with a single preference: "Pharmacy - Allow Issue to Same Department".
+ *
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Named
+@SessionScoped
+public class DepartmentPreferencesController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String KEY_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT = "Pharmacy - Allow Issue to Same Department";
+    private static final boolean DEFAULT_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT = false;
+
+    @Inject
+    private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    private boolean allowPharmacyIssueToSameDepartment;
+
+    public DepartmentPreferencesController() {
+    }
+
+    @PostConstruct
+    public void init() {
+        loadPreferences();
+    }
+
+    /**
+     * Loads department-level preferences for the logged-in user's current department.
+     */
+    public void loadPreferences() {
+        Department department = getLoggedUserDepartment();
+        allowPharmacyIssueToSameDepartment = configOptionApplicationController.getBooleanValueByKeyForDepartment(
+                KEY_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT, department, DEFAULT_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT);
+    }
+
+    /**
+     * Persists department-level preferences for the logged-in user's current department.
+     * Requires the Admin privilege.
+     *
+     * @return null (stay on the same page)
+     */
+    public String savePreferences() {
+        if (!webUserController.hasPrivilege("Admin")) {
+            JsfUtil.addErrorMessage("You do not have permission to change department preferences.");
+            return null;
+        }
+        Department department = getLoggedUserDepartment();
+        if (department == null) {
+            JsfUtil.addErrorMessage("No department selected. Please select a department first.");
+            return null;
+        }
+        configOptionApplicationController.setBooleanValueByKeyForDepartment(
+                KEY_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT, department, allowPharmacyIssueToSameDepartment);
+        JsfUtil.addSuccessMessage("Department preferences saved.");
+        return null;
+    }
+
+    /**
+     * Resets department-level preferences to system defaults for the logged-in
+     * user's current department. Requires the Admin privilege.
+     *
+     * @return null (stay on the same page)
+     */
+    public String resetToDefaults() {
+        if (!webUserController.hasPrivilege("Admin")) {
+            JsfUtil.addErrorMessage("You do not have permission to change department preferences.");
+            return null;
+        }
+        Department department = getLoggedUserDepartment();
+        if (department == null) {
+            JsfUtil.addErrorMessage("No department selected. Please select a department first.");
+            return null;
+        }
+        allowPharmacyIssueToSameDepartment = DEFAULT_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT;
+        configOptionApplicationController.setBooleanValueByKeyForDepartment(
+                KEY_ALLOW_PHARMACY_ISSUE_TO_SAME_DEPARTMENT, department, allowPharmacyIssueToSameDepartment);
+        JsfUtil.addSuccessMessage("Department preferences reset to defaults.");
+        return null;
+    }
+
+    public Department getLoggedUserDepartment() {
+        return sessionController.getDepartment();
+    }
+
+    public String getLoggedUserDepartmentName() {
+        Department department = getLoggedUserDepartment();
+        return department == null ? "" : department.getName();
+    }
+
+    public boolean isAllowPharmacyIssueToSameDepartment() {
+        return allowPharmacyIssueToSameDepartment;
+    }
+
+    public void setAllowPharmacyIssueToSameDepartment(boolean allowPharmacyIssueToSameDepartment) {
+        this.allowPharmacyIssueToSameDepartment = allowPharmacyIssueToSameDepartment;
+    }
+
+}

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1576,6 +1576,7 @@ public class ConfigOptionApplicationController implements Serializable {
      * @param value the value to persist
      */
     public void setLongTextValueByKeyForDepartment(String key, Department dept, String value) {
+        String sanitized = Jsoup.clean(value, Safelist.basic());
         if (dept == null) {
             setLongTextValueByKey(key, value);
             return;
@@ -1583,9 +1584,8 @@ public class ConfigOptionApplicationController implements Serializable {
         ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
         if (option == null) {
             option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
-                    OptionValueType.LONG_TEXT, value);
+                    OptionValueType.LONG_TEXT, sanitized);
         }
-        String sanitized = Jsoup.clean(value, Safelist.basic());
         option.setValueType(OptionValueType.LONG_TEXT);
         option.setOptionValue(sanitized);
         optionFacade.edit(option);

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1472,6 +1472,99 @@ public class ConfigOptionApplicationController implements Serializable {
         loadApplicationOptions();
     }
 
+    /**
+     * Retrieves a department-scoped boolean preference (OptionScope.DEPARTMENT).
+     * Falls back to the application-scoped value when department is null.
+     * Creates the department-scoped ConfigOption (with defaultValue) if absent.
+     *
+     * @param key the preference key (e.g. "Pharmacy - Allow Issue to Same Department")
+     * @param dept the department the preference is scoped to
+     * @param defaultValue the value to persist if the option does not exist yet
+     * @return the current boolean value of the department-scoped preference
+     */
+    public Boolean getBooleanValueByKeyForDepartment(String key, Department dept, boolean defaultValue) {
+        if (dept == null) {
+            return getBooleanValueByKey(key, defaultValue);
+        }
+        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        if (option == null || option.getValueType() != OptionValueType.BOOLEAN) {
+            option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
+                    OptionValueType.BOOLEAN, Boolean.toString(defaultValue));
+        }
+        return Boolean.parseBoolean(option.getOptionValue());
+    }
+
+    /**
+     * Persists a department-scoped boolean preference (OptionScope.DEPARTMENT),
+     * creating the ConfigOption if it does not already exist. Falls back to the
+     * application-scoped setter when department is null.
+     *
+     * @param key the preference key
+     * @param dept the department the preference is scoped to
+     * @param value the value to persist
+     */
+    public void setBooleanValueByKeyForDepartment(String key, Department dept, boolean value) {
+        if (dept == null) {
+            setBooleanValueByKey(key, value);
+            return;
+        }
+        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        if (option == null) {
+            option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
+                    OptionValueType.BOOLEAN, Boolean.toString(value));
+        }
+        option.setValueType(OptionValueType.BOOLEAN);
+        option.setOptionValue(Boolean.toString(value));
+        optionFacade.edit(option);
+    }
+
+    /**
+     * Retrieves a department-scoped long-text preference (OptionScope.DEPARTMENT).
+     * Falls back to the application-scoped value when department is null.
+     * Creates the department-scoped ConfigOption (with defaultValue) if absent.
+     *
+     * @param key the preference key
+     * @param dept the department the preference is scoped to
+     * @param defaultValue the value to persist if the option does not exist yet
+     * @return the current text value of the department-scoped preference
+     */
+    public String getLongTextValueByKeyForDepartment(String key, Department dept, String defaultValue) {
+        if (dept == null) {
+            return getLongTextValueByKey(key, defaultValue);
+        }
+        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        if (option == null || option.getValueType() != OptionValueType.LONG_TEXT) {
+            option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
+                    OptionValueType.LONG_TEXT, defaultValue);
+        }
+        return option.getOptionValue();
+    }
+
+    /**
+     * Persists a department-scoped long-text preference (OptionScope.DEPARTMENT),
+     * creating the ConfigOption if it does not already exist. Falls back to the
+     * application-scoped setter when department is null.
+     *
+     * @param key the preference key
+     * @param dept the department the preference is scoped to
+     * @param value the value to persist
+     */
+    public void setLongTextValueByKeyForDepartment(String key, Department dept, String value) {
+        if (dept == null) {
+            setLongTextValueByKey(key, value);
+            return;
+        }
+        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        if (option == null) {
+            option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
+                    OptionValueType.LONG_TEXT, value);
+        }
+        String sanitized = Jsoup.clean(value, Safelist.basic());
+        option.setValueType(OptionValueType.LONG_TEXT);
+        option.setOptionValue(sanitized);
+        optionFacade.edit(option);
+    }
+
     public boolean isPreventPasswordReuse() {
         return getBooleanValueByKey("prevent_password_reuse", false);
     }

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -79,6 +79,32 @@ public class ConfigOptionApplicationController implements Serializable {
         return optionFacade.findFirstByJpqlWithLock(jpql.toString(), params);
     }
 
+    private ConfigOption findActiveOption(String key, OptionScope scope, Institution institution, Department department, WebUser webUser) {
+        StringBuilder jpql = new StringBuilder("SELECT o FROM ConfigOption o WHERE o.retired=false AND o.optionKey=:key AND o.scope=:scope");
+        Map<String, Object> params = new HashMap<>();
+        params.put("key", key);
+        params.put("scope", scope);
+        if (institution != null) {
+            jpql.append(" AND o.institution = :institution");
+            params.put("institution", institution);
+        } else {
+            jpql.append(" AND o.institution IS NULL");
+        }
+        if (department != null) {
+            jpql.append(" AND o.department = :department");
+            params.put("department", department);
+        } else {
+            jpql.append(" AND o.department IS NULL");
+        }
+        if (webUser != null) {
+            jpql.append(" AND o.webUser = :webUser");
+            params.put("webUser", webUser);
+        } else {
+            jpql.append(" AND o.webUser IS NULL");
+        }
+        return optionFacade.findFirstByJpql(jpql.toString(), params);
+    }
+
     public ConfigOption createApplicationOptionIfAbsent(String key, OptionValueType type, String value) {
         ConfigOption option = optionFacade.createOptionIfNotExists(key, OptionScope.APPLICATION, null, null, null, type, value);
         if (!isLoadingApplicationOptions) {
@@ -1486,7 +1512,7 @@ public class ConfigOptionApplicationController implements Serializable {
         if (dept == null) {
             return getBooleanValueByKey(key, defaultValue);
         }
-        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        ConfigOption option = findActiveOption(key, OptionScope.DEPARTMENT, null, dept, null);
         if (option == null || option.getValueType() != OptionValueType.BOOLEAN) {
             option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
                     OptionValueType.BOOLEAN, Boolean.toString(defaultValue));
@@ -1532,7 +1558,7 @@ public class ConfigOptionApplicationController implements Serializable {
         if (dept == null) {
             return getLongTextValueByKey(key, defaultValue);
         }
-        ConfigOption option = findActiveOptionWithLock(key, OptionScope.DEPARTMENT, null, dept, null);
+        ConfigOption option = findActiveOption(key, OptionScope.DEPARTMENT, null, dept, null);
         if (option == null || option.getValueType() != OptionValueType.LONG_TEXT) {
             option = optionFacade.createOptionIfNotExists(key, OptionScope.DEPARTMENT, null, dept, null,
                     OptionValueType.LONG_TEXT, defaultValue);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -2962,10 +2962,10 @@ public class PharmacyIssueController implements Serializable {
             JsfUtil.addErrorMessage("Please Select a Department");
             return "";
         }
-        if (Objects.equals(toDepartment, sessionController.getLoggedUser().getDepartment())) {
+        if (Objects.equals(toDepartment, sessionController.getDepartment())) {
             // Check if department preference allows same-department issues
             boolean allowSameDept = configOptionApplicationController.getBooleanValueByKeyForDepartment(
-                    "Pharmacy - Allow Issue to Same Department", sessionController.getLoggedUser().getDepartment(), false);
+                    "Pharmacy - Allow Issue to Same Department", sessionController.getDepartment(), false);
             if (!allowSameDept) {
                 JsfUtil.addErrorMessage("Your department does not allow pharmacy disposal issues to the same department. Contact your department administrator to enable this feature.");
                 return "";

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -2965,7 +2965,7 @@ public class PharmacyIssueController implements Serializable {
         if (Objects.equals(toDepartment, sessionController.getLoggedUser().getDepartment())) {
             // Check if department preference allows same-department issues
             boolean allowSameDept = configOptionApplicationController.getBooleanValueByKeyForDepartment(
-                    "Pharmacy - Allow Issue to Same Department", sessionController.getDepartment(), false);
+                    "Pharmacy - Allow Issue to Same Department", sessionController.getLoggedUser().getDepartment(), false);
             if (!allowSameDept) {
                 JsfUtil.addErrorMessage("Your department does not allow pharmacy disposal issues to the same department. Contact your department administrator to enable this feature.");
                 return "";

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -2963,8 +2963,13 @@ public class PharmacyIssueController implements Serializable {
             return "";
         }
         if (Objects.equals(toDepartment, sessionController.getLoggedUser().getDepartment())) {
-            JsfUtil.addErrorMessage("Cannot Make an Issue to the Same Department");
-            return "";
+            // Check if department preference allows same-department issues
+            boolean allowSameDept = configOptionApplicationController.getBooleanValueByKeyForDepartment(
+                    "Pharmacy - Allow Issue to Same Department", sessionController.getDepartment(), false);
+            if (!allowSameDept) {
+                JsfUtil.addErrorMessage("Your department does not allow pharmacy disposal issues to the same department. Contact your department administrator to enable this feature.");
+                return "";
+            }
         }
         getPreBill().setFromInstitution(sessionController.getInstitution());
         getPreBill().setFromDepartment(sessionController.getDepartment());

--- a/src/main/webapp/admin/department_preferences.xhtml
+++ b/src/main/webapp/admin/department_preferences.xhtml
@@ -40,13 +40,15 @@
                             </f:facet>
 
                             <!-- Department Warning -->
-                            <div class="alert alert-warning mb-3" role="alert" rendered="#{departmentPreferencesController.loggedUserDepartment eq null}">
-                                <i class="fa fa-exclamation-triangle"></i>
-                                <strong class="ms-2">No Department Selected</strong>
-                                <p class="mt-2 ms-2">
-                                    You need to be logged into a specific department to manage department preferences.
-                                </p>
-                            </div>
+                            <h:panelGroup rendered="#{departmentPreferencesController.loggedUserDepartment eq null}">
+                                <div class="alert alert-warning mb-3" role="alert">
+                                    <i class="fa fa-exclamation-triangle"></i>
+                                    <strong class="ms-2">No Department Selected</strong>
+                                    <p class="mt-2 ms-2">
+                                        You need to be logged into a specific department to manage department preferences.
+                                    </p>
+                                </div>
+                            </h:panelGroup>
 
                             <p:panel header="Pharmacy" styleClass="my-3" rendered="#{departmentPreferencesController.loggedUserDepartment ne null}">
                                 <h:panelGrid columns="2" styleClass="alignTop w-100" columnClasses="col-8,col-4">

--- a/src/main/webapp/admin/department_preferences.xhtml
+++ b/src/main/webapp/admin/department_preferences.xhtml
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <!-- Privilege Guard: Only administrators can access this page -->
+                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                    <h:form id="departmentPreferencesForm">
+                        <p:messages id="messages" closable="true"/>
+
+                        <p:panel styleClass="mb-3">
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between align-items-center w-100">
+                                    <h:outputText value="Department Preferences &#8212; #{departmentPreferencesController.loggedUserDepartmentName}"/>
+                                    <h:panelGroup>
+                                        <p:commandButton
+                                            value="Save"
+                                            icon="fa fa-save"
+                                            styleClass="ui-button-success"
+                                            action="#{departmentPreferencesController.savePreferences}"
+                                            process="@form"
+                                            update=":departmentPreferencesForm"/>
+                                        <p:commandButton
+                                            value="Reset to Defaults"
+                                            icon="fa fa-undo"
+                                            styleClass="ui-button-danger ms-2"
+                                            action="#{departmentPreferencesController.resetToDefaults}"
+                                            process="@this"
+                                            update=":departmentPreferencesForm"
+                                            onclick="return confirm('Reset all department preferences on this page to their system defaults?')"/>
+                                    </h:panelGroup>
+                                </div>
+                            </f:facet>
+
+                            <!-- Department Warning -->
+                            <div class="alert alert-warning mb-3" role="alert" rendered="#{departmentPreferencesController.loggedUserDepartment eq null}">
+                                <i class="fa fa-exclamation-triangle"></i>
+                                <strong class="ms-2">No Department Selected</strong>
+                                <p class="mt-2 ms-2">
+                                    You need to be logged into a specific department to manage department preferences.
+                                </p>
+                            </div>
+
+                            <p:panel header="Pharmacy" styleClass="my-3" rendered="#{departmentPreferencesController.loggedUserDepartment ne null}">
+                                <h:panelGrid columns="2" styleClass="alignTop w-100" columnClasses="col-8,col-4">
+
+                                    <h:outputLabel for="allowIssueToSameDept" value="Allow Disposal Issue to Same Department" styleClass="form-label"/>
+                                    <p:selectBooleanButton
+                                        id="allowIssueToSameDept"
+                                        onIcon="fas fa-check"
+                                        offIcon="fas fa-times"
+                                        onLabel="Allowed"
+                                        offLabel="Not Allowed"
+                                        styleClass="form-control"
+                                        value="#{departmentPreferencesController.allowPharmacyIssueToSameDepartment}"/>
+
+                                </h:panelGrid>
+                            </p:panel>
+
+                            <!-- Info Section -->
+                            <div class="alert alert-info mt-3" role="alert">
+                                <i class="fa fa-info-circle"></i>
+                                <strong class="ms-2">About Department Preferences</strong>
+                                <p class="mt-2 ms-2">
+                                    Department preferences let each department independently enable or disable
+                                    specific behaviors, instead of relying on a single system-wide setting.
+                                    Changes made here only affect the
+                                    <strong>#{departmentPreferencesController.loggedUserDepartmentName}</strong>
+                                    department and take effect immediately after saving.
+                                </p>
+                                <p class="ms-2">
+                                    <strong>Allow Disposal Issue to Same Department:</strong>
+                                    When enabled, this department is allowed to create a pharmacy disposal issue
+                                    where the issuing and receiving department are the same. When disabled (the
+                                    system default), such issues are blocked.
+                                </p>
+                            </div>
+
+                        </p:panel>
+                    </h:form>
+                </h:panelGroup>
+
+                <!-- Access denied message for non-admin users -->
+                <h:panelGroup rendered="#{not webUserController.hasPrivilege('Admin')}">
+                    <p:panel header="Access Denied" styleClass="mb-3">
+                        <div class="alert alert-danger" role="alert">
+                            <h:outputText styleClass="fa fa-ban fa-2x" style="vertical-align: middle;"/>
+                            <strong class="ms-3">Insufficient Privileges</strong>
+                            <p class="mt-2 ms-2">
+                                You do not have permission to access this page.
+                                Only administrators can manage department preferences.
+                            </p>
+                        </div>
+                    </p:panel>
+                </h:panelGroup>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary

Implement a department-level configuration preferences system allowing each department to independently enable/disable features (starting with pharmacy disposal issue to same department). Includes comprehensive wiki documentation.

## Changes

### Core Infrastructure (Tasks 1-3)
- **ConfigOptionApplicationController:** Add 4 new public methods for department-scoped preference queries/updates
  - `getBooleanValueByKeyForDepartment(key, dept, defaultValue): Boolean`
  - `setBooleanValueByKeyForDepartment(key, dept, value): void`
  - `getLongTextValueByKeyForDepartment(key, dept, defaultValue): String`
  - `setLongTextValueByKeyForDepartment(key, dept, value): void`
  - Reuse existing `findActiveOptionWithLock` and `ConfigOptionFacade` infrastructure
  - Fall back to application-scoped methods when department is null

- **DepartmentPreferencesController:** New SessionScoped controller for managing preferences
  - Loads/saves "Pharmacy - Allow Issue to Same Department" preference per logged-in user's department
  - Admin privilege check on modifications
  - Success/error messages via JsfUtil

- **department_preferences.xhtml:** New JSF page for department preference management
  - Admin-only authorization guard
  - Department name display in header
  - Checkbox for "Allow Disposal Issue to Same Department"
  - Save and Reset to Defaults buttons
  - Info section explaining department preferences

### Feature Integration (Task 4)
- **PharmacyIssueController:** Update `processDisposalIssue()` validation
  - Replace hardcoded same-department block with preference check
  - Check department preference: `"Pharmacy - Allow Issue to Same Department"`
  - Updated error message directing users to contact department admin

### Documentation (Task 5)
- Created in wiki repo (../hmis.wiki):
  - `Department-Scoped-Preferences.md` — Overview and concept explanation
  - `Department-Scoped-Preferences-Administrator-Guide.md` — Step-by-step guide for department heads/admins
  - `Pharmacy-Disposal-Issue-Same-Department.md` — Feature-specific end-user documentation

## Testing

- `mvn clean compile -DskipTests` passes cleanly after all changes
- PharmacyIssueController compiles with new preference check
- Wiki markdown syntax validated
- All cross-links between new wiki articles verified

## How to Test Manually

1. Deploy to Payara and log in as department admin
2. Navigate: Administration → Department Preferences
3. Verify page displays "Department Preferences — [Your Department Name]"
4. Enable "Allow Disposal Issue to Same Department" checkbox and save
5. Go to Pharmacy → Disposal Issue
6. Select own department as destination (should now be allowed, previously showed error)
7. Verify error appears again after disabling the preference

## No Breaking Changes

- Reuses existing ConfigOption entity (no schema changes)
- Follows existing HMIS patterns (ApplicationScoped, SessionScoped, JsfUtil)
- Department preference defaults to false (disabled), preserving current behavior for departments that don't configure it

## Related

- Closes issue #[number] (if applicable)
- Enables future per-department feature toggles
- Establishes framework for additional department-scoped preferences

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Admin-only department preferences page to manage the “Allow disposal issue to same department” setting.
  * Administrators can save or reset the setting for the currently selected department.
  * Changes take effect immediately for that department.
  * Displays clear messaging when no department is selected or access is denied.

* **Bug Fixes**
  * Disposal issues for the same department are now allowed or blocked based on the department-configured preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->