### PR TITLE
fix(inward,nursing): add panel and function privilege gating to Inpatient Dashboard and Nursing Workbench

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -215,15 +215,6 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelDocuments, "Documents Panel"), dashboardPanelsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelReports, "Reports Panel"), dashboardPanelsNode);
 
-        TreeNode nursingWorkBenchPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Workbench Panels"), inwardNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelEdit, "Edit Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelClinicalData, "Clinical Data Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelRoomManagement, "Room Management Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelService, "Service Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
-
         TreeNode inwardSurgeryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Surgery"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryAdd, "Add Surgery"), inwardSurgeryNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryManage, "Manage Surgery"), inwardSurgeryNode);
@@ -991,7 +982,15 @@ public class UserPrivilageController implements Serializable {
         TreeNode showDrugCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowDrugCharges, "Show Drug Charges"), nurseNode);
         TreeNode ShowServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowServiceCharges, "Show Service Charges"), nurseNode);
         TreeNode ShowTimeServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowTimeServiceCharges, "Show Time Service Charges"), nurseNode);
-        
+
+        TreeNode nursingWorkBenchPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Workbench Panels"), nurseNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelEdit, "Edit Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelClinicalData, "Clinical Data Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelRoomManagement, "Room Management Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelService, "Service Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
 
         // Admin Privileges
         TreeNode superAdminNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.SuperAdmin, "Super Admin"), allNode);

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -166,6 +166,9 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsAdmission, "Admission"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsEditAdmission, "Edit Admission Details"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsInwardAppoinment, "Inward Appointment"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPatientDetailsFromAdmission, "Edit Patient Details From Admission"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPaymentDetails, "Edit Payment Details"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardManageAllergies, "Manage Allergies"), admissionsNode);
 
         TreeNode appointmentNode = new DefaultTreeNode(new PrivilegeHolder(null, "Appointment"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAppointmentMenu, "Appointment Menu"), appointmentNode);
