### PR TITLE
BHT Issue Receive: split nurse/admission entry points, add nav buttons, A4/POS/FiveFive prints

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -69,6 +69,11 @@ public class PharmacyConfigController implements Serializable {
     private boolean grnReturnReceiptCustom1;
     private boolean grnReturnReceiptCustom2;
 
+    // BHT Issue Receive Settings
+    private boolean bhtIssueReceiveReceiptA4;
+    private boolean bhtIssueReceiveReceiptPos;
+    private boolean bhtIssueReceiveReceiptFiveFive;
+
     // Transfer Receive Settings
     private boolean transferReceiveA4;
     private boolean transferReceiveTemplate;
@@ -263,6 +268,11 @@ public class PharmacyConfigController implements Serializable {
         grnReturnReceiptCustom1 = configOptionController.getBooleanValueByKey("GRN Return Receipt Paper is Custom 1", false);
         grnReturnReceiptCustom2 = configOptionController.getBooleanValueByKey("GRN Return Receipt Paper is Custom 2", true);
 
+        // BHT Issue Receive Settings
+        bhtIssueReceiveReceiptA4 = configOptionController.getBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is A4", true);
+        bhtIssueReceiveReceiptPos = configOptionController.getBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is POS", false);
+        bhtIssueReceiveReceiptFiveFive = configOptionController.getBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is FiveFive", false);
+
         // Transfer Receive Settings
         transferReceiveA4 = configOptionController.getBooleanValueByKey("Pharmacy Transfer Receive Receipt is A4", true);
         transferReceiveTemplate = configOptionController.getBooleanValueByKey("Pharmacy Transfer Receive Bill is Template", false);
@@ -455,6 +465,11 @@ public class PharmacyConfigController implements Serializable {
             // GRN Return Settings
             configOptionController.setBooleanValueByKey("GRN Return Receipt Paper is Custom 1", grnReturnReceiptCustom1);
             configOptionController.setBooleanValueByKey("GRN Return Receipt Paper is Custom 2", grnReturnReceiptCustom2);
+
+            // BHT Issue Receive Settings
+            configOptionController.setBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is A4", bhtIssueReceiveReceiptA4);
+            configOptionController.setBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is POS", bhtIssueReceiveReceiptPos);
+            configOptionController.setBooleanValueByKey("Pharmacy BHT Issue Receive Receipt is FiveFive", bhtIssueReceiveReceiptFiveFive);
 
             // Transfer Receive Settings
             configOptionController.setBooleanValueByKey("Pharmacy Transfer Receive Receipt is A4", transferReceiveA4);
@@ -1164,6 +1179,30 @@ public class PharmacyConfigController implements Serializable {
         this.grnReceiptCustom2 = grnReceiptCustom2;
     }
     
+
+    public boolean isBhtIssueReceiveReceiptA4() {
+        return bhtIssueReceiveReceiptA4;
+    }
+
+    public void setBhtIssueReceiveReceiptA4(boolean bhtIssueReceiveReceiptA4) {
+        this.bhtIssueReceiveReceiptA4 = bhtIssueReceiveReceiptA4;
+    }
+
+    public boolean isBhtIssueReceiveReceiptPos() {
+        return bhtIssueReceiveReceiptPos;
+    }
+
+    public void setBhtIssueReceiveReceiptPos(boolean bhtIssueReceiveReceiptPos) {
+        this.bhtIssueReceiveReceiptPos = bhtIssueReceiveReceiptPos;
+    }
+
+    public boolean isBhtIssueReceiveReceiptFiveFive() {
+        return bhtIssueReceiveReceiptFiveFive;
+    }
+
+    public void setBhtIssueReceiveReceiptFiveFive(boolean bhtIssueReceiveReceiptFiveFive) {
+        this.bhtIssueReceiveReceiptFiveFive = bhtIssueReceiveReceiptFiveFive;
+    }
 
     public boolean isTransferReceiveA4() {
         return transferReceiveA4;

--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyBhtIssueReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyBhtIssueReceiveController.java
@@ -8,12 +8,14 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.StockFacade;
+import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -66,6 +68,11 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
     private boolean printPreview;
     private boolean settling;
 
+    private Date fromDate;
+    private Date toDate;
+    private PatientEncounter admissionPatientEncounter;
+    private boolean admissionScoped;
+
     public void makeNull() {
         issuedBill = null;
         receivedBill = null;
@@ -74,14 +81,23 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
 
     public String navigateToPendingList() {
         makeNull();
+        admissionScoped = false;
+        admissionPatientEncounter = null;
         loadPendingIssueBills();
         return "/ward/ward_pharmacy_bht_issue_receive_list?faces-redirect=true";
     }
 
     public void loadPendingIssueBills() {
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfDay(CommonFunctions.addDaysToDate(new Date(), -7L));
+        }
+        if (toDate == null) {
+            toDate = CommonFunctions.getEndOfDay();
+        }
         String jpql = "SELECT b FROM Bill b WHERE b.billType = :bt AND b.billTypeAtomic = :bta "
                 + "AND b.patientEncounter.currentPatientRoom.roomFacilityCharge.department = :dept "
                 + "AND b.cancelled = false "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate "
                 + "AND NOT EXISTS (SELECT r FROM Bill r WHERE r.backwardReferenceBill = b "
                 + "AND r.billTypeAtomic = :acceptBta AND r.cancelled = false) "
                 + "ORDER BY b.createdAt DESC";
@@ -89,6 +105,36 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
         params.put("bt", BillType.PharmacyBhtPre);
         params.put("bta", BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
         params.put("dept", sessionController.getDepartment());
+        params.put("acceptBta", BillTypeAtomic.ACCEPT_ISSUED_MEDICINE_INWARD);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+        pendingIssueBills = billFacade.findByJpql(jpql, params);
+    }
+
+    /**
+     * Admission-scoped counterpart of {@link #navigateToPendingList()} for the
+     * Inpatient Dashboard entry point - lists pending receipts for just this
+     * admission, with no date filter, since the set is inherently small.
+     */
+    public String navigateToPendingListForAdmission(PatientEncounter encounter) {
+        makeNull();
+        admissionScoped = true;
+        admissionPatientEncounter = encounter;
+        loadPendingIssueBillsForAdmission(encounter);
+        return "/ward/ward_pharmacy_bht_issue_receive_list_for_admission?faces-redirect=true";
+    }
+
+    private void loadPendingIssueBillsForAdmission(PatientEncounter encounter) {
+        String jpql = "SELECT b FROM Bill b WHERE b.billType = :bt AND b.billTypeAtomic = :bta "
+                + "AND b.patientEncounter = :encounter "
+                + "AND b.cancelled = false "
+                + "AND NOT EXISTS (SELECT r FROM Bill r WHERE r.backwardReferenceBill = b "
+                + "AND r.billTypeAtomic = :acceptBta AND r.cancelled = false) "
+                + "ORDER BY b.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bt", BillType.PharmacyBhtPre);
+        params.put("bta", BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
+        params.put("encounter", encounter);
         params.put("acceptBta", BillTypeAtomic.ACCEPT_ISSUED_MEDICINE_INWARD);
         pendingIssueBills = billFacade.findByJpql(jpql, params);
     }
@@ -294,8 +340,10 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
     }
 
     public String navigateBackToPendingList() {
-        makeNull();
-        return "/ward/ward_pharmacy_bht_issue_receive_list?faces-redirect=true";
+        if (admissionScoped && admissionPatientEncounter != null) {
+            return navigateToPendingListForAdmission(admissionPatientEncounter);
+        }
+        return navigateToPendingList();
     }
 
     public Bill getIssuedBill() {
@@ -334,5 +382,37 @@ public class WardPharmacyBhtIssueReceiveController implements Serializable {
 
     public void setPrintPreview(boolean printPreview) {
         this.printPreview = printPreview;
+    }
+
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public PatientEncounter getAdmissionPatientEncounter() {
+        return admissionPatientEncounter;
+    }
+
+    public void setAdmissionPatientEncounter(PatientEncounter admissionPatientEncounter) {
+        this.admissionPatientEncounter = admissionPatientEncounter;
+    }
+
+    public boolean isAdmissionScoped() {
+        return admissionScoped;
+    }
+
+    public void setAdmissionScoped(boolean admissionScoped) {
+        this.admissionScoped = admissionScoped;
     }
 }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -976,7 +976,7 @@
                                             id="btnReceiveMedicinesFromPharmacyInpatient"
                                             value="Receive Medicines from Pharmacy"
                                             ajax="false"
-                                            action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
+                                            action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingListForAdmission(admissionController.current)}"
                                             icon="fa fa-truck-medical"
                                             rendered="#{webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
                                             class="w-100"/>

--- a/src/main/webapp/resources/pharmacy/inward/bhtIssueReceiveA4.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/bhtIssueReceiveA4.xhtml
@@ -1,0 +1,220 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="a4bill" style="align-content: center">
+
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>
+                </div>
+            </div>
+
+            <div class="" style="text-align: center; margin-top: 10px; font-weight: bold;font-size: 13pt">
+                <h:outputLabel value="Medicines Received" />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <br/>
+                <hr/>
+                <br/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 99%!important;" >
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Bill No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.deptId}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Received At" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MMM/yyyy hh:mm a" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter ne null}">
+                        <tr >
+                            <td style="text-align: left;" >
+                                <h:outputLabel value="BHT No " class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td style="width: 10px;"></td>
+                            <td >:</td>
+                            <td style="width: 5px;"></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;"></td>
+                            <td>
+                                <h:outputLabel value="Patient" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td>
+                                <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" class="billDetailsFiveFive"></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Issued From" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.fromDepartment.name}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Received Into" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.department.name}" class="billDetailsFiveFive"></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Carried By" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td colspan="5">
+                            <h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                </table>
+            </div>
+
+            <div class="itemHeadingsFiveFive" >
+
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td colspan="3" style="text-align: center;" class="billline">
+                            <hr/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width:55%!important;">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width:25%!important;">
+                            <h:outputLabel value="BATCH / EXPIRY" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td  style="width:20%!important;text-align: right; padding-right: 30px!important">
+                            <h:outputLabel value="RECEIVED QTY"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="3" style="text-align: center;" class="billline">
+                            <hr/>
+                        </td>
+                    </tr>
+
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip"   >
+                        <tr>
+                            <td style="overflow: visible;">
+                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.item.name}" style="text-transform: capitalize!important;" ></h:outputLabel>
+                            </td>
+                            <td>
+                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.pharmaceuticalBillItem.itemBatch.batchNo}"></h:outputLabel>
+                                <h:outputLabel class="itemsBlockRightFiveFive" value=" / "/>
+                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right;" >
+                                <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.pharmaceuticalBillItem.qty}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+
+                </table>
+            </div>
+
+            <div class="billline">
+                <br/>
+                <hr/>
+                <br/>
+            </div>
+
+            <div  >
+                <table style="width: 100%;">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.billItems.size()}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Received By : " />
+                        </td>
+                        <td class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.bill.creater.staff.code}" ></h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer" style="text-align: center;">
+                <br/>
+                <h:outputLabel value="#{sessionController.userPreference.pharmacyBillFooter}"/>
+                <br/>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/inward/bhtIssueReceiveFiveFive.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/bhtIssueReceiveFiveFive.xhtml
@@ -1,0 +1,179 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbill" style="border: 1px solid black;">
+
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1} "/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Medicines Received"   />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billDetails" >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td style="width: 30%; text-align: left;" >
+                            <h:outputLabel value="Date" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails" style="font-size: 10px!important">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MMM/yyyy hh:mm a" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30%;text-align: left;" >
+                            <h:outputLabel value="Bill No" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.deptId}"  class="billDetails" style="font-size: 10px!important">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter ne null}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: left;" >
+                                <h:outputLabel value="BHT" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 60%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" class="billDetails" style="font-size: 10px!important">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="width: 30% ;text-align: left;" >
+                                <h:outputLabel value="Patient" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 60%;text-align: left;">
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"  class="billDetails" style="font-size: 10px!important">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Received Into" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.department.name}" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Carried By" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" class="billDetails" style="font-size: 10px!important"></h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="w-100">
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td style="width: 55%; padding-left: 20px;">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        <td  style="width:10%;text-align: right; padding-right: 30px;">
+                            <h:outputLabel value="QTY"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td colspan="4" >
+                            <div class="billline">
+                                <h:outputLabel value="-----------------------------------------------"   />
+                            </div>
+                        </td>
+                    </tr>
+
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" >
+                        <tr>
+                            <td colspan="1" style="overflow: visible; padding-left: 20px;">
+                                <h:outputLabel value="#{bip.searialNo+1}  -  #{bip.item.name}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
+                                </h:outputLabel>
+                            </td>
+                            <td>
+                                <h:outputLabel value="#{bip.pharmaceuticalBillItem.qty}" styleClass="itemsBlock" style="text-align: left;" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div  >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left; padding-left: 20px;">
+                            <h:outputLabel   value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                            <h:outputLabel   value="#{cc.attrs.bill.billItems.size()}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <br></br>
+            <br></br>
+
+            <div class="cashierPrinting">
+                <h:outputLabel value="Received By : #{cc.attrs.bill.creater.staff.code}"/>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/inward/bhtIssueReceivePos.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/bhtIssueReceivePos.xhtml
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbill" style="margin-left: 50px; page-break-after: always;">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.department.address}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone1} "/>
+                    <h:outputLabel value="#{cc.attrs.bill.department.telephone2}"/>
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Medicines Received" />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billDetails" >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td style="width: 30%; text-align: left;" >
+                            <h:outputLabel value="Date" class="billDetails" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails" >
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="dd/MMM/yyyy hh:mm a" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Bill No" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.deptId}" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter ne null}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: left;" >
+                                <h:outputLabel value="BHT No" ></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 60%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" ></h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="width: 30% ;text-align: left;" >
+                                <h:outputLabel value="Patient" ></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 60%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" ></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Issued From" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.fromDepartment.name}" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Received Into" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.department.name}" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel value="Carried By" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 60%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.toStaff.person.nameWithTitle}" ></h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline" style="width: 90%; margin-left: 5%;">
+                <hr/>
+            </div>
+
+            <div >
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td style="width: 45%; padding-right: 10px;">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        <td  style="width:35%;text-align: left;">
+                            <h:outputLabel value="BATCH / EXPIRY"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        <td  style="width:20%;text-align: right; padding-right: 10px;">
+                            <h:outputLabel value="QTY"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td colspan="3" class="w-100">
+                            <h:outputLabel value="------------------------------------------------------------"   />
+                        </td>
+                    </tr>
+
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                        <tr>
+                            <td colspan="3" style="overflow: visible;">
+                                <h:outputLabel value="#{bip.searialNo+1} - #{bip.item.name}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>
+                                <h:outputLabel styleClass="itemsBlock" value="#{bip.pharmaceuticalBillItem.itemBatch.batchNo}"></h:outputLabel>
+                                <h:outputLabel styleClass="itemsBlock" value=" / "/>
+                                <h:outputLabel styleClass="itemsBlock" value="#{bip.pharmaceuticalBillItem.itemBatch.dateOfExpire}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                </h:outputLabel>
+                            </td>
+                            <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 10px;" >
+                                <h:outputLabel styleClass="itemsBlockRight" value="#{bip.pharmaceuticalBillItem.qty}"    >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+
+                </table>
+            </div>
+
+            <div class="billline" style="width: 90%; margin-left: 5%;">
+                <hr/>
+            </div>
+
+            <div  >
+                <table style="width: 100%;">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel   value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsBlock">
+                            <h:outputLabel   value="#{cc.attrs.bill.billItems.size()}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer">
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_receive.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_receive.xhtml
@@ -4,19 +4,41 @@
                 template="/resources/template/template.xhtml"
                 xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:f="http://xmlns.jcp.org/jsf/core">
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward">
 
     <ui:define name="content">
         <h:form id="wardPharmacyBhtIssueReceiveForm" onkeypress="if(event.keyCode == 13 &amp;&amp; event.target.type != 'textarea') { return false; }">
 
             <p:panel rendered="#{!wardPharmacyBhtIssueReceiveController.printPreview}">
                 <f:facet name="header">
