### PR TITLE
fix(ward-pharmacy): separate dispense-note comment from prescription Directions on BHT issue request

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1456,6 +1456,7 @@ public class PharmacyRequestForBhtController implements Serializable {
         newBillItem.setQty(getQty());
         newBillItem.setInwardChargeType(InwardChargeType.Medicine);
         newBillItem.setBill(getPreBill());
+        newBillItem.setInstructions(billItem.getInstructions());
         // Required so resolvePackageOverrideRate()'s cumulative-quantity JPQL (bi.patientEncounter = :pe)
         // can find this row on subsequent dispenses of the same package-listed item.
         newBillItem.setPatientEncounter(patientEncounter);

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -573,8 +573,8 @@
                                                         class="ui-button-success"
                                                         title="Calculate the dispense item and quantity from the prescription and add it to the dispense request"
                                                         action="#{pharmacyRequestForBhtController.calculateAndAddBillItem}"
-                                                        process="@this acMedicine acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"
-                                                        update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acMedicine acItem focusItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtDrugOrderComments"   >
+                                                        process="@this acMedicine acItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtComments txtDrugOrderComments"
+                                                        update="growl :#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} acMedicine acItem focusItem txtQty txtDose doseUnitPanel cmbFrequency txtDuration cmbDuration prescribedFrom prescribedTo txtComments txtDrugOrderComments"   >
                                                     </p:commandButton>
                                                 </div>
                                             </div>
@@ -658,7 +658,7 @@
                                         <div class="row mt-1">
                                             <div class="col-md-12">
                                                 <p:outputLabel value="Comment" />
-                                                <p:inputTextarea id="txtDrugOrderComments" value="#{pharmacyRequestForBhtController.billItem.prescription.comment}" class="w-100" />
+                                                <p:inputTextarea id="txtDrugOrderComments" value="#{pharmacyRequestForBhtController.billItem.instructions}" class="w-100" />
                                             </div>
                                         </div>
 
@@ -689,6 +689,9 @@
                                                         <h:outputText rendered="#{bi.prescription.duration ne null}" value="Duration: #{bi.prescription.duration} #{bi.prescription.durationUnit.name}" />
                                                     </h:panelGroup>
                                                 </h:panelGroup>
+                                            </p:column>
+                                            <p:column headerText="Comment" width="15em">
+                                                <h:outputText value="#{bi.instructions}" />
                                             </p:column>
                                             <p:column headerText="Edit" width="5em">
                                                 <p:commandButton


### PR DESCRIPTION
## Summary
- Fixes #22172: the "Directions" column on the Ward Pharmacy BHT Issue Request page (`ward_pharmacy_bht_issue_request_bill.xhtml`) was showing only the Dispense Request panel's quick-note comment instead of the prescription details, because both that box and the Prescription panel's own comment box were bound to the same `billItem.prescription.comment` field.
- The Dispense Request panel's comment box now writes to the existing (previously unused on this page) `BillItem.instructions` field, and a new dedicated **Comment** column was added to the Bill Items table to display it.
- The **Directions** column now shows only prescription-derived text (item + dose/frequency/duration + the Prescription panel's own comment, when entered there) — unchanged logic, just no longer clobbered by the other box.
- Also fixed a related bug found during verification: the "Calculate & Add" button's AJAX `process`/`update` attribute lists never included the Prescription panel's own comment field (`txtComments`), so historically its value only ever reached the server by piggy-backing on the shared field via the other box. Added it to both lists.

## Test plan
Verified end-to-end on local Payara + MySQL (`coop` DB) against inpatient BHT/56746 (Inward department):
- [x] Case A — only Dispense Request comment filled, "Add Dispense Only": Directions shows plain item/qty text, new Comment column shows the note.
- [x] Case B — Prescription panel filled (dose/frequency/duration + its own comment), "Calculate & Add": Directions shows full prescription text + its comment, Comment column empty.
- [x] Case C — both comment boxes filled: Directions and Comment stay independent of each other.
- [x] Settled the request and confirmed in MySQL that `BILLITEM.DESCREPTION` and `BILLITEM.INSTRUCTIONS` persist independently as expected.
- [x] Confirmed the Main Pharmacy issue-side page and the BHT reprint page are unaffected (neither reads `instructions`, and the reprint page's `descreption`-based Directions logic is unchanged).

Screenshots and full verification details posted on the issue: https://github.com/hmislk/hmis/issues/22172#issuecomment-4994968619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Comment column to BHT pharmacy issue requests.
  * Prescription and drug-order comments are now captured and displayed with bill items.

* **Bug Fixes**
  * Preserves item instructions when adding pharmacy request items.
  * Ensures comment fields refresh correctly after calculating and adding items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->