### PR TITLE
feat(pharmacy): warn on repeated medication orders for same inpatient

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -685,6 +685,49 @@ expecting the request to be saved, a DB check afterward will show nothing was cr
 **"Settle Request"** (confirm-dialog-guarded) to actually persist a BHT pharmacy request. Verified while
 testing issue #22153.
 
+## 31. `ward_pharmacy_bht_issue_request_bill.xhtml`'s "Add Dispense Only" path sets `department`/`toDepartment` backwards
+
+`PharmacyRequestForBhtController`'s no-prescription creation path (the one behind
+"Add Dispense Only" → "Settle Request") sets `getPreBill().setToDepartment(getDepartment())`,
+where `getDepartment()` is the page's *Requesting Department* selector (the ward, e.g.
+"Inward") — the opposite of what the prescription-based "Calculate & Add" path does. The
+resulting bill ends up with `department` = the requesting ward and `toDepartment` = the
+requesting ward too, instead of `toDepartment` = the fulfilling pharmacy. Per §16, the
+pharmacist's "Issue Medicines" list (`ward_pharmacy_bht_issue_request_list_for_issue.xhtml`)
+filters on `toDepartment = session department`, so a request created via "Add Dispense Only"
+silently never appears there — "Search All"/"Search Not Issued" both return "No records
+found." even with the correct BHT number. This looks like a pre-existing, unrelated bug (not
+reproducible via the prescription-based creation path) — found incidentally while testing
+issue #22000; not fixed there since it was out of that issue's scope. If blocked on this
+during a future E2E pass, either use "Calculate & Add" instead of "Add Dispense Only" to
+create the test request, or correct `BILL.DEPARTMENT_ID`/`TODEPARTMENT_ID` directly in the
+local dev DB to unblock testing.
+
+## 32. A `FacesMessage` can be server-confirmed even when the browser never shows it
+
+Two related traps when checking whether `JsfUtil.addWarningMessage(...)` actually fired:
+
+- **A page-local `p:growl` without a `life` attribute never auto-dismisses**, unlike
+  `template.xhtml`'s global growl (`life="3000"`). If a later click lands on where the toast is
+  rendered, Playwright's actionability check reports `<span class="ui-growl-title">...
+  intercepts pointer events` and the click times out. Work around it in a test session with
+  `browser_evaluate`: `() => document.querySelectorAll('.ui-growl-item').forEach(el =>
+  el.remove())` — do not treat this as something the product code needs to fix unless the
+  issue you're working on is specifically about that page's growl behavior.
+- **On an `ajax="false"` (full-postback) button, a `life`-bound growl can auto-hide before you
+  take a snapshot**, making it look like the message never fired even though it did. Don't
+  trust a missed visual — inspect the actual HTTP response instead:
+  `browser_network_requests` (filter on the page's `.xhtml`, `static: true` if needed) to find
+  the POST matching the button's `name` parameter (e.g. `j_idt523%3AbtnAdd=`), then
+  `browser_network_request` with `part: "response-body"` on that index. For an AJAX
+  (`javax.faces.partial.ajax=true`) update, look for `<update id="...:growl">` containing
+  `PrimeFaces.cw("Growl",...,msgs:[{summary:"...",severity:'warn'}]})`. For a full postback,
+  grep the (often huge) HTML response body for the expected message text instead of loading it
+  into context. Verified while testing issue #22000, where this was the deciding evidence that
+  the warning fired correctly on a page whose *unrelated* pre-existing widget-init JS error
+  (`TypeError: Cannot read properties of undefined (reading 'hasAttribute')`, present since
+  before any interaction) prevented the growl from rendering visually at all.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -16,6 +16,7 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -408,6 +409,14 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
                     JsfUtil.addErrorMessage("This batch is already in the bill. Edit the quantity instead.");
                     return;
                 }
+            }
+        }
+
+        if (patientEncounter != null && selectedStockDto.getItemId() != null) {
+            Item candidateItem = itemFacade.getReference(selectedStockDto.getItemId());
+            String reorderMsg = pharmacyService.getReorderWarningMessage(patientEncounter, candidateItem);
+            if (!reorderMsg.isEmpty()) {
+                JsfUtil.addWarningMessage(reorderMsg);
             }
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1445,6 +1445,11 @@ public class PharmacyRequestForBhtController implements Serializable {
 
         }
 
+        String reorderMsg = pharmacyService.getReorderWarningMessage(patientEncounter, billItem.getItem());
+        if (!reorderMsg.isEmpty()) {
+            JsfUtil.addWarningMessage(reorderMsg);
+        }
+
         // Create a new billItem for the collection to avoid entity state issues
         BillItem newBillItem = new BillItem();
         newBillItem.setItem(billItem.getItem());

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2449,6 +2449,12 @@ public class PharmacySaleBhtController implements Serializable {
         billItem.setInwardChargeType(InwardChargeType.Medicine);
 
         billItem.setItem(getTmpStock().getItemBatch().getItem());
+
+        String reorderMsg = pharmacyService.getReorderWarningMessage(patientEncounter, billItem.getItem());
+        if (!reorderMsg.isEmpty()) {
+            JsfUtil.addWarningMessage(reorderMsg);
+        }
+
         billItem.setQty(qty);
 //        billItem.setBill(getPreBill());
         billItem.setSearialNo(getBillItems().size() + 1);

--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -11,6 +11,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
@@ -23,6 +24,7 @@ import com.divudi.core.entity.pharmacy.Vtm;
 import com.divudi.core.facade.ClinicalFindingValueFacade;
 import com.divudi.core.facade.AmpFacade;
 import com.divudi.core.facade.AmppFacade;
+import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.light.common.BillLight;
 import com.divudi.service.BillService;
 import java.util.ArrayList;
@@ -52,6 +54,9 @@ public class PharmacyService {
 
     @EJB
     private AmpFacade ampFacade;
+
+    @EJB
+    private BillItemFacade billItemFacade;
 
     public List<ClinicalFindingValue> getAllergyListForPatient(Patient patient) {
 
@@ -273,6 +278,59 @@ public class PharmacyService {
             }
         }
         return "";
+    }
+
+    /**
+     * Checks whether the given item already has an ACTIVE (non-cancelled,
+     * non-retired) prior order somewhere earlier in the same admission
+     * (patient encounter). This is a soft/informational check only - it does
+     * NOT block re-ordering, since doctors legitimately re-order the same
+     * medicine multiple times within one admission (e.g. reverting to an
+     * earlier antibiotic after culture/ABST results come back).
+     *
+     * @param patientEncounter the current inward admission
+     * @param item the medicine item being added
+     * @return true if an active prior order for this item exists in this
+     * admission
+     */
+    public boolean hasActiveInwardMedicineOrder(PatientEncounter patientEncounter, Item item) {
+        if (patientEncounter == null || patientEncounter.getId() == null
+                || item == null || item.getId() == null) {
+            return false;
+        }
+        String jpql = "SELECT COUNT(bi) FROM BillItem bi "
+                + "WHERE bi.retired = false "
+                + "AND bi.bill.retired = false "
+                + "AND bi.bill.cancelled = false "
+                + "AND bi.bill.patientEncounter = :pe "
+                + "AND bi.item = :item "
+                + "AND bi.bill.billTypeAtomic IN :atomics";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", patientEncounter);
+        params.put("item", item);
+        params.put("atomics", Arrays.asList(
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE,
+                BillTypeAtomic.REQUEST_MEDICINE_INWARD,
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD));
+        return billItemFacade.findLongByJpql(jpql, params) > 0;
+    }
+
+    /**
+     * Builds a soft, non-blocking warning message when the given item
+     * already has an active prior order earlier in the same admission.
+     *
+     * @param patientEncounter the current inward admission
+     * @param item the medicine item being added
+     * @return a warning message, or an empty string if there is no prior
+     * active order
+     */
+    public String getReorderWarningMessage(PatientEncounter patientEncounter, Item item) {
+        if (!hasActiveInwardMedicineOrder(patientEncounter, item)) {
+            return "";
+        }
+        return "NOTE: " + item.getName()
+                + " has already been ordered earlier during this admission. "
+                + "Re-ordering is allowed if clinically appropriate.";
     }
 
     public void addBillItemInstructions(BillItem billItem) {


### PR DESCRIPTION
## Summary

Closes #22000.

Doctors may legitimately re-order the same medicine multiple times during a single admission (e.g. start Nalidixic acid for a UTI → switch to Ciprofloxacin as the patient worsens → revert to Nalidixic acid once ABST/culture results confirm the original choice). This PR adds a **soft, non-blocking warning** instead of restricting re-ordering, shown when a medicine being added already has an active (non-cancelled) prior order earlier in the same admission — across all 3 pharmacy-inward entry points:

- Direct issue to inpatient (`InpatientDirectIssueNativeSqlController.addBillItem()`)
- Ward/doctor medication request (`PharmacyRequestForBhtController.addBillItem()`)
- Pharmacy issuing against a request (`PharmacySaleBhtController.addBillItemNew()`)

The check is purely informational (`JsfUtil.addWarningMessage`, `SEVERITY_WARN`) — it **never blocks the add**, mirroring the existing non-blocking allergy-warning pattern in `InpatientClinicalDataController`.

## Implementation

- `PharmacyService.hasActiveInwardMedicineOrder(PatientEncounter, Item)` / `getReorderWarningMessage(...)` — new helper methods alongside the existing allergy-check methods.
- JPQL queries `BillItem` via `bi.bill.patientEncounter` (not `bi.patientEncounter`, which the native-SQL direct-issue path never populates) across the 3 positive `BillTypeAtomic` values (`DIRECT_ISSUE_INWARD_MEDICINE`, `REQUEST_MEDICINE_INWARD`, `ISSUE_MEDICINE_ON_REQUEST_INWARD`), filtered by `bill.cancelled = false` so fully-cancelled prior orders are correctly ignored.
- Uses `findLongByJpql` (not `findDoubleByJpql`) per project convention for `COUNT` queries.

## Scope decisions
- Exact `Item` identity match only — no VTM/generic-name equivalence (switching between two brand items of the same generic won't trigger the warning in this pass).
- Discharge medicine issuing is out of scope (distinct end-of-admission workflow).
- No config toggle — always on, matching the allergy-warning precedent.

## Test plan

Verified end-to-end against a local Payara instance + real DB via Playwright, using a freshly created test admission (BHT/56746):

- [x] Direct-issue Paracetamol — no warning (first order for this admission).
- [x] Direct-issue Paracetamol again — warning shown, item still added successfully (add never blocked).
- [x] Ward medication request for the same medicine — warning confirmed via AJAX response (`severity:'warn'`).
- [x] Pharmacy issuing against that request — warning confirmed via full-postback HTTP response.
- [x] Cancelled prior orders correctly excluded — verified the query excludes fully-cancelled bills.
- [x] `mvn clean package` builds cleanly; server log clean of exceptions after fixing an EclipseLink `IN :list` binding issue caught during testing (see commit).

Screenshots and full verification narrative posted on the issue: https://github.com/hmislk/hmis/issues/22000#issuecomment-4991162389

Also recorded two incidental, pre-existing, out-of-scope findings (a page department-field bug and a testing technique for verifying `FacesMessage`s server-side when a page's growl doesn't render) in `developer_docs/testing/playwright-e2e-workflow.md` §31–32 for future E2E passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when a medicine has already been ordered for the current patient encounter.
  * Re-ordering remains allowed after the warning is displayed.
  * Applied reorder notifications across inpatient issue, ward request, and pharmacy sale workflows.

* **Documentation**
  * Added Playwright guidance for validating warning messages and troubleshooting dispense-only workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->