### PR TITLE
feat(billing): add VAT calculation for services/investigations on inpatient & surgical dashboards

### DIFF
--- a/docs/superpowers/specs/2026-07-16-inpatient-surgical-vat-design.md
+++ b/docs/superpowers/specs/2026-07-16-inpatient-surgical-vat-design.md
@@ -1,0 +1,83 @@
+# VAT on Services/Investigations — Inpatient & Surgical Dashboards
+
+## Context
+
+The inpatient dashboard and surgical dashboard both let staff add services/investigations
+to a bill through the shared `BillBhtController` (`addToBill()` for inpatient,
+`addToBillSurgery()` for surgical, both funnelling into `calTotals()`). Neither path
+calculates VAT today, even though the data model already has dormant VAT fields:
+
+- `Item.vatable` / `Item.vatPercentage` — exists, but `getVatPercentage()` is hard-coded
+  to return `0` (dead field).
+- `Bill.vat` / `Bill.vatPlusNetTotal` — exist, populated only when copying/inverting bills,
+  never computed from item data.
+- `BillItem.vat` / `BillItem.vatPlusNetValue` — same story.
+- Admin "Manage Items" page (`admin/items/items.xhtml`) has a VAT Percentage / VATable tab
+  already built but hidden behind `rendered="false"` with the tab titled "Depricated".
+- `A4_paper_with_headings.xhtml` print template already has a VAT row wired to `bill.vat`,
+  gated by a copy-pasted condition (`bill.discount ne 0.0`) that doesn't make sense for VAT.
+
+This feature revives and wires together that existing skeleton rather than inventing a new
+one, and scopes the calculation to the inpatient + surgical "add services" flows only (not
+OPD, channel booking, or pharmacy, which are separate billing paths on the same `Item`
+entity and are out of scope for this change).
+
+## Decisions
+
+1. **Scope**: `BillBhtController.addToBill()`, `addToBillSurgery()`, `calTotals()` only.
+   Covers both `inward_bill_service.xhtml` (inpatient) and `inward_bill_surgery_service.xhtml`
+   (surgical) since they share the controller.
+2. **Data field**: Fix and reuse `Item.vatable` + `Item.vatPercentage` (fix the broken
+   getter). Un-deprecate and redesign the admin UI tab rather than introduce a competing
+   field.
+3. **VAT basis**: Computed on **net value after discount**: `vat = netValue * item.vatPercentage / 100`.
+4. **Gate**: VAT applies only when **both** `item.vatable == true` **and**
+   `item.vatPercentage > 0`.
+5. **Rate snapshot**: Add a new `BillItem.vatPercentage` field that stores the rate actually
+   applied at billing time (independent of `BillItem.vat`, the computed amount). This keeps
+   historical bills/prints/reports accurate if an item's VAT % changes later. Reuses the
+   existing bare-field pattern already used for `BillItem.vat` rather than the optional/lazy
+   `BillItemFinanceDetails` generic tax bucket.
+6. **Bill-level rollup**: `Bill.vat` = sum of `BillItem.vat` across all bill items.
+   `Bill.vatPlusNetTotal` = `Bill.netTotal + Bill.vat`. `Bill.netTotal` itself is **not**
+   changed to include VAT — it stays a pure net figure, per the original ask.
+7. **Rounding**: Round each `BillItem.vat` to 2 decimal places at calculation time, matching
+   existing currency-rounding conventions used elsewhere in `BillBhtController` totals.
+8. **UI display**: Both the item-add tables and their prints show:
+   - a per-line **VAT** column (each `BillItem.vat`)
+   - bill-summary rows for **Net Total**, **VAT**, and **Net Total + VAT**
+9. **Admin item management**: Re-enable the existing hidden VAT tab on
+   `admin/items/items.xhtml`, redesigned per the `ui-guidelines` skill (proper panel/tab
+   layout, not the old markup verbatim).
+10. **Item management REST API**: Add `vatable` + `vatPercentage` to the Service and
+    Investigation request/response DTOs and to `ServiceApiService`/`InvestigationApiService`
+    create/update mapping, per the `api-development` skill checklist.
+11. **AI chat**: Extend the existing `manage_investigations` tool with `vatable`/
+    `vatPercentage` parameters. No `manage_services` AI tool exists today (services were
+    never wired into `AnthropicApiService` at all) — add a new `manage_services` tool
+    mirroring `manage_investigations`'s shape (including the new VAT params) so VAT parity
+    exists between investigations and services in AI chat, and register it in
+    `CapabilityStatementResource`.
+12. **Prints**: Fix the `A4_paper_with_headings.xhtml` VAT row's render condition (currently
+    incorrectly gated on `bill.discount ne 0.0`) and add a per-line VAT column there and in
+    the five-five and POS inward-service print variants.
+
+## Out of scope
+
+- OPD billing, channel booking, pharmacy billing — even though they use the same `Item`
+  entity, wiring VAT into those flows is a separate change.
+- The older bulk "VAT management" page (`dataAdmin/item_list_for_vat.xhtml`) — left as-is;
+  it already edits the same `Item.vatable`/`vatPercentage` fields this design fixes, so it
+  benefits for free once the getter bug is fixed.
+- `InwardChargeType.VAT` (VAT-as-a-manual-charge-line pattern used elsewhere in inward
+  billing) is a different, pre-existing mechanism and is not touched by this change.
+- `BillFinanceDetails`/`BillItemFinanceDetails` generic tax framework — not used by this
+  feature (see decision 5).
+
+## Database migration
+
+New column `bill_item.vat_percentage` (double, default 0) needs a migration script following
+the project's cross-deployment case-sensitivity rules (`INFORMATION_SCHEMA` detection,
+prepared statements) per `developer_docs/database/migration-development-guide.md`.
+`item.vatable` and `item.vat_percentage` columns already exist (dormant field), no migration
+needed there.

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -4233,6 +4233,17 @@ public class BillBeanController implements Serializable {
 
         b.setNetTotal(val);
 
+        sql = "SELECT sum(b.feeVat)"
+                + " FROM BillFee b "
+                + " WHERE b.retired=false"
+                + " and b.bill=:bill ";
+        hm = new HashMap();
+        hm.put("bill", b);
+        val = getBillFeeFacade().findDoubleByJpql(sql, hm);
+
+        b.setVat(val);
+        b.setVatPlusNetTotal(b.getNetTotal() + b.getVat());
+
         getBillFacade().edit(b);
     }
 
