### PR TITLE
fix(inward): fill empty space in Guardian Detail and Appointment tabs

### DIFF
--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -305,7 +305,7 @@
                                         <p:panel header="Other">                           
                                             <p:tabView class="p-0">
                                                 <p:tab title="Guardian Detail">
-                                                    <h:panelGrid columns="2">
+                                                    <h:panelGrid columns="2" styleClass="w-100" columnClasses="col-4,col-8">
                                                         <p:outputLabel value="Title"/>
                                                         <p:selectOneMenu 
                                                             id="cmbTitle" 
@@ -321,13 +321,13 @@
                                                         <p:outputLabel value="NIC / Passport"/>
                                                         <p:inputText class="mx-2 w-100" id="gnic" maxlength="12" autocomplete="off" value="#{admissionController.current.guardian.nic}"/>
                                                         <p:outputLabel value="Address" />
-                                                        <h:panelGrid columns="2">
+                                                        <h:panelGrid columns="2" styleClass="w-100">
                                                             <p:inputText class="mx-2 w-100" id="gadd" autocomplete="off"  value="#{admissionController.current.guardian.address}"  />
                                                             <p:commandButton id="btnCopyAdd" class="ui-button-warning mx-2" icon="fas fa-paste" process="btnCopyAdd :#{p:resolveClientId('@id(txtAddress)', view)}" update="gadd " action="#{admissionController.copyPatientAddressToGurdian}"/>
                                                         </h:panelGrid>
 
                                                         <p:outputLabel value="Mobile No" />
-                                                        <h:panelGrid columns="2">
+                                                        <h:panelGrid columns="2" styleClass="w-100">
                                                             <p:inputText class="mx-2 w-100" id="gmno"    value="#{admissionController.current.guardian.mobile}"  />
                                                             <p:commandButton id="btnCopyPho" class="ui-button-warning mx-2" icon="fas fa-paste" process="btnCopyPho :#{p:resolveClientId('@id(txtMobile)', view)}" update="gmno" action="#{admissionController.copyPatientPhoneNumberToGurdian}"/>
                                                             <p:spacer />
@@ -350,14 +350,17 @@
                                                     </h:panelGrid>
                                                 </p:tab>
                                                 <p:tab title="Appointment" >
-                                                    <p:autoComplete 
+                                                    <p:autoComplete
                                                         forceSelection="true"
-                                                        id="aBill" 
-                                                        value="#{admissionController.appointmentBill}" 
-                                                        completeMethod="#{billController.completeAppointmentBill}" 
-                                                        var="apt2" 
-                                                        itemLabel="#{apt2.patient.person.nameWithTitle}" 
-                                                        itemValue="#{apt2}" >
+                                                        id="aBill"
+                                                        value="#{admissionController.appointmentBill}"
+                                                        completeMethod="#{billController.completeAppointmentBill}"
+                                                        var="apt2"
+                                                        itemLabel="#{apt2.patient.person.nameWithTitle}"
+                                                        itemValue="#{apt2}"
+                                                        class="w-100 form-control"
+                                                        styleClass="w-100"
+                                                        inputStyleClass="w-100">
                                                         <p:ajax event="itemSelect" process="aBill" update="panSearch2 :#{p:resolveFirstComponentWithId('ptd',view).clientId} @all" listener="#{admissionController.listnerForAppoimentSelect(admissionController.appointmentBill)}" />
                                                         <p:column>
                                                             #{apt2.deptId}


### PR DESCRIPTION
## Summary
- Fixes #22205 — the "Other" panel on `inward_admission.xhtml` (Admit a Patient page) had a large empty area to the right of the **Guardian Detail** and **Appointment** tabs, squeezing the actual fields into a narrow column.
- **Guardian Detail tab**: the wrapping `h:panelGrid` rendered as a shrink-to-fit HTML table with no width styling, so it never stretched to the panel's available width. Added `styleClass="w-100"` + `columnClasses="col-4,col-8"` (Bootstrap utility classes, matching this codebase's existing convention in e.g. `analytics/pharmacy/stock_history.xhtml`) to the outer grid, and `styleClass="w-100"` to the two nested grids (Address / Mobile No paste-button rows) so they stretch too.
- **Appointment tab**: the patient-search `p:autoComplete` (`id="aBill"`) had no width styling at all, unlike every other autocomplete on this page. Added the same `class="w-100 form-control" styleClass="w-100" inputStyleClass="w-100"` combination used elsewhere on this page (e.g. the Workplace autocomplete).
- JSF/XHTML-only change — no Java, entity, or schema changes.

## Test plan
- [ ] Manual visual verification pending — not yet verified end-to-end by Claude (per explicit instruction from the developer, who will verify locally once this PR is up).
- [ ] Load `Admit a Patient` → "Other" panel → confirm Guardian Detail fields now span the panel width with no dead space on the right.
- [ ] Switch to the Appointment tab → confirm the patient search box now spans the available width.
- [ ] Confirm the paste-to-guardian buttons (Address, Mobile No) still function and align correctly at the new width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)