### PR TITLE
docs(testing): privilege DEPARTMENT_ID gotcha for playwright-e2e workflow

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -478,6 +478,15 @@ cached per session at login and won't pick up a new row otherwise. This came up 
 `BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
 user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
 
+**`DEPARTMENT_ID` must be the `WebUser`'s home department (`WebUser.department`), not
+the department selected on the login screen.** `SessionController.getUserPrivileges()`
+calls `fillUserPrivileges(getLoggedUser(), getLoggedUser().getDepartment(), false)` —
+that second argument is the user's fixed home department field, and `deptIsNull=false`
+means a `DEPARTMENT_ID IS NULL` row is **never** matched, regardless of which department
+was picked at login. Check `SELECT DEPARTMENT_ID FROM webuser WHERE ID=<id>` first and
+insert the privilege row with that exact `DEPARTMENT_ID` — a NULL-department row silently
+does nothing, even after a full logout/login cycle.
+
 ## 21. Inward "Add Services" item picker — the Filter box does not load other departments' items
 
 On `inward/inward_bill_service.xhtml` (and the surgery equivalent) the item selector shows

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -478,14 +478,18 @@ cached per session at login and won't pick up a new row otherwise. This came up 
 `BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
 user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
 
-**`DEPARTMENT_ID` must be the `WebUser`'s home department (`WebUser.department`), not
-the department selected on the login screen.** `SessionController.getUserPrivileges()`
-calls `fillUserPrivileges(getLoggedUser(), getLoggedUser().getDepartment(), false)` —
-that second argument is the user's fixed home department field, and `deptIsNull=false`
-means a `DEPARTMENT_ID IS NULL` row is **never** matched, regardless of which department
-was picked at login. Check `SELECT DEPARTMENT_ID FROM webuser WHERE ID=<id>` first and
-insert the privilege row with that exact `DEPARTMENT_ID` — a NULL-department row silently
-does nothing, even after a full logout/login cycle.
+**`WebUser.department` is not a fixed "home department" — `SessionController.selectDepartment()`
+overwrites and persists it (`loggedUser.setDepartment(department); getFacede().edit(loggedUser)`)
+every time the department-selection screen is submitted, which is why it pre-fills with
+whatever was picked last time.** The catch for privilege testing:
+`SessionController.getUserPrivileges()` calls
+`fillUserPrivileges(getLoggedUser(), getLoggedUser().getDepartment(), false)` — by the time
+this runs, `getLoggedUser().getDepartment()` already equals the department just selected for
+*this* login, and `deptIsNull=false` means a `DEPARTMENT_ID IS NULL` privilege row is **never**
+matched, no matter which department that is. Query `SELECT DEPARTMENT_ID FROM webuser WHERE
+ID=<id>` *after* selecting the department you're about to test with, and insert the privilege
+row with that exact `DEPARTMENT_ID` — a NULL-department row silently does nothing, even after
+a full logout/login cycle.
 
 ## 21. Inward "Add Services" item picker — the Filter box does not load other departments' items
 


### PR DESCRIPTION
## Summary

Follow-up to #22187 (already merged) — these two documentation commits were pushed to the branch *after* that PR was merged, so they never made it into `development`. This PR carries just the doc fix.

- Documents a gotcha discovered while QA-verifying #22186: a `webuserprivilege` row with `DEPARTMENT_ID = NULL` is silently ignored by `SessionController.fillUserPrivileges()`.
- Corrects an inaccurate first draft of that note — `WebUser.department` is not fixed creation-time metadata; `selectDepartment()` overwrites and persists it on every login (buddhika caught this).

No source code changes — `developer_docs/testing/playwright-e2e-workflow.md` only.

## Test plan

- [x] Docs-only change, no compilation impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified troubleshooting guidance for testing department-based privileges.
  * Documented how department selection affects privilege matching.
  * Added instructions to use the effective department ID when configuring privilege test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->