@@ -199,6 +202,40 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBill, "Interim Bill"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBillSearch, "Interim Bill Search"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillReportEdit, "Edit Patient Name After Payment Finalized"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDoctorPaymentAccess, "Doctor Payment Access"), inwardBillingNode);
+
+        TreeNode dashboardPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Inpatient Dashboard Panels"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelAdmission, "Admission Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelBilling, "Billing Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelServices, "Services Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelRoomManagement, "Room Management Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelOperationTheatre, "Operation Theatre Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelClinicalData, "Clinical Data Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelPharmaceuticals, "Pharmaceuticals Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelDocuments, "Documents Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelReports, "Reports Panel"), dashboardPanelsNode);
+
+        TreeNode nursingWorkBenchPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Workbench Panels"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelEdit, "Edit Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelClinicalData, "Clinical Data Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelRoomManagement, "Room Management Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelService, "Service Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
+
+        TreeNode inwardSurgeryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Surgery"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryAdd, "Add Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryManage, "Manage Surgery"), inwardSurgeryNode);
+
+        TreeNode clinicalDataViewNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical Data Access"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPatientHistoryView, "Patient History View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardClinicalNotesView, "Clinical Notes View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardWardMedicationsView, "Ward Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDischargeMedicationsView, "Discharge Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardInvestigationsView, "Investigations View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardImagesView, "Images View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDiagnosisCardView, "Diagnosis Card View"), clinicalDataViewNode);
 
         TreeNode inwardPharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyMenu, "Pharmacy Menu"), inwardPharmacyNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -140,13 +140,48 @@ public enum Privileges {
     InpatientLetter("Inpatient Letter"),
     InwardPackageAdministration("Inward Package Administration"),
     InwardPackageAdmission("Inward Package Admission"),
+    InwardEditPatientDetailsFromAdmission("Inward Edit Patient Details From Admission"),
+    InwardEditPaymentDetails("Inward Edit Payment Details"),
+    InwardManageAllergies("Inward Manage Allergies"),
+    InwardDoctorPaymentAccess("Inward Doctor Payment Access"),
+    InwardSurgeryAdd("Inward Surgery Add"),
+    InwardSurgeryManage("Inward Surgery Manage"),
+    InwardPatientHistoryView("Inward Patient History View"),
+    InwardClinicalNotesView("Inward Clinical Notes View"),
+    InwardWardMedicationsView("Inward Ward Medications View"),
+    InwardDischargeMedicationsView("Inward Discharge Medications View"),
+    InwardInvestigationsView("Inward Investigations View"),
+    InwardImagesView("Inward Images View"),
+    InwardDiagnosisCardView("Inward Diagnosis Card View"),
     //</editor-fold>
-    
+
+    //<editor-fold defaultstate="collapsed" desc="Inpatient Dashboard Panels">
+    InpatientDashboardPanelAdmission("Inpatient Dashboard - Admission Panel"),
+    InpatientDashboardPanelBilling("Inpatient Dashboard - Billing Panel"),
+    InpatientDashboardPanelServices("Inpatient Dashboard - Services Panel"),
+    InpatientDashboardPanelRoomManagement("Inpatient Dashboard - Room Management Panel"),
+    InpatientDashboardPanelOperationTheatre("Inpatient Dashboard - Operation Theatre Panel"),
+    InpatientDashboardPanelClinicalData("Inpatient Dashboard - Clinical Data Panel"),
+    InpatientDashboardPanelPharmaceuticals("Inpatient Dashboard - Pharmaceuticals Panel"),
+    InpatientDashboardPanelDocuments("Inpatient Dashboard - Documents Panel"),
+    InpatientDashboardPanelReports("Inpatient Dashboard - Reports Panel"),
+    //</editor-fold>
+
     //<editor-fold defaultstate="collapsed" desc="Nurse">
     NursingWorkBench("Nursing Work Bench"),
     ShowDrugCharges("Show Drug Charges"),
     ShowServiceCharges("Show Service Charges"),
     ShowTimeServiceCharges("Show Time Service Charges"),
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="Nursing Workbench Panels">
+    NursingWorkBenchPanelEdit("Nursing Workbench - Edit Panel"),
+    NursingWorkBenchPanelClinicalData("Nursing Workbench - Clinical Data Panel"),
+    NursingWorkBenchPanelRoomManagement("Nursing Workbench - Room Management Panel"),
+    NursingWorkBenchPanelService("Nursing Workbench - Service Panel"),
+    NursingWorkBenchPanelOperationTheatre("Nursing Workbench - Operation Theatre Panel"),
+    NursingWorkBenchPanelPharmaceuticals("Nursing Workbench - Pharmaceuticals Panel"),
+    NursingWorkBenchPanelReports("Nursing Workbench - Reports Panel"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Finance">
@@ -1164,8 +1199,15 @@ public enum Privileges {
             case ShowDrugCharges:
             case ShowServiceCharges:
             case ShowTimeServiceCharges:
+            case NursingWorkBenchPanelEdit:
+            case NursingWorkBenchPanelClinicalData:
+            case NursingWorkBenchPanelRoomManagement:
+            case NursingWorkBenchPanelService:
+            case NursingWorkBenchPanelOperationTheatre:
+            case NursingWorkBenchPanelPharmaceuticals:
+            case NursingWorkBenchPanelReports:
                 return "Nursing Work Bench";
-                
+
             case WatingRoomAdmitPatient:
             case InwardAppointmentMenu:
             case AddInwardAppointment:
@@ -1195,6 +1237,28 @@ public enum Privileges {
             case WardAcceptTheatreReturn:
             case InwardServiceItemRequestApproval:
             case InwardServiceItemRequestRejection:
+            case InpatientDashboardPanelAdmission:
+            case InpatientDashboardPanelBilling:
+            case InpatientDashboardPanelServices:
+            case InpatientDashboardPanelRoomManagement:
+            case InpatientDashboardPanelOperationTheatre:
+            case InpatientDashboardPanelClinicalData:
+            case InpatientDashboardPanelPharmaceuticals:
+            case InpatientDashboardPanelDocuments:
+            case InpatientDashboardPanelReports:
+            case InwardEditPatientDetailsFromAdmission:
+            case InwardEditPaymentDetails:
+            case InwardManageAllergies:
+            case InwardDoctorPaymentAccess:
+            case InwardSurgeryAdd:
+            case InwardSurgeryManage:
+            case InwardPatientHistoryView:
+            case InwardClinicalNotesView:
+            case InwardWardMedicationsView:
+            case InwardDischargeMedicationsView:
+            case InwardInvestigationsView:
+            case InwardImagesView:
+            case InwardDiagnosisCardView:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -201,12 +201,13 @@
 
                     <!-- Column 2: Admission / Billing / Services / Room Management -->
                     <div class="col-3">
-                        <p:panel header="Admission" class="m-1">
+                        <p:panel header="Admission" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelAdmission')}">
                             <div class="row g-2">
                                 <div class="col-12">
                                     <p:commandButton
                                         value="Edit Admission"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardAdmissionsEditAdmission')}"
                                         action="#{admissionController.navigateToEditAdmission}"
                                         icon="fa fa-edit"
                                         class="w-100">
@@ -219,6 +220,7 @@
                                     <p:commandButton
                                         value="Edit Patient Details"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardEditPatientDetailsFromAdmission')}"
                                         action="#{patientController.navigateToOpdPatientEdit()}"
                                         icon="fa fa-edit"
                                         class="w-100">
@@ -231,6 +233,7 @@
                                     <p:commandButton
                                         value="Edit Payment Details"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardEditPaymentDetails')}"
                                         action="#{bhtEditController.navigateToEditPaymentDetails()}"
                                         icon="fa-solid fa-credit-card"
                                         class="w-100 ui-button-info">
@@ -243,6 +246,7 @@
                                     <p:commandButton
                                         value="Manage Allergies"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardManageAllergies')}"
                                         action="#{bhtEditController.navigateToManageAllergies()}"
                                         icon="fa-solid fa-allergies"
                                         class="w-100">
@@ -255,6 +259,7 @@
                                     <p:commandButton
                                         value="Cancel Admission"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardAdmissionCancel')}"
                                         action="#{bhtEditController.navigateToCancelAdmission()}"
                                         icon="fas fa-ban"
                                         class="w-100 ui-button-danger">
@@ -273,7 +278,7 @@
                                         class="w-100 ui-button-secondary">
                                     </p:commandButton>
                                 </h:panelGroup>
-                                <h:panelGroup rendered="#{admissionController.current.parentEncounter == null}" layout="block" styleClass="col-6">
+                                <h:panelGroup rendered="#{admissionController.current.parentEncounter == null and webUserController.hasPrivilege('InwardAdmissionsAdmission')}" layout="block" styleClass="col-6">
                                     <p:commandButton
                                         value="Add Baby Admission"
                                         disabled="#{admissionController.current.discharged eq true}"
@@ -305,7 +310,7 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Billing" class="m-1" rendered="#{admissionController.current.parentEncounter == null}">
+                        <p:panel header="Billing" class="m-1" rendered="#{admissionController.current.parentEncounter == null and webUserController.hasPrivilege('InpatientDashboardPanelBilling')}">
                             <h:panelGroup layout="block" rendered="#{webUserController.hasPrivilege('Developers')}">
                                 <div class="border border-warning rounded p-2 mb-2 shadow-sm" style="background-color:#fffdf5;">
                                     <div class="d-flex justify-content-between align-items-center mb-2 pb-1 border-bottom">
@@ -404,7 +409,7 @@
                             <div class="row g-2">
                                 <div class="col-12">
                                     <p:commandButton
-                                        rendered="#{(not admissionController.current.discharged or not admissionController.current.paymentFinalized) and not bhtSummeryController.patientEncounterHasProvisionalBill}"
+                                        rendered="#{(not admissionController.current.discharged or not admissionController.current.paymentFinalized) and not bhtSummeryController.patientEncounterHasProvisionalBill and webUserController.hasPrivilege('InwardBillingInterimBill')}"
                                         action="#{bhtSummeryController.navigateToIntrimBillFromPatientProfile()}"
                                         value="Interim Bill"
                                         ajax="false"
@@ -415,7 +420,7 @@
                                             target="#{bhtSummeryController.patientEncounter}"/>
                                     </p:commandButton>
                                     <p:commandButton
-                                        rendered="#{(not admissionController.current.discharged or not admissionController.current.paymentFinalized) and bhtSummeryController.patientEncounterHasProvisionalBill}"
+                                        rendered="#{(not admissionController.current.discharged or not admissionController.current.paymentFinalized) and bhtSummeryController.patientEncounterHasProvisionalBill and webUserController.hasPrivilege('InwardBillingInterimBill')}"
                                         action="#{inwardSearch.navigateToProvisionalBillForAdmission()}"
                                         value="Provisional Bill"
                                         class="w-100"
@@ -429,7 +434,7 @@
 
                                 <div class="col-12">
                                     <p:commandButton
-                                        rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized}"
+                                        rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSettleFinalBill')}"
                                         value="Final Bill"
                                         ajax="false"
                                         action="#{inwardSearch.navigateToFinalBillForAdmission}"
@@ -444,6 +449,7 @@
                                     <p:commandButton
                                         value="Payments"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardDoctorPaymentAccess')}"
                                         action="#{inwardSearch.navigateDoctorPayment}"
                                         icon="fa fa-file"
                                         class="w-100">
@@ -457,6 +463,7 @@
                                         value="Estimated Bill"
                                         icon="fa fa-calculator"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardBillingInterimBill')}"
                                         action="#{bhtSummeryController.navigateToIntrimBillEstimate}"
                                         class="w-100 ui-button-secondary">
                                         <f:setPropertyActionListener
@@ -467,12 +474,13 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Services" class="m-1">
+                        <p:panel header="Services" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelServices')}">
                             <div class="row g-2">
                                 <div class="col-12">
                                     <p:commandButton
                                         value="Add Services &amp; Investigations"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddServices')}"
                                         action="#{billBhtController.navigateToAddServicesFromAdmissionProfile()}"
                                         icon="fa fa-plus-square"
                                         class="w-100">
@@ -485,6 +493,7 @@
                                     <p:commandButton
                                         value="Add Outside Charges"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddOutSideCharges')}"
                                         action="#{inwardAdditionalChargeController.navigateToAddOutsideChargeFromInpatientProfile()}"
                                         icon="fa fa-external-link-square-alt"
                                         class="w-100">
@@ -497,6 +506,7 @@
                                     <p:commandButton
                                         value="Add Professional Fees"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddProfessionalFee')}"
                                         action="#{inwardProfessionalBillController.navigateToAddProfessionalFeesFromInpatientProfile(admissionController.current)}"
                                         icon="fa fa-user-md"
                                         class="w-100">
@@ -509,6 +519,7 @@
                                     <p:commandButton
                                         value="Add Estimated Professional Fee"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddProfessionalFee')}"
                                         action="#{inwardProfessionalBillController.navigateToAddEstimatedProfessionalFeeFromInpatientProfile()}"
                                         icon="fa fa-user-md"
                                         class="w-100">
@@ -521,6 +532,7 @@
                                     <p:commandButton
                                         value="Add Timed Services"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddTimedServices')}"
                                         action="#{inwardTimedItemController.navigateToAddInwardTimedServicesFromInpatientProfile(admissionController.current)}"
                                         icon="fa fa-clock"
                                         class="w-100">
@@ -532,7 +544,7 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Room Management" class="m-1">
+                        <p:panel header="Room Management" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelRoomManagement')}">
                             <div class="p-2 rounded mb-2" style="background-color:#eef1f4;">
                                 <div class="text-uppercase small fw-bold text-muted mb-2">Status</div>
                                 <div class="row g-2">
@@ -683,7 +695,7 @@
 
                     <!-- Column 3: Surgeries / Clinical Data -->
                     <div class="col-3">
-                        <p:panel class="m-1">
+                        <p:panel class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelOperationTheatre')}">
                             <f:facet name="header">
                                 <h:outputText value="Operation Theatre"/>
                             </f:facet>
@@ -714,7 +726,7 @@
                                         value="Add Surgeries"
                                         icon="fa fa-clock"
                                         ajax="false"
-                                        rendered="#{not admissionController.current.paymentFinalized}"
+                                        rendered="#{not admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSurgeryAdd')}"
                                         action="#{surgeryBillController.navigateToAddSurgeriesFromAdmissionProfile}"
                                         class="w-100">
                                         <f:setPropertyActionListener
@@ -727,6 +739,7 @@
                                         value="Manage Surgeries"
                                         icon="fa fa-list"
                                         ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardSurgeryManage')}"
                                         action="#{surgeryBillController.navigateToSurgeryListFromAdmissionProfile()}"
                                         class="w-100">
                                         <f:setPropertyActionListener
@@ -782,7 +795,7 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Clinical Data" class="m-1">
+                        <p:panel header="Clinical Data" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelClinicalData')}">
                             <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
                                 <div class="text-uppercase small fw-bold text-muted mb-2">Actions</div>
                                 <div class="row g-2">
@@ -834,6 +847,7 @@
                                             value="Patient History"
                                             action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardPatientHistoryView')}"
                                             icon="fa fa-history"
                                             class="w-100">
                                             <f:setPropertyActionListener
@@ -845,6 +859,7 @@
                                         <p:commandButton
                                             value="Clinical Notes"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardClinicalNotesView')}"
                                             action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
                                             icon="fa fa-file-medical-alt"
                                             class="w-100">
@@ -854,6 +869,7 @@
                                         <p:commandButton
                                             value="Ward Medications"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardWardMedicationsView')}"
                                             action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
                                             icon="fa fa-pills"
                                             class="w-100">
@@ -873,6 +889,7 @@
                                         <p:commandButton
                                             value="Discharge Medications"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardDischargeMedicationsView')}"
                                             action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
                                             icon="fa fa-prescription-bottle-alt"
                                             class="w-100">
@@ -882,6 +899,7 @@
                                         <p:commandButton
                                             value="Investigations"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardInvestigationsView')}"
                                             action="#{admissionController.navigateToInpatientInvestigations()}"
                                             icon="fa fa-search"
                                             class="w-100">
@@ -891,6 +909,7 @@
                                         <p:commandButton
                                             value="Images"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardImagesView')}"
                                             action="#{admissionController.navigateToInpatientImages}"
                                             icon="fa fa-images"
                                             class="w-100">
@@ -900,6 +919,7 @@
                                         <p:commandButton
                                             value="Diagnosis Card"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardDiagnosisCardView')}"
                                             action="#{admissionController.navigateToInpatientDiagnosisCard()}"
                                             icon="fa fa-diagnoses"
                                             class="w-100">
@@ -912,7 +932,7 @@
 
                     <!-- Column 4: Pharmaceuticals / Reports -->
                     <div class="col-3">
-                        <p:panel header="Pharmaceuticals &amp; Consumables" class="m-1">
+                        <p:panel header="Pharmaceuticals &amp; Consumables" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelPharmaceuticals')}">
                             <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
                                 <div class="text-uppercase small fw-bold text-muted mb-2">Actions</div>
                                 <div class="row g-2">
@@ -920,6 +940,7 @@
                                         <p:commandButton
                                             value="Request from Pharmacy"
                                             ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest')}"
                                             action="#{admissionController.navigateToPharmacyBhtRequest}"
                                             icon="fa fa-prescription-bottle-alt"
                                             class="w-100">
@@ -1045,7 +1066,7 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Documents" class="m-1">
+                        <p:panel header="Documents" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelDocuments')}">
                             <div class="row g-2">
                                 <div class="col-6">
                                     <p:commandButton
@@ -1080,12 +1101,13 @@
                             </div>
                         </p:panel>
 
-                        <p:panel header="Reports" class="m-1">
+                        <p:panel header="Reports" class="m-1" rendered="#{webUserController.hasPrivilege('InpatientDashboardPanelReports')}">
                             <div class="row g-2">
                                 <div class="col-6">
                                     <p:commandButton
                                         id="btnPharmacyIssues"
                                         value="Pharmacy Issue Summary"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemListDto()}"
                                         icon="fa fa-rocket"
                                         ajax="false"
@@ -1103,6 +1125,7 @@
                                     <p:commandButton
                                         id="btnServiceSummary"
                                         value="Service Summary"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientServiceItemListDto()}"
                                         icon="fa fa-stethoscope"
                                         ajax="false"
@@ -1120,6 +1143,7 @@
                                     <p:commandButton
                                         id="btnServiceBills"
                                         value="All Inward Service Bills"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientServiceBillListDto()}"
                                         icon="fa fa-file-invoice"
                                         ajax="false"
