### PR TITLE
feat(inward-final-bill): add a new credit company to the BHT from the Credit Company Allocation section

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2062,6 +2062,17 @@ public class BhtSummeryController implements Serializable {
         if (creditCompanyAllocations == null) {
             creditCompanyAllocations = new ArrayList<>();
         }
+        // Check what is actually registered against the encounter, not just what is
+        // on screen: populateCreditCompanyAllocations() stops allocating once the due
+        // is covered, so a registered company can be absent from the allocation list
+        // and would otherwise be persisted a second time here.
+        for (EncounterCreditCompany registered : fillCreditCompaniesByPatient(patientEncounter)) {
+            if (newEncounterCreditCompany.getInstitution().equals(registered.getInstitution())) {
+                JsfUtil.addErrorMessage(newEncounterCreditCompany.getInstitution().getName()
+                        + " is already registered for this BHT");
+                return false;
+            }
+        }
         for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
             if (!alloc.isPatientPortion()
                     && newEncounterCreditCompany.getInstitution().equals(alloc.getCreditCompany())) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -92,6 +92,7 @@ import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.primefaces.PrimeFaces;
 import org.primefaces.event.ReorderEvent;
 import org.primefaces.event.RowEditEvent;
 
@@ -173,6 +174,7 @@ public class BhtSummeryController implements Serializable {
     private List<ChargeItemTotal> chargeItemTotals;
     List<PatientRoom> patientRooms;
     private List<CreditCompanyAllocation> creditCompanyAllocations;
+    private EncounterCreditCompany newEncounterCreditCompany;
     //////////////////////////
     private double grantTotal = 0.0;
     private double discount;
@@ -2016,6 +2018,117 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
+     * Adds a credit company to this BHT from the final bill page. The
+     * EncounterCreditCompany is persisted immediately — it becomes part of the
+     * encounter's permanent company list, exactly as when added at admission —
+     * and an allocation row is added so the cashier can settle against it right
+     * away. The company takes up to its credit limit out of the patient's
+     * remaining co-payment share.
+     */
+    public void addNewCreditCompany() {
+        boolean added = false;
+        try {
+            added = addNewCreditCompanyInternal();
+        } finally {
+            // Tell the client whether the add passed so the dialog closes only on
+            // success (see btnAddCreditCompany oncomplete).
+            if (PrimeFaces.current().isAjaxRequest()) {
+                PrimeFaces.current().ajax().addCallbackParam("creditCompanyAdded", added);
+            }
+        }
+    }
+
+    /**
+     * @return true when the company was persisted and allocated; false when a
+     * validation check rejected the input.
+     */
+    private boolean addNewCreditCompanyInternal() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return false;
+        }
+        if (patientEncounter.getPaymentMethod() != PaymentMethod.Credit) {
+            JsfUtil.addErrorMessage("Credit companies can only be added to a credit admission");
+            return false;
+        }
+        if (newEncounterCreditCompany == null || newEncounterCreditCompany.getInstitution() == null) {
+            JsfUtil.addErrorMessage("Please select a credit company");
+            return false;
+        }
+        if (newEncounterCreditCompany.getCreditLimit() <= 0) {
+            JsfUtil.addErrorMessage("Please enter a credit limit greater than zero");
+            return false;
+        }
+        if (creditCompanyAllocations == null) {
+            creditCompanyAllocations = new ArrayList<>();
+        }
+        for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+            if (!alloc.isPatientPortion()
+                    && newEncounterCreditCompany.getInstitution().equals(alloc.getCreditCompany())) {
+                JsfUtil.addErrorMessage(newEncounterCreditCompany.getInstitution().getName()
+                        + " is already allocated for this BHT");
+                return false;
+            }
+        }
+
+        newEncounterCreditCompany.setPatientEncounter(patientEncounter);
+        newEncounterCreditCompany.setCreatedAt(new Date());
+        newEncounterCreditCompany.setCreater(sessionController.getLoggedUser());
+        newEncounterCreditCompany.setRetired(false);
+        encounterCreditCompanyFacade.create(newEncounterCreditCompany);
+
+        double expected = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
+        double ccSum = 0.0;
+        for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
+            if (!alloc.isPatientPortion()) {
+                ccSum += alloc.getAllocatedAmount();
+            }
+        }
+        double allocatable = Math.max(0.0, Math.min(expected - ccSum, newEncounterCreditCompany.getCreditLimit()));
+        creditCompanyAllocations.add(new CreditCompanyAllocation(newEncounterCreditCompany, allocatable));
+        moveCompanyRowsAbovePatientRow();
+        recalculatePatientPortion();
+
+        JsfUtil.addSuccessMessage(newEncounterCreditCompany.getInstitution().getName() + " added");
+        newEncounterCreditCompany = new EncounterCreditCompany();
+        return true;
+    }
+
+    /**
+     * Clears the add-credit-company form so the popup opens blank rather than
+     * showing whatever was typed the last time it was cancelled.
+     */
+    public void prepareNewCreditCompany() {
+        newEncounterCreditCompany = new EncounterCreditCompany();
+    }
+
+    /**
+     * Keeps every credit company row grouped together at the top of the
+     * allocation table with the patient co-payment row displayed last. A newly
+     * added company is appended to the end of the list, which would otherwise
+     * push it below the patient row created earlier by
+     * {@link #populateCreditCompanyAllocations()}. The sort is stable, so the
+     * existing company order is preserved.
+     */
+    private void moveCompanyRowsAbovePatientRow() {
+        if (creditCompanyAllocations == null) {
+            return;
+        }
+        creditCompanyAllocations.sort(Comparator.comparing(CreditCompanyAllocation::isPatientPortion));
+    }
+
+    public EncounterCreditCompany getNewEncounterCreditCompany() {
+        if (newEncounterCreditCompany == null) {
+            newEncounterCreditCompany = new EncounterCreditCompany();
+        }
+        return newEncounterCreditCompany;
+    }
+
+    public void setNewEncounterCreditCompany(EncounterCreditCompany newEncounterCreditCompany) {
+        this.newEncounterCreditCompany = newEncounterCreditCompany;
+    }
+
+    /**
      * Recalculates the patient co-payment row so it always equals: net due –
      * sum of all CC company allocations. Called via p:ajax whenever a CC
      * company amount is changed by the user.
@@ -2954,6 +3067,7 @@ public class BhtSummeryController implements Serializable {
         toTime = null;
         patientRooms = null;
         creditCompanyAllocations = null;
+        newEncounterCreditCompany = null;
         estimatedBillView = false;
     }
 

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -653,8 +653,20 @@
 
                     <p:panel id="creditAllocationPanel" styleClass="mx-1 mt-3" rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit' and not empty bhtSummeryController.creditCompanyAllocations}">
                         <f:facet name="header">
-                            <h:outputLabel value="Credit Company Allocation" />
+                            <div class="d-flex align-items-center justify-content-between">
+                                <h:outputLabel value="Credit Company Allocation" />
+                                <p:commandButton
+                                    id="viewAddCreditCompanyDlg"
+                                    value="Add Credit Company"
+                                    icon="fa fa-plus"
+                                    class="ui-button-success"
+                                    process="@this"
+                                    actionListener="#{bhtSummeryController.prepareNewCreditCompany()}"
+                                    update=":#{p:resolveFirstComponentWithId('addCreditCompanyContent',view).clientId}"
+                                    oncomplete="PF('addCreditCompanyDlgWv').show()"/>
+                            </div>
                         </f:facet>
+
                         <p:dataTable value="#{bhtSummeryController.creditCompanyAllocations}" var="alloc" styleClass="w-100"
                                      rowStyleClass="#{alloc.patientPortion ? 'patient-copay-row' : ''}">
                             <p:column headerText="Payer">
@@ -689,6 +701,93 @@
                             </p:column>
                         </p:dataTable>
                     </p:panel>
+
+                    <p:dialog header="Add Credit Company to BHT"
+                              id="addCreditCompanyDlg"
+                              widgetVar="addCreditCompanyDlgWv"
+                              modal="true"
+                              showEffect="fade"
+                              hideEffect="fade"
+                              resizable="false"
+                              position="center"
+                              fitViewport="true"
+                              width="520"
+                              style="padding:20px;">
+                        <h:panelGroup id="addCreditCompanyContent" layout="block">
+                            <div class="mb-2">
+                                <h:outputLabel value="Credit Company" styleClass="form-label"/>
+                                <p:autoComplete
+                                    id="acNewCreditCompany"
+                                    class="w-100"
+                                    inputStyleClass="w-100"
+                                    forceSelection="true"
+                                    value="#{bhtSummeryController.newEncounterCreditCompany.institution}"
+                                    completeMethod="#{creditCompanyController.completeCredit}"
+                                    var="ix"
+                                    maxResults="20"
+                                    itemLabel="#{ix.name}"
+                                    itemValue="#{ix}"/>
+                            </div>
+                            <div class="mb-2">
+                                <h:outputLabel value="Credit Limit" styleClass="form-label"/>
+                                <p:inputText
+                                    id="newCreditLimit"
+                                    class="w-100"
+                                    style="text-align:right;"
+                                    autocomplete="off"
+                                    onclick="this.select();"
+                                    value="#{bhtSummeryController.newEncounterCreditCompany.creditLimit}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </p:inputText>
+                            </div>
+                            <div class="mb-2">
+                                <h:outputLabel value="Description" styleClass="form-label"/>
+                                <p:inputText
+                                    id="newDescreption"
+                                    class="w-100"
+                                    autocomplete="off"
+                                    value="#{bhtSummeryController.newEncounterCreditCompany.descreption}"/>
+                            </div>
+                            <div class="mb-2">
+                                <h:outputLabel value="Policy No" styleClass="form-label"/>
+                                <p:inputText
+                                    id="newPolicyNo"
+                                    class="w-100"
+                                    autocomplete="off"
+                                    value="#{bhtSummeryController.newEncounterCreditCompany.policyNo}"/>
+                            </div>
+                            <div class="mb-3">
+                                <h:outputLabel value="Reference No" styleClass="form-label"/>
+                                <p:inputText
+                                    id="newReferanceNo"
+                                    class="w-100"
+                                    autocomplete="off"
+                                    value="#{bhtSummeryController.newEncounterCreditCompany.referanceNo}"/>
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <p:commandButton
+                                    value="Cancel"
+                                    icon="fa fa-times"
+                                    class="ui-button-secondary ui-button-outlined"
+                                    process="@this"
+                                    onclick="PF('addCreditCompanyDlgWv').hide(); return false;"/>
+                                <p:commandButton
+                                    id="btnAddCreditCompany"
+                                    value="Add"
+                                    icon="fa fa-plus"
+                                    class="ui-button-success"
+                                    process="addCreditCompanyContent"
+                                    actionListener="#{bhtSummeryController.addNewCreditCompany()}"
+                                    update="addCreditCompanyContent
+                                            :#{p:resolveFirstComponentWithId('addCreditCompanyGrowl',view).clientId}
+                                            :#{p:resolveFirstComponentWithId('creditAllocationPanel',view).clientId}"
+                                    oncomplete="if (args &amp;&amp; args.creditCompanyAdded) { PF('addCreditCompanyDlgWv').hide(); }"/>
+                            </div>
+                        </h:panelGroup>
+                    </p:dialog>
+
+                    <!-- Outside the dialog: the success message must survive the dialog closing -->
+                    <p:growl id="addCreditCompanyGrowl" showDetail="false" showSummary="true" life="4000"/>
 
                     <p:panel header="Profesionall Fee" class="mt-3">
                         <p:dataTable


### PR DESCRIPTION
## Summary

Lets a cashier add a new credit company to the BHT directly from the **Credit Company Allocation** section of the Inward Final Bill, through a popup with the company details.

Previously that section could only show the `EncounterCreditCompany` records created at admission. When a patient produced a second insurance card at discharge — or the company was missed at admission — the cashier had to abandon the bill, add the company on the admission / BHT edit page, and start the final bill again.

Closes #22190
Part of #21169 — Multiple Insurance Claim Management process.

## What changed

**`BhtSummeryController.java`**

- `addNewCreditCompany()` — validates the input, persists the `EncounterCreditCompany` against the encounter immediately (so it joins the BHT's permanent company list, exactly as when added at admission), adds an allocation row taking up to its credit limit out of the patient's remaining share, and recalculates the patient co-payment row.
- Split into a private `addNewCreditCompanyInternal()` returning a boolean so the public method can report a `creditCompanyAdded` callback param. The validations raise `JsfUtil` messages rather than JSF validators, so `args.validationFailed` is never set and the popup needs this flag to know whether to close. Mirrors the existing `PharmacyRequestForBhtController.saveEditedBillItem` precedent.
- `moveCompanyRowsAbovePatientRow()` — keeps company rows grouped with the **Patient** row last. A newly added company is appended and would otherwise sort below the patient row created by `populateCreditCompanyAllocations()`. Stable sort, so existing company order is preserved.
- `prepareNewCreditCompany()` — resets the form so the popup opens blank.
- The new field is cleared alongside `creditCompanyAllocations` when the BHT changes.

**`inward_bill_final.xhtml`**

- **Add Credit Company** button in the panel header, opening a modal via the same `oncomplete="PF(...).show()"` pattern as the existing Fee Breakdown dialog on this page.
- Popup fields: Credit Company (autocomplete over credit institutions), Credit Limit, Description, Policy No, Reference No; Cancel and Add.
- Add updates the whole allocation panel so the new row and recalculated patient co-payment appear together, and closes the popup only on success.
- The growl sits **outside** the dialog deliberately — inside it, the success message would be destroyed the moment the dialog closed. The template growl could not be reused because it lives outside the form and is not refreshed by this button.

## Validations

The popup stays open and shows the error when:

- No credit company is selected
- Credit limit is not greater than zero
- The company is already allocated on this BHT
- The admission is not a `Credit` admission

## Behaviour notes

- **Add only** — removing or editing existing companies remains on the admission / BHT edit pages.
- **Settlement is unchanged.** The new allocation flows through the existing `settle()` → `saveCCBillForAllocation()` path and produces a normal CC commitment bill, subject to the existing credit limit and over-allocation checks in `checkCreditAllocationTotal()`.
- Row order is now: all credit company rows, then the **Patient** co-payment row last.

## Testing

- [x] `mvn compile` passes
- [ ] Add a company to a credit BHT and confirm the row appears with the other companies, the Patient row stays last, and the blue patient figure drops by the allocated amount
- [ ] Click Add with no company selected — popup must stay open with the error
- [ ] Add a company whose net due is already fully covered — should add a zero row rather than over-allocate
- [ ] Confirm the company persists: reopen the admission page and check it appears in the BHT's company list
- [ ] Settle and confirm a CC commitment bill is created for the new company

## Screenshots

_To be added._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add Credit Company” button to the credit allocation panel.
  * Introduced a PrimeFaces dialog to capture credit company, credit limit, policy number, description, and reference number.
  * When adding a credit company, the bill is updated with the new allocation and allocation totals are recalculated.
  * Patient co-payment amounts are automatically recalculated and the final allocation order is adjusted.
  * Added success/validation feedback and ensured the add form resets between uses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->