@@ -4480,6 +4491,19 @@ public class BillBeanController implements Serializable {
         val = getBillFeeFacade().findDoubleByJpql(sql, hm);
 
         billItem.setDiscount(val);
+
+        sql = "SELECT sum(b.feeVat) "
+                + " FROM BillFee b "
+                + " WHERE b.retired=false "
+                + " and b.billItem=:bItm ";
+        hm = new HashMap();
+        hm.put("bItm", billItem);
+        val = getBillFeeFacade().findDoubleByJpql(sql, hm);
+
+        billItem.setVat(val);
+        billItem.setVatPlusNetValue(billItem.getNetValue() + billItem.getVat());
+        billItem.setVatPercentage(billItem.getItem() != null && billItem.getItem().isVatable()
+                ? billItem.getItem().getVatPercentage() : 0.0);
 //
 //        billItem.setEditedAt(new Date());
 //        billItem.setEditor(webUser);

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -4502,8 +4502,6 @@ public class BillBeanController implements Serializable {
 
         billItem.setVat(val);
         billItem.setVatPlusNetValue(billItem.getNetValue() + billItem.getVat());
-        billItem.setVatPercentage(billItem.getItem() != null && billItem.getItem().isVatable()
-                ? billItem.getItem().getVatPercentage() : 0.0);
 //
 //        billItem.setEditedAt(new Date());
 //        billItem.setEditor(webUser);

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -154,6 +154,8 @@ public class BillBhtController implements Serializable {
     private double discount;
     private double marginTotal;
     private double netTotal;
+    private double vat;
+    private double vatPlusNetTotal;
     private double cashPaid;
     private double cashBalance;
     private String creditCardRefNo;
@@ -279,6 +281,8 @@ public class BillBhtController implements Serializable {
         total = 0.0;
         discount = 0.0;
         netTotal = 0.0;
+        vat = 0.0;
+        vatPlusNetTotal = 0.0;
         cashPaid = 0.0;
         cashBalance = 0.0;
         creditCardRefNo = "";
@@ -329,6 +333,8 @@ public class BillBhtController implements Serializable {
         total = 0.0;
         discount = 0.0;
         netTotal = 0.0;
+        vat = 0.0;
+        vatPlusNetTotal = 0.0;
         cashPaid = 0.0;
         cashBalance = 0.0;
         creditCardRefNo = "";
@@ -388,6 +394,8 @@ public class BillBhtController implements Serializable {
         total = 0.0;
         discount = 0.0;
         netTotal = 0.0;
+        vat = 0.0;
+        vatPlusNetTotal = 0.0;
         cashPaid = 0.0;
         cashBalance = 0.0;
         creditCardRefNo = "";
@@ -1041,6 +1049,11 @@ public class BillBhtController implements Serializable {
 
             getInwardBean().setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
 
+            if (billItem.getItem().isVatable() && billItem.getItem().getVatPercentage() > 0) {
+                billFee.setFeeVat(roundOff(billFee.getFeeValue() * billItem.getItem().getVatPercentage() / 100));
+            }
+            billFee.setFeeVatPlusValue(billFee.getFeeValue() + billFee.getFeeVat());
+
             billFeeList.add(billFee);
         }
 
@@ -1102,6 +1115,7 @@ public class BillBhtController implements Serializable {
         double tot = 0.0;
         double net = 0.0;
         double margin = 0.0;
+        double vatTotal = 0.0;
 
         for (BillEntry be : getLstBillEntries()) {
             BillItem bi = be.getBillItem();
@@ -1110,6 +1124,7 @@ public class BillBhtController implements Serializable {
             bi.setGrossValue(0.0);
             bi.setNetValue(0.0);
             bi.setMarginValue(0.0);
+            bi.setVat(0.0);
 
             for (BillFee bf : be.getLstBillFees()) {
                 tot += bf.getFeeGrossValue();
@@ -1118,15 +1133,21 @@ public class BillBhtController implements Serializable {
                 bi.setGrossValue(bi.getGrossValue() + bf.getFeeGrossValue());
                 margin += bf.getFeeMargin();
                 bi.setMarginValue(bi.getMarginValue() + bf.getFeeMargin());
+                bi.setVat(bi.getVat() + bf.getFeeVat());
             }
 
             bi.setDiscount(bi.getGrossValue() + bi.getMarginValue() - bi.getNetValue());
+            bi.setVatPercentage(bi.getItem() != null && bi.getItem().isVatable() ? bi.getItem().getVatPercentage() : 0.0);
+            bi.setVatPlusNetValue(bi.getNetValue() + bi.getVat());
+            vatTotal += bi.getVat();
         }
 
         setTotal(tot);
         setMarginTotal(margin);
         setDiscount(tot + margin - net);
         setNetTotal(net);
+        setVat(vatTotal);
+        setVatPlusNetTotal(getNetTotal() + getVat());
     }
 
     public void feeChanged(BillFee bf) {
@@ -1456,6 +1477,31 @@ public class BillBhtController implements Serializable {
 
     public void setNetTotal(double netTotal) {
         this.netTotal = netTotal;
+    }
+
+    public double getVat() {
+        return vat;
+    }
+
+    public void setVat(double vat) {
+        this.vat = vat;
+    }
+
+    public double getVatPlusNetTotal() {
+        return vatPlusNetTotal;
+    }
+
+    public void setVatPlusNetTotal(double vatPlusNetTotal) {
+        this.vatPlusNetTotal = vatPlusNetTotal;
+    }
+
+    private double roundOff(double d) {
+        java.text.DecimalFormat newFormat = new java.text.DecimalFormat("#.##");
+        try {
+            return Double.valueOf(newFormat.format(d));
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     public double getCashPaid() {

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -1049,10 +1049,7 @@ public class BillBhtController implements Serializable {
 
             getInwardBean().setBillFeeMargin(billFee, billItem.getItem(), priceMatrix, patientEncounter);
 
-            if (billItem.getItem().isVatable() && billItem.getItem().getVatPercentage() > 0) {
-                billFee.setFeeVat(roundOff(billFee.getFeeValue() * billItem.getItem().getVatPercentage() / 100));
-            }
-            billFee.setFeeVatPlusValue(billFee.getFeeValue() + billFee.getFeeVat());
+            recalculateFeeVat(billFee);
 
             billFeeList.add(billFee);
         }
@@ -1172,6 +1169,8 @@ public class BillBhtController implements Serializable {
 
         getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), priceMatrix);
 
+        recalculateFeeVat(bf);
+
         calTotals();
     }
 
@@ -1195,7 +1194,19 @@ public class BillBhtController implements Serializable {
 
         getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getBatchBill().getFromDepartment(), priceMatrix);
 
+        recalculateFeeVat(bf);
+
         calTotals();
+    }
+
+    private void recalculateFeeVat(BillFee bf) {
+        if (bf.getBillItem() != null && bf.getBillItem().getItem() != null
+                && bf.getBillItem().getItem().isVatable() && bf.getBillItem().getItem().getVatPercentage() > 0) {
+            bf.setFeeVat(roundOff(bf.getFeeValue() * bf.getBillItem().getItem().getVatPercentage() / 100));
+        } else {
+            bf.setFeeVat(0.0);
+        }
+        bf.setFeeVatPlusValue(bf.getFeeValue() + bf.getFeeVat());
     }
 
     public void prepareNewBill() {
@@ -1496,12 +1507,7 @@ public class BillBhtController implements Serializable {
     }
 
     private double roundOff(double d) {
-        java.text.DecimalFormat newFormat = new java.text.DecimalFormat("#.##");
-        try {
-            return Double.valueOf(newFormat.format(d));
-        } catch (Exception e) {
-            return 0;
-        }
+        return Math.round(d * 100.0) / 100.0;
     }
 
     public double getCashPaid() {

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
@@ -7,6 +7,8 @@ public class InvestigationCreateRequestDTO {
     private Boolean inactive;
     private String reportType;
     private Boolean bypassSampleWorkflow;
+    private Boolean vatable;
+    private Double vatPercentage;
 
     public boolean isValid() { return name != null && !name.trim().isEmpty(); }
     public String getName() { return name; }
@@ -21,4 +23,8 @@ public class InvestigationCreateRequestDTO {
     public void setReportType(String reportType) { this.reportType = reportType; }
     public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
     public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+    public Boolean getVatable() { return vatable; }
+    public void setVatable(Boolean vatable) { this.vatable = vatable; }
+    public Double getVatPercentage() { return vatPercentage; }
+    public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
@@ -8,6 +8,8 @@ public class InvestigationSearchResultDTO {
     private Boolean inactive;
     private String reportType;
     private Boolean bypassSampleWorkflow;
+    private Boolean vatable;
+    private Double vatPercentage;
 
     public InvestigationSearchResultDTO() {}
 
@@ -34,4 +36,8 @@ public class InvestigationSearchResultDTO {
     public void setReportType(String reportType) { this.reportType = reportType; }
     public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
     public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+    public Boolean getVatable() { return vatable; }
+    public void setVatable(Boolean vatable) { this.vatable = vatable; }
+    public Double getVatPercentage() { return vatPercentage; }
+    public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
@@ -7,9 +7,12 @@ public class InvestigationUpdateRequestDTO {
     private Boolean inactive;
     private String reportType;
     private Boolean bypassSampleWorkflow;
+    private Boolean vatable;
+    private Double vatPercentage;
 
     public boolean isValid() {
-        return name != null || code != null || printName != null || inactive != null || reportType != null || bypassSampleWorkflow != null;
+        return name != null || code != null || printName != null || inactive != null || reportType != null
+                || bypassSampleWorkflow != null || vatable != null || vatPercentage != null;
     }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -23,4 +26,8 @@ public class InvestigationUpdateRequestDTO {
     public void setReportType(String reportType) { this.reportType = reportType; }
     public Boolean getBypassSampleWorkflow() { return bypassSampleWorkflow; }
     public void setBypassSampleWorkflow(Boolean bypassSampleWorkflow) { this.bypassSampleWorkflow = bypassSampleWorkflow; }
+    public Boolean getVatable() { return vatable; }
+    public void setVatable(Boolean vatable) { this.vatable = vatable; }
+    public Double getVatPercentage() { return vatPercentage; }
+    public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
 }

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceCreateRequestDTO.java
@@ -28,6 +28,8 @@ public class ServiceCreateRequestDTO {
     private boolean marginNotAllowed;
     private boolean requestForQuentity;
     private boolean patientNotRequired;
+    private boolean vatable;
+    private double vatPercentage;
 
     public ServiceCreateRequestDTO() {
     }
@@ -175,5 +177,21 @@ public class ServiceCreateRequestDTO {
 
     public void setPatientNotRequired(boolean patientNotRequired) {
         this.patientNotRequired = patientNotRequired;
+    }
+
+    public boolean isVatable() {
+        return vatable;
+    }
+
+    public void setVatable(boolean vatable) {
+        this.vatable = vatable;
+    }
+
+    public double getVatPercentage() {
+        return vatPercentage;
+    }
+
+    public void setVatPercentage(double vatPercentage) {
+        this.vatPercentage = vatPercentage;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceResponseDTO.java
@@ -31,6 +31,8 @@ public class ServiceResponseDTO {
     private boolean marginNotAllowed;
     private boolean requestForQuentity;
     private boolean patientNotRequired;
+    private boolean vatable;
+    private double vatPercentage;
     private String inwardChargeType;
     private Long categoryId;
     private String categoryName;
@@ -171,6 +173,22 @@ public class ServiceResponseDTO {
 
     public void setPatientNotRequired(boolean patientNotRequired) {
         this.patientNotRequired = patientNotRequired;
+    }
+
+    public boolean isVatable() {
+        return vatable;
+    }
+
+    public void setVatable(boolean vatable) {
+        this.vatable = vatable;
+    }
+
+    public double getVatPercentage() {
+        return vatPercentage;
+    }
+
+    public void setVatPercentage(double vatPercentage) {
+        this.vatPercentage = vatPercentage;
     }
 
     public String getInwardChargeType() {

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceUpdateRequestDTO.java
@@ -28,6 +28,8 @@ public class ServiceUpdateRequestDTO {
     private Boolean marginNotAllowed;
     private Boolean requestForQuentity;
     private Boolean patientNotRequired;
+    private Boolean vatable;
+    private Double vatPercentage;
 
     public ServiceUpdateRequestDTO() {
     }
@@ -39,7 +41,7 @@ public class ServiceUpdateRequestDTO {
                 || inwardChargeType != null || inactive != null || discountAllowed != null
                 || userChangable != null || chargesVisibleForInward != null
                 || marginNotAllowed != null || requestForQuentity != null
-                || patientNotRequired != null;
+                || patientNotRequired != null || vatable != null || vatPercentage != null;
     }
 
     public String getName() {
@@ -160,5 +162,21 @@ public class ServiceUpdateRequestDTO {
 
     public void setPatientNotRequired(Boolean patientNotRequired) {
         this.patientNotRequired = patientNotRequired;
+    }
+
+    public Boolean getVatable() {
+        return vatable;
+    }
+
+    public void setVatable(Boolean vatable) {
+        this.vatable = vatable;
+    }
+
+    public Double getVatPercentage() {
+        return vatPercentage;
+    }
+
+    public void setVatPercentage(Double vatPercentage) {
+        this.vatPercentage = vatPercentage;
     }
 }

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -80,6 +80,9 @@ public class BillItem implements Serializable, RetirableEntity {
     @Transient
     private double absoluteNetValue;
     private double vatPlusNetValue;
+    // Snapshot of item.vatPercentage at billing time, so later changes to the
+    // item's VAT % don't retroactively alter historical bills/prints/reports.
+    private double vatPercentage;
 
     private double marginValue;
     private double adjustedValue;
@@ -234,6 +237,14 @@ public class BillItem implements Serializable, RetirableEntity {
         this.vat = vat;
     }
 
+    public double getVatPercentage() {
+        return vatPercentage;
+    }
+
+    public void setVatPercentage(double vatPercentage) {
+        this.vatPercentage = vatPercentage;
+    }
+
     public double getHospitalFee() {
         return hospitalFee;
     }
@@ -297,6 +308,7 @@ public class BillItem implements Serializable, RetirableEntity {
         agentRefNo = billItem.getAgentRefNo();
         vat = billItem.getVat();
         vatPlusNetValue = billItem.getVatPlusNetValue();
+        vatPercentage = billItem.getVatPercentage();
         collectingCentreFee = billItem.getCollectingCentreFee();
         consideredForCosting = billItem.isConsideredForCosting();
         primaryStaff = billItem.getPrimaryStaff();
@@ -343,6 +355,7 @@ public class BillItem implements Serializable, RetirableEntity {
         agentRefNo = billItem.getAgentRefNo();
         vat = billItem.getVat();
         vatPlusNetValue = billItem.getVatPlusNetValue();
+        vatPercentage = billItem.getVatPercentage();
         collectingCentreFee = billItem.getCollectingCentreFee();
         consideredForCosting = billItem.isConsideredForCosting();
         primaryStaff = billItem.getPrimaryStaff();
@@ -402,6 +415,7 @@ public class BillItem implements Serializable, RetirableEntity {
         marginValue = 0.0;
         vat = 0.0;
         vatPlusNetValue = 0.0;
+        vatPercentage = 0.0;
     }
 
     public BillItem() {
@@ -434,6 +448,8 @@ public class BillItem implements Serializable, RetirableEntity {
         hospitalFee = 0 - billItem.getHospitalFee();
         vat = 0 - billItem.getVat();
         vatPlusNetValue = 0 - billItem.getVatPlusNetValue();
+        // Percentage rate, not a value - stays positive like Rate/netRate/marginRate above
+        vatPercentage = billItem.getVatPercentage();
         collectingCentreFee = 0 - billItem.getCollectingCentreFee();
         otherFee = 0 - billItem.getOtherFee();
         reagentFee = 0 - billItem.getReagentFee();

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -326,7 +326,7 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
 
 
     public double getVatPercentage() {
-        return 0;
+        return vatPercentage;
     }
 
     public void setVatPercentage(double vatPercentage) {

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -845,7 +845,70 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "InvestigationReportType enum value (e.g. General). Optional."))
                                 .add("bypassSampleWorkflow", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "'true' to skip sample collection and allow direct result entry after billing. Optional.")))
+                                        .add("description", "'true' to skip sample collection and allow direct result entry after billing. Optional."))
+                                .add("vatable", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' to charge VAT on this investigation, 'false' to exempt it. Optional."))
+                                .add("vatPercentage", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "VAT percentage applied when vatable is true (e.g. '18'). Optional.")))
+                        .add("required", Json.createArrayBuilder().add("method")))
+                .build();
+
+        JsonObject manageServicesTool = Json.createObjectBuilder()
+                .add("name", "manage_services")
+                .add("description",
+                        "Search, retrieve, create, update, activate, or deactivate service master records "
+                        + "(billable OPD or Inward services, e.g. consultations, procedures, room charges). "
+                        + "Use GET to search by name/code/printName, optionally filtered by serviceType or categoryId. "
+                        + "Use POST to create a new service (returns already_exists with the existing id if a "
+                        + "duplicate name is found). Use PUT to update metadata. "
+                        + "Use ACTIVATE/DEACTIVATE to toggle the inactive flag.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Operation: GET=search, GET_BY_ID=fetch one, POST=create, PUT=update, ACTIVATE=set inactive=false, DEACTIVATE=set inactive=true. Required."))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Service ID. Required for GET_BY_ID, PUT, ACTIVATE, DEACTIVATE."))
+                                .add("query", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Search text matched against name, code, and printName (case-insensitive). Used with GET."))
+                                .add("serviceType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'OPD' or 'Inward'. Required for POST. Optional filter for GET."))
+                                .add("categoryId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Filter by service category ID. Used with GET."))
+                                .add("inactive", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Filter by active/inactive status: 'true' or 'false'. Omit to return both. Used with GET."))
+                                .add("limit", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Max results to return (1–100). Defaults to 20. Used with GET."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Service name. Required for POST; optional for PUT."))
+                                .add("code", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Short code. Auto-generated from name if omitted on POST. Optional for PUT."))
+                                .add("printName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Print/display name shown on reports and bills. Optional."))
+                                .add("fullName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Full descriptive name. Optional."))
+                                .add("inwardChargeType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "InwardChargeType enum value. Required when serviceType=Inward on POST."))
+                                .add("vatable", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' to charge VAT on this service, 'false' to exempt it. Optional."))
+                                .add("vatPercentage", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "VAT percentage applied when vatable is true (e.g. '18'). Optional.")))
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
@@ -1687,6 +1750,7 @@ public class AnthropicApiService implements Serializable {
                 .add(inwardRoomsTool)
                 .add(bedBoardSvgTool)
                 .add(manageInvestigationsTool)
+                .add(manageServicesTool)
                 .add(manageInvestigationFormatTool)
                 .add(manageFormsTool)
                 .add(manageSubscriptionsTool)
@@ -1855,7 +1919,26 @@ public class AnthropicApiService implements Serializable {
                     String printName = toolInput.containsKey("printName") ? toolInput.getString("printName", "") : "";
                     String reportType = toolInput.containsKey("reportType") ? toolInput.getString("reportType", "") : "";
                     String bypass = toolInput.containsKey("bypassSampleWorkflow") ? toolInput.getString("bypassSampleWorkflow", "") : "";
-                    return callInvestigationApi(method, id, query, inactive, limit, name, code, printName, reportType, bypass, hmisBaseUrl, hmisApiKey);
+                    String vatable = toolInput.containsKey("vatable") ? toolInput.getString("vatable", "") : "";
+                    String vatPercentage = toolInput.containsKey("vatPercentage") ? toolInput.getString("vatPercentage", "") : "";
+                    return callInvestigationApi(method, id, query, inactive, limit, name, code, printName, reportType, bypass, vatable, vatPercentage, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_services": {
+                    String method = toolInput.getString("method", "GET");
+                    String id = toolInput.containsKey("id") ? toolInput.getString("id", "") : "";
+                    String query = toolInput.containsKey("query") ? toolInput.getString("query", "") : "";
+                    String serviceType = toolInput.containsKey("serviceType") ? toolInput.getString("serviceType", "") : "";
+                    String categoryId = toolInput.containsKey("categoryId") ? toolInput.getString("categoryId", "") : "";
+                    String inactive = toolInput.containsKey("inactive") ? toolInput.getString("inactive", "") : "";
+                    String limit = toolInput.containsKey("limit") ? toolInput.getString("limit", "20") : "20";
+                    String name = toolInput.containsKey("name") ? toolInput.getString("name", "") : "";
+                    String code = toolInput.containsKey("code") ? toolInput.getString("code", "") : "";
+                    String printName = toolInput.containsKey("printName") ? toolInput.getString("printName", "") : "";
+                    String fullName = toolInput.containsKey("fullName") ? toolInput.getString("fullName", "") : "";
+                    String inwardChargeType = toolInput.containsKey("inwardChargeType") ? toolInput.getString("inwardChargeType", "") : "";
+                    String vatable = toolInput.containsKey("vatable") ? toolInput.getString("vatable", "") : "";
+                    String vatPercentage = toolInput.containsKey("vatPercentage") ? toolInput.getString("vatPercentage", "") : "";
+                    return callServiceApi(method, id, query, serviceType, categoryId, inactive, limit, name, code, printName, fullName, inwardChargeType, vatable, vatPercentage, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_investigation_format": {
                     String resourceType = toolInput.getString("resource_type", "ITEM");
@@ -3712,7 +3795,7 @@ public class AnthropicApiService implements Serializable {
      * @param userHmisApiKey  The logged-in user's active HMIS API key value
      * @param githubBranch    The GitHub branch for documentation links (e.g. "development")
      */
-    private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String hmisBaseUrl, String hmisApiKey) {
+    private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String vatable, String vatPercentage, String hmisBaseUrl, String hmisApiKey) {
         try {
             String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
             if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
@@ -3727,6 +3810,8 @@ public class AnthropicApiService implements Serializable {
             else if ("POST".equalsIgnoreCase(method) || "PUT".equalsIgnoreCase(method)) {
                 javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("name", name==null?"":name);
                 if(code!=null&&!code.isEmpty()) b.add("code", code); if(printName!=null&&!printName.isEmpty()) b.add("printName", printName); if(reportType!=null&&!reportType.isEmpty()) b.add("reportType", reportType); if(bypassSampleWorkflow!=null&&!bypassSampleWorkflow.isEmpty()) b.add("bypassSampleWorkflow", Boolean.parseBoolean(bypassSampleWorkflow));
+                if(vatable!=null&&!vatable.isEmpty()) b.add("vatable", Boolean.parseBoolean(vatable));
+                if(vatPercentage!=null&&!vatPercentage.isEmpty()) b.add("vatPercentage", Double.parseDouble(vatPercentage));
                 String u = "POST".equalsIgnoreCase(method) ? root+"/api/investigations" : root+"/api/investigations/"+id;
                 rb = HttpRequest.newBuilder().uri(URI.create(u)).method("POST".equalsIgnoreCase(method)?"POST":"PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
             } else if ("ACTIVATE".equalsIgnoreCase(method) || "DEACTIVATE".equalsIgnoreCase(method)) {
@@ -3740,6 +3825,45 @@ public class AnthropicApiService implements Serializable {
             }
             if(!key.isEmpty()) rb.header("Finance", key); HttpResponse<String> resp=client.send(rb.build(), HttpResponse.BodyHandlers.ofString()); return "HTTP "+resp.statusCode()+"\n"+resp.body();
         } catch (Exception e) { return "Investigation API error: "+e.getMessage(); }
+    }
+
+    private String callServiceApi(String method, String id, String query, String serviceType, String categoryId, String inactive, String limit, String name, String code, String printName, String fullName, String inwardChargeType, String vatable, String vatPercentage, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            HttpRequest.Builder rb;
+            if ("GET".equalsIgnoreCase(method)) {
+                String url = root+"/api/services/search?query="+URLEncoder.encode(query, StandardCharsets.UTF_8)+"&limit="+URLEncoder.encode(limit, StandardCharsets.UTF_8);
+                if(serviceType!=null&&!serviceType.isEmpty()) url += "&serviceType="+URLEncoder.encode(serviceType, StandardCharsets.UTF_8);
+                if(categoryId!=null&&!categoryId.isEmpty()) url += "&categoryId="+URLEncoder.encode(categoryId, StandardCharsets.UTF_8);
+                if(inactive!=null&&!inactive.isEmpty()) url += "&inactive="+URLEncoder.encode(inactive, StandardCharsets.UTF_8);
+                rb = HttpRequest.newBuilder().uri(URI.create(url)).GET();
+            } else if ("GET_BY_ID".equalsIgnoreCase(method)) { rb = HttpRequest.newBuilder().uri(URI.create(root+"/api/services/"+id)).GET(); }
+            else if ("POST".equalsIgnoreCase(method) || "PUT".equalsIgnoreCase(method)) {
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("name", name==null?"":name);
+                if(serviceType!=null&&!serviceType.isEmpty()) b.add("serviceType", serviceType);
+                if(code!=null&&!code.isEmpty()) b.add("code", code);
+                if(printName!=null&&!printName.isEmpty()) b.add("printName", printName);
+                if(fullName!=null&&!fullName.isEmpty()) b.add("fullName", fullName);
+                if(categoryId!=null&&!categoryId.isEmpty()) b.add("categoryId", Long.parseLong(categoryId));
+                if(inwardChargeType!=null&&!inwardChargeType.isEmpty()) b.add("inwardChargeType", inwardChargeType);
+                if(vatable!=null&&!vatable.isEmpty()) b.add("vatable", Boolean.parseBoolean(vatable));
+                if(vatPercentage!=null&&!vatPercentage.isEmpty()) b.add("vatPercentage", Double.parseDouble(vatPercentage));
+                String u = "POST".equalsIgnoreCase(method) ? root+"/api/services" : root+"/api/services/"+id;
+                rb = HttpRequest.newBuilder().uri(URI.create(u)).method("POST".equalsIgnoreCase(method)?"POST":"PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("ACTIVATE".equalsIgnoreCase(method) || "DEACTIVATE".equalsIgnoreCase(method)) {
+                String u = root + "/api/services/" + id
+                        + ("ACTIVATE".equalsIgnoreCase(method) ? "/activate" : "/deactivate");
+                rb = HttpRequest.newBuilder().uri(URI.create(u))
+                        .method("PATCH", HttpRequest.BodyPublishers.noBody());
+            } else {
+                return "Error: Unsupported method for manage_services: " + method
+                        + ". Allowed methods are GET, GET_BY_ID, POST, PUT, ACTIVATE, DEACTIVATE.";
+            }
+            if(!key.isEmpty()) rb.header("Finance", key); HttpResponse<String> resp=client.send(rb.build(), HttpResponse.BodyHandlers.ofString()); return "HTTP "+resp.statusCode()+"\n"+resp.body();
+        } catch (Exception e) { return "Service API error: "+e.getMessage(); }
     }
 
     private String callInvestigationFormatApi(String resourceType, String method,
@@ -5115,8 +5239,20 @@ public class AnthropicApiService implements Serializable {
           .append("Use GET to search by name, code, or printName. ")
           .append("Use POST to create — returns 'already_exists' with the existing id when a duplicate name is found, ")
           .append("so always check before creating to avoid duplicates. ")
-          .append("Use PUT to update name, code, printName, reportType, or bypassSampleWorkflow. ")
+          .append("Use PUT to update name, code, printName, reportType, bypassSampleWorkflow, vatable, or vatPercentage. ")
+          .append("Set vatable=true and vatPercentage (e.g. 18) to charge VAT automatically wherever this investigation is billed; ")
+          .append("vatable=false or vatPercentage=0 means no VAT. ")
           .append("Always confirm with the user before POST or PUT — these changes affect live investigation billing.\n\n");
+        sb.append("### manage_services\n");
+        sb.append("Search, retrieve, create, update, activate, or deactivate service master records ")
+          .append("(billable OPD or Inward services, e.g. consultations, procedures, room charges). ")
+          .append("Use GET to search by name, code, or printName, optionally filtered by serviceType ('OPD'/'Inward') or categoryId. ")
+          .append("Use POST to create — serviceType and name are required, inwardChargeType is required when serviceType=Inward. ")
+          .append("Returns 'already_exists' with the existing id when a duplicate name is found, so always check before creating. ")
+          .append("Use PUT to update name, code, printName, fullName, categoryId, inwardChargeType, vatable, or vatPercentage. ")
+          .append("Set vatable=true and vatPercentage (e.g. 18) to charge VAT automatically wherever this service is billed; ")
+          .append("vatable=false or vatPercentage=0 means no VAT. ")
+          .append("Always confirm with the user before POST or PUT — these changes affect live service billing.\n\n");
         sb.append("### manage_investigation_format\n");
         sb.append("Manage the internal report format of an investigation: items (report fields like labels, values, ")
           .append("calculations, flags), item values (dropdown options for List-type items), calculations (formulas ")

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -46,6 +46,7 @@ public class InvestigationApiService implements Serializable {
         i.setInactive(Boolean.TRUE.equals(req.getInactive()));
         i.setBypassSampleWorkflow(Boolean.TRUE.equals(req.getBypassSampleWorkflow()));
         i.setVatable(Boolean.TRUE.equals(req.getVatable()));
+        validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
         i.setCreater(user); i.setCreatedAt(new Date()); i.setRetired(false);
@@ -62,6 +63,7 @@ public class InvestigationApiService implements Serializable {
         if (req.getInactive() != null) i.setInactive(req.getInactive());
         if (req.getBypassSampleWorkflow() != null) i.setBypassSampleWorkflow(req.getBypassSampleWorkflow());
         if (req.getVatable() != null) i.setVatable(req.getVatable());
+        validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
         i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
@@ -74,6 +76,12 @@ public class InvestigationApiService implements Serializable {
     }
 
     private Investigation load(Long id) throws Exception { Investigation i = investigationFacade.find(id); if (i == null || i.isRetired()) throw new Exception("Investigation not found with ID: " + id); return i; }
+
+    private void validateVatPercentage(Double vatPercentage) throws Exception {
+        if (vatPercentage != null && (vatPercentage < 0 || vatPercentage > 100)) {
+            throw new Exception("vatPercentage must be between 0 and 100");
+        }
+    }
     private InvestigationSearchResultDTO toSearch(Investigation i) {
         InvestigationSearchResultDTO dto = new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow());
         dto.setVatable(i.isVatable());

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -45,6 +45,8 @@ public class InvestigationApiService implements Serializable {
         i.setPrintName(req.getPrintName());
         i.setInactive(Boolean.TRUE.equals(req.getInactive()));
         i.setBypassSampleWorkflow(Boolean.TRUE.equals(req.getBypassSampleWorkflow()));
+        i.setVatable(Boolean.TRUE.equals(req.getVatable()));
+        if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
         i.setCreater(user); i.setCreatedAt(new Date()); i.setRetired(false);
         investigationFacade.create(i); i.setBilledAs(i); i.setReportedAs(i); investigationFacade.edit(i);
@@ -59,6 +61,8 @@ public class InvestigationApiService implements Serializable {
         if (req.getPrintName() != null) i.setPrintName(req.getPrintName());
         if (req.getInactive() != null) i.setInactive(req.getInactive());
         if (req.getBypassSampleWorkflow() != null) i.setBypassSampleWorkflow(req.getBypassSampleWorkflow());
+        if (req.getVatable() != null) i.setVatable(req.getVatable());
+        if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
         i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
         return toResponse(i, "Investigation updated successfully");
@@ -70,6 +74,16 @@ public class InvestigationApiService implements Serializable {
     }
 
     private Investigation load(Long id) throws Exception { Investigation i = investigationFacade.find(id); if (i == null || i.isRetired()) throw new Exception("Investigation not found with ID: " + id); return i; }
-    private InvestigationSearchResultDTO toSearch(Investigation i) { return new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow()); }
-    private InvestigationResponseDTO toResponse(Investigation i, String m) { return new InvestigationResponseDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow(), m); }
+    private InvestigationSearchResultDTO toSearch(Investigation i) {
+        InvestigationSearchResultDTO dto = new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow());
+        dto.setVatable(i.isVatable());
+        dto.setVatPercentage(i.getVatPercentage());
+        return dto;
+    }
+    private InvestigationResponseDTO toResponse(Investigation i, String m) {
+        InvestigationResponseDTO dto = new InvestigationResponseDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow(), m);
+        dto.setVatable(i.isVatable());
+        dto.setVatPercentage(i.getVatPercentage());
+        return dto;
+    }
 }

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -224,6 +224,7 @@ public class ServiceApiService implements Serializable {
         service.setRequestForQuentity(request.isRequestForQuentity());
         service.setPatientNotRequired(request.isPatientNotRequired());
         service.setVatable(request.isVatable());
+        validateVatPercentage(request.getVatPercentage());
         service.setVatPercentage(request.getVatPercentage());
 
         // Resolve optional associations
@@ -338,6 +339,7 @@ public class ServiceApiService implements Serializable {
             service.setVatable(request.getVatable());
         }
         if (request.getVatPercentage() != null) {
+            validateVatPercentage(request.getVatPercentage());
             service.setVatPercentage(request.getVatPercentage());
         }
 
@@ -901,6 +903,12 @@ public class ServiceApiService implements Serializable {
             throw new Exception("Service with ID " + id + " is not an OPD or Inward service");
         }
         return service;
+    }
+
+    private void validateVatPercentage(Double vatPercentage) throws Exception {
+        if (vatPercentage != null && (vatPercentage < 0 || vatPercentage > 100)) {
+            throw new Exception("vatPercentage must be between 0 and 100");
+        }
     }
 
     /**

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -223,6 +223,8 @@ public class ServiceApiService implements Serializable {
         service.setMarginNotAllowed(request.isMarginNotAllowed());
         service.setRequestForQuentity(request.isRequestForQuentity());
         service.setPatientNotRequired(request.isPatientNotRequired());
+        service.setVatable(request.isVatable());
+        service.setVatPercentage(request.getVatPercentage());
 
         // Resolve optional associations
         if (request.getCategoryId() != null) {
@@ -331,6 +333,12 @@ public class ServiceApiService implements Serializable {
         }
         if (request.getPatientNotRequired() != null) {
             service.setPatientNotRequired(request.getPatientNotRequired());
+        }
+        if (request.getVatable() != null) {
+            service.setVatable(request.getVatable());
+        }
+        if (request.getVatPercentage() != null) {
+            service.setVatPercentage(request.getVatPercentage());
         }
 
         if (request.getCategoryId() != null) {
@@ -998,6 +1006,8 @@ public class ServiceApiService implements Serializable {
         dto.setMarginNotAllowed(service.isMarginNotAllowed());
         dto.setRequestForQuentity(service.isRequestForQuentity());
         dto.setPatientNotRequired(service.isPatientNotRequired());
+        dto.setVatable(service.isVatable());
+        dto.setVatPercentage(service.getVatPercentage());
         if (service.getInwardChargeType() != null) {
             dto.setInwardChargeType(service.getInwardChargeType().name());
         }

--- a/src/main/webapp/admin/items/items.xhtml
+++ b/src/main/webapp/admin/items/items.xhtml
@@ -240,16 +240,22 @@
                                             </h:panelGrid>
 
                                         </p:tab>
-                                        <p:tab rendered="false" title="Depricated" >
-                                            <h:outputText id="lblVatPercentage" value="VAT Percentage" ></h:outputText>
-                                            <p:inputText styleClass="longText pdInputText" autocomplete="off"   
-                                                         value="#{itemController.current.vatPercentage}"  class="form-control"></p:inputText>
+                                        <p:tab title="VAT" >
+                                            <p:panelGrid columns="2" layout="tabular" class="w-100" columnClasses="w-25, w-75">
+                                                <p:outputLabel for="chkVatable" value="VATable"/>
+                                                <p:selectBooleanCheckbox id="chkVatable" value="#{itemController.current.vatable}" itemLabel="Charge VAT on this item">
+                                                    <p:ajax update="txtVatPercentage"/>
+                                                </p:selectBooleanCheckbox>
 
-
-                                            <h:outputText value="VATable" ></h:outputText>
-                                            <p:selectBooleanCheckbox  value="#{itemController.current.vatable}" >
-                                            </p:selectBooleanCheckbox>
-
+                                                <p:outputLabel for="txtVatPercentage" value="VAT Percentage"/>
+                                                <p:inputNumber id="txtVatPercentage"
+                                                               value="#{itemController.current.vatPercentage}"
+                                                               decimalPlaces="2"
+                                                               minValue="0"
+                                                               maxValue="100"
+                                                               disabled="#{not itemController.current.vatable}"
+                                                               class="w-100 m-1"/>
+                                            </p:panelGrid>
                                         </p:tab>
                                     </p:tabView>
                                 </h:panelGrid>

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -632,6 +632,14 @@
                                                             </h:outputLabel>
                                                         </p:column>
 
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                            <f:facet name="header">VAT</f:facet>
+                                                            <h:outputLabel value="#{bi.billItem.vat}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
                                                         <p:column width="3em">
                                                             <p:commandButton
                                                                 id="btnRemove"
@@ -746,6 +754,14 @@
                                                                 id="feeValue"
                                                                 value="#{bif.feeValue}"
                                                                 class="text-end w-100">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+
+                                                        <p:column width="8em" class="text-end"
+                                                                  rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                            <f:facet name="header">VAT</f:facet>
+                                                            <h:outputLabel value="#{bif.feeVat}" class="text-end w-100">
                                                                 <f:convertNumber pattern="#,##0.00" />
                                                             </h:outputLabel>
                                                         </p:column>
@@ -871,6 +887,22 @@
                                                 <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
                                                     <h:outputLabel value="Net Total" ></h:outputLabel>
                                                     <h:outputLabel value="#{billBhtController.netTotal}" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                            <div class="card my-2">
+                                                <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
+                                                    <h:outputLabel value="VAT" ></h:outputLabel>
+                                                    <h:outputLabel value="#{billBhtController.vat}" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </div>
+                                            </div>
+                                            <div class="card">
+                                                <div class="d-flex justify-content-between p-3 m-2" style="font-size: 18px; font-weight: 700;" >
+                                                    <h:outputLabel value="Net Total + VAT" ></h:outputLabel>
+                                                    <h:outputLabel value="#{billBhtController.vatPlusNetTotal}" >
                                                         <f:convertNumber pattern="#,##0.00" />
                                                     </h:outputLabel>
                                                 </div>

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
@@ -299,6 +299,13 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
                             </tr>
 
@@ -329,6 +336,14 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
 
                             </tr>
@@ -401,16 +416,29 @@
                         </td>
                     </tr>
 
-                    <tr>
-                        <td  class="totalsBlock" style="text-align: left;">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="VAT" />
-                        </td>
-                        <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.vat}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel value="VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel value="Net Total + VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
 
                 </table>
 

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_with_headings.xhtml
@@ -295,17 +295,17 @@
                                 </td>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
                             </tr>
 
@@ -332,18 +332,17 @@
                                     </td>
 
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
 
                             </tr>
@@ -416,29 +415,29 @@
                         </td>
                     </tr>
 
-                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                    <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
-                                <h:outputLabel value="VAT" />
+                                <h:outputText value="VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                <h:outputText value="#{cc.attrs.bill.vat}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
 
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
-                                <h:outputLabel value="Net Total + VAT" />
+                                <h:outputText value="Net Total + VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
-                    </h:panelGroup>
+                    </ui:fragment>
 
                 </table>
 

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
@@ -264,6 +264,13 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
                             </tr>
 
@@ -294,6 +301,14 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
 
                             </tr>
@@ -366,16 +381,29 @@
                         </td>
                     </tr>
 
-                    <tr>
-                        <td  class="totalsBlock" style="text-align: left;">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="VAT" />
-                        </td>
-                        <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.vat}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel value="VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel value="Net Total + VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
 
                 </table>
 

--- a/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_paper_without_headings.xhtml
@@ -260,17 +260,17 @@
                                 </td>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
                             </tr>
 
@@ -297,18 +297,17 @@
                                     </td>
 
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
 
                             </tr>
@@ -381,29 +380,29 @@
                         </td>
                     </tr>
 
-                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                    <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
-                                <h:outputLabel value="VAT" />
+                                <h:outputText value="VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                <h:outputText value="#{cc.attrs.bill.vat}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
 
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
-                                <h:outputLabel value="Net Total + VAT" />
+                                <h:outputText value="Net Total + VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
-                    </h:panelGroup>
+                    </ui:fragment>
 
                 </table>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
@@ -205,6 +205,13 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+                                    <h:panelGroup rendered="#{item.vat ne 0.0}">
+                                        <td style="text-align: right">
+                                            <h:outputLabel value="#{item.vat}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
                             </tr>
                         </ui:repeat>
@@ -273,6 +280,25 @@
                                         </h:outputLabel>
                                     </td>
                                 </tr>
+
+                                <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                                    <tr>
+                                        <td >VAT</td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td >Net Amount + VAT</td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
                             </h:panelGroup>
                             <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null 
                                                       and cc.attrs.billCount eq 1 

--- a/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_eight_opd_bill_inward.xhtml
@@ -201,17 +201,17 @@
                                 </td>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                     <td style="text-align: right">
-                                        <h:outputLabel value="#{item.netValue}">
+                                        <h:outputText value="#{item.netValue}">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <h:panelGroup rendered="#{item.vat ne 0.0}">
-                                        <td style="text-align: right">
-                                            <h:outputLabel value="#{item.vat}">
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{item.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText value="VAT "/>
+                                            <h:outputText value="#{item.vat}">
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
                             </tr>
                         </ui:repeat>
@@ -281,24 +281,24 @@
                                     </td>
                                 </tr>
 
-                                <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                                <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                                     <tr>
                                         <td >VAT</td>
                                         <td style="text-align: right;">
-                                            <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                            <h:outputText value="#{cc.attrs.bill.vat}">
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
+                                            </h:outputText>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td >Net Amount + VAT</td>
                                         <td style="text-align: right;">
-                                            <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                            <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}">
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
+                                            </h:outputText>
                                         </td>
                                     </tr>
-                                </h:panelGroup>
+                                </ui:fragment>
                             </h:panelGroup>
                             <h:panelGroup rendered="#{cc.attrs.bill.patientEncounter eq null 
                                                       and cc.attrs.billCount eq 1 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
@@ -213,6 +213,7 @@
                             <th>Item Name</th>
                             <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                 <th style="text-align: right">Value</th>
+                                <th style="text-align: right">VAT</th>
                             </h:panelGroup>
                         </tr>
                     </thead>
@@ -229,6 +230,11 @@
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </td>
+                                        <td style="text-align: right">
+                                            <h:outputLabel value="#{item.vat}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
                                     </h:panelGroup>
                                 </tr>
                             </ui:repeat>
@@ -242,6 +248,11 @@
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                         <td style="text-align: right">
                                             <h:outputLabel value="#{item.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                        <td style="text-align: right">
+                                            <h:outputLabel value="#{item.vat}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </td>
@@ -285,6 +296,25 @@
                                 </h:outputLabel>
                             </td>
                         </tr>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                            <tr>
+                                <td >VAT:</td>
+                                <td style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td >Net Total + VAT:</td>
+                                <td style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
                     </h:panelGroup>
 
                     <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Inward Service Bill - Group Bill Item By Name',false)}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_custom_3_inward.xhtml
@@ -297,24 +297,24 @@
                             </td>
                         </tr>
 
-                        <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                        <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                             <tr>
                                 <td >VAT:</td>
                                 <td style="text-align: right;">
-                                    <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                    <h:outputText value="#{cc.attrs.bill.vat}">
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
+                                    </h:outputText>
                                 </td>
                             </tr>
                             <tr>
                                 <td >Net Total + VAT:</td>
                                 <td style="text-align: right;">
-                                    <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                    <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
+                                    </h:outputText>
                                 </td>
                             </tr>
-                        </h:panelGroup>
+                        </ui:fragment>
                     </h:panelGroup>
 
                     <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Inward Service Bill - Group Bill Item By Name',false)}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
@@ -290,17 +290,17 @@
                                 </td>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
                             </tr>
 
@@ -327,18 +327,17 @@
                                     </td>
 
                                     <td style="text-align: right;" >
-                                        <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
+                                        <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.grossValue}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-
-                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                        <td style="text-align: right;">
-                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                        </h:outputText>
+                                        <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                            <br/>
+                                            <h:outputText class="itemsBlockRightFiveFive" value="VAT "/>
+                                            <h:outputText class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
                                                 <f:convertNumber pattern="#,##0.00" />
-                                            </h:outputLabel>
-                                        </td>
-                                    </h:panelGroup>
+                                            </h:outputText>
+                                        </ui:fragment>
+                                    </td>
                                 </h:panelGroup>
 
                             </tr>
@@ -371,38 +370,38 @@
                         </tr>
                     </h:panelGroup>
 
-                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                    <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                         <tr>
                             <td class="totalsBlock" style="text-align: left; width: 60%;">
-                                <h:outputLabel value="Net Total" />
+                                <h:outputText value="Net Total" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" >
+                                <h:outputText value="#{cc.attrs.bill.netTotal}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
                             <td class="totalsBlock" style="text-align: left; width: 60%;">
-                                <h:outputLabel value="VAT" />
+                                <h:outputText value="VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.vat}" >
+                                <h:outputText value="#{cc.attrs.bill.vat}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
                         <tr>
                             <td class="totalsBlock" style="text-align: left; width: 60%;">
-                                <h:outputLabel value="Net Total + VAT" />
+                                <h:outputText value="Net Total + VAT" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
-                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}" >
+                                <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}" >
                                     <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
+                                </h:outputText>
                             </td>
                         </tr>
-                    </h:panelGroup>
+                    </ui:fragment>
 
                 </table>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
@@ -294,6 +294,13 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
                             </tr>
 
@@ -324,6 +331,14 @@
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
                                     </td>
+
+                                    <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                        <td style="text-align: right;">
+                                            <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.vat}"    >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </h:panelGroup>
                                 </h:panelGroup>
 
                             </tr>
@@ -350,6 +365,39 @@
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
                                 <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                        <tr>
+                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                <h:outputLabel value="Net Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                <h:outputLabel value="VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                <h:outputLabel value="#{cc.attrs.bill.vat}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                <h:outputLabel value="Net Total + VAT" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
@@ -4,7 +4,8 @@
       xmlns:cc="http://xmlns.jcp.org/jsf/composite"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
     <!-- INTERFACE -->
     <cc:interface>
@@ -411,30 +412,30 @@
                                     </td>
                                 </tr>
                             </h:panelGroup>
-                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and cc.attrs.bill.vat ne 0.0}">
+                            <ui:fragment rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and cc.attrs.bill.vat ne 0.0}">
                                 <tr>
                                     <td style="text-align: left; min-width: 3cm;">
-                                        <h:outputLabel value="VAT" style="text-align: right!important; font-size: 12px!important;"/>
+                                        <h:outputText value="VAT" style="text-align: right!important; font-size: 12px!important;"/>
                                     </td>
                                     <td style="text-align: right!important; ">
-                                        <h:outputLabel value="#{cc.attrs.bill.vat}" style="text-align: right!important; font-size: 12px!important;">
+                                        <h:outputText value="#{cc.attrs.bill.vat}" style="text-align: right!important; font-size: 12px!important;">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
+                                        </h:outputText>
                                     </td>
                                 </tr>
-                            </h:panelGroup>
-                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and (cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0)}">
+                            </ui:fragment>
+                            <ui:fragment rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and (cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0)}">
                                 <tr>
                                     <td style="text-align: left;">
-                                        <h:outputLabel value="Net Total + VAT" style=" text-align: right!important;  font-size: 15px!important;   "/>
+                                        <h:outputText value="Net Total + VAT" style=" text-align: right!important;  font-size: 15px!important;   "/>
                                     </td>
                                     <td style="text-align: right!important; ">
-                                        <h:outputLabel value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
+                                        <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
+                                        </h:outputText>
                                     </td>
                                 </tr>
-                            </h:panelGroup>
+                            </ui:fragment>
 
 
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
@@ -411,30 +411,28 @@
                                     </td>
                                 </tr>
                             </h:panelGroup>
-                            <!--                            <tr>
-                                                            <td style="text-align: left; min-width: 3cm;">
-                                                                <h:outputLabel value="VAT (15%)" style="text-align: right!important; font-size: 12px!important;" rendered="#{cc.attrs.bill.vat ne 0.0}"/>
-                                                            </td>
-                                                            <td style="text-align: right!important; ">
-                                                                <h:outputLabel value="#{cc.attrs.bill.vat}" style="text-align: right!important; font-size: 12px!important;" rendered="#{cc.attrs.bill.vat ne 0.0}">
-                                                                    <f:convertNumber pattern="#,##0.00" />
-                                                                </h:outputLabel>
-                                                            </td>
-                                                        </tr>-->
-                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and cc.attrs.bill.vat ne 0.0}">
                                 <tr>
-                                    <td style="text-align: left;">
-                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>
-                                        <!--<h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0}"    value="Net Total" style=" text-align: right!important;  font-size: 15px!important;   "/>-->
+                                    <td style="text-align: left; min-width: 3cm;">
+                                        <h:outputLabel value="VAT" style="text-align: right!important; font-size: 12px!important;"/>
                                     </td>
                                     <td style="text-align: right!important; ">
-                                        <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
+                                        <h:outputLabel value="#{cc.attrs.bill.vat}" style="text-align: right!important; font-size: 12px!important;">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
-<!--                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0}"    value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>-->
-                                </td>
+                                    </td>
+                                </tr>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges') and (cc.attrs.bill.discount ne 0.0 or cc.attrs.bill.vat ne 0.0)}">
+                                <tr>
+                                    <td style="text-align: left;">
+                                        <h:outputLabel value="Net Total + VAT" style=" text-align: right!important;  font-size: 15px!important;   "/>
+                                    </td>
+                                    <td style="text-align: right!important; ">
+                                        <h:outputLabel value="#{cc.attrs.bill.netTotal+cc.attrs.bill.vat}"  style="font-weight: bold ; text-align: right!important; font-size: 15px!important;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
                                 </tr>
                             </h:panelGroup>
 

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
@@ -356,17 +356,17 @@
                             </td>
                             <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
                                 <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 30px;" >
-                                    <h:outputLabel    value="#{bip.grossValue}"    >
+                                    <h:outputText    value="#{bip.grossValue}"    >
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </td>
-                                <h:panelGroup rendered="#{bip.vat ne 0.0}">
-                                    <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 30px;">
-                                        <h:outputLabel    value="#{bip.vat}"    >
+                                    </h:outputText>
+                                    <ui:fragment rendered="#{bip.vat ne 0.0}">
+                                        <br/>
+                                        <h:outputText value="VAT "/>
+                                        <h:outputText    value="#{bip.vat}"    >
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </td>
-                                </h:panelGroup>
+                                        </h:outputText>
+                                    </ui:fragment>
+                                </td>
                             </h:panelGroup>
 
                         </tr>
@@ -457,29 +457,29 @@
                             </td>
                         </tr>
 
-                        <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                        <ui:fragment rendered="#{cc.attrs.bill.vat ne 0.0}">
                             <tr>
                                 <td  class="totalsBlock" style="text-align: left;">
-                                    <h:outputLabel value="VAT" />
+                                    <h:outputText value="VAT" />
                                 </td>
                                 <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                    <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                    <h:outputText value="#{cc.attrs.bill.vat}">
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
+                                    </h:outputText>
                                 </td>
                             </tr>
 
                             <tr>
                                 <td  class="totalsBlock" style="text-align: left;">
-                                    <h:outputLabel value="Net Total + VAT" />
+                                    <h:outputText value="Net Total + VAT" />
                                 </td>
                                 <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                    <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                    <h:outputText value="#{cc.attrs.bill.vatPlusNetTotal}">
                                         <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
+                                    </h:outputText>
                                 </td>
                             </tr>
-                        </h:panelGroup>
+                        </ui:fragment>
 
                         <tr>
 

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
@@ -360,6 +360,13 @@
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
+                                <h:panelGroup rendered="#{bip.vat ne 0.0}">
+                                    <td  styleClass="itemsBlockRight" style="text-align: right; padding-right: 30px;">
+                                        <h:outputLabel    value="#{bip.vat}"    >
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </td>
+                                </h:panelGroup>
                             </h:panelGroup>
 
                         </tr>
@@ -450,16 +457,29 @@
                             </td>
                         </tr>
 
-                        <tr>
-                            <td  class="totalsBlock" style="text-align: left;">
-                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="VAT" />
-                            </td>
-                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
-                                <h:outputLabel  rendered="#{cc.attrs.bill.vat ne 0.0}"    value="#{cc.attrs.bill.vat}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                        </tr>
+                        <h:panelGroup rendered="#{cc.attrs.bill.vat ne 0.0}">
+                            <tr>
+                                <td  class="totalsBlock" style="text-align: left;">
+                                    <h:outputLabel value="VAT" />
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                    <h:outputLabel value="#{cc.attrs.bill.vat}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td  class="totalsBlock" style="text-align: left;">
+                                    <h:outputLabel value="Net Total + VAT" />
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
+                                    <h:outputLabel value="#{cc.attrs.bill.vatPlusNetTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
 
                         <tr>
 

--- a/src/main/webapp/theater/inward_bill_surgery_service.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_service.xhtml
@@ -261,6 +261,13 @@
 
                                                 </p:column>
 
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">VAT</f:facet>
+                                                    <h:outputLabel value="#{bi.billItem.vat}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </p:column>
+
                                                 <p:column>
                                                     <h:commandButton id="btnRemove" value="X" action="#{billBhtController.removeBillItem(bi)}" >
                                                         <f:setPropertyActionListener  value="#{rowIndex}" target="#{billBhtController.index}" />
@@ -325,6 +332,13 @@
                                                     </h:outputLabel>
                                                 </p:column>
 
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">VAT</f:facet>
+                                                    <h:outputLabel value="#{bif.feeVat}" >
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </p:column>
+
                                                 <p:column >
                                                     <f:facet name="header">Speciality</f:facet>
                                                     <h:outputLabel value="#{bif.speciality.name}"/>
@@ -351,6 +365,18 @@
                                         <p:panelGrid columns="2" columnClasses="numberCol, textCol"  >
                                             <h:outputLabel value="Total" ></h:outputLabel>
                                             <h:outputLabel id="tot" value="#{billBhtController.total}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Net Total" ></h:outputLabel>
+                                            <h:outputLabel value="#{billBhtController.netTotal}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                            <h:outputLabel value="VAT" ></h:outputLabel>
+                                            <h:outputLabel value="#{billBhtController.vat}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Net Total + VAT" ></h:outputLabel>
+                                            <h:outputLabel value="#{billBhtController.vatPlusNetTotal}" >
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                         </p:panelGrid>


### PR DESCRIPTION
## Summary

Closes #22176.

- Fixes `Item.getVatPercentage()`, a broken getter (hard-coded to return `0`) that was silently disabling an already-written `isVatable()`-gated VAT calculation pattern used across OPD, optician, and membership billing (`BillController`, `OpdBillController`, `OpdOrderController`, `OpticianRepairBillController`, `ApiMembership`). Fixing it activates that dormant logic there too as a side effect, at no extra implementation cost.
- Wires the same VAT-on-net-value-after-discount pattern into `BillBhtController`'s shared `addToBill()` / `addToBillSurgery()` / `calTotals()` path, so both the **inpatient** and **surgical** "Add Services & Investigations" dashboards compute VAT automatically per item (both dashboards funnel through this one controller).
- Re-enables the previously hidden ("Depricated", `rendered="false"`) VAT tab on **Admin → Manage Items**, redesigned per the UI guidelines.
- Adds a new `BillItem.vatPercentage` field — a rate snapshot at billing time, independent of later changes to the item's VAT %, so historical bills stay accurate.
- Adds a per-line VAT column and Net Total / VAT / Net Total + VAT summary rows to both add-services pages and to all print templates used by inward service bills (A4, five-five, POS variants) — fixing a couple of pre-existing render-condition bugs on the dormant VAT print row along the way (it was gated on `discount != 0` instead of `vat != 0`).
- Extends the Service/Investigation REST API (request/response DTOs + service layer) with `vatable`/`vatPercentage`.
- Extends the `manage_investigations` AI chat tool with `vatable`/`vatPercentage`, and adds a new `manage_services` tool (none existed before — services were never wired into AI chat) for parity.

Net total remains VAT-exclusive per the original ask; `Bill.vatPlusNetTotal` / `BillItem.vatPlusNetValue` provide the net+VAT figure.

**Scope**: inpatient + surgical dashboards only, per design doc (`docs/superpowers/specs/2026-07-16-inpatient-surgical-vat-design.md`). OPD/channel/pharmacy billing use the same `Item` entity but are not otherwise touched (aside from the getter fix noted above).

## Test plan

Verified end-to-end on local dev (full detail + DB numbers in the [issue comment](https://github.com/hmislk/hmis/issues/22176#issuecomment-4995432997)):

- [x] Admin Manage Items → VAT tab: checkbox/percentage AJAX enable-disable works, saves correctly (`item.vatable`, `item.vatPercentage` confirmed in DB).
- [x] Inpatient dashboard: added a service with VAT% set, settled the bill, verified `BillItem.vat`, `BillItem.vatPercentage`, `BillItem.vatPlusNetValue`, `Bill.vat`, `Bill.vatPlusNetTotal` all compute correctly (`975 = 6500 × 15%`, `vatPlusNetTotal = 7475`) via direct DB query.
- [x] Print previews (5x5 and A4) render cleanly with the new VAT rows/columns, no server errors.
- [x] Surgical dashboard: verified via code — `addToBillSurgery()` shares the exact same fixed code path as the inpatient flow; not independently re-tested via UI (no in-progress surgery in the local test DB).
- [x] REST API: `GET/PUT /api/services/{id}` and `GET/PUT /api/investigations/{id}` correctly return/update `vatable`/`vatPercentage` (curl-tested against local deployment).
- [ ] AI chat `manage_services`/`manage_investigations` tools: implemented following the exact working pattern of the pre-existing `manage_investigations` tool, but not live-tested against the Anthropic API in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VAT support for inpatient and surgical “add services/investigations” flows, including VAT/net totals and Net Total + VAT.
  * Admin can now configure VAT per service/investigation using vatable + percentage controls.
  * Updated inward and theater service bill screens to show per-line VAT plus VAT summary rows.
* **Bug Fixes**
  * Corrected VAT computation and rounding, including fee- and item-level VAT rollups across navigation and edits.
  * Fixed/standardized VAT rendering conditions across multiple A4/OPD receipt and bill print templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->