### PR TITLE
fix(inward): freeze pharmacy/inward transactions after nursing discharge

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -12,6 +12,7 @@ import com.divudi.bean.clinical.*;
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.SearchController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 
 import com.divudi.bean.pharmacy.PharmacySaleController;
 import com.divudi.core.data.BillType;
@@ -173,6 +174,8 @@ public class InpatientClinicalDataController implements Serializable {
     com.divudi.bean.common.NotificationController notificationController;
     @Inject
     private MedicationAdministrationController medicationAdministrationController;
+    @Inject
+    private WebUserController webUserController;
 
     /**
      * Properties
@@ -3214,6 +3217,12 @@ public class InpatientClinicalDataController implements Serializable {
     public void addEncounterMedicine() {
         if (current == null || current.getId() == null) {
             JsfUtil.addErrorMessage("Save the assessment before adding medicines.");
+            return;
+        }
+        boolean nursingDischarged = current.isNursingDischarged()
+                || (current.getParentEncounter() != null && current.getParentEncounter().isNursingDischarged());
+        if (nursingDischarged && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
+            JsfUtil.addErrorMessage("Cannot add charges: nursing discharge has been confirmed for this patient.");
             return;
         }
         if (getEncounterMedicine().getPrescription().getItem() == null) {

--- a/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
@@ -12,6 +12,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.PaymentMethod;
@@ -61,6 +62,8 @@ public class InwardServiceRefundController implements Serializable {
     private BillController billController;
     @Inject
     private AdmissionController admissionController;
+    @Inject
+    private WebUserController webUserController;
 
     private List<BillItem> refundingItems;
     private String comment;
@@ -124,6 +127,11 @@ public class InwardServiceRefundController implements Serializable {
         Bill bill = billFacade.find(sessionBill.getId());
         if (bill == null || bill.isRetired()) {
             JsfUtil.addErrorMessage("Bill not available");
+            return null;
+        }
+        if (bill.getPatientEncounter() != null && bill.getPatientEncounter().isNursingDischarged()
+                && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
+            JsfUtil.addErrorMessage("Cannot return services: nursing discharge has been confirmed for this patient.");
             return null;
         }
         inwardSearch.setBill(bill);

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -428,6 +428,10 @@ public class BhtIssueReturnController implements Serializable {
 //            JsfUtil.addErrorMessage("Checked Bill. Can not Return");
 //            return;
 //        }
+        if (getBill().getPatientEncounter().isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot return medicines: nursing discharge has already been confirmed for this patient.");
+            return;
+        }
         if (getBill().getPatientEncounter().isPaymentFinalized()) {
             JsfUtil.addErrorMessage("This Bill Already Discharged");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -127,6 +127,10 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
             JsfUtil.addErrorMessage("Please select a BHT.");
             return;
         }
+        if (patientEncounter.isNursingDischarged()) {
+            JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
+            return;
+        }
         if (patientEncounter.isDischarged()) {
             JsfUtil.addErrorMessage("Sorry, patient is discharged.");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1578,7 +1578,7 @@ public class PharmacySaleBhtController implements Serializable {
             JsfUtil.addErrorMessage("Please add items to the bill.");
             return;
         }
-        if (errorCheck()) {
+        if (errorCheck(true)) {
             return;
         }
         if (hasAllergyConflicts(getPreBill().getBillItems())) {
@@ -1730,6 +1730,10 @@ public class PharmacySaleBhtController implements Serializable {
     }
 
     private boolean errorCheck() {
+        return errorCheck(false);
+    }
+
+    private boolean errorCheck(boolean skipNursingDischargeCheck) {
         if (getPatientEncounter() == null || getPatientEncounter().getPatient() == null) {
             JsfUtil.addErrorMessage("Please Select a BHT");
             return true;
@@ -1749,7 +1753,7 @@ public class PharmacySaleBhtController implements Serializable {
 
         }
 
-        if (getPatientEncounter().isNursingDischarged()) {
+        if (!skipNursingDischargeCheck && getPatientEncounter().isNursingDischarged()) {
             JsfUtil.addErrorMessage("Cannot issue medicines: nursing discharge has already been confirmed for this patient.");
             return true;
         }


### PR DESCRIPTION
## Summary

Closes gaps in the "freeze transactions after nursing discharge" logic (#21995). The freeze pattern was already correctly applied to Services/Investigations/Surgery/Timed-Items (privilege-bypass allowed) and to pharmacy request/theatre-issue (unconditional block, no bypass), but was **missing or wrong** in 5 places:

1. **`InpatientDirectIssueNativeSqlController`** — "Direct Issue to BHTs" (the live native-SQL dashboard page) had no nursing-discharge check at all. Added an unconditional block (pharmacy billing transaction, no privilege override — consistent with the existing "except pharmacy billing" carve-out).
2. **`PharmacySaleBhtController`** — the shared `errorCheck()` wrongly blocked **Issue Discharge Medicines** too, even though discharge-medicine issuance must stay allowed post-discharge. Overloaded `errorCheck(boolean skipNursingDischargeCheck)` so only that one call site skips the check; all 4 other callers (regular BHT issue, accept, request, store issue) keep it unchanged.
3. **`InpatientClinicalDataController`** — "Managing prescriptions" (Clinical Notes → Inward Medicines) had no check. Added with the `InwardAddChargesAfterNursingDischarge` privilege bypass (clinical order, not pharmacy billing). Note: the clinical-assessment page binds to a *child* `PatientEncounter` (type `ClinicalAssessment`), not the admission encounter directly, so the check walks up via `getParentEncounter()` — discovered and fixed during Playwright verification.
4. **`InwardServiceRefundController`** — "Cancel/return services" had no check. Added with the same privilege bypass (inverse of "order service", which already has one).
5. **`BhtIssueReturnController`** — drug return had no check. Added an unconditional block (pharmacy billing transaction, no bypass).

`WardPharmacyReturnToPharmacyController` was investigated and found out of scope — it operates on department-level ward stock with no per-patient/BHT concept.

## Verification

Tested end-to-end with Playwright against a fresh test admission (BHT/56745) on local Payara + MySQL:

- Created admission → added a service bill and a direct-issue bill pre-discharge → performed Nursing Discharge (after first discharging the patient's room, a precondition of `NursingDischargeController`).
- **Direct Issue to BHTs**: confirmed blocked post-discharge with the new error message, no bill created.
- **Issue Discharge Medicines**: confirmed still succeeds post-discharge (the bug fix) — bill `DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE` created.
- **Managing prescriptions**: confirmed blocked for a normal user (no privilege), confirmed allowed for a privileged user (`InwardAddChargesAfterNursingDischarge` granted then retired then restored on the test account to exercise both paths).
- **Cancel/return services**: confirmed allowed via the privilege bypass — refund bill created.
- **Drug return**: confirmed blocked with the new error message, no bill created.
- **Request Medicines from Pharmacy**: confirmed still blocked (pre-existing, unconditional).

Screenshots and full narrative posted on the issue: https://github.com/hmislk/hmis/issues/21995#issuecomment-4988932116

## Test plan

- [x] `mvn clean package -DskipTests` compiles cleanly
- [x] Manual Playwright verification of all 5 fixed transactions (blocked/allowed as designed) plus the 1 pre-existing correct behavior, with DB-level confirmation that no bill rows were created for blocked attempts
- [x] No UI/XHTML changes, no new privilege, no schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added permission-based authorization guards to block inward charge/medicine operations after nursing discharge unless the user has the required privilege.
  - Prevented inward-service refunds, medicine returns, and direct medicine issues once nursing discharge is confirmed, with clear error messaging.
  - Adjusted pharmacy discharge-issue settlement to follow the correct post-nursing-discharge workflow by bypassing the nursing-discharge validation step when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->