### PR TITLE
fix(inward): block Patient Profile navigation when no patient is selected

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -871,7 +871,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     }
 
     public String navigateToOpdPatientProfile() {
-        if (current == null) {
+        if (current == null || current.getId() == null) {
             JsfUtil.addErrorMessage("No patient selected");
             return "";
         }


### PR DESCRIPTION
## Summary
- On the Admit a Patient page (`inward_admission.xhtml`), clicking **Patient Profile** without selecting a patient navigated to `/opd/patient.xhtml` with a completely blank profile.
- Root cause: `AdmissionController.getPatient()` lazily creates a blank `Patient` (with `id == null`) and persists it into `current.patient` as a side effect whenever the page renders and checks `admissionController.patient` (e.g. the "Select a Patient" header text in `patient_details_for_addmission.xhtml`). By the time the button is clicked, `current.patient` is non-null, so `PatientController.navigateToOpdPatientProfile()`'s existing `current == null` guard doesn't catch it.
- Fix: strengthen the guard to also check `current.getId() == null`, so navigation is blocked and the existing "No patient selected" message (shown via the template's global growl) is displayed instead.
- This method is shared by ~55 other pages that show a "Patient Profile" link; all of them expect a persisted/selected patient, so the stricter guard is safe there too.

Closes #22201

## Test plan
- [ ] On Inward > Admit a Patient, without selecting a patient, click **Patient Profile** — confirm it stays on the page and shows "No patient selected".
- [ ] Search/select a patient, click **Patient Profile** — confirm it still navigates to the OPD patient profile correctly.
- [ ] Spot-check one or two other pages that use the same button (e.g. `opd/opd_bill.xhtml`, `inward/inward_bill_payment.xhtml`) to confirm normal profile navigation is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patient profile navigation by preventing access when no valid patient is selected.
  * Preserved the existing error message and behavior for invalid selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->