@@ -1137,6 +1161,7 @@
                                     <p:commandButton
                                         id="btnPharmacyAndServiceSummary"
                                         value="Pharmacy &amp; Services Summary"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientPharmacyAndServiceItemListDto()}"
                                         icon="fa fa-list-alt"
                                         ajax="false"
@@ -1153,6 +1178,7 @@
                                 <div class="col-6">
                                     <p:commandButton
                                         value="Lab Bill Summary"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientLabItemList}"
                                         icon="fa fa-flask"
                                         ajax="false"
@@ -1168,6 +1194,7 @@
                                 <div class="col-6">
                                     <p:commandButton
                                         value="Lab Result Summary"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{encounterLaboratoryChartViewController.navigateToProcessInvestigations(admissionController.current)}"
                                         ajax="false"
                                         icon="pi pi-chart-line"
@@ -1179,6 +1206,7 @@
                                         id="btnLegacy"
                                         ajax="false"
                                         value="Pharmacy Issue Summary (Legacy)"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                         action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemList}"
                                         icon="fa fa-prescription-bottle-alt"
                                         class="w-100 ui-button-secondary"

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -109,32 +109,35 @@
                                         </div>
                                     </h:panelGroup>
                                     <div class="row m-3">
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelEdit')}">
                                             <div class="col-2">
                                                 <p:panel header="Edit">
                                                     <div class="d-grid gap-3">
