### PR TITLE
fix(pharmacy): stamp departmentType on transfer request approval, Fast Issue, and Fast Receive

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -187,7 +187,10 @@ public class TransferIssueDirectController implements Serializable {
         if (billItem.getItem() != null) {
             DepartmentType itemDeptType = billItem.getItem().getDepartmentType();
             if (issuedBill.getDepartmentType() == null) {
-                issuedBill.setDepartmentType(itemDeptType);
+                // #22146: default to Pharmacy when the item itself carries no department
+                // type, mirroring TransferRequestController.addItem() — a direct-issue
+                // bill should never be saved with departmentType left null.
+                issuedBill.setDepartmentType(itemDeptType != null ? itemDeptType : DepartmentType.Pharmacy);
             } else if (itemDeptType != null && !itemDeptType.equals(issuedBill.getDepartmentType())) {
                 JsfUtil.addErrorMessage("Cannot add items from different department types. "
                         + "Bill is set for " + issuedBill.getDepartmentType().getLabel()

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueNativeSqlController.java
@@ -13,6 +13,7 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.dto.TransferIssueItemRowDto;
 import com.divudi.core.data.dto.TransferIssuePrintDto;
@@ -205,8 +206,9 @@ public class TransferIssueNativeSqlController implements Serializable {
         if (issuedBill != null) {
             draft.setToStaff(issuedBill.getToStaff());
         }
-        billFacade.create(draft);
         issuedBill = draft;
+        stampDepartmentTypeIfMissing();
+        billFacade.create(draft);
         draftMode = true;
         JsfUtil.addSuccessMessage("Draft fast issue saved. Please proceed to Finalize.");
     }
@@ -584,6 +586,27 @@ public class TransferIssueNativeSqlController implements Serializable {
         issuedBill.setDepartment(sessionController.getDepartment());
         issuedBill.setCreater(sessionController.getLoggedUser());
         issuedBill.setCreatedAt(new Date());
+        stampDepartmentTypeIfMissing();
+    }
+
+    /**
+     * Department-type-filtered reports drop bills left NULL (#22056). The request bill
+     * normally already carries a departmentType (TransferRequestController stamps it on
+     * first item add); this is the fallback for legacy requests that predate that stamp —
+     * take the first issued item's type, defaulting to Pharmacy (#22146).
+     */
+    private void stampDepartmentTypeIfMissing() {
+        if (issuedBill.getDepartmentType() != null) {
+            return;
+        }
+        if (requestedBill != null && requestedBill.getDepartmentType() != null) {
+            issuedBill.setDepartmentType(requestedBill.getDepartmentType());
+            return;
+        }
+        if (issueItems != null && !issueItems.isEmpty()) {
+            String dt = issueItems.get(0).getDepartmentType();
+            issuedBill.setDepartmentType(dt != null ? DepartmentType.valueOf(dt) : DepartmentType.Pharmacy);
+        }
     }
 
     private void applyBillNumbers(Bill bill) {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -14,6 +14,7 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.dto.TransferReceiveItemRowDto;
 import com.divudi.core.data.dto.TransferReceivePrintDto;
 import com.divudi.core.entity.Bill;
@@ -778,7 +779,28 @@ public class TransferReceiveNativeSqlController implements Serializable {
         bill.setCreater(sessionController.getLoggedUser());
         bill.setCreatedAt(new Date());
         bill.setComments(comments);
+        stampDepartmentTypeIfMissing(bill);
         return bill;
+    }
+
+    /**
+     * Department-type-filtered reports drop bills left NULL (#22056). The issued bill
+     * normally already carries a departmentType (stamped when it was issued); this is
+     * the fallback for legacy issued bills that predate that stamp — take the first
+     * received item's type, defaulting to Pharmacy (#22146).
+     */
+    private void stampDepartmentTypeIfMissing(Bill bill) {
+        if (bill.getDepartmentType() != null) {
+            return;
+        }
+        if (issuedBill != null && issuedBill.getDepartmentType() != null) {
+            bill.setDepartmentType(issuedBill.getDepartmentType());
+            return;
+        }
+        if (itemRowList != null && !itemRowList.isEmpty()) {
+            String dt = itemRowList.get(0).getDepartmentType();
+            bill.setDepartmentType(dt != null ? DepartmentType.valueOf(dt) : DepartmentType.Pharmacy);
+        }
     }
 
     private void applyBillNumbers(Bill bill) {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -389,6 +389,8 @@ public class TransferRequestController implements Serializable {
         } else if (!transferRequestPreBillItems.isEmpty() && transferRequestPreBillItems.get(0).getItem() != null) {
             DepartmentType firstItemType = transferRequestPreBillItems.get(0).getItem().getDepartmentType();
             newApprovedBill.setDepartmentType(firstItemType != null ? firstItemType : DepartmentType.Pharmacy);
+        } else {
+            newApprovedBill.setDepartmentType(DepartmentType.Pharmacy);
         }
 
         newApprovedBill.setCreatedAt(new Date());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -382,6 +382,14 @@ public class TransferRequestController implements Serializable {
         newApprovedBill.setFromInstitution(preBillToCreateApprovedBill.getFromInstitution());
         newApprovedBill.setToDepartment(preBillToCreateApprovedBill.getToDepartment());
         newApprovedBill.setToInstitution(preBillToCreateApprovedBill.getToInstitution());
+        // Bill.copy() above does not carry departmentType — stamp it explicitly so the
+        // approved request bill doesn't lose the type the PRE bill already had (#22146).
+        if (preBillToCreateApprovedBill.getDepartmentType() != null) {
+            newApprovedBill.setDepartmentType(preBillToCreateApprovedBill.getDepartmentType());
+        } else if (!transferRequestPreBillItems.isEmpty() && transferRequestPreBillItems.get(0).getItem() != null) {
+            DepartmentType firstItemType = transferRequestPreBillItems.get(0).getItem().getDepartmentType();
+            newApprovedBill.setDepartmentType(firstItemType != null ? firstItemType : DepartmentType.Pharmacy);
+        }
 
         newApprovedBill.setCreatedAt(new Date());
         newApprovedBill.setCreater(sessionController.getLoggedUser());

--- a/src/main/java/com/divudi/core/data/dto/TransferIssueItemRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/TransferIssueItemRowDto.java
@@ -38,6 +38,9 @@ public class TransferIssueItemRowDto implements Serializable {
 
     private String itemDtype;
 
+    /** Item.departmentType (enum name as String), used to stamp the issued bill when the request bill lacks one. */
+    private String departmentType;
+
     /** Pack size: >1 for Ampp (units per pack), 1.0 for Amp/default. */
     private double unitsPerPack = 1.0;
 
@@ -107,6 +110,9 @@ public class TransferIssueItemRowDto implements Serializable {
 
     public String getItemDtype() { return itemDtype; }
     public void setItemDtype(String itemDtype) { this.itemDtype = itemDtype; }
+
+    public String getDepartmentType() { return departmentType; }
+    public void setDepartmentType(String departmentType) { this.departmentType = departmentType; }
 
     public double getUnitsPerPack() { return unitsPerPack; }
     public void setUnitsPerPack(double unitsPerPack) { this.unitsPerPack = unitsPerPack; }

--- a/src/main/java/com/divudi/core/data/dto/TransferReceiveItemRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/TransferReceiveItemRowDto.java
@@ -54,6 +54,9 @@ public class TransferReceiveItemRowDto implements Serializable {
     /** Resolved AMP item ID for StockHistory (same as itemId unless the item is Ampp). */
     private Long ampItemId;
 
+    /** Item.departmentType (enum name as String), used to stamp the received bill when the issued bill lacks one. */
+    private String departmentType;
+
     private double unitsPerPack;
     private double purchaseRate;
     private double retailRate;
@@ -198,6 +201,14 @@ public class TransferReceiveItemRowDto implements Serializable {
 
     public void setAmpItemId(Long ampItemId) {
         this.ampItemId = ampItemId;
+    }
+
+    public String getDepartmentType() {
+        return departmentType;
+    }
+
+    public void setDepartmentType(String departmentType) {
+        this.departmentType = departmentType;
     }
 
     public double getUnitsPerPack() {

--- a/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
@@ -117,7 +117,8 @@ public class TransferIssueNativeSqlService {
                 + " COALESCE(i.code, '') AS itemCode,"
                 + " i.DTYPE AS itemDtype,"
                 + " CASE WHEN i.DTYPE = 'Ampp' THEN COALESCE(i.dblValue, 1.0) ELSE 1.0 END AS packSize,"
-                + " CASE WHEN i.DTYPE = 'Ampp' THEN COALESCE(i.amp_ID, i.ID) ELSE i.ID END AS ampItemId"
+                + " CASE WHEN i.DTYPE = 'Ampp' THEN COALESCE(i.amp_ID, i.ID) ELSE i.ID END AS ampItemId,"
+                + " i.departmentType AS departmentType"
                 + " FROM " + billItemTable() + " bi"
                 + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
                 + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
@@ -246,6 +247,7 @@ public class TransferIssueNativeSqlService {
             double packSize      = toDouble(reqRow[9]);
             if (packSize <= 0) packSize = 1.0;
             long ampItemId       = ((Number) reqRow[10]).longValue();
+            String deptType      = reqRow[11] == null ? null : reqRow[11].toString();
             boolean isVmp        = "Vmp".equals(dtype);
 
             if (remainingQty <= 0.001) {
@@ -294,6 +296,7 @@ public class TransferIssueNativeSqlService {
                 empty.setItemName(itemName);
                 empty.setItemCode(itemCode);
                 empty.setItemDtype(dtype);
+                empty.setDepartmentType(deptType);
                 empty.setUnitsPerPack(packSize);
                 empty.setRequestedQty(requestedQty);
                 empty.setAlreadyIssuedQty(alreadyIssued);
@@ -363,6 +366,7 @@ public class TransferIssueNativeSqlService {
                 dto.setItemName(rowItemName);
                 dto.setItemCode(rowItemCode);
                 dto.setItemDtype(rowDtype);
+                dto.setDepartmentType(deptType);
                 dto.setUnitsPerPack(packSize);
                 dto.setDeptStockId(stockId);
                 dto.setItemBatchId(itemBatchId);
@@ -398,6 +402,7 @@ public class TransferIssueNativeSqlService {
                 empty.setItemName(itemName);
                 empty.setItemCode(itemCode);
                 empty.setItemDtype(dtype);
+                empty.setDepartmentType(deptType);
                 empty.setUnitsPerPack(packSize);
                 empty.setRequestedQty(requestedQty);
                 empty.setAlreadyIssuedQty(alreadyIssued);

--- a/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
@@ -100,7 +100,8 @@ public class TransferReceiveNativeSqlService {
                 + " ib.batchNo, COALESCE(ib.dateOfExpire, pbi.doe) AS dateOfExpire, ib.purcahseRate, ib.retailsaleRate,"
                 + " ib.wholesaleRate, COALESCE(ib.costRate, 0) AS costRate,"
                 + " i.ID AS itemId, i.name AS itemName, COALESCE(i.code, '') AS itemCode,"
-                + " i.DTYPE AS itemDtype, COALESCE(i.dblValue, 1) AS dblValue"
+                + " i.DTYPE AS itemDtype, COALESCE(i.dblValue, 1) AS dblValue,"
+                + " i.departmentType AS departmentType"
                 + " FROM " + billItemTable() + " bi"
                 + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
                 + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
@@ -148,7 +149,8 @@ public class TransferReceiveNativeSqlService {
             // row[6]=pbi.staffStock_ID, row[7]=pbi.itemBatch_ID, row[8]=pbi.qty(units in stock),
             // row[9]=ib.batchNo, row[10]=COALESCE(ib.dateOfExpire,pbi.doe), row[11]=ib.purcahseRate,
             // row[12]=ib.retailsaleRate, row[13]=ib.wholesaleRate, row[14]=ib.costRate,
-            // row[15]=i.ID, row[16]=i.name, row[17]=i.code, row[18]=i.DTYPE, row[19]=i.dblValue
+            // row[15]=i.ID, row[16]=i.name, row[17]=i.code, row[18]=i.DTYPE, row[19]=i.dblValue,
+            // row[20]=i.departmentType
 
             long biId = ((Number) row[0]).longValue();
 
@@ -196,6 +198,7 @@ public class TransferReceiveNativeSqlService {
             dto.setAmpItemId(((Number) row[15]).longValue()); // may be refined by controller for Ampp items
             dto.setItemName(row[16] != null ? row[16].toString() : "");
             dto.setItemCode(row[17] != null ? row[17].toString() : "");
+            dto.setDepartmentType(row[20] != null ? row[20].toString() : null);
             dto.setBatchNo(row[9] != null ? row[9].toString() : "");
             dto.setDateOfExpire(toDate(row[10]));
             dto.setUnitsPerPack(unitsPerPack);


### PR DESCRIPTION
## Summary

- The `pharmacy_transfer_issued_list.xhtml` **Department Type** column showed `-` for every row, including bills created today. Root-caused to two independent gaps:
  1. `TransferRequestController.createNewApprovedTransferRequestBill()` promotes a PRE request bill via `Bill.copy()`, which does not carry `departmentType` — so the approved request bill loses the type even though the PRE bill had it correctly set.
  2. The active native-SQL "Fast Issue" (`TransferIssueNativeSqlController`/`Service`) and "Fast Receive" (`TransferReceiveNativeSqlController`/`Service`) flows — which replaced the older JPA-based controllers that got a similar fix under #22056/PR #22060 — never stamped `departmentType` at all on their bill headers.
- Also fixed a smaller related gap in `TransferIssueDirectController`, which copied `Item.departmentType` but had no Pharmacy fallback when the item itself carried no type (unlike `TransferRequestController`, which already defaults to Pharmacy).
- Resolution policy (per issue discussion): copy from the parent bill's `departmentType` when present; otherwise take the **first** item's department type, defaulting to `Pharmacy` if that item has none. Zero-item saves are already blocked by existing validation in every affected controller, so `departmentType` is now always resolvable whenever a bill is actually saved.

## Root cause evidence

Live on the local `coop` DB: bill `13988384` (`PHARMACY_ISSUE`, created via Fast Issue) had `departmentType = NULL` even though both its items were unanimously `Item.departmentType = 'Pharmacy'`.

## Test plan

Verified end-to-end locally (Main Pharmacy ⇄ OPD Pharmacy, item: Panadol 500mg tab):
- [x] Created a new Transfer Request (`OP/MP/26/000023`) — PRE bill correctly captured `departmentType = Pharmacy` (unchanged behavior, `TransferRequestController.addItem()` already worked).
- [x] Approved the request — **before fix**: approved bill lost `departmentType` (NULL). **After fix**: approved bill `13988386` carries `departmentType = Pharmacy`.
- [x] Fast Issue against the approved request — issue bill `13988387` carries `departmentType = Pharmacy`; confirmed on the issued-list UI showing "Pharmacy" instead of "-".
- [x] Fast Receive against the issue — receive bill `13988388` carries `departmentType = Pharmacy`.
- [x] `mvn clean package -DskipTests` — compiles and builds clean.
- [x] Local redeploy — no errors in `server.log`.

Historical NULL rows are a separate data-correction concern (existing `PharmacyTransferDeptTypeBackfillService`/`Api` can be used for that) and are out of scope for this capture-side fix.

Closes #22146

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pharmacy transfer workflows to consistently retain department information across issue, receive, request, and approval processes.
  * Added fallback handling to prevent transfer bills from being saved without a department type.
  * Improved compatibility with older requests that lack department details.
* **Enhancements**
  * Department information is now carried through transfer item data during issue and receive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->