### PR TITLE
fix(inventory-reports,pharmacy): show selected values in selectCheckboxMenu filters

### DIFF
--- a/src/main/webapp/pharmacy/auto_ordering_by_distributor.xhtml
+++ b/src/main/webapp/pharmacy/auto_ordering_by_distributor.xhtml
@@ -65,7 +65,8 @@
 
                                         <h:outputLabel value="Bill types" ></h:outputLabel>
                                         <p:selectCheckboxMenu class="w-100 mx-2"  value="#{reorderController.billTypes}" 
-                                                              label="Select Bill Types"  >
+                                                              label="Select Bill Types"
+                                                              updateLabel="true"  >
                                             <f:selectItems value="#{enumController.pharmacyBillTypes}" var="pbt" itemLabel="#{pbt.label}" itemValue="#{pbt}" ></f:selectItems>
                                         </p:selectCheckboxMenu>
 

--- a/src/main/webapp/pharmacy/direct_purchase_summery_report.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase_summery_report.xhtml
@@ -202,7 +202,7 @@
 
 
 
-                            <p:selectCheckboxMenu value="#{pharmacyReportController.fromInstitutionList}" label="Select Suppliers"
+                            <p:selectCheckboxMenu value="#{pharmacyReportController.fromInstitutionList}" label="Select Suppliers" updateLabel="true"
                                                   id="supplierMenu"
                                                   filter="true"
                                                   class="w-100"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_fast_moving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_fast_moving.xhtml
@@ -27,7 +27,7 @@
                                             value="#{reportsTransfer.department}"  >
                             </p:autoComplete>
                             <h:outputLabel value="Movement Type" ></h:outputLabel>
-                            <p:selectCheckboxMenu  class="w-100 mx-2" value="#{reportsTransfer.billTypes}" label="Bill Types"  >
+                            <p:selectCheckboxMenu  class="w-100 mx-2" value="#{reportsTransfer.billTypes}" label="Bill Types" updateLabel="true"  >
                                 <f:selectItems value="#{enumController.pharmacyBillTypes3}" var="pbt" itemLabel="#{pbt.label}" itemValue="#{pbt}" ></f:selectItems>
                             </p:selectCheckboxMenu>
                             <h:outputLabel value="From" ></h:outputLabel>

--- a/src/main/webapp/pharmacy/pharmacy_report_department_non_moving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_non_moving.xhtml
@@ -34,7 +34,7 @@
                         >
                         </p:autoComplete>
                         <h:outputLabel value="Movement Type"></h:outputLabel>
-                        <p:selectCheckboxMenu class="w-100 mx-4" value="#{reportsStock.billTypes}" label="Bill Types">
+                        <p:selectCheckboxMenu class="w-100 mx-4" value="#{reportsStock.billTypes}" label="Bill Types" updateLabel="true">
                             <f:selectItems value="#{enumController.pharmacyBillTypes3}" var="pbt"
                                            itemLabel="#{pbt.label}" itemValue="#{pbt}"></f:selectItems>
                         </p:selectCheckboxMenu>

--- a/src/main/webapp/pharmacy/pharmacy_report_department_slow_moving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_slow_moving.xhtml
@@ -25,7 +25,7 @@
                                 <p:autoComplete class="w-100 mx-4" inputStyleClass="w-100" completeMethod="#{departmentController.completeDept}" var="dept" itemLabel="#{dept.name}" itemValue="#{dept}" forceSelection="true" value="#{reportsTransfer.department}"  >
                                 </p:autoComplete>
                             <h:outputLabel value="Movement Type" ></h:outputLabel>
-                                <p:selectCheckboxMenu class="w-100 mx-4" value="#{reportsTransfer.billTypes}" label="Bill Type">
+                                <p:selectCheckboxMenu class="w-100 mx-4" value="#{reportsTransfer.billTypes}" label="Bill Type" updateLabel="true">
                                     <f:selectItems value="#{enumController.pharmacyBillTypes2}" var="pbt" ></f:selectItems>
                                 </p:selectCheckboxMenu>
                             <h:outputLabel value="From" ></h:outputLabel>

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
@@ -67,6 +67,7 @@
                                             id="departmentTypeFilter"
                                             value="#{reportsStock.selectedDepartmentTypes}"
                                             label="Select Department Types"
+                                            updateLabel="true"
                                             styleClass="w-100"
                                             filter="true"
                                             filterMatchMode="contains"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary.xhtml
@@ -67,6 +67,7 @@
                                             id="departmentTypeFilter"
                                             value="#{reportsStock.selectedDepartmentTypes}"
                                             label="Select Department Types"
+                                            updateLabel="true"
                                             styleClass="w-100"
                                             filter="true"
                                             filterMatchMode="contains"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -66,6 +66,7 @@
                                             id="departmentTypeFilter"
                                             value="#{reportsStock.selectedDepartmentTypes}"
                                             label="Select Department Types"
+                                            updateLabel="true"
                                             styleClass="w-100"
                                             filter="true"
                                             filterMatchMode="contains"

--- a/src/main/webapp/pharmacy/pharmacy_report_short_expiry_by_amp_period.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_short_expiry_by_amp_period.xhtml
@@ -67,6 +67,7 @@
                                             id="departmentTypeFilter"
                                             value="#{reportsStock.selectedDepartmentTypes}"
                                             label="Select Department Types"
+                                            updateLabel="true"
                                             styleClass="w-100"
                                             filter="true"
                                             filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/add_to_stock_bills.xhtml