-                    <div class="d-flex justify-content-between align-items-center">
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                         <div>
                             <h:outputText styleClass="fa-solid fa-truck-medical"/>
                             <p:outputLabel value="Receive Medicines - Bill #{wardPharmacyBhtIssueReceiveController.issuedBill.deptId}" class="mx-4"/>
                         </div>
-                        <div>
+                        <div class="d-flex gap-2 flex-wrap">
+                            <p:commandButton
+                                id="btnInpatientDashboard"
+                                value="Inpatient Dashboard"
+                                icon="fa fa-id-card"
+                                ajax="false"
+                                class="ui-button-secondary"
+                                rendered="#{wardPharmacyBhtIssueReceiveController.issuedBill ne null}"
+                                action="#{admissionController.navigateToAdmissionProfilePage}">
+                                <f:setPropertyActionListener
+                                    value="#{wardPharmacyBhtIssueReceiveController.issuedBill.patientEncounter}"
+                                    target="#{admissionController.current}"/>
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnNursingWorkBenchView"
+                                value="Nursing WorkBench"
+                                title="Back to the nursing workbench"
+                                rendered="#{webUserController.hasPrivilege('NursingWorkBench')}"
+                                action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
+                                ajax="false"
+                                class="ui-button-info ui-button-outlined"
+                                icon="fa fa-arrow-left"/>
                             <p:commandButton
                                 id="btnBackToPendingList"
                                 value="Back to List"