-                                                        <p:commandButton 
-                                                            value="Edit Admission" 
+                                                        <p:commandButton
+                                                            value="Edit Admission"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardAdmissionsEditAdmission')}"
                                                             action="#{admissionController.navigateToEditAdmission()}"
                                                             actionListener="#{bhtEditController.prepereForNew()}"
                                                             icon="fa fa-edit"
                                                             class="w-100 ">
                                                         </p:commandButton>
-                                                        
-                                                        <p:commandButton 
-                                                            value="Room Change" 
+
+                                                        <p:commandButton
+                                                            value="Room Change"
                                                             ajax="false"
-                                                            action="#{admissionController.navigateToRoomChange()}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
+                                                            action="#{admissionController.navigateToRoomChange()}"
                                                             icon="fa fa-exchange-alt"
                                                             actionListener="#{roomChangeController.recreate()}"
                                                             class="w-100">
                                                         </p:commandButton>
 
-                                                        <p:commandButton 
-                                                            value="Guardian Room Change" 
+                                                        <p:commandButton
+                                                            value="Guardian Room Change"
                                                             ajax="false"
-                                                            action="#{admissionController.navigateToGuardianRoomChange()}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
+                                                            action="#{admissionController.navigateToGuardianRoomChange()}"
                                                             actionListener="#{roomChangeController.recreate()}"
                                                             icon="fa fa-users"
                                                             class="w-100">
