### PR TITLE
fix(pharmacy): fix inward pharmacy request search/edit bugs (#22196)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -754,6 +754,43 @@ Two related traps when checking whether `JsfUtil.addWarningMessage(...)` actuall
   (`TypeError: Cannot read properties of undefined (reading 'hasAttribute')`, present since
   before any interaction) prevented the growl from rendering visually at all.
 
+## 33. Binding a `p:inputText` through a nullable session-scoped entity property crashes on first submit
+
+`ward/issue_for_bht_request_list.xhtml` bound its BHT-No search box to
+`#{searchController.patientEncounter.bhtNo}` — a nested property path through
+`SearchController.patientEncounter`, which is `@SessionScoped` and never
+initialized on this page (nothing sets it before rendering; unlike the 3 lab
+pages that bind `value="#{searchController.patientEncounter}"` — the whole
+object, not a nested field — via `p:autoComplete`/`p:selectOneMenu`, which
+tolerate `null`). Every submit threw `EL: Target Unreachable, 'null' returned
+null` (HTTP 500) during `UIInput.getConvertedValue`, both with and without
+typing into the field — the crash happens on *any* postback of the form, not
+just when the bound property is touched. Fixed for #22196 by rebinding to
+`searchController.searchKeyword.bhtNo` (a plain `String`, default `""`),
+matching the pattern already used by ~28 other pages in this codebase (grep
+`searchController.searchKeyword.bhtNo` across `*.xhtml`). **Lesson**: never
+bind a `p:inputText` through a nested path on a session-scoped controller's
+entity-typed field unless something on the *same* page is guaranteed to have
+set that entity first — bind through a dedicated search-keyword/DTO field
+instead.
+
+## 34. Local dev DB can silently drift behind the entity model — watch for `Unknown column` on unrelated pages
+
+While testing #22196, clicking "View Request" on an inward pharmacy request
+threw `SQLSyntaxErrorException: Unknown column 'VATPERCENTAGE' in 'field
+list'` loading `BillItem` rows — the local `coop` DB's `BILLITEM` table
+predates the `vatPercentage` field added to the `BillItem` entity, and there
+is no DDL/migration step in the local dev workflow that keeps schema in sync
+automatically. This is unrelated to whatever feature is under test and will
+recur for any page that touches `BillItem`. Fix locally with a plain additive
+column matching the sibling `VAT`/`VATPLUSNETVALUE` columns:
+`ALTER TABLE BILLITEM ADD COLUMN VATPERCENTAGE DOUBLE NULL DEFAULT NULL AFTER
+VAT;` — do not add this to a migration script (it's a local-only environment
+gap, not a schema change accompanying a code change). If a fresh
+`Unknown column` error appears on an otherwise-unrelated page, check
+`SHOW COLUMNS FROM <table>` against the entity's fields before assuming the
+feature under test is broken.
+
 ## 20. Don't `disable` + `enable` the app to clear the L2 cache — restart the domain
 
 The disable→enable trick for flushing a poisoned EclipseLink shared cache (§ noted in

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5418,7 +5418,7 @@ public class SearchController implements Serializable {
     public List<Bill> createInwardPharmacyRequests() {
         String sql;
         HashMap tmp = new HashMap();
-        tmp.put("admission", getPatientEncounter());
+        tmp.put("toDep", getSessionController().getDepartment());
         tmp.put("bTp", BillType.InwardPharmacyRequest);
         tmp.put("bta", BillTypeAtomic.REQUEST_MEDICINE_INWARD);
         sql = "Select b "
@@ -5426,8 +5426,11 @@ public class SearchController implements Serializable {
                 + " where b.retired=false "
                 + " and  b.toDepartment=:toDep"
                 + " and b.billType=:bTp "
-                + " and b.billTypeAtomic = :bta "
-                + " and b.patientEncounter=:admission ";
+                + " and b.billTypeAtomic = :bta ";
+        if (getSearchKeyword().getBhtNo() != null && !getSearchKeyword().getBhtNo().trim().equals("")) {
+            sql += " and  ((b.patientEncounter.bhtNo) like :bht )";
+            tmp.put("bht", "%" + getSearchKeyword().getBhtNo().trim().toUpperCase() + "%");
+        }
         sql += " order by b.createdAt desc  ";
         return getBillFacade().findByJpql(sql, tmp, TemporalType.TIMESTAMP, 100);
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -668,7 +668,9 @@ public class PharmacyBillSearch implements Serializable {
         }
         pharmacyRequestForBhtController.setBillPreview(false);
         pharmacyRequestForBhtController.setPatientEncounter(bill.getPatientEncounter());
-        pharmacyRequestForBhtController.setDepartment(bill.getFromDepartment());
+        // `department` on PharmacyRequestForBhtController means the target pharmacy
+        // (toDepartment), not the ward (fromDepartment) — see loadDraftForEditing().
+        pharmacyRequestForBhtController.setDepartment(bill.getToDepartment());
         pharmacyRequestForBhtController.setPreBill((PreBill) bill);
         billFacade.edit(bill);
         return "/ward/ward_pharmacy_bht_issue_request_edit?faces-redirect=true";

--- a/src/main/webapp/ward/issue_for_bht_request_list.xhtml
+++ b/src/main/webapp/ward/issue_for_bht_request_list.xhtml
@@ -24,7 +24,7 @@
                                              action="#{searchController.navigateToIssueForBhtRequests}" />
                             <p:spacer height="10"/>
                             <h:outputLabel value="BHT No"/> 
-                            <p:inputText autocomplete="off"  value="#{searchController.patientEncounter.bhtNo}" />                                                
+                            <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.bhtNo}" />                                                
                             
                         </h:panelGrid>
                     </div>


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs found while working on #22004 (PR #22192), plus one additional bug found while verifying the fix (same root-cause pattern — a page binding through a nullable session-scoped controller property).

- **`SearchController.createInwardPharmacyRequests()`**: JPQL referenced `:toDep` but never bound it — threw `IllegalArgumentException` on every call. Now bound to `getSessionController().getDepartment()`, matching the sibling `createInwardBHTForIssueTable` method. Reworked the query to filter by optional BHT No text (`searchController.searchKeyword.bhtNo`) instead of requiring a pre-populated `PatientEncounter`.
- **`PharmacyBillSearch.editInwardPharmacyRequestBill()`**: passed `bill.getFromDepartment()` (the ward) where `PharmacyRequestForBhtController.department` expects the target pharmacy (`toDepartment`) — same bug class already fixed in `loadDraftForEditing()` (PR #22192).
- **`ward/issue_for_bht_request_list.xhtml`**: BHT No search box bound through `searchController.patientEncounter.bhtNo`, a nested property path on a `@SessionScoped` field that's never initialized on this page — every submit threw an EL "Target Unreachable" 500 error, independent of the `:toDep` fix. Rebound to `searchController.searchKeyword.bhtNo`, the pattern already used by ~28 other search pages in this codebase.

## Test plan

- [x] Rebuilt and redeployed locally (Maven `clean package` + `asadmin redeploy`)
- [x] 149 existing unit/regression tests pass, including `SearchControllerDepartmentFilterRegressionTest$ToDepartmentFilterTest`
- [x] Playwright: logged in as Main Pharmacy, navigated to `ward/issue_for_bht_request_list.xhtml`, searched by BHT No — confirmed no exception and results correctly scoped to the department (previously HTTP 500 on every submit)
- [x] Playwright: opened an already-settled inward pharmacy request (`Inward//26/000137`, BHT/53355) via "View Request" → "Edit Request" — confirmed the edit page header shows "Main Pharmacy" (toDepartment) as the target, not "Ward 56/I" (fromDepartment)
- [x] Confirmed via server log: no `IllegalArgumentException`/`QueryException`/EL errors on either flow after the fix
- [x] Added a new learnings section (§33, §34) to `developer_docs/testing/playwright-e2e-workflow.md` documenting the nested-property-binding crash pattern and an unrelated local-DB schema-drift gotcha (`VATPERCENTAGE` column) hit while testing

## Evidence

Search results correctly scoped to department:

![Search results scoped to department](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22196-search-results-scoped-to-department.png)

Edit page shows the correct target pharmacy, not the ward:

![Edit request shows correct target pharmacy](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22196-edit-request-correct-target-pharmacy.png)

Closes #22196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of inward pharmacy requests by BHT number, including case-insensitive matching and whitespace handling.
  * Corrected department selection when editing inward pharmacy request bills.
  * Fixed BHT number entry on the ward request list to ensure searches and navigation use the entered value.
  * Prevented submission failures caused by uninitialized search fields.

* **Documentation**
  * Added troubleshooting guidance for common end-to-end testing failures and local database schema mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->