### PR TITLE
fix(skills): guard generate-ddl wiki checkout --theirs on real conflicts only

### DIFF
--- a/.claude/skills/generate-ddl/SKILL.md
+++ b/.claude/skills/generate-ddl/SKILL.md
@@ -200,8 +200,15 @@ if [ -d "$WIKI_DIR" ]; then
   git stash --include-untracked
   git pull --rebase origin master || true
   git stash pop || true
-  # Re-apply our version of the DDL page (in case of rebase conflict)
-  git checkout --theirs Database-Schema-DDL-Generation-Guide.md 2>/dev/null || true
+  # Only touch --theirs if the pop actually left an unmerged (conflicted)
+  # entry for this file. Outside a real conflict `git checkout --theirs`
+  # on a fully-merged path checks it out from HEAD/index, silently
+  # discarding the working-tree content stash pop just restored — which
+  # then makes the "diff --cached --quiet" check below wrongly conclude
+  # there's nothing to commit.
+  if git ls-files -u -- Database-Schema-DDL-Generation-Guide.md | grep -q .; then
+    git checkout --theirs Database-Schema-DDL-Generation-Guide.md
+  fi
   git add Database-Schema-DDL-Generation-Guide.md
   git rebase --continue 2>/dev/null || true
   # Commit (skip if nothing staged, e.g. rebase already applied it)


### PR DESCRIPTION
## Summary
- `.claude/skills/generate-ddl/SKILL.md` step 9 unconditionally ran `git checkout --theirs Database-Schema-DDL-Generation-Guide.md` after `git stash pop`, even when there was no actual merge conflict.
- Outside a real conflict, `--theirs` on a fully-merged path just checks the file out from HEAD/index, silently discarding the freshly generated wiki content that `stash pop` had just restored — the following `git diff --cached --quiet` check then wrongly reports "nothing to commit" and the DDL update is lost without any error.
- Now `--theirs` only runs when `git ls-files -u` shows the file is actually unmerged (a real conflict).

Fixes #22199 — hit live while running `/generate-ddl` on 2026-07-18; the fresh DDL almost got silently dropped from the wiki push.

## Test plan
- [x] Re-ran the full `/generate-ddl` skill end-to-end with the fixed step 9: no-conflict path now correctly preserves and commits the new wiki content (verified via `git diff HEAD --quiet` showing a real diff before commit, and the commit landing in `hmis.wiki`).
- [x] No Java/business logic touched — skill markdown only, no compilation needed.

Closes #22199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki update handling during publishing to ensure conflict resolution only occurs when an actual unresolved conflict remains.
  * Prevented already-resolved schema documentation changes from being unintentionally overwritten during updates.
  * Increased reliability when committing and synchronizing database schema documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->