+++ b/src/main/webapp/reports/inventoryReports/add_to_stock_bills.xhtml
@@ -171,6 +171,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/bht_issue.xhtml
+++ b/src/main/webapp/reports/inventoryReports/bht_issue.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/closing_stock_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/closing_stock_report.xhtml
@@ -70,6 +70,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -48,6 +48,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -48,6 +48,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -65,6 +65,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     styleClass="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/expiry_item.xhtml
+++ b/src/main/webapp/reports/inventoryReports/expiry_item.xhtml
@@ -234,6 +234,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/good_in_transit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/good_in_transit.xhtml
@@ -320,6 +320,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/grn.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn.xhtml
@@ -238,6 +238,7 @@
                                 id="departmentTypeFilter"
                                 value="#{pharmacyController.selectedDepartmentTypes}"
                                 label="Select Department Types"
+                                updateLabel="true"
                                 class="w-100"
                                 filter="true"
                                 filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_cash.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_credit.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/grn_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_report.xhtml
@@ -47,6 +47,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/ip_drug_return.xhtml
+++ b/src/main/webapp/reports/inventoryReports/ip_drug_return.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/op_drug_return.xhtml
+++ b/src/main/webapp/reports/inventoryReports/op_drug_return.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/opd_credit.xhtml
+++ b/src/main/webapp/reports/inventoryReports/opd_credit.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/opd_sale.xhtml
+++ b/src/main/webapp/reports/inventoryReports/opd_sale.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/purchase_return.xhtml
+++ b/src/main/webapp/reports/inventoryReports/purchase_return.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/slow_fast_none_movement.xhtml
+++ b/src/main/webapp/reports/inventoryReports/slow_fast_none_movement.xhtml
@@ -225,6 +225,7 @@
                                 id="departmentTypeFilter"
                                 value="#{pharmacyReportController.selectedDepartmentTypes}"
                                 label="Select Department Types"
+                                updateLabel="true"
                                 class="w-100"
                                 filter="true"
                                 filterMatchMode="contains"
@@ -326,6 +327,7 @@
                                 class="w-100"
                                 value="#{pharmacyReportController.billTypes}"
                                 label="All Bill Types"
+                                updateLabel="true"
                                 title="Leave empty to include all bill types">
                             <f:selectItems
                                     value="#{enumController.pharmacyBillTypesForMovementReports}"

--- a/src/main/webapp/reports/inventoryReports/stock_adjustment_issue.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_adjustment_issue.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_adjustment_receive.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_adjustment_receive.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_consumption.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
@@ -50,6 +50,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_correction.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_correction.xhtml
@@ -57,6 +57,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_ledger.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_ledger.xhtml
@@ -255,6 +255,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_ledger_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_ledger_dto.xhtml
@@ -276,6 +276,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/stock_transfer_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_transfer_report.xhtml
@@ -345,6 +345,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/transfer_issue.xhtml
+++ b/src/main/webapp/reports/inventoryReports/transfer_issue.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"

--- a/src/main/webapp/reports/inventoryReports/transfer_receive.xhtml
+++ b/src/main/webapp/reports/inventoryReports/transfer_receive.xhtml
@@ -56,6 +56,7 @@
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
                                     label="Select Department Types"
+                                    updateLabel="true"
                                     class="w-100"
                                     filter="true"
                                     filterMatchMode="contains"


### PR DESCRIPTION
## Summary
- The Stock Ledger report's Department Type filter (`p:selectCheckboxMenu`) never showed the selected value back to the user — it always displayed the static placeholder text, even after checking items.
- Root cause: PrimeFaces `p:selectCheckboxMenu` defaults `updateLabel` to `false`, so the widget's label never refreshes to reflect the current selection unless explicitly enabled.
- Fix: added `updateLabel="true"` to every affected `p:selectCheckboxMenu` filter (department type, bill type, supplier) across the **Inventory Reports** and **Pharmacy** report modules — the same copy-pasted pattern was missing it in 36 files, not just Stock Ledger.

## Files changed
- `reports/inventoryReports/*` (27 files) — department type filters, plus `slow_fast_none_movement.xhtml`'s bill type filter
- `pharmacy/*` (9 files) — department type, bill type, and supplier filters

Scope was intentionally limited to Inventory + Pharmacy reports (the module this issue and its parent #21992 live in). The same missing-`updateLabel` pattern also exists in ~18 unrelated files (salary reports, channel/OPD, EMR, cashier) — left out of this PR, flagged for a separate follow-up if wanted.

## Test plan
- [x] Reproduced the bug live on Stock Ledger: selected "Pharmacy", closed dropdown — box still showed placeholder "Department Type" (before fix)
- [x] Applied `updateLabel="true"` fix, hot-synced XHTML, reloaded
- [x] Stock Ledger: single selection ("Pharmacy") and multi-selection ("Pharmacy, Store") now display correctly
- [x] Spot-checked `grn_cash.xhtml` (different file, different attribute-ordering style) — selecting "Kitchen" now displays correctly
- [x] All 36 changed files validated as well-formed XML
- [x] JSF-only changes, no Java touched, no compilation needed

Closes #22148

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple department-type and related multi-select filters across inventory and pharmacy reports so their checkbox menu labels now refresh to reflect the current selections.
  * Improved label updating for bill/supplier multi-select controls where applicable, ensuring the on-screen filter summary stays accurate after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->