### PR TITLE
feat(inward): show Gross/Discount/Margin/VAT breakdown on interim bill page

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3462,14 +3462,23 @@ public class BhtSummeryController implements Serializable {
         grantTotal = 0;
         discount = 0;
         adjustedTotal = 0;
+        grossTotal = 0;
+        marginTotal = 0;
+        vatTotal = 0;
         for (ChargeItemTotal c : getChargeItemTotals()) {
             grantTotal += c.getTotal();
             discount += c.getDiscount();
             adjustedTotal += c.getAdjustedTotal();
+            grossTotal += c.getGross();
+            marginTotal += c.getMargin();
+            vatTotal += c.getVat();
         }
     }
 
     double adjustedTotal = 0;
+    double grossTotal = 0;
+    double marginTotal = 0;
+    double vatTotal = 0;
 
     public double getGrantTotal() {
         return grantTotal;
@@ -3485,6 +3494,30 @@ public class BhtSummeryController implements Serializable {
 
     public void setDiscount(double discount) {
         this.discount = discount;
+    }
+
+    public double getGrossTotal() {
+        return grossTotal;
+    }
+
+    public void setGrossTotal(double grossTotal) {
+        this.grossTotal = grossTotal;
+    }
+
+    public double getMarginTotal() {
+        return marginTotal;
+    }
+
+    public void setMarginTotal(double marginTotal) {
+        this.marginTotal = marginTotal;
+    }
+
+    public double getVatTotal() {
+        return vatTotal;
+    }
+
+    public void setVatTotal(double vatTotal) {
+        this.vatTotal = vatTotal;
     }
 
     public double getDue() {
@@ -3543,6 +3576,8 @@ public class BhtSummeryController implements Serializable {
 
             setChargeValueFromAdditional();
 
+            setGrossMarginVatBreakdown();
+
         }
 
         setNetAdjustValue();
@@ -3582,6 +3617,74 @@ public class BhtSummeryController implements Serializable {
             double adj = bulkTotals.getOrDefault(cit.getInwardChargeType(), 0.0);
             double tot = cit.getTotal();
             cit.setTotal(tot + adj);
+        }
+    }
+
+    /**
+     * Populates Gross/Service Charge (Margin)/VAT on each ChargeItemTotal so the
+     * "Charges" summary table and the Summary panel can show the full breakdown,
+     * not just the net total. Services/investigations (BillItem-backed) come from
+     * a bulk JPQL sum grouped by InwardChargeType; Professional/Assisting fees
+     * (BillFee-backed, staff fee records) are summed from the lists already
+     * fetched for their respective tabs.
+     */
+    private void setGrossMarginVatBreakdown() {
+        Map<InwardChargeType, double[]> serviceBreakdown = getInwardBean().calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk(getPatientEncounter(), childPatientEncouters);
+
+        for (ChargeItemTotal cit : chargeItemTotals) {
+            double[] values = serviceBreakdown.get(cit.getInwardChargeType());
+            if (values != null) {
+                cit.setGross(values[0]);
+                cit.setMargin(values[1]);
+                cit.setVat(values[2]);
+            } else {
+                cit.setGross(cit.getTotal());
+            }
+        }
+
+        double proGross = 0.0;
+        double proMargin = 0.0;
+        double proVat = 0.0;
+        for (BillFee bf : getProfesionallFee()) {
+            proGross += bf.getFeeGrossValue() != null ? bf.getFeeGrossValue() : bf.getFeeValue();
+            proMargin += bf.getFeeMargin();
+            proVat += bf.getFeeVat();
+        }
+
+        double docGross = 0.0;
+        double docMargin = 0.0;
+        double docVat = 0.0;
+        for (BillFee bf : getDoctorAndNurseFee()) {
+            docGross += bf.getFeeGrossValue() != null ? bf.getFeeGrossValue() : bf.getFeeValue();
+            docMargin += bf.getFeeMargin();
+            docVat += bf.getFeeVat();
+        }
+
+        boolean mergedProAndDoc = configOptionApplicationController.getBooleanValueByKey(
+                "Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false);
+
+        for (ChargeItemTotal cit : chargeItemTotals) {
+            if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                if (mergedProAndDoc) {
+                    cit.setGross(proGross + docGross);
+                    cit.setMargin(proMargin + docMargin);
+                    cit.setVat(proVat + docVat);
+                } else {
+                    cit.setGross(proGross);
+                    cit.setMargin(proMargin);
+                    cit.setVat(proVat);
+                }
+            } else if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
+                if (mergedProAndDoc) {
+                    cit.setGross(0.0);
+                    cit.setMargin(0.0);
+                    cit.setVat(0.0);
+                } else {
+                    cit.setGross(docGross);
+                    cit.setMargin(docMargin);
+                    cit.setVat(docVat);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -551,6 +551,45 @@ public class InwardBeanController implements Serializable {
         return totalsMap;
     }
 
+    /**
+     * Bulk query to get the Gross/Margin/VAT totals per InwardChargeType for
+     * services/investigations (BillItem-backed), mirroring
+     * {@link #calServiceBillItemsTotalByInwardChargeTypeBulk}. Returns a map of
+     * InwardChargeType -> {gross, margin, vat}.
+     */
+    public Map<InwardChargeType, double[]> calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        String sql = "SELECT s.item.inwardChargeType, sum(s.grossValue), sum(s.marginValue), sum(s.vat) "
+                + " FROM BillItem s"
+                + " WHERE s.retired=false "
+                + " AND s.bill.billType=:btp "
+                + " AND s.bill.patientEncounter IN :pe"
+                + " GROUP BY s.item.inwardChargeType";
+
+        HashMap hm = new HashMap();
+        hm.put("btp", BillType.InwardBill);
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
+        hm.put("pe", pts);
+
+        List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, hm, TemporalType.TIMESTAMP);
+
+        Map<InwardChargeType, double[]> totalsMap = new HashMap<>();
+        if (results != null) {
+            for (Object[] row : results) {
+                InwardChargeType chargeType = (InwardChargeType) row[0];
+                double gross = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+                double margin = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+                double vat = row[3] != null ? ((Number) row[3]).doubleValue() : 0.0;
+                totalsMap.put(chargeType, new double[]{gross, margin, vat});
+            }
+        }
+
+        return totalsMap;
+    }
+
     public double calculateProfessionalCharges(PatientEncounter patientEncounter, List<PatientEncounter> cpts, boolean isEstimatedBill) {
         HashMap hm = new HashMap();
         String sql = "SELECT sum(bt.feeValue)"
@@ -1894,15 +1933,24 @@ public class InwardBeanController implements Serializable {
                 // BULK QUERY 4: Get all checked counts
                 Map<Long, Long> checkedCounts = getBulkCheckedBillItemCounts(items, patientEncounter);
 
+                // BULK QUERY 5: Get Gross/Discount/Margin/Net/VAT value breakdown
+                Map<Long, double[]> valueBreakdown = getBulkBillItemValueBreakdown(items, pts);
+
                 // Apply the counts to items (no more database queries!)
                 for (Item itm : items) {
                     long billed = billedCounts.getOrDefault(itm.getId(), 0L);
                     long cancelled = cancelledCounts.getOrDefault(itm.getId(), 0L);
                     long refund = refundCounts.getOrDefault(itm.getId(), 0L);
                     long checked = checkedCounts.getOrDefault(itm.getId(), 0L);
+                    double[] values = valueBreakdown.getOrDefault(itm.getId(), new double[5]);
 
                     itm.setTransCheckedCount(checked);
                     itm.setTransBillItemCount(billed - (cancelled + refund));
+                    itm.setTransGrossValue(values[0]);
+                    itm.setTransDiscount(values[1]);
+                    itm.setTransMarginValue(values[2]);
+                    itm.setTransNetValue(values[3]);
+                    itm.setTransVat(values[4]);
                 }
             }
 
@@ -1960,6 +2008,46 @@ public class InwardBeanController implements Serializable {
         }
 
         return countMap;
+    }
+
+    /**
+     * Bulk query to get the Gross/Discount/Margin/Net/VAT value breakdown for
+     * multiple items at once. Returns a map of itemId -> {gross, discount, margin, net, vat}.
+     */
+    private Map<Long, double[]> getBulkBillItemValueBreakdown(List<Item> items, List<PatientEncounter> pts) {
+        if (items == null || items.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        HashMap hm = new HashMap();
+        String sql = "SELECT b.item.id, sum(b.grossValue), sum(b.discount), sum(b.marginValue), sum(b.netValue), sum(b.vat) "
+                + " FROM BillItem b "
+                + " WHERE b.retired=false "
+                + " and b.bill.billType=:btp "
+                + " and b.bill.patientEncounter IN :pe "
+                + " and b.item IN :items "
+                + " GROUP BY b.item.id";
+
+        hm.put("btp", BillType.InwardBill);
+        hm.put("pe", pts);
+        hm.put("items", items);
+
+        List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, hm, TemporalType.TIME);
+
+        Map<Long, double[]> valueMap = new HashMap<>();
+        if (results != null) {
+            for (Object[] row : results) {
+                Long itemId = (Long) row[0];
+                double gross = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+                double discount = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+                double margin = row[3] != null ? ((Number) row[3]).doubleValue() : 0.0;
+                double net = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
+                double vat = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
+                valueMap.put(itemId, new double[]{gross, discount, margin, net, vat});
+            }
+        }
+
+        return valueMap;
     }
 
     /**

--- a/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
@@ -21,6 +21,9 @@ public class ChargeItemTotal {
     private double discount = 0;
     private double netTotal = 0;
     private double adjustedTotal = 0.0;
+    private double gross = 0;
+    private double margin = 0;
+    private double vat = 0;
     private String comments;
     private List<PatientRoom> patientRooms;
     List<BillFee> billFees;
@@ -70,6 +73,30 @@ public class ChargeItemTotal {
 
     public void setAdjustedTotal(double adjustedTotal) {
         this.adjustedTotal = adjustedTotal;
+    }
+
+    public double getGross() {
+        return gross;
+    }
+
+    public void setGross(double gross) {
+        this.gross = gross;
+    }
+
+    public double getMargin() {
+        return margin;
+    }
+
+    public void setMargin(double margin) {
+        this.margin = margin;
+    }
+
+    public double getVat() {
+        return vat;
+    }
+
+    public void setVat(double vat) {
+        this.vat = vat;
     }
 
     public String getComments() {

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -213,6 +213,16 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
     private double transBillItemCount;
     @Transient
     double transCheckedCount;
+    @Transient
+    private double transGrossValue;
+    @Transient
+    private double transDiscount;
+    @Transient
+    private double transMarginValue;
+    @Transient
+    private double transNetValue;
+    @Transient
+    private double transVat;
 
     @Temporal(javax.persistence.TemporalType.DATE)
     Date effectiveFrom;
@@ -387,6 +397,46 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
 
     public void setTransCheckedCount(double transCheckedCount) {
         this.transCheckedCount = transCheckedCount;
+    }
+
+    public double getTransGrossValue() {
+        return transGrossValue;
+    }
+
+    public void setTransGrossValue(double transGrossValue) {
+        this.transGrossValue = transGrossValue;
+    }
+
+    public double getTransDiscount() {
+        return transDiscount;
+    }
+
+    public void setTransDiscount(double transDiscount) {
+        this.transDiscount = transDiscount;
+    }
+
+    public double getTransMarginValue() {
+        return transMarginValue;
+    }
+
+    public void setTransMarginValue(double transMarginValue) {
+        this.transMarginValue = transMarginValue;
+    }
+
+    public double getTransNetValue() {
+        return transNetValue;
+    }
+
+    public void setTransNetValue(double transNetValue) {
+        this.transNetValue = transNetValue;
+    }
+
+    public double getTransVat() {
+        return transVat;
+    }
+
+    public void setTransVat(double transVat) {
+        this.transVat = transVat;
     }
 
     public boolean isMarginNotAllowed() {

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -277,13 +277,39 @@
 
 
                                         <div class="card p-4">
+                                            <h:panelGrid columns="3" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}" style="font-size: 16px;">
+                                                <h:outputLabel value="Gross Total"/>
+                                                <h:outputLabel value=":" class="mx-2"/>
+                                                <h:outputLabel value="#{bhtSummeryController.grossTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+
+                                                <h:outputLabel value="Service Charge (Margin)"/>
+                                                <h:outputLabel value=":" class="mx-2"/>
+                                                <h:outputLabel value="#{bhtSummeryController.marginTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+
+                                                <h:outputLabel value="Bill Level Discount"/>
+                                                <h:outputLabel value=":" class="mx-2"/>
+                                                <h:outputLabel value="#{bhtSummeryController.discount}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+
+                                                <h:outputLabel value="VAT"/>
+                                                <h:outputLabel value=":" class="mx-2"/>
+                                                <h:outputLabel value="#{bhtSummeryController.vatTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </h:panelGrid>
+
                                             <h:panelGrid columns="3" style="font-weight: bold; font-size: 22px;">
                                                 <h:outputLabel  value="Total Charges"/>
                                                 <h:outputLabel value=":" class="mx-2"/>
                                                 <h:outputLabel value="#{bhtSummeryController.grantTotal}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
-                                                
+
                                                 <h:outputLabel value="Paid By Patient   " />
                                                 <h:outputLabel value=":" class="mx-2"/>
                                                 <h:outputLabel value="#{bhtSummeryController.paid}">
@@ -373,6 +399,31 @@
                                         </p:column>
                                         <p:column  sortBy="#{c.total}"  headerText="Total" rendered="#{c.total > 0}" styleClass="text-end">
                                             <h:outputLabel value="#{c.total}" style="font-weight: bold">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Gross" rendered="#{c.total > 0 and webUserController.hasPrivilege('ShowServiceCharges')}" styleClass="text-end">
+                                            <h:outputLabel value="#{c.gross}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Discount" rendered="#{c.total > 0 and webUserController.hasPrivilege('ShowServiceCharges')}" styleClass="text-end">
+                                            <h:outputLabel value="#{c.discount}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Service Charge" rendered="#{c.total > 0 and webUserController.hasPrivilege('ShowServiceCharges')}" styleClass="text-end">
+                                            <h:outputLabel value="#{c.margin}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Net" rendered="#{c.total > 0 and webUserController.hasPrivilege('ShowServiceCharges')}" styleClass="text-end">
+                                            <h:outputLabel value="#{c.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="VAT" rendered="#{c.total > 0 and webUserController.hasPrivilege('ShowServiceCharges')}" styleClass="text-end">
+                                            <h:outputLabel value="#{c.vat}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>
@@ -552,6 +603,36 @@
                                                     </f:facet>
                                                 </p:column>
 
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Gross"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Discount"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Service Charge"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Net"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="VAT"/>
+                                                    </f:facet>
+                                                </p:column>
+
                                                 <p:column >
                                                     <f:facet name="header">
                                                         <h:outputLabel value="Count"/>
@@ -603,6 +684,31 @@
                                             </f:facet>
                                             <p:column styleClass="text-start">
                                                 <h:outputLabel value="#{ser.name}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                            </p:column>
+                                            <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ser.transGrossValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ser.transDiscount}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ser.transMarginValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ser.transNetValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                                <h:outputLabel value="#{ser.transVat}" rendered="#{ser.transBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end">
                                                 <h:outputLabel value="#{ser.transBillItemCount}" rendered="#{ser.transBillItemCount ne 0}"/>
@@ -973,14 +1079,38 @@
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
-                                        
+
+                                        <p:column headerText="Gross" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeGrossValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Discount" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeDiscount}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Service Charge" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeMargin}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
                                         <p:column headerText="Fee Value" >
                                             <h:outputLabel value="#{pf.feeValue}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                             <p:badge class="mx-2" value="Free Of Charge" rendered="#{pf.freeOfCharge}" severity="warning"></p:badge>
                                         </p:column>
-                                        
+
+                                        <p:column headerText="VAT" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeVat}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
                                         <p:column headerText="Fee At">
                                             <h:outputLabel value="#{pf.feeAt}">
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>
@@ -1038,13 +1168,37 @@
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
-                                        
+
+                                        <p:column headerText="Gross" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeGrossValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Discount" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeDiscount}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Service Charge" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeMargin}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
                                         <p:column headerText="Fee Value" >
                                             <h:outputLabel value="#{pf.feeValue}">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
+                                        <p:column headerText="VAT" class="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <h:outputLabel value="#{pf.feeVat}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:column>
+
                                         <p:column headerText="Fee At">
                                             <h:outputLabel value="#{pf.feeAt}">
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>


### PR DESCRIPTION
## Summary

Closes #22186.

The Interim Bill page (`inward_bill_intrim.xhtml`, `BhtSummeryController`) only ever showed **net charges** in its "Fees and Details" Charges tables and its Summary panel — even though the underlying `BillFee`/`BillItem` entities already carry gross value, discount, service charge (margin), and VAT, populated by the recently-merged VAT work (#22183, PR #22183). This was a pure rendering gap; no new persistence was needed.

**Changes:**
- **Service Details tab**: added Gross / Discount / Service Charge / Net / VAT columns per item (this tab previously showed *only counts*, no monetary value at all). New transient fields on `Item` (`transGrossValue`, `transDiscount`, `transMarginValue`, `transNetValue`, `transVat`), populated via a new bulk JPQL query in `InwardBeanController.createDepartmentBillItemsOptimized` (sibling to the existing bulk count queries).
- **Professional Fees / Assisting Fees tabs**: added Gross / Discount / Service Charge / VAT columns bound directly to existing `BillFee` fields — pure XHTML change, no backend needed.
- **"Charges" mini-table**: added Discount / Gross / Service Charge / Net / VAT columns. New `gross`/`margin`/`vat` fields on `ChargeItemTotal`, populated via a new bulk JPQL method (`calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk`) for services/investigations, and summed in-memory from the already-fetched Professional/Assisting fee lists for those categories.
- **Summary panel**: added Gross Total, Service Charge (Margin), Bill Level Discount (this exposes a value — `BhtSummeryController.discount` — that was already computed and used in the Due calculation, but never shown to the user), and VAT rows.

All new columns/rows are gated by the existing `ShowServiceCharges` privilege, matching the convention already used on the sibling `inward_bill_service.xhtml` / `inward_bill_surgery_service.xhtml` pages.

Categories with no gross/margin/VAT concept today (Room Details, Medicine/Store Issue, Out Side Charges, Payments) are intentionally left unchanged — showing fabricated zero-breakdowns there would be misleading, not a fix.

## Verification

Rebuilt and redeployed locally, then drove the real page end-to-end with Playwright against admission **BHT/55354** (patient Tharindu Senanayake, a live, non-discharged admission with a real VAT-bearing service — 2 lab `BillItem`s with `VAT=975` each):

- **Service Details tab**: "PCR Test" row shows Gross 13,000.00 / Discount 0.00 / Service Charge 0.00 / Net 13,000.00 / **VAT 1,950.00** (Count 2.0) — matches `2 × 6500` gross and `2 × 975` VAT in the DB exactly.
- **Charges mini-table**: "Laboratory Charges" row shows Gross 16,300.00 / Discount 0.00 / Service Charge 0.00 / Net 16,300.00 / **VAT 1,950.00**; Room/Medicine/Admission/Administration rows correctly show 0.00 margin/VAT (no such component for those categories).
- **Summary panel**: Gross Total 76,110.57 / Service Charge (Margin) 0.00 / Bill Level Discount 0.00 / **VAT 1,950.00**, and existing Total Charges unchanged at 76,110.57 — consistent with the mini-table breakdown.
- **Professional Fees tab**: new columns render correctly with an empty dataset (this admission has no doctor/staff fee records) — confirmed no errors.
- Confirmed the privilege gate itself works: with `ShowServiceCharges` *not* granted, all new columns/rows are correctly hidden; granting it (via a temporary local-only DB privilege insert, removed after testing) reveals them with the correct values above.
- No exceptions in `server.log` across the full verification pass.

## Test plan

- [x] Backend builds clean (`mvn clean package -DskipTests`)
- [x] Manually verified via Playwright against local Payara + real DB data (see above)
- [x] Confirmed privilege gating hides/shows content correctly
- [x] No new persisted fields/schema changes (transient/DTO fields only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gross, discount, service charge, net, and VAT breakdowns to interim billing summaries and detailed charge tables.
  * Added aggregate gross, service charge, and VAT totals to billing calculations.
  * Added detailed financial values to service, professional fee, and assisting fee entries.
  * Service charge details are displayed only for users with the appropriate privilege.
* **Improvements**
  * Improved billing data aggregation for more complete and efficient charge calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->