@@ -94,59 +116,131 @@
 
                 <p:messages showDetail="true"/>
 
-                <div class="row mb-3">
-                    <div class="col-md-3">
-                        <h:outputLabel value="BHT No" class="fw-bold"/>
-                        <p:outputLabel value="#{wardPharmacyBhtIssueReceiveController.receivedBill.patientEncounter.bhtNo}" class="d-block"/>
-                    </div>
-                    <div class="col-md-3">
-                        <h:outputLabel value="Patient" class="fw-bold"/>
-                        <p:outputLabel value="#{wardPharmacyBhtIssueReceiveController.receivedBill.patientEncounter.patient.person.nameWithTitle}" class="d-block"/>
-                    </div>
-                    <div class="col-md-3">
-                        <h:outputLabel value="Received Into" class="fw-bold"/>
-                        <p:outputLabel value="#{wardPharmacyBhtIssueReceiveController.receivedBill.department.name}" class="d-block"/>
-                    </div>
-                    <div class="col-md-3">
-                        <h:outputLabel value="Received At" class="fw-bold"/>
-                        <p:outputLabel value="#{wardPharmacyBhtIssueReceiveController.receivedBill.createdAt}" class="d-block">
-                            <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                        </p:outputLabel>
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                    <p:commandButton
+                        id="btnBackToPendingListAfterReceive"
+                        value="Back to Pending List"
+                        icon="fas fa-arrow-left"
+                        ajax="false"
+                        class="ui-button-secondary"
+                        action="#{wardPharmacyBhtIssueReceiveController.navigateBackToPendingList}"/>
+
+                    <div class="d-flex gap-2 flex-wrap">
+                        <p:commandButton
+                            id="btnInpatientDashboardAfterReceive"
+                            value="Inpatient Dashboard"
+                            icon="fa fa-id-card"
+                            ajax="false"
+                            class="ui-button-secondary"
+                            action="#{admissionController.navigateToAdmissionProfilePage}">
+                            <f:setPropertyActionListener
+                                value="#{wardPharmacyBhtIssueReceiveController.receivedBill.patientEncounter}"
+                                target="#{admissionController.current}"/>
+                        </p:commandButton>
+                        <p:commandButton
+                            id="btnNursingWorkBenchViewAfterReceive"
+                            value="Nursing WorkBench"
+                            title="Back to the nursing workbench"
+                            rendered="#{webUserController.hasPrivilege('NursingWorkBench')}"
+                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
+                            ajax="false"
+                            class="ui-button-info ui-button-outlined"
+                            icon="fa fa-arrow-left"/>
+                        <p:commandButton
+                            id="btnBhtIssueReceivePrintConfig"
+                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                            value="Settings"
+                            icon="fas fa-cog"
+                            class="ui-button-secondary"
+                            type="button"
+                            onclick="PF('bhtIssueReceiveConfigDialog').show();"/>
+                        <p:commandButton
+                            id="btnPrintReceivedBill"
+                            value="Print"
+                            icon="fas fa-print"
+                            class="ui-button-info"
+                            ajax="false"
+                            action="#">
+                            <p:printer target="gpBhtIssueReceiveBillPreview"/>
+                        </p:commandButton>
                     </div>
                 </div>
 