@@ -153,7 +156,7 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelClinicalData')}">
                                             <div class="col-3">
                                                 <p:panel header="Clinical Data">
                                                     <div class="d-grid gap-3">
@@ -162,6 +165,7 @@
                                                             value="Patient History"
                                                             action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardPatientHistoryView')}"
                                                             icon="fa fa-history"
                                                             class="w-100">
                                                             <f:setPropertyActionListener
@@ -173,6 +177,7 @@
                                                             id="btnClinicalNotesNurse"
                                                             value="Clinical Notes"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardClinicalNotesView')}"
                                                             action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
                                                             icon="fa fa-file-medical-alt"
                                                             class="w-100">
@@ -182,6 +187,7 @@
                                                             id="btnWardMedicationsNurse"
                                                             value="Ward Medications"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardWardMedicationsView')}"
                                                             action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
                                                             icon="fa fa-pills"
                                                             class="w-100">
@@ -201,6 +207,7 @@
                                                             id="btnDischargeMedicationsNurse"
                                                             value="Discharge Medications"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardDischargeMedicationsView')}"
                                                             action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
                                                             icon="fa fa-prescription-bottle-alt"
                                                             class="w-100">
@@ -210,6 +217,7 @@
                                                             id="btnInvestigationsNurse"
                                                             value="Investigations"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardInvestigationsView')}"
                                                             action="#{admissionController.navigateToInpatientInvestigations()}"
                                                             icon="fa fa-search"
                                                             class="w-100">
