### PR TITLE
fix(pharmacy-bht-issue): qty edit calculation using correct field

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -460,12 +460,15 @@ public class PharmacySaleBhtController implements Serializable {
      * movement in the Cost Of Goods Sold report (found via COGS E2E
      * verification: request 20, issue 10 → bill said 458.70, stock moved 10,
      * COGS saw +10 instead of -10).
+     *
+     * Uses qty (not qtyInUnit) because the UI binds directly to qty for editing;
+     * qtyInUnit is not updated by JSF and retains its original value.
      */
     private void recalculateEditedIssueRow(BillItem tmp) {
         if (tmp == null || tmp.getPharmaceuticalBillItem() == null) {
             return;
         }
-        double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQtyInUnit());
+        double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQty());
         tmp.setQty(editedQty);
         tmp.getPharmaceuticalBillItem().setQtyInUnit((float) (0 - editedQty));
         tmp.getPharmaceuticalBillItem().setQty(0 - editedQty);


### PR DESCRIPTION
## Summary

Fixed critical bug in BHT medicine issue qty edit where edited quantities were silently ignored.

**Issue #6286**: BHT Request need to Substitute & Change Qty & issue (not More than Requested)

## Problem

When users edited the quantity in the BHT issue request table:
1. UI displays quantity from `PharmaceuticalBillItem.qty` (negative, e.g., -15)
2. User edits it to new value (e.g., 10)
3. JSF updates `qty` field
4. BUT: `recalculateEditedIssueRow()` was using `qtyInUnit` instead of `qty`
5. Since `qtyInUnit` is NOT bound to UI, it retained original value
6. **Result**: Edited quantity was silently ignored, original qty used for calculations

## Solution

**File**: `src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java`
**Line**: 471

Changed from:
```java
double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQtyInUnit());
```

To:
```java
double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQty());
```

This ensures the edited quantity (which JSF just updated) is used for:
- Rate recalculations
- Margin updates  
- Total updates
- BillItemFinanceDetails creation

## Issue Requirements Verified

✅ **Substitute Items** - "Select a Substitute" button already implemented (lines 290-298 in XHTML)
✅ **Change Quantity** - Editable Qty field with validation (now working correctly with this fix)
✅ **Prevent Over-issue** - `getRemainingQuantityForItem()` prevents issuing more than requested (lines 2025-2047)

## Testing

- Qty edit now correctly updates financial calculations
- BillItem and BIFD quantities properly maintained through settlement
- Stock movements reflect edited quantities correctly

Closes #6286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected edited pharmacy sale quantities used during recalculation and re-signing.
  * Updated row totals and financial values to reflect the quantity entered in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->