-                <p:dataTable
-                    id="receivedItemTable"
-                    rowKey="#{i.id}"
-                    value="#{wardPharmacyBhtIssueReceiveController.receivedBill.billItems}"
-                    var="i"
-                    class="w-100">
+                <h:panelGroup id="gpBhtIssueReceiveBillPreview">
 
-                    <p:column headerText="Item">
-                        <h:outputText value="#{i.item.name}"/>
-                    </p:column>
+                    <h:panelGroup
+                        rendered="#{configOptionController.getBooleanValueByKey('Pharmacy BHT Issue Receive Receipt is A4', true)}"
+                        styleClass="noBorder">
+                        <phe:bhtIssueReceiveA4 bill="#{wardPharmacyBhtIssueReceiveController.receivedBill}"/>
+                    </h:panelGroup>
 
-                    <p:column headerText="Batch No">
-                        <h:outputText value="#{i.pharmaceuticalBillItem.itemBatch.batchNo}"/>
-                    </p:column>
+                    <h:panelGroup
+                        rendered="#{configOptionController.getBooleanValueByKey('Pharmacy BHT Issue Receive Receipt is POS', false)}"
+                        styleClass="noBorder">
+                        <phe:bhtIssueReceivePos bill="#{wardPharmacyBhtIssueReceiveController.receivedBill}"/>
+                    </h:panelGroup>
 