@@ -219,6 +227,7 @@
                                                             id="btnImagesNurse"
                                                             value="Images"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardImagesView')}"
                                                             action="#{admissionController.navigateToInpatientImages}"
                                                             icon="fa fa-images"
                                                             class="w-100">
@@ -228,6 +237,7 @@
                                                             id="btnDiagnosisCardNurse"
                                                             value="Diagnosis Card"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardDiagnosisCardView')}"
                                                             action="#{admissionController.navigateToInpatientDiagnosisCard()}"
                                                             icon="fa fa-diagnoses"
                                                             class="w-100">
@@ -269,7 +279,7 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelRoomManagement')}">
                                             <div class="col-2">
                                                 <p:panel header="Room Management">
                                                     <div class="d-grid gap-3">
@@ -336,43 +346,48 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelService')}">
                                             <div class="col-3">
                                                 <p:panel header="Service">
                                                     <div class="d-grid gap-3">
-                                                        <p:commandButton 
-                                                            value="Add Services &amp; Investigations" 
+                                                        <p:commandButton
+                                                            value="Add Services &amp; Investigations"
                                                             ajax="false"
-                                                            action="#{billBhtController.navigateToAddServicesFromAdmissionProfile()}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddServices')}"
+                                                            action="#{billBhtController.navigateToAddServicesFromAdmissionProfile()}"
                                                             icon="fa fa-plus-square"
                                                             class="w-100">
                                                         </p:commandButton>
-                                                        <p:commandButton 
-                                                            value="Add Outside Charges" 
+                                                        <p:commandButton
+                                                            value="Add Outside Charges"
                                                             ajax="false"
-                                                            action="#{inwardAdditionalChargeController.navigateToAddOutsideChargeFromInpatientProfile()}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddOutSideCharges')}"
+                                                            action="#{inwardAdditionalChargeController.navigateToAddOutsideChargeFromInpatientProfile()}"
                                                             icon="fa fa-external-link-square-alt"
                                                             class="w-100">
                                                         </p:commandButton>
-                                                        <p:commandButton 
-                                                            value="Add Professional Fees" 
+                                                        <p:commandButton
+                                                            value="Add Professional Fees"
                                                             ajax="false"
-                                                            action="#{inwardProfessionalBillController.navigateToAddProfessionalFeesFromInpatientProfile(admissionController.current)}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddProfessionalFee')}"
+                                                            action="#{inwardProfessionalBillController.navigateToAddProfessionalFeesFromInpatientProfile(admissionController.current)}"
                                                             icon="fa fa-user-md"
                                                             class="w-100">
                                                         </p:commandButton>
