### PR TITLE
fix(inward): reject medication administration when nurse has no staff record

### DIFF
--- a/src/main/java/com/divudi/bean/inward/MedicationAdministrationController.java
+++ b/src/main/java/com/divudi/bean/inward/MedicationAdministrationController.java
@@ -127,6 +127,10 @@ public class MedicationAdministrationController implements Serializable {
             JsfUtil.addErrorMessage("Select a status.");
             return;
         }
+        if (sessionController.getLoggedUser().getStaff() == null) {
+            JsfUtil.addErrorMessage("Your user account is not linked to a staff record; medication administration cannot be recorded.");
+            return;
+        }
         if (administerStatus == MedicationAdministrationStatus.GIVEN) {
             if (selectedStock == null) {
                 JsfUtil.addErrorMessage("Select a batch.");


### PR DESCRIPTION
## Summary
- Closes #22179
- `MedicationAdministrationController.recordAdministration()` set `administeredBy` directly from `sessionController.getLoggedUser().getStaff()` with no null check
- When the logged-in `WebUser` has no linked `Staff` record, the created `MedicationAdministrationRecord` was persisted with `administeredBy = null`
- The Ward Medications drug chart (`inward_ward_medicines.xhtml`) then rendered the administration history line as `"... Given 1.0 <batch> by"` — the administering nurse's name silently missing, losing the clinical audit trail of who administered the dose
- Added a guard: if the logged-in user has no linked staff record, reject with a clear error ("Your user account is not linked to a staff record; medication administration cannot be recorded.") instead of persisting an incomplete record

## Verification (local Payara, `http://localhost:9090/rh`)
Full workflow exercised via Playwright against the local dev DB:
1. Logged into Inward, searched admissions, opened BHT/53355
2. Prescribed Paracetamol 500mg QDS via Ward Medications
3. Requested the medicine from Main Pharmacy, switched department, issued it as a pharmacy bill (Panadol 500mg tab x 20)
4. Back in Inward, opened Ward Medications for the same BHT and clicked Administer

**Before the fix** — reproduced the reported bug: the administration history rendered as:
```
2026-07-16 23:35 - Given 1.0 30092026 by
```
(nurse name missing). Confirmed in the DB: the new `medicationadministrationrecord` row had `ADMINISTEREDBY_ID = NULL`.

**After the fix**, tested both paths:
- **Staff-less user** (WebUser with `STAFF_ID IS NULL`) clicking Confirm on the Administer dialog: now blocked with the error "Your user account is not linked to a staff record; medication administration cannot be recorded." — no record created (confirmed via DB, no orphaned row).
- **Staff-linked user**: administration recorded successfully, and the drug chart now correctly shows:
```
2026-07-16 23:59 - Given 1.0 30092026 by Dr. SUSITHA AMARASINGHE
```

## Test plan
- [x] Reproduced the bug end-to-end via Playwright against a local deployment
- [x] Confirmed root cause via DB inspection (`ADMINISTEREDBY_ID` null vs. populated)
- [x] Verified the fix blocks the bad path with a clear error and no data written
- [x] Verified the fix still allows normal administration recording with correct staff attribution
- [x] `mvn clean package -DskipTests` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure medication administration records are linked to an assigned staff member.
  * Displayed an error and prevented record creation when no staff assignment is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->