-                    <p:column headerText="Received Quantity">
-                        <h:outputText value="#{i.pharmaceuticalBillItem.qty}">
-                            <f:convertNumber pattern="#,##0.00"/>
-                        </h:outputText>
-                    </p:column>
+                    <h:panelGroup
+                        rendered="#{configOptionController.getBooleanValueByKey('Pharmacy BHT Issue Receive Receipt is FiveFive', false)}"
+                        styleClass="noBorder">
+                        <phe:bhtIssueReceiveFiveFive bill="#{wardPharmacyBhtIssueReceiveController.receivedBill}"/>
+                    </h:panelGroup>
 
-                </p:dataTable>
-
-                <p:commandButton
-                    id="btnBackToPendingListAfterReceive"
-                    value="Back to Pending List"
-                    icon="fas fa-arrow-left"
-                    ajax="false"
-                    class="ui-button-secondary mt-3"
-                    action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"/>
+                </h:panelGroup>
 
             </p:panel>
+
+            <!-- BHT Issue Receive Print Configuration Dialog -->
+            <p:dialog id="bhtIssueReceiveConfigDialog"
+                      header="BHT Issue Receive Printer Configuration"
+                      widgetVar="bhtIssueReceiveConfigDialog"
+                      modal="true"
+                      width="500"
+                      resizable="false"
+                      closeOnEscape="true">
+
+                <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="bhtIssueReceiveConfigForm"/>
+
+                <h:form id="bhtIssueReceiveConfigForm">
+                    <div class="mb-3">
+                        <h:selectBooleanCheckbox
+                            id="cbBhtIssueReceiveA4"
+                            value="#{pharmacyConfigController.bhtIssueReceiveReceiptA4}"/>
+                        <h:outputLabel for="cbBhtIssueReceiveA4" value="A4 Paper" class="ms-2"/>
+                    </div>
+                    <div class="mb-3">
+                        <h:selectBooleanCheckbox
+                            id="cbBhtIssueReceivePos"
+                            value="#{pharmacyConfigController.bhtIssueReceiveReceiptPos}"/>
+                        <h:outputLabel for="cbBhtIssueReceivePos" value="POS Paper" class="ms-2"/>
+                    </div>
+                    <div class="mb-3">
+                        <h:selectBooleanCheckbox
+                            id="cbBhtIssueReceiveFiveFive"
+                            value="#{pharmacyConfigController.bhtIssueReceiveReceiptFiveFive}"/>
+                        <h:outputLabel for="cbBhtIssueReceiveFiveFive" value="5 x 5 Paper" class="ms-2"/>
+                    </div>
+
+                    <p:messages showDetail="true" closable="true"/>
+
+                    <div class="d-flex gap-2">
+                        <p:commandButton
+                            id="btnApplyBhtIssueReceiveConfig"
+                            value="Apply &amp; Close"
+                            icon="fas fa-save"
+                            class="ui-button-success"
+                            ajax="false"
+                            action="#{pharmacyConfigController.saveConfig}"/>
+                        <p:commandButton
+                            id="btnCancelBhtIssueReceiveConfig"
+                            value="Cancel"
+                            icon="fas fa-times"
+                            class="ui-button-secondary"
+                            onclick="PF('bhtIssueReceiveConfigDialog').hide(); return false;"
+                            type="button"/>
+                    </div>
+                </h:form>
+            </p:dialog>
         </h:form>
     </ui:define>
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_receive_list_for_admission.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_receive_list_for_admission.xhtml
@@ -7,40 +7,40 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <ui:define name="content">
-        <h:form id="wardPharmacyBhtIssueReceiveListForm">
+        <h:form id="wardPharmacyBhtIssueReceiveListForAdmissionForm">
             <p:panel class="w-100">
                 <f:facet name="header">
                     <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                         <div>
                             <h:outputText styleClass="fa-solid fa-truck-medical"/>