-                                                        <p:commandButton 
-                                                            value="Add Estimated Professional Fee" 
+                                                        <p:commandButton
+                                                            value="Add Estimated Professional Fee"
                                                             ajax="false"
-                                                            action="#{inwardProfessionalBillController.navigateToAddEstimatedProfessionalFeeFromInpatientProfile()}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddProfessionalFee')}"
+                                                            action="#{inwardProfessionalBillController.navigateToAddEstimatedProfessionalFeeFromInpatientProfile()}"
                                                             icon="fa fa-user-md"
                                                             class="w-100">
                                                         </p:commandButton>
 
-                                                        <p:commandButton 
+                                                        <p:commandButton
                                                             value="Add Timed Services"
                                                             ajax="false"
-                                                            action="#{inwardTimedItemController.navigateToAddInwardTimedServicesFromInpatientProfile(admissionController.current)}" 
+                                                            rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddTimedServices')}"
+                                                            action="#{inwardTimedItemController.navigateToAddInwardTimedServicesFromInpatientProfile(admissionController.current)}"
                                                             icon="fa fa-clock"
                                                             class="w-100">
                                                         </p:commandButton>
@@ -380,7 +395,7 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelOperationTheatre')}">
                                             <div class="col-3">
                                                 <p:panel header="Operation Theatre">
                                                     <div class="d-grid gap-3">
@@ -426,7 +441,7 @@
                                                             value="Add Surgeries"
                                                             icon="fa fa-clock"
                                                             ajax="false"
-                                                            rendered="#{admissionController.current ne null and not admissionController.current.paymentFinalized}"
+                                                            rendered="#{admissionController.current ne null and not admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSurgeryAdd')}"
                                                             action="#{surgeryBillController.navigateToAddSurgeriesFromAdmissionProfile}"
                                                             class="w-100">
                                                             <f:setPropertyActionListener
@@ -439,6 +454,7 @@
                                                             value="Manage Surgeries"
                                                             icon="fa fa-list"
                                                             ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('InwardSurgeryManage')}"
                                                             action="#{surgeryBillController.navigateToSurgeryListFromAdmissionProfile()}"
                                                             class="w-100">
                                                             <f:setPropertyActionListener
@@ -495,7 +511,7 @@
                                         </h:panelGroup>
                                     </div>
                                     <div class="row m-3">
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelPharmaceuticals')}">
                                             <div class="col-6">
                                                 <p:panel header="Pharmaceuticals &amp; Consumables">
                                                     <div class="d-grid gap-3">
@@ -625,49 +641,52 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
-                                        <h:panelGroup  rendered="true">
+                                        <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelReports')}">
                                             <div class="col-6">
                                                 <p:panel header="Reports">
                                                     <div class="d-grid gap-3">
-                                                        <p:commandButton 
+                                                        <p:commandButton
                                                             ajax="false"
-                                                            value="Pharmacy Issue Summary (Entity)" 
-                                                            action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemList}" 
+                                                            value="Pharmacy Issue Summary (Entity)"
+                                                            rendered="#{webUserController.hasPrivilege('InwardReport')}"
+                                                            action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemList}"
                                                             icon="fa fa-prescription-bottle-alt"
                                                             class="w-100"
                                                             title="Traditional entity-based report">
-                                                            <f:setPropertyActionListener 
-                                                                value="#{admissionController.current}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{admissionController.current}"
                                                                 target="#{inwardReportControllerBht.patientEncounter}" />
-                                                            <f:setPropertyActionListener 
-                                                                value="#{null}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{null}"
                                                                 target="#{inwardReportControllerBht.department}" />
                                                         </p:commandButton>
-                                                        <p:commandButton 
-                                                            value="Pharmacy Issue Summary (DTO - Fast)" 
-                                                            action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemListDto()}" 
+                                                        <p:commandButton
+                                                            value="Pharmacy Issue Summary (DTO - Fast)"
+                                                            rendered="#{webUserController.hasPrivilege('InwardReport')}"
+                                                            action="#{inwardReportControllerBht.navigateToInpatientPharmacyItemListDto()}"
                                                             icon="fa fa-rocket"
                                                             ajax="false"
                                                             class="w-100 ui-button-success"
                                                             title="High-performance DTO-based report - Recommended">
-                                                            <f:setPropertyActionListener 
-                                                                value="#{admissionController.current}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{admissionController.current}"
                                                                 target="#{inwardReportControllerBht.patientEncounter}" />
