### PR TITLE
fix(dataAdmin): move Patient Data Management tab above System Administrator Functions

### DIFF
--- a/src/main/webapp/dataAdmin/admin_data_administration.xhtml
+++ b/src/main/webapp/dataAdmin/admin_data_administration.xhtml
@@ -273,59 +273,6 @@
                                         </div>
                                     </p:tab>
 
-                                    <p:tab title="System Administrator Functions" disabled="false" >
-                                        <div class="d-grid gap-2">
-                                            <p:commandButton
-                                                ajax="false" 
-                                                action="#{dataAdministrationController.navigateToCheckMissingFields()}" 
-                                                value="Update Database Structure"  
-                                                class="w-100 m-1"
-                                                />
-                                            
-                                            <p:commandButton
-                                                ajax="false" 
-                                                action="#{databaseMigrationController.navigateToDatabaseMigration()}" 
-                                                value="Database Migration"  
-                                                class="w-100 m-1"
-                                                />
-
-                                            <p:commandButton
-                                                ajax="false" 
-                                            action="#{dataAdministrationController.navigateToDownloadLogFiles()}"
-                                            value="To Download Log Files"
-                                            class="w-100 m-1"
-                                            />
-
-                                            <p:commandButton
-                                                ajax="false"
-                                                action="#{dataAdministrationController.navigateToReportExecutionLogs()}"
-                                                value="Process Execution Logs"
-                                                class="w-100 m-1"
-                                                />
-
-                                            <p:commandButton
-                                                ajax="false" 
-                                                action="#{dataAdministrationController.navigateToNameToCode()}" 
-                                                value="Name To Code"  
-                                                class="w-100 m-1"
-                                                />
-                                            <p:commandButton
-                                                ajax="false" 
-                                                action="admin_functions?faces-redirect=true" 
-                                                value="Admin Functions"  
-                                                class="m-1 w-100"
-                                                />
-
-                                            <p:commandButton 
-                                                value="Test Error Handling"
-                                                action="#{dataAdministrationController.causeError}"
-                                                ajax="false"
-                                                styleClass="ui-button-danger w-100 m-1" />
-
-                                        </div>
-                                    </p:tab>
-
-
                                     <p:tab title="Patient Data Management"
                                            rendered="#{webUserController.hasPrivilege('MergePatients') or webUserController.hasPrivilege('AdminInactivePatients')}">
                                         <div class="d-grid gap-2">
@@ -343,6 +290,59 @@
                                                 action="#{patientController.navigateToInactivePatients()}"
                                                 icon="fa fa-user-slash"
                                                 rendered="#{webUserController.hasPrivilege('AdminInactivePatients')}" />
+                                        </div>
+                                    </p:tab>
+
+                                    <!-- Keep System Administrator Functions as the last tab; add new tabs above this one. -->
+                                    <p:tab title="System Administrator Functions" disabled="false" >
+                                        <div class="d-grid gap-2">
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="#{dataAdministrationController.navigateToCheckMissingFields()}"
+                                                value="Update Database Structure"
+                                                class="w-100 m-1"
+                                                />
+
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="#{databaseMigrationController.navigateToDatabaseMigration()}"
+                                                value="Database Migration"
+                                                class="w-100 m-1"
+                                                />
+
+                                            <p:commandButton
+                                                ajax="false"
+                                            action="#{dataAdministrationController.navigateToDownloadLogFiles()}"
+                                            value="To Download Log Files"
+                                            class="w-100 m-1"
+                                            />
+
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="#{dataAdministrationController.navigateToReportExecutionLogs()}"
+                                                value="Process Execution Logs"
+                                                class="w-100 m-1"
+                                                />
+
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="#{dataAdministrationController.navigateToNameToCode()}"
+                                                value="Name To Code"
+                                                class="w-100 m-1"
+                                                />
+                                            <p:commandButton
+                                                ajax="false"
+                                                action="admin_functions?faces-redirect=true"
+                                                value="Admin Functions"
+                                                class="m-1 w-100"
+                                                />
+
+                                            <p:commandButton
+                                                value="Test Error Handling"
+                                                action="#{dataAdministrationController.causeError}"
+                                                ajax="false"
+                                                styleClass="ui-button-danger w-100 m-1" />
+
                                         </div>
                                     </p:tab>
 


### PR DESCRIPTION
## Summary
- Moves the **Patient Data Management** tab above **System Administrator Functions** on the Data Administration page, since it's a more commonly used function.
- Keeps **System Administrator Functions** as the last tab, with a comment marking it so future tabs are added above it, not after.

## Test plan
- [ ] Load `/rh/faces/dataAdmin/admin_data_administration.xhtml` as a user with `MergePatients` or `AdminInactivePatients` privilege and confirm Patient Data Management now appears before System Administrator Functions.
- [ ] Confirm System Administrator Functions still renders correctly as the last tab.
- [ ] Confirm all buttons within both tabs still navigate correctly.

Closes #22203