-                            <p:outputLabel value="Medicines Pending Receipt - #{sessionController.department.name}" class="mx-4"/>
+                            <p:outputLabel value="Medicines Pending Receipt - BHT #{wardPharmacyBhtIssueReceiveController.admissionPatientEncounter.bhtNo} - #{wardPharmacyBhtIssueReceiveController.admissionPatientEncounter.patient.person.nameWithTitle}" class="mx-4"/>
                         </div>
-                        <div class="d-flex align-items-center gap-2">
-                            <h:outputLabel value="From" class="mx-1"/>
-                            <p:calendar id="fromDate" value="#{wardPharmacyBhtIssueReceiveController.fromDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" inputStyleClass="form-control"/>
-                            <h:outputLabel value="To" class="mx-1"/>
-                            <p:calendar id="toDate" value="#{wardPharmacyBhtIssueReceiveController.toDate}" pattern="#{sessionController.applicationPreference.shortDateFormat}" inputStyleClass="form-control"/>
+                        <div class="d-flex gap-2">
                             <p:commandButton
-                                id="btnSearchPendingList"
-                                value="Search"
-                                icon="fas fa-search"
+                                id="btnInpatientDashboardFromReceiveList"
+                                value="Inpatient Dashboard"
+                                icon="fa fa-id-card"
                                 ajax="false"
-                                class="ui-button-success mx-1"
-                                action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"/>
+                                class="ui-button-secondary"
+                                action="#{admissionController.navigateToAdmissionProfilePage}">
+                                <f:setPropertyActionListener
+                                    value="#{wardPharmacyBhtIssueReceiveController.admissionPatientEncounter}"
+                                    target="#{admissionController.current}"/>
+                            </p:commandButton>
                             <p:commandButton
-                                id="btnRefreshPendingList"
+                                id="btnRefreshPendingListForAdmission"
                                 value="Refresh"
                                 icon="fas fa-sync"
                                 ajax="false"
                                 class="ui-button-secondary"
-                                action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"/>
+                                action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingListForAdmission(wardPharmacyBhtIssueReceiveController.admissionPatientEncounter)}"/>
                         </div>
                     </div>
                 </f:facet>
 
                 <p:dataTable
-                    id="pendingIssueTable"
-                    widgetVar="pendingIssueTable"
+                    id="pendingIssueTableForAdmission"
+                    widgetVar="pendingIssueTableForAdmission"
                     rowKey="#{p.id}"
                     value="#{wardPharmacyBhtIssueReceiveController.pendingIssueBills}"
                     var="p"
@@ -50,18 +50,10 @@
                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                     rowsPerPageTemplate="5,10,15"
                     class="w-100"
-                    emptyMessage="No pending medicine receipts for this ward.">
+                    emptyMessage="No pending medicine receipts for this admission.">
 
                     <p:column headerText="Bill No">
                         <h:outputText value="#{p.deptId}"/>
-                    </p:column>
-
-                    <p:column headerText="BHT No">
-                        <h:outputLabel value="#{p.patientEncounter.bhtNo}"/>
-                    </p:column>
-
-                    <p:column headerText="Patient">
-                        <h:outputLabel value="#{p.patientEncounter.patient.person.nameWithTitle}"/>
                     </p:column>
 
                     <p:column headerText="Issued From">
@@ -84,7 +76,7 @@
 
                     <p:column headerText="Actions">
                         <p:commandButton
