### PR TITLE
fix(inward): replace Theatre Room autocomplete with select-one dropdown

### DIFF
--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -69,6 +69,7 @@ public class PatientTransferController implements Serializable {
     // Theatre workflow fields
     private Bill selectedSurgeryBill;
     private List<Bill> surgeryBillsForCurrentAdmission;
+    private List<RoomFacilityCharge> theatreRoomsForCurrentInstitution;
     private List<PatientTransferRequest> pendingTheatreRequests;
     private List<PatientTransferRequest> inTheatreRequests;
     private List<PatientTransferRequest> pendingReturnRequests;
@@ -466,6 +467,7 @@ public class PatientTransferController implements Serializable {
         selectedSurgeryBill = null;
         notes = null;
         surgeryBillsForCurrentAdmission = loadSurgeryBillsForAdmission(admission);
+        theatreRoomsForCurrentInstitution = roomFacilityChargeController.findTheatreRoomsForInstitution(sessionController.getInstitution());
         return "/inward/inward_send_to_theatre?faces-redirect=true";
     }
 
@@ -758,6 +760,13 @@ public class PatientTransferController implements Serializable {
             surgeryBillsForCurrentAdmission = new ArrayList<>();
         }
         return surgeryBillsForCurrentAdmission;
+    }
+
+    public List<RoomFacilityCharge> getTheatreRoomsForCurrentInstitution() {
+        if (theatreRoomsForCurrentInstitution == null) {
+            theatreRoomsForCurrentInstitution = new ArrayList<>();
+        }
+        return theatreRoomsForCurrentInstitution;
     }
 
     public Bill getSelectedSurgeryBill() {

--- a/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
@@ -11,6 +11,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.inward.RoomFacility;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.util.JsfUtil;
@@ -114,6 +115,21 @@ public class RoomFacilityChargeController implements Serializable {
                 + "WHERE rm.retired = false "
                 + "AND rm.department.departmentType = :deptType "
                 + "AND UPPER(rm.name) LIKE :q "
+                + "ORDER BY rm.name";
+        return getFacade().findByJpql(sql, hm);
+    }
+
+    public List<RoomFacilityCharge> findTheatreRoomsForInstitution(Institution institution) {
+        if (institution == null) {
+            return new ArrayList<>();
+        }
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("deptType", DepartmentType.Theatre);
+        hm.put("institution", institution);
+        String sql = "SELECT rm FROM RoomFacilityCharge rm "
+                + "WHERE rm.retired = false "
+                + "AND rm.department.departmentType = :deptType "
+                + "AND rm.department.institution = :institution "
                 + "ORDER BY rm.name";
         return getFacade().findByJpql(sql, hm);
     }

--- a/src/main/webapp/inward/inward_send_to_theatre.xhtml
+++ b/src/main/webapp/inward/inward_send_to_theatre.xhtml
@@ -54,28 +54,19 @@
 
                     <!-- Theatre Room -->
                     <div class="col-md-6">
-                        <h:outputLabel for="acTheatreRoom" value="Theatre Room" styleClass="fw-bold mb-1"/>
+                        <h:outputLabel for="selTheatreRoom" value="Theatre Room" styleClass="fw-bold mb-1"/>
                         <div>
-                            <p:autoComplete
-                                id="acTheatreRoom"
-                                widgetVar="wTheatreRoom"
-                                forceSelection="true"
+                            <p:selectOneMenu
+                                id="selTheatreRoom"
                                 value="#{patientTransferController.targetRoomFacilityCharge}"
-                                completeMethod="#{roomFacilityChargeController.completeTheatreRoom}"
-                                var="tr"
-                                itemLabel="#{tr.name}"
-                                itemValue="#{tr}"
-                                placeholder="Type theatre room name..."
-                                minQueryLength="1"
-                                maxResults="10"
                                 style="width:100%">
-                                <p:column headerText="Room">
-                                    <h:outputText value="#{tr.name}"/>
-                                </p:column>
-                                <p:column headerText="Department">
-                                    <h:outputText value="#{tr.department.name}"/>
-                                </p:column>
-                            </p:autoComplete>
+                                <f:selectItem itemLabel="— Select Theatre Room —" itemValue="#{null}"/>
+                                <f:selectItems
+                                    value="#{patientTransferController.theatreRoomsForCurrentInstitution}"
+                                    var="tr"
+                                    itemLabel="#{tr.name}"
+                                    itemValue="#{tr}"/>
+                            </p:selectOneMenu>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Replaced the `p:autoComplete` Theatre Room field on the Send Patient to Theatre page (`inward_send_to_theatre.xhtml`) with a `p:selectOneMenu`, listing all active theatre rooms for the logged-in institution — following the same pattern already used for the Surgery field on the same page.
- Added `RoomFacilityChargeController.findTheatreRoomsForInstitution(Institution)`, a JPQL query filtering `RoomFacilityCharge` by `DepartmentType.Theatre` and the given institution.
- `PatientTransferController.navigateToSendToTheatre()` now loads `theatreRoomsForCurrentInstitution` fresh on every navigation (mirroring `surgeryBillsForCurrentAdmission`), so the list reflects the current session's institution and any newly created theatre rooms without needing a restart.

## Test plan
- [ ] Login, navigate to an admission's Send to Theatre page, confirm the Theatre Room field renders as a dropdown listing theatre rooms for the logged-in institution
- [ ] Select a theatre room and submit; confirm the transfer request is created with the correct target room
- [ ] Verify the existing autocomplete on `surgery_status.xhtml` (which shares `completeTheatreRoom`) is unaffected

Closes #22207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Theatre Room dropdown when sending patients to theatre.
  * Displays available theatre rooms for the selected institution.
  * Includes a default “Select Theatre Room” option.

* **Bug Fixes**
  * Prevented unavailable or unrelated theatre rooms from appearing in the selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->