### PR TITLE
fix(pharmacy): harden GRN costing and returns against double-click duplicates

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -248,7 +248,11 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
     }
 
-    public String cancelCurrentReturn() {
+    // synchronized: no double-click guard exists on the Cancel action. A double-click
+    // could race two calls through this session-scoped bean past the guards below before
+    // either had persisted currentBill.cancelled, both attempting to cancel the same bill
+    // (same bug class as PurchaseOrderController.approve(), issue #22194).
+    public synchronized String cancelCurrentReturn() {
         // Validate bill exists and is persisted
         if (currentBill == null || currentBill.getId() == null) {
             JsfUtil.addErrorMessage("Cannot cancel: No valid Direct Purchase Return found.");
@@ -341,13 +345,26 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         JsfUtil.addSuccessMessage("Direct Purchase Return Request Saved Successfully");
     }
 
-    public void finalizeRequest() {
+    // synchronized: no double-click guard exists on the Finalize action. A double-click
+    // could race two calls through this session-scoped bean past validateFinalization()
+    // (which never checks whether the bill was already finalized) before either had
+    // persisted currentBill.checkedBy, duplicating the finalize save (same bug class as
+    // PurchaseOrderController.approve(), issue #22194).
+    public synchronized void finalizeRequest() {
         if (!isAuthorized("FINALIZE", "FinalizeDirectPurchaseReturn")) {
             return;
         }
 
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No bill selected to finalize");
+            return;
+        }
+
+        // Check if this return request is already finalized to prevent a queued
+        // double-submit (blocked on the synchronized lock above) from finalizing it
+        // a second time.
+        if (currentBill.getCheckedBy() != null) {
+            JsfUtil.addErrorMessage("This return request is already finalized");
             return;
         }
 
@@ -466,7 +483,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         return allMatch;
     }
 
-    public void approve() {
+    // synchronized: no double-click guard exists on the Approve action. validateApproval()'s
+    // already-approved check reads the session-scoped currentBill rather than fresh DB
+    // state, so it is non-atomic - a double-click could race two calls past it before either
+    // had persisted currentBill.completed, duplicating stock deduction/payment creation
+    // (same bug class as PurchaseOrderController.approve(), issue #22194).
+    public synchronized void approve() {
         if (!isAuthorized("APPROVE", "ApproveDirectPurchaseReturn")) {
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -3050,8 +3050,21 @@ public class GrnCostingController implements Serializable {
         JsfUtil.addSuccessMessage("GRN Saved");
     }
 
-    public void finalizeGrnWithSaveApprove() {
+    // synchronized: the Finalize button on pharmacy_grn_costing_with_save_approve.xhtml
+    // has only a confirm() dialog and a rendered="#{!completed}" button-hide that depends
+    // on a full-page re-render to take effect - it does not stop a fast double-click before
+    // the re-render lands. A double-click raced two calls through this session-scoped bean
+    // before either had persisted the completed flag, duplicating the GRN save/finalize
+    // (same bug class as PurchaseOrderController.approve() / TransferRequestController
+    // .approveTransferRequestBill(), issue #22194).
+    public synchronized void finalizeGrnWithSaveApprove() {
         if (!isAuthorized("FINALIZE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnFinalize")) {
+            return;
+        }
+        // Check if this GRN is already finalized to prevent a queued double-submit
+        // (blocked on the synchronized lock above) from finalizing it a second time.
+        if (getCurrentGrnBillPre().isCompleted()) {
+            JsfUtil.addErrorMessage("This GRN is already finalized");
             return;
         }
         // Apply same validations as authorize button
@@ -3224,8 +3237,20 @@ public class GrnCostingController implements Serializable {
         return false;
     }
 
-    public void approveGrnWithSaveApprove() {
+    // synchronized: the Approve button on pharmacy_grn_costing_with_save_approve.xhtml
+    // has only a confirm() dialog, no double-click guard. A double-click raced two calls
+    // through this session-scoped bean before either had persisted billTypeAtomic as
+    // PHARMACY_GRN, duplicating the GRN item batch/stock creation (same bug class as
+    // PurchaseOrderController.approve() / TransferRequestController
+    // .approveTransferRequestBill(), issue #22194).
+    public synchronized void approveGrnWithSaveApprove() {
         if (!isAuthorized("APPROVE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnApprove")) {
+            return;
+        }
+        // Check if this GRN is already approved to prevent a queued double-submit
+        // (blocked on the synchronized lock above) from approving it a second time.
+        if (getCurrentGrnBillPre().getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN) {
+            JsfUtil.addErrorMessage("This GRN is already approved");
             return;
         }
         // Always use bill's invoice number, ignore controller reference

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -310,7 +310,12 @@ public class IssueReturnController implements Serializable {
         JsfUtil.addSuccessMessage("Saved");
     }
 
-    public void finalizeDisposalIssueReturnBill() {
+    // synchronized: no double-click guard exists on the Finalize action. Although
+    // disposalReturnAlreadyProcessed() below reads fresh DB state, it is still a
+    // check-then-act sequence - a double-click could race two calls past the check
+    // before either had persisted the bill, duplicating the finalize save (same bug
+    // class as PurchaseOrderController.approve(), issue #22194).
+    public synchronized void finalizeDisposalIssueReturnBill() {
         if (!isAuthorized("FINALIZE", "FinalizeDisposalReturn")) {
             return;
         }
@@ -350,7 +355,11 @@ public class IssueReturnController implements Serializable {
         JsfUtil.addSuccessMessage("Finalized");
     }
 
-    public void settleDisposalIssueReturnBill() {
+    // synchronized: no double-click guard existed prior to #22194. Although
+    // disposalReturnAlreadyProcessed() below reads fresh DB state, it is still a
+    // check-then-act sequence - a double-click could race two calls past the check
+    // before either had persisted the bill, duplicating stock movements/payment.
+    public synchronized void settleDisposalIssueReturnBill() {
         if (!isAuthorized("APPROVE", "ApproveDisposalReturn")) {
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -322,6 +322,17 @@ public class IssueReturnController implements Serializable {
         if (disposalReturnAlreadyProcessed()) {
             return;
         }
+        // disposalReturnAlreadyProcessed() does not check checkedBy (settleDisposalIssueReturnBill()
+        // relies on that same helper and requires checkedBy already set), so a queued double-submit
+        // reaching this point after the first call finished would re-finalize and overwrite the
+        // checkeAt/checkedBy/editedAt audit fields (CodeRabbit finding on #22194/PR #22197).
+        if (getReturnBill().getId() != null) {
+            Bill freshForFinalizeCheck = getBillFacade().findWithoutCache(getReturnBill().getId());
+            if (freshForFinalizeCheck != null && freshForFinalizeCheck.getCheckedBy() != null) {
+                JsfUtil.addErrorMessage("This disposal return has already been finalized. Reload the page before continuing.");
+                return;
+            }
+        }
         // Validate return comment is provided
         if (returnBill.getComments() == null || returnBill.getComments().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return Comment is required. Please provide a reason for the return.");


### PR DESCRIPTION
## Summary

Coverage audit (`tmp/2026-07-17_ruhunu_pharmacy_double_click_coverage.md`) found two areas with no double-click / duplicate-submission protection in either `development` or `ruhunu-prod`. Same bug class already fixed in `PurchaseOrderController.approve()` and `TransferRequestController`: a session-scoped bean + non-atomic "already processed" check + racing AJAX double-submit lets two threads duplicate persisted bill items/stock movements.

**1. GRN manage-costing (`GrnCostingController`, priority 1 — active Ruhunu workflow)**
- `finalizeGrnWithSaveApprove()` — added `synchronized` + already-finalized guard (`currentGrnBillPre.isCompleted()`)
- `approveGrnWithSaveApprove()` — added `synchronized` + already-approved guard (`billTypeAtomic == PHARMACY_GRN`, the only place that transition happens)

**2. Returns workflows (priority 2 — proactive sweep, no known incident yet)**
- `DirectPurchaseReturnWorkflowController.finalizeRequest()` — added `synchronized` + a new already-finalized guard (`currentBill.getCheckedBy() != null`) that didn't exist before at all
- `DirectPurchaseReturnWorkflowController.approve()` / `cancelCurrentReturn()` — added `synchronized` (already-approved/already-cancelled guards existed, just needed serializing)
- `IssueReturnController.finalizeDisposalIssueReturnBill()` / `settleDisposalIssueReturnBill()` (disposal issue returns) — added `synchronized` (the existing `disposalReturnAlreadyProcessed()` guard reads fresh DB state but is still check-then-act, so needed serializing)

`DisposalReturnWorkflowController` was left untouched — it's a pure navigation/list bean with no approve/finalize/cancel logic of its own; that logic lives in `IssueReturnController`.

## Test plan
- [x] `mvn clean package` — BUILD SUCCESS, 149 tests passing
- [x] Local redeploy to Payara, verified no errors in `server.log`
- [x] Traced each new guard condition against real local DB rows to confirm the check fires on genuinely "already processed" state (e.g. confirmed a real completed GRN has `billTypeAtomic=PHARMACY_GRN`, matching the new guard)
- [ ] Full Playwright UI double-click reproduction was attempted but blocked by pre-existing, unrelated data/wiring issues in the local seed data (GRN item-population and Direct-Purchase-Return item-copy showing empty grids for reasons unrelated to this change) — discussed with the developer, who approved proceeding on compile + code-path verification given the change mirrors an already-proven, low-risk pattern used elsewhere in the same controllers group.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented double-submit/double-processing for pharmacy purchase returns, GRN costing finalization/approval, and issue return disposal finalization/settlement.
  * Added stronger guards to block re-finalization when an item is already completed/checked or already approved.
  * Improved reliability under repeated or near-simultaneous user actions by ensuring workflow transitions can’t run concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->