-                            id="btnReceive"
+                            id="btnReceiveForAdmission"
                             title="Receive Medicines #{p.deptId}"
                             class="ui-button-success m-1"
                             ajax="false"


### PR DESCRIPTION
## Summary

Fixes the three usability gaps in the "Receive Medicines from Pharmacy" flow (`WardPharmacyBhtIssueReceiveController`, #21467) reported in #22154:

1. **Split entry points**: Nursing Workbench still routes to the department-wide `ward_pharmacy_bht_issue_receive_list.xhtml`, now with **From/To Date filters** (defaulting to the last 7 days) wired into `loadPendingIssueBills()`. The Inpatient Dashboard button now routes to a **new admission-scoped page** (`ward_pharmacy_bht_issue_receive_list_for_admission.xhtml`) via `navigateToPendingListForAdmission(PatientEncounter)`, with no date filter since the set is inherently small.
2. **Navigation buttons**: `ward_pharmacy_bht_issue_receive.xhtml` (the confirm page) now has **Inpatient Dashboard** and **Nursing WorkBench** buttons on both the pre-confirm and post-confirm (print-preview) panels, matching the existing pattern from `ward_pharmacy_bht_issue.xhtml` and `ward_pharmacy_bht_issue_request_bill.xhtml`. `navigateBackToPendingList()` now dispatches back to whichever list originated the flow (admission-scoped vs department-wide).
3. **Print composites**: the plain `p:dataTable` print preview is replaced with proper **A4/POS/FiveFive** print composites (`resources/pharmacy/inward/bhtIssueReceive{A4,Pos,FiveFive}.xhtml`), toggled via a department-scoped gear/Settings dialog (new `PharmacyConfigController` fields + `configOptionController`), following the `pharmacy_transfer_receive.xhtml` config-button pattern (not the deprecated paper-type dropdown).

## Verification

Built and redeployed locally (`mvn clean package` — 149 tests pass, no compile warnings beyond pre-existing ones), then verified end-to-end with Playwright against a local Payara instance, logged in as a real ward user (department: Inward) against a real pending BHT issue bill:

- **Flow A (Inpatient Dashboard → admission-scoped)**: navigated to the admission profile, clicked "Receive Medicines from Pharmacy" → landed on the new admission-scoped list (header shows patient name + BHT, no date filter) → clicked Receive → confirmed the new Inpatient Dashboard / Nursing WorkBench buttons render on the confirm page → clicked Confirm Receipt (JS dialog accepted) → verified the print-preview panel renders with Settings/Print buttons and the same nav buttons.
  - Verified in the DB: the `ACCEPT_ISSUED_MEDICINE_INWARD` receive bill was created correctly, linked back to the issue bill via `backwardReferenceBill`, correct patient encounter and department.
  - Toggled the Settings dialog through all 3 checkbox combinations — confirmed A4, POS, and FiveFive composites each render without error (verified via screenshots and `server.log`/browser console — no errors in either).
- **Flow B (Nursing Workbench → department-wide)**: after Flow A, navigated via Nursing Workbench → "Receive Medicines from Pharmacy" → confirmed the department-wide list now shows From/To Date calendar filters (defaulting to the last 7 days) and correctly shows "No pending medicine receipts for this ward" since the only pending bill for that ward was just received in Flow A — confirms the `NOT EXISTS`/date-filter JPQL still excludes already-received bills correctly.

Screenshots were captured during testing but are not attached here — they contained live patient name/BHT data from the local test DB and publishing them (even redacted) was blocked by policy since redaction correctness can't be independently verified. Happy to share screen or walk through the flow live if useful for review.

## Test plan

- [x] `mvn clean package` — build + unit tests pass
- [x] Playwright E2E: admission-scoped entry point (Inpatient Dashboard → list → receive → confirm → print preview)
- [x] Playwright E2E: department-wide entry point (Nursing Workbench → date-filtered list → empty after receive)
- [x] DB verification: receive bill created with correct `backwardReferenceBill`, `patientEncounter`, `department`
- [x] All 3 print formats (A4/POS/FiveFive) toggle and render without error
- [x] No `server.log` or browser console errors during any step

Closes #22154

🤖 Generated with [Claude Code](https://claude.ai/code)