-                                                            <f:setPropertyActionListener 
-                                                                value="#{null}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{null}"
                                                                 target="#{inwardReportControllerBht.department}" />
                                                         </p:commandButton>
-                                                        <p:commandButton 
-                                                            value="Lab Bill Summary" 
-                                                            action="#{inwardReportControllerBht.navigateToInpatientLabItemList}" 
+                                                        <p:commandButton
+                                                            value="Lab Bill Summary"
+                                                            rendered="#{webUserController.hasPrivilege('InwardReport')}"
+                                                            action="#{inwardReportControllerBht.navigateToInpatientLabItemList}"
                                                             icon="fa fa-flask"
                                                             ajax="false"
                                                             class="w-100">
-                                                            <f:setPropertyActionListener 
-                                                                value="#{admissionController.current}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{admissionController.current}"
                                                                 target="#{inwardReportControllerBht.patientEncounter}" />
-                                                            <f:setPropertyActionListener 
-                                                                value="#{null}" 
+                                                            <f:setPropertyActionListener
+                                                                value="#{null}"
                                                                 target="#{inwardReportControllerBht.department}" />
                                                         </p:commandButton>
                                                     </div>


### PR DESCRIPTION
## Summary

Closes #22175

Neither the Inpatient Dashboard (`inward/admission_profile.xhtml`) nor the Nursing Workbench (`nurse/index.xhtml`) had consistent privilege gating. This wasn't just incompleteness — it was an active bypass: several buttons on these pages duplicate actions that are already privilege-gated on the Home dashboard (`home.xhtml`) and sidebar menu (`resources/ezcomp/menu.xhtml`), but the same privilege check was never wired onto these two convenience pages. A user without `InwardServicesAndItemsAddServices`, for example, couldn't see "Add Services & Investigations" on Home, but could click the identical button on either page.

### What changed

- **16 new panel privileges** (9 for the Dashboard, 7 for the Nursing Workbench — kept as separate enum values per page per project convention, since these are two separate privilege sets even where a panel is named identically on both pages).
- **13 new function privileges** for actions that had no matching privilege anywhere in the app (Clinical Notes, Ward/Discharge Medications, Investigations, Images, Diagnosis Card, Patient History, Edit Payment Details, Manage Allergies, Doctor Payments, Add/Manage Surgeries).
- **Reused ~10 existing function privileges** wherever one already existed and is enforced elsewhere, instead of duplicating: `InwardServicesAndItemsAdd*`, `InwardBillingInterimBill`, `InwardSettleFinalBill`, `InwardAdmissionsEditAdmission`, `InwardAdmissionCancel`, `InwardAdmissionsAdmission`, `InwardPharmacyIssueRequest`, `InwardRoomRoomChange`/`InwardRoomGurdianRoomChange`, `InwardReport`.
- All new privileges registered in `UserPrivilageController.createPrivilegeHolderTreeNodes()` so they're assignable from `/admin/users/user_privileges.xhtml`.
- **Two-level gating**: a panel privilege gates whether the whole panel renders, and each button inside additionally needs its own function privilege. JSF component nesting means a user needs both to reach a function — panel-only or function-only access isn't enough.

### Test plan

- [x] Built and redeployed locally (`mvn clean package -DskipTests` + `asadmin redeploy`); no `server.log` errors.
- [x] Confirmed all 29 new privileges appear correctly nested in the admin privilege tree and are assignable.
- [x] Verified persistence directly in the local `coop` MySQL DB (`WEBUSERPRIVILEGE` table) — all 29 privileges saved and active.
- [x] Playwright pass against a real admission, three states:
  - No privileges granted → every action panel hidden on both pages (only the pre-existing view-only panels / `InwardLaboratory`-gated Laboratory panel remain).
  - All privileges granted → every panel and button renders and is clickable.
  - Panel privilege revoked while function privileges stay granted → panel disappears entirely, proving the AND-gate (not OR).
- [x] Confirmed the previously-bypassed privileges now correctly gate their buttons on both pages, matching Home/menu behavior.

Full before/after screenshots and verification detail: https://github.com/hmislk/hmis/issues/22175#issuecomment-4995216705

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular access controls for inpatient admission, billing, services, room management, surgery, clinical data, pharmaceuticals, documents, and reports.
  * Added configurable dashboard panel permissions for inpatient and nursing workflows.
  * Added permissions for editing patient and payment details, managing allergies, doctor payment access, and surgery management.
  * Added dedicated access controls for patient history, clinical notes, medications, investigations, images, and diagnosis cards.
* **Bug Fixes**
  * Restricted panels and actions to authorized staff, improving visibility and access consistency across inpatient and nursing workbenches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->