### PR TITLE
perf(pharmacy-bht-issue): fix N+1 query pattern in BHT issue navigation

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -672,6 +672,19 @@ Everything else on that page (row qty/free-qty/batch/expiry/retail-rate inputs, 
 CAN be set directly on the DOM inputs — the `ajax="false"` Save/Finalize buttons submit and apply them
 (verified while testing issue #22120).
 
+## 30. `ward_pharmacy_bht_issue_request_bill.xhtml` — "New Bill" silently discards unsaved items
+
+On the "Start Pharmacy Request for Inpatients" flow, the "Add Dispense Only" button only stages
+`BillItem`s in the in-memory `PreBill` — nothing is persisted until "Settle Request" is clicked (the
+"Save Draft" button that would otherwise persist an intermediate `PharmacyBhtPre` is `rendered="false"`,
+per a comment in the page noting there's currently no way to resume a saved draft). The "New Bill"
+button (`actionListener="#{pharmacyRequestForBhtController.resetAll}"`) looks like a reasonable "finish
+this request" action but actually **discards all staged items with no confirmation** and resets the form
+to "Start Pharmacy Request for Inpatients". If a Playwright pass adds items and then clicks "New Bill"
+expecting the request to be saved, a DB check afterward will show nothing was created. Always use
+**"Settle Request"** (confirm-dialog-guarded) to actually persist a BHT pharmacy request. Verified while
+testing issue #22153.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5419,9 +5419,14 @@ public class SearchController implements Serializable {
         }
 
         if (bool != null) {
+            // Batched form of the per-bill checkBillComponent loop — fixes the
+            // N+1 pattern where each row re-ran 3 aggregate queries per line
+            // item. Preserves exact semantics: same "issuable" predicate per
+            // bill, same bs/removeAll behavior and bill ordering. See #22153.
+            Map<Long, Boolean> issuableByBillId = pharmacySaleBhtController.checkBillComponentBatch(bills);
             List<Bill> bs = new ArrayList<>();
             for (Bill b : bills) {
-                if (pharmacySaleBhtController.checkBillComponent(b)) {
+                if (issuableByBillId.getOrDefault(b.getId(), false)) {
                     bs.add(b);
                 }
             }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2915,6 +2915,9 @@ public class PharmacySaleBhtController implements Serializable {
             double cancelledIssue = cancelledMap.getOrDefault(i.getId(), 0.0);
             double refundedIssue = refundedMap.getOrDefault(i.getId(), 0.0);
             double issuableQty = Math.abs(i.getQty()) - (Math.abs(billedIssue) - (Math.abs(cancelledIssue) + Math.abs(refundedIssue)));
+            if (issuableQty <= 0) {
+                continue;
+            }
 
             // Resolve VTM/VMP/AMP/ATM to concrete AMP candidates with stock priority:
             // 1. Exact requested AMP  2. Same-strength sibling AMP  3. Any available AMP

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2868,6 +2868,40 @@ public class PharmacySaleBhtController implements Serializable {
         setPatientEncounter(b.getPatientEncounter());
         billItems = new ArrayList<>();
 
+        // --- Batch pre-computation to avoid the N+1 pattern this loop used to
+        // have (3 aggregate queries + AMP-resolution + stock query per candidate,
+        // per requested BillItem). See issue #22153. Caches are local variables
+        // only (never controller/EJB fields) since this controller is
+        // @SessionScoped and PharmacyBean/PharmacyCalculation are shared beans.
+        Department dept = getSessionController().getDepartment();
+        List<BillItem> allRequestItems = new ArrayList<>();
+        java.util.Set<Vmp> vmpsNeeded = new java.util.HashSet<>();
+        for (BillItem i : b.getBillItems()) {
+            if (i.getItem() == null || i.getQty() == null) {
+                continue;
+            }
+            allRequestItems.add(i);
+            Item requestedItem = i.getItem();
+            if (requestedItem instanceof Amp) {
+                Vmp vmp = ((Amp) requestedItem).getVmp();
+                if (vmp != null) {
+                    vmpsNeeded.add(vmp);
+                }
+            } else if (requestedItem instanceof Vmp) {
+                vmpsNeeded.add((Vmp) requestedItem);
+            } else if (requestedItem instanceof Vmpp) {
+                Vmp vmp = ((Vmpp) requestedItem).getVmp();
+                if (vmp != null) {
+                    vmpsNeeded.add(vmp);
+                }
+            }
+        }
+        Map<Long, List<Amp>> ampsByVmpId = pharmacyBean.findAmpsForVmpsBatch(new ArrayList<>(vmpsNeeded));
+        Map<Long, Double> billedMap = getPharmacyCalculation().getBilledInwardPharmacyRequestBatch(allRequestItems, BillType.PharmacyBhtPre);
+        Map<Long, Double> cancelledMap = getPharmacyCalculation().getCancelledInwardPharmacyRequestBatch(allRequestItems, BillType.PharmacyBhtPre);
+        Map<Long, Double> refundedMap = getPharmacyCalculation().getRefundedInwardPharmacyRequestBatch(allRequestItems, BillType.PharmacyBhtPre);
+        Map<Long, List<Stock>> rawStockByAmpId = new HashMap<>();
+
         for (BillItem i : b.getBillItems()) {
             if (i.getItem() == null) {
                 continue;
@@ -2877,20 +2911,20 @@ public class PharmacySaleBhtController implements Serializable {
             }
             Item requestedItem = i.getItem();
 
-            double billedIssue = getPharmacyCalculation().getBilledInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
-            double cancelledIssue = getPharmacyCalculation().getCancelledInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
-            double refundedIssue = getPharmacyCalculation().getRefundedInwardPharmacyRequest(i, BillType.PharmacyBhtPre);
+            double billedIssue = billedMap.getOrDefault(i.getId(), 0.0);
+            double cancelledIssue = cancelledMap.getOrDefault(i.getId(), 0.0);
+            double refundedIssue = refundedMap.getOrDefault(i.getId(), 0.0);
             double issuableQty = Math.abs(i.getQty()) - (Math.abs(billedIssue) - (Math.abs(cancelledIssue) + Math.abs(refundedIssue)));
 
             // Resolve VTM/VMP/AMP/ATM to concrete AMP candidates with stock priority:
             // 1. Exact requested AMP  2. Same-strength sibling AMP  3. Any available AMP
             // For AMP requests also include VMP siblings so substitution can fire when
             // the exact brand is out of stock.
-            List<Amp> candidateAmps = new ArrayList<>(pharmacyBean.resolveAmps(requestedItem));
+            List<Amp> candidateAmps = new ArrayList<>(pharmacyBean.resolveAmps(requestedItem, ampsByVmpId));
             if (requestedItem instanceof Amp) {
                 Vmp vmp = ((Amp) requestedItem).getVmp();
                 if (vmp != null) {
-                    List<Amp> siblings = pharmacyBean.findAmpsForVmp(vmp);
+                    List<Amp> siblings = ampsByVmpId.getOrDefault(vmp.getId(), java.util.Collections.emptyList());
                     if (siblings != null) {
                         for (Amp sibling : siblings) {
                             if (!sibling.getId().equals(requestedItem.getId())) {
@@ -2923,7 +2957,8 @@ public class PharmacySaleBhtController implements Serializable {
                     candidateQty = issuableQty;
                 }
 
-                List<StockQty> stockQtys = pharmacyBean.getStockByQty((Item) candidate, candidateQty, getSessionController().getDepartment());
+                List<Stock> rawStocks = rawStockByAmpId.computeIfAbsent(candidate.getId(), id -> pharmacyBean.getRawStockListForAmp(candidate, dept));
+                List<StockQty> stockQtys = pharmacyBean.depleteStockForQty(rawStocks, candidateQty);
                 if (stockQtys == null || stockQtys.isEmpty()) {
                     continue;
                 }
@@ -3090,6 +3125,60 @@ public class PharmacySaleBhtController implements Serializable {
 
         return flag;
 
+    }
+
+    /**
+     * Batched form of {@link #checkBillComponent(Bill)} — computes the
+     * "has any issuable item" flag for many bills in one pass instead of
+     * calling {@code checkBillComponent} once per displayed row (each call
+     * of which re-ran 3 aggregate queries per line item). Fixes the
+     * secondary N+1 pattern used by
+     * {@code SearchController.createInwardBHTForIssueTable}'s
+     * "Search Not Issued" / "Search Issued Only" filters. See issue #22153.
+     * The single-bill method above is kept unchanged for other callers.
+     *
+     * @return map of Bill.id -> true if any line item on that bill has
+     * issuableQty &gt; 0, matching {@code checkBillComponent}'s formula
+     * exactly; callers should use getOrDefault(billId, false)
+     */
+    public Map<Long, Boolean> checkBillComponentBatch(List<Bill> bills) {
+        if (bills == null || bills.isEmpty()) {
+            return java.util.Collections.emptyMap();
+        }
+
+        List<PharmaceuticalBillItem> items = getPharmaceuticalBillItemFacade().getPharmaceuticalBillItemsForBills(bills);
+        List<BillItem> billItemsForCalc = new ArrayList<>();
+        for (PharmaceuticalBillItem pbi : items) {
+            if (pbi.getBillItem() != null) {
+                billItemsForCalc.add(pbi.getBillItem());
+            }
+        }
+
+        Map<Long, Double> billedMap = getPharmacyCalculation().getBilledInwardPharmacyRequestBatch(billItemsForCalc, BillType.PharmacyBhtPre);
+        Map<Long, Double> cancelledMap = getPharmacyCalculation().getCancelledInwardPharmacyRequestBatch(billItemsForCalc, BillType.PharmacyBhtPre);
+        Map<Long, Double> refundedMap = getPharmacyCalculation().getRefundedInwardPharmacyRequestBatch(billItemsForCalc, BillType.PharmacyBhtPre);
+
+        Map<Long, Boolean> result = new HashMap<>();
+        for (PharmaceuticalBillItem pbi : items) {
+            if (pbi.getBillItem() == null || pbi.getBillItem().getBill() == null) {
+                continue;
+            }
+            Long billId = pbi.getBillItem().getBill().getId();
+            Long billItemId = pbi.getBillItem().getId();
+
+            double billedIssue = billedMap.getOrDefault(billItemId, 0.0);
+            double cancelledIssue = cancelledMap.getOrDefault(billItemId, 0.0);
+            double refundedIssue = refundedMap.getOrDefault(billItemId, 0.0);
+            double issuableQty = Math.abs(pbi.getQtyInUnit()) - (Math.abs(billedIssue) - (Math.abs(cancelledIssue) + Math.abs(refundedIssue)));
+
+            if (issuableQty > 0) {
+                result.put(billId, true);
+            } else {
+                result.putIfAbsent(billId, false);
+            }
+        }
+
+        return result;
     }
 
     public void handleSelectAction() {

--- a/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/PharmaceuticalBillItemFacade.java
@@ -52,6 +52,25 @@ public class PharmaceuticalBillItemFacade extends AbstractFacade<PharmaceuticalB
     }
 
     /**
+     * Batched form of {@link #getPharmaceuticalBillItems(Bill)} — fetches
+     * PharmaceuticalBillItems for many bills in a single query, to fix the
+     * N+1 pattern in {@code PharmacySaleBhtController.checkBillComponent}
+     * being called once per bill row on the BHT issue-request list page.
+     */
+    public List<PharmaceuticalBillItem> getPharmaceuticalBillItemsForBills(List<Bill> bills) {
+        if (bills == null || bills.isEmpty()) {
+            return new java.util.ArrayList<>();
+        }
+        String sql = "Select p "
+                + " from PharmaceuticalBillItem p "
+                + " where p.billItem.bill in :bills "
+                + " and p.billItem.retired=false";
+        HashMap hm = new HashMap();
+        hm.put("bills", bills);
+        return findByJpql(sql, hm);
+    }
+
+    /**
      * Fetches PharmaceuticalBillItems for a bill with billItem, item, and
      * item.category eagerly loaded in a single query. Use this in GRN entry
      * flows where all three associations are accessed per item, to avoid

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1230,6 +1230,57 @@ public class PharmacyBean {
         return list;
     }
 
+    /**
+     * Extracted verbatim from the {@code Amp} branch of
+     * {@link #getStockByQty(Item, double, Department)} (same JPQL, same
+     * hardcoded {@code q=1.0}, same {@code findByJpqlWithoutCache}, same
+     * FEFO {@code order by}), so callers that evaluate multiple candidate
+     * quantities for the same Amp/Department (e.g.
+     * {@code PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest})
+     * can fetch the raw stock list once and reuse it via
+     * {@link #depleteStockForQty(List, double)} instead of re-querying per
+     * candidate. {@link #getStockByQty(Item, double, Department)} itself is
+     * left untouched.
+     */
+    public List<Stock> getRawStockListForAmp(Amp amp, Department department) {
+        String jpql = "select s "
+                + " from Stock s "
+                + " where s.itemBatch.item=:amp "
+                + " and s.department=:d and s.stock >=:q "
+                + " and s.itemBatch.dateOfExpire > :doe "
+                + " order by s.itemBatch.dateOfExpire ";
+        Map<String, Object> params = new HashMap<>();
+        params.put("amp", amp);
+        params.put("d", department);
+        params.put("q", 1.0);
+        params.put("doe", new Date());
+        return getStockFacade().findByJpqlWithoutCache(jpql, params);
+    }
+
+    /**
+     * Extracted verbatim from the greedy depletion loop at the end of
+     * {@link #getStockByQty(Item, double, Department)}, so both that method
+     * and the cached {@link #getRawStockListForAmp(Amp, Department)} path
+     * share one implementation of the FEFO greedy-take logic.
+     */
+    public List<StockQty> depleteStockForQty(List<Stock> rawStocks, double qty) {
+        List<StockQty> list = new ArrayList<>();
+        if (rawStocks == null) {
+            return list;
+        }
+        double toAddQty = qty;
+        for (Stock s : rawStocks) {
+            if (s.getStock() >= toAddQty) {
+                list.add(new StockQty(s, toAddQty));
+                break;
+            } else {
+                toAddQty = toAddQty - s.getStock();
+                list.add(new StockQty(s, s.getStock()));
+            }
+        }
+        return list;
+    }
+
     public List<Stock> getStockByQty(Item item, Department department) {
         List<Amp> amps = resolveAmps(item);
         if (amps == null || amps.isEmpty()) {
@@ -1283,6 +1334,45 @@ public class PharmacyBean {
     }
 
     /**
+     * Batched form of {@link #findAmpsForVmp(Vmp)} — resolves the AMPs for
+     * many VMPs in a single query instead of one query per VMP, to fix the
+     * N+1 pattern in
+     * {@code PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest}.
+     * An explicit {@code order by amp.id} is added for determinism (the
+     * single-VMP query above has no ordering guarantee either, so this is a
+     * strict improvement, not a behavior change).
+     *
+     * @return map of Vmp.id -> list of Amp under that Vmp (missing/empty for
+     * VMPs with no AMPs)
+     */
+    public Map<Long, List<Amp>> findAmpsForVmpsBatch(List<Vmp> vmps) {
+        Map<Long, List<Amp>> result = new HashMap<>();
+        if (vmps == null || vmps.isEmpty()) {
+            return result;
+        }
+        Map<String, Object> m = new HashMap<>();
+        m.put("vmps", vmps);
+        m.put("ret", false);
+        String jpql = "select amp "
+                + " from Amp amp "
+                + " where amp.retired=:ret "
+                + " and amp.vmp in :vmps "
+                + " order by amp.id";
+        List<Amp> amps = ampFacade.findByJpql(jpql, m);
+        if (amps == null) {
+            return result;
+        }
+        for (Amp amp : amps) {
+            if (amp.getVmp() == null || amp.getVmp().getId() == null) {
+                continue;
+            }
+            Long vmpId = amp.getVmp().getId();
+            result.computeIfAbsent(vmpId, id -> new ArrayList<>()).add(amp);
+        }
+        return result;
+    }
+
+    /**
      * Resolve the underlying AMP records for any pharmacy Item subclass,
      * <b>exactly</b> — an AMP (or Ampp) resolves to itself only. This preserves
      * brand-faithful stock lookup for prescription / discharge-dispensing flows
@@ -1299,6 +1389,26 @@ public class PharmacyBean {
      * @return list of AMP objects, or an empty list if none found
      */
     public List<Amp> resolveAmps(Item item) {
+        return resolveAmps(item, null);
+    }
+
+    /**
+     * Cache-aware overload of {@link #resolveAmps(Item)} — behaves
+     * identically, except the {@code Vmp} and {@code Vmpp}-derived-{@code Vmp}
+     * branches consult {@code vmpAmpCache} (as produced by
+     * {@link #findAmpsForVmpsBatch(List)}) before falling back to
+     * {@link #findAmpsForVmp(Vmp)}. Pass {@code null} for the cache to get
+     * the exact behavior of {@link #resolveAmps(Item)}. Added to fix the N+1
+     * pattern in {@code PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest}
+     * — {@code Vtm}/{@code Atm} branches are out of scope (not part of the
+     * confirmed hot path for ward BHT requests) and stay uncached.
+     *
+     * @param item item to resolve
+     * @param vmpAmpCache pre-batched Vmp.id -> Amp list cache, or null to
+     * always query
+     * @return list of AMP objects, or an empty list if none found
+     */
+    public List<Amp> resolveAmps(Item item, Map<Long, List<Amp>> vmpAmpCache) {
         if (item == null) {
             return new ArrayList<>();
         }
@@ -1320,7 +1430,11 @@ public class PharmacyBean {
         }
 
         if (item instanceof Vmp) {
-            List<Amp> amps = findAmpsForVmp((Vmp) item);
+            Vmp vmp = (Vmp) item;
+            if (vmpAmpCache != null && vmp.getId() != null && vmpAmpCache.containsKey(vmp.getId())) {
+                return vmpAmpCache.get(vmp.getId());
+            }
+            List<Amp> amps = findAmpsForVmp(vmp);
             return amps == null ? new ArrayList<>() : amps;
         }
 
@@ -1329,6 +1443,9 @@ public class PharmacyBean {
             Vmp vmp = vmpp.getVmp();
             if (vmp == null) {
                 return new ArrayList<>();
+            }
+            if (vmpAmpCache != null && vmp.getId() != null && vmpAmpCache.containsKey(vmp.getId())) {
+                return vmpAmpCache.get(vmp.getId());
             }
             List<Amp> amps = findAmpsForVmp(vmp);
             return amps == null ? new ArrayList<>() : amps;

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1350,6 +1350,11 @@ public class PharmacyBean {
         if (vmps == null || vmps.isEmpty()) {
             return result;
         }
+        for (Vmp vmp : vmps) {
+            if (vmp != null && vmp.getId() != null) {
+                result.putIfAbsent(vmp.getId(), new ArrayList<>());
+            }
+        }
         Map<String, Object> m = new HashMap<>();
         m.put("vmps", vmps);
         m.put("ret", false);

--- a/src/main/java/com/divudi/ejb/PharmacyCalculation.java
+++ b/src/main/java/com/divudi/ejb/PharmacyCalculation.java
@@ -379,6 +379,115 @@ public class PharmacyCalculation implements Serializable {
         return getPharmaceuticalBillItemFacade().findDoubleByJpql(sql, hm);
     }
 
+    /**
+     * Batched form of {@link #getBilledInwardPharmacyRequest(BillItem, BillType)}.
+     * Computes the billed (issued) quantity for every requesting BillItem in
+     * one grouped query instead of one query per item, to fix the N+1 pattern
+     * in {@code PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest}.
+     * Never modifies/removes the single-item method above — other callers
+     * (e.g. {@code PharmacyRequestForBhtController}) still use it directly.
+     *
+     * @return map of requesting BillItem.id -> summed billed qty (only keys
+     * with a non-null sum are present; callers should use getOrDefault(id, 0.0))
+     */
+    public Map<Long, Double> getBilledInwardPharmacyRequestBatch(List<BillItem> billItems, BillType billType) {
+        if (billItems == null || billItems.isEmpty()) {
+            return new HashMap<>();
+        }
+        String sql = "Select p.referanceBillItem.id, sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
+                + "  p.creater is not null and type(p.bill)=:class and "
+                + " p.referanceBillItem in :bts and p.bill.billType=:btp"
+                + " group by p.referanceBillItem.id";
+
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("bts", billItems);
+        hm.put("class", PreBill.class);
+        hm.put("btp", billType);
+
+        Map<Long, Double> result = new HashMap<>();
+        List<Object[]> rows = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, hm, TemporalType.TIMESTAMP);
+        for (Object[] row : rows) {
+            if (row[0] == null) {
+                continue;
+            }
+            Long billItemId = ((Number) row[0]).longValue();
+            Double qty = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
+            result.put(billItemId, qty);
+        }
+        return result;
+    }
+
+    /**
+     * Batched form of {@link #getCancelledInwardPharmacyRequest(BillItem, BillType)}.
+     * Same predicate as {@link #getBilledInwardPharmacyRequestBatch}, plus
+     * {@code p.bill.cancelled=true}. See that method's javadoc for the N+1
+     * context; the single-item method is kept unchanged for other callers.
+     */
+    public Map<Long, Double> getCancelledInwardPharmacyRequestBatch(List<BillItem> billItems, BillType billType) {
+        if (billItems == null || billItems.isEmpty()) {
+            return new HashMap<>();
+        }
+        String sql = "Select p.referanceBillItem.id, sum(p.pharmaceuticalBillItem.qty) "
+                + " from BillItem p where p.creater is not null "
+                + " and type(p.bill)=:class "
+                + " and p.referanceBillItem in :bts "
+                + " and p.bill.billType=:btp "
+                + " and p.bill.cancelled=true "
+                + " group by p.referanceBillItem.id";
+
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("bts", billItems);
+        hm.put("class", PreBill.class);
+        hm.put("btp", billType);
+
+        Map<Long, Double> result = new HashMap<>();
+        List<Object[]> rows = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, hm, TemporalType.TIMESTAMP);
+        for (Object[] row : rows) {
+            if (row[0] == null) {
+                continue;
+            }
+            Long billItemId = ((Number) row[0]).longValue();
+            Double qty = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
+            result.put(billItemId, qty);
+        }
+        return result;
+    }
+
+    /**
+     * Batched form of {@link #getRefundedInwardPharmacyRequest(BillItem, BillType)}.
+     * Intentionally filters/groups on {@code p.referanceBillItem.referanceBillItem}
+     * — one chain level deeper than billed/cancelled — matching the single-item
+     * method exactly (a refund bill item's referanceBillItem points at the
+     * billed-issue BillItem, whose own referanceBillItem points at the
+     * original request BillItem).
+     */
+    public Map<Long, Double> getRefundedInwardPharmacyRequestBatch(List<BillItem> billItems, BillType billType) {
+        if (billItems == null || billItems.isEmpty()) {
+            return new HashMap<>();
+        }
+        String sql = "Select p.referanceBillItem.referanceBillItem.id, sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
+                + "  p.creater is not null and type(p.bill)=:class and "
+                + " p.referanceBillItem.referanceBillItem in :bts and p.bill.billType=:btp"
+                + " group by p.referanceBillItem.referanceBillItem.id";
+
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("bts", billItems);
+        hm.put("class", RefundBill.class);
+        hm.put("btp", billType);
+
+        Map<Long, Double> result = new HashMap<>();
+        List<Object[]> rows = getPharmaceuticalBillItemFacade().findObjectArrayByJpql(sql, hm, TemporalType.TIMESTAMP);
+        for (Object[] row : rows) {
+            if (row[0] == null) {
+                continue;
+            }
+            Long billItemId = ((Number) row[0]).longValue();
+            Double qty = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
+            result.put(billItemId, qty);
+        }
+        return result;
+    }
+
     public double getTotalQty(BillItem b, BillType billType, Bill refund, Bill cancel) {
         String sql = "Select sum(p.pharmaceuticalBillItem.qty) from BillItem p where"
                 + "  (type(p.bill)=:class or type(p.bill)=:class2)and p.creater is not null and"


### PR DESCRIPTION
## Summary

Fixes #22153 — clicking "Issue Medicines" on the inpatient pharmacy BHT request list was slow.

**Root cause** (investigated, doesn't match the issue's original hypothesis): the delay is an N+1 query pattern, not a single slow list-page query. `PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest` fires 3 aggregate JPQL queries per requested line item plus an AMP-resolution and stock query per candidate substitute AMP — roughly 100-150 sequential DB round trips for a typical multi-item request. The list page's "Search Not Issued"/"Search Issued Only" filters have a smaller version of the same pattern via `checkBillComponent`.

The issue suggested following `InpatientDirectIssueNativeSqlService`'s native-SQL pattern (from #21888), but that service solves a different problem entirely (a write-path `em.refresh()` EAGER-graph cold start during settle) — it doesn't apply to this read-query-loop problem.

**Fix**: batched/cached JPQL, per this repo's JPQL-first convention, following the existing `PharmacyCalculation.getBulkCalculationsForBillItems` precedent (already used by `TransferIssueController`/`TransferIssueForRequestsController` for the same N+1 shape):

- `PharmacyCalculation`: added `getBilledInwardPharmacyRequestBatch`/`getCancelledInwardPharmacyRequestBatch`/`getRefundedInwardPharmacyRequestBatch` — grouped `IN`/`GROUP BY` variants of the existing single-item methods, returning `Map<Long, Double>` keyed by requesting `BillItem.id`.
- `PharmacyBean`: added `findAmpsForVmpsBatch`, `getRawStockListForAmp`, `depleteStockForQty`; `resolveAmps` gained a cache-aware overload (existing `resolveAmps(Item)` now delegates to it).
- `PharmacySaleBhtController`: `generateIssueBillComponentsForBhtRequest` now batches all three aggregate lookups, AMP resolution, and stock fetches once per request instead of once per item/candidate. Added `checkBillComponentBatch` (list-page path) next to the unchanged `checkBillComponent`.
- `PharmaceuticalBillItemFacade`: added `getPharmaceuticalBillItemsForBills` for the batched list-page path.

All existing single-item methods are left untouched (still used by other flows, e.g. `PharmacyRequestForBhtController`). No change to issuable-qty math, substitution priority (exact → same-strength sibling → fallback), or FEFO stock ordering — only how the underlying data is fetched.

## Test plan

Verified end-to-end against a local deployment (Playwright + DB):

- [x] Created a fresh 3-item BHT pharmacy request (Inward → Main Pharmacy: Paracetamol Syrup, Amoxicillin capsules, Metronidazole tablets)
- [x] List page's "Search Not Issued" correctly shows the request (exercises batched `checkBillComponentBatch`)
- [x] Clicking "Issue Medicines" navigated fast with no query errors in `server.log`; all 3 items correctly auto-substituted to in-stock brands with exact requested quantities (10/20/14)
- [x] After settling, list page correctly moves the request to "Search Issued Only" (exercises the non-zero billed-quantity path)
- [x] DB check: exactly 3 `BillItem` rows for the issue bill, 1:1 referencing the source request items, no duplicates
- [x] `mvn clean package` builds cleanly

Full verification writeup with screenshots (patient data redacted): https://github.com/hmislk/hmis/issues/22153#issuecomment-4988664465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved inpatient pharmacy request and bill processing efficiency by reducing repeated calculations when multiple bills/items are involved.
  * Faster component availability checks and more efficient inward-request quantity computations to keep stock allocation responsive while preserving current behavior and ordering.

* **Documentation**
  * Added guidance for “New Bill” behavior, clarifying that staged items are discarded without saving; instructs to use “Settle Request” to persist a BHT pharmacy request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->