### PR TITLE
fix(inward): highlight pending theatre acceptance and guard against wrong-flow acceptance

### DIFF
--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -296,6 +296,11 @@ public class PatientTransferController implements Serializable {
         if (req == null) {
             return;
         }
+        if (req.getTheatreTransferType() == TheatreTransferType.SEND_TO_THEATRE) {
+            JsfUtil.addErrorMessage("This is a theatre transfer request. Use \"Accept Theatre Patient\" instead.");
+            loadPendingForDepartment();
+            return;
+        }
 
         Date effectiveAt = req.getAcceptedAt() != null ? req.getAcceptedAt() : new Date();
         req.setAcceptedAt(effectiveAt);
@@ -363,6 +368,30 @@ public class PatientTransferController implements Serializable {
         String jpql = "SELECT r FROM PatientTransferRequest r "
                 + "WHERE r.status = :status "
                 + "AND r.toRoomFacilityCharge.department = :department "
+                + "AND r.theatreTransferType IS NULL "
+                + "AND r.retired = false";
+        List<PatientTransferRequest> result = patientTransferRequestFacade.findByJpql(jpql, params, 1);
+        return result != null && !result.isEmpty();
+    }
+
+    /**
+     * True if there are any PENDING theatre-bound (SEND_TO_THEATRE) transfer
+     * requests targeting the logged-in user's department. Used to enable/
+     * disable the Accept Theatre Patient button.
+     */
+    public boolean isHasPendingTheatreRequestsForDepartment() {
+        Department userDept = sessionController.getDepartment();
+        if (userDept == null) {
+            return false;
+        }
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("status", TransferRequestStatus.PENDING);
+        params.put("type", TheatreTransferType.SEND_TO_THEATRE);
+        params.put("department", userDept);
+        String jpql = "SELECT r FROM PatientTransferRequest r "
+                + "WHERE r.status = :status "
+                + "AND r.theatreTransferType = :type "
+                + "AND r.toRoomFacilityCharge.department = :department "
                 + "AND r.retired = false";
         List<PatientTransferRequest> result = patientTransferRequestFacade.findByJpql(jpql, params, 1);
         return result != null && !result.isEmpty();
@@ -375,6 +404,7 @@ public class PatientTransferController implements Serializable {
         String jpql = "SELECT r FROM PatientTransferRequest r "
                 + "WHERE r.status = :status "
                 + "AND r.toRoomFacilityCharge.department = :department "
+                + "AND r.theatreTransferType IS NULL "
                 + "AND r.retired = false "
                 + "ORDER BY r.initiatedAt";
         pendingRequests = patientTransferRequestFacade.findByJpql(jpql, params);

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -765,6 +765,7 @@
                                         rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient')}"
                                         value="Accept Theatre Patient"
                                         ajax="false"
+                                        disabled="#{not patientTransferController.hasPendingTheatreRequestsForDepartment}"
                                         action="#{patientTransferController.navigateToTheatreAccept()}"
                                         icon="fa fa-hospital"
                                         class="w-100 ui-button-info">

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -423,6 +423,7 @@
                                                             icon="fa fa-check-circle"
                                                             ajax="false"
                                                             rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient')}"
+                                                            disabled="#{not patientTransferController.hasPendingTheatreRequestsForDepartment}"
                                                             action="#{patientTransferController.navigateToTheatreAccept()}"
                                                             class="w-100 ui-button-success">
                                                         </p:commandButton>


### PR DESCRIPTION
## Summary

Fixes #22211 — two related issues on the inpatient dashboard's Room Management / Operating Theatre panels:

1. **Feature**: "Accept Theatre Patient" now highlights (enables) only when there's a pending `SEND_TO_THEATRE` request for the logged-in department, mirroring the existing "Accept Patients" pattern (`isHasPendingRequestsForDepartment`). Added `PatientTransferController.isHasPendingTheatreRequestsForDepartment()`, scoped the same way as `loadPendingForTheatre()`.
2. **Bug fix**: `loadPendingForDepartment()` and `isHasPendingRequestsForDepartment()` (backing the generic "Accept Patients" list/button) now filter `theatreTransferType IS NULL`, so theatre-bound transfer requests can no longer leak into the plain "Pending Patients" list or enable the generic accept button. Previously a user with both `InwardRoomPatientAccept` and `TheatreAcceptPatient` privileges could accidentally accept a theatre-bound transfer through the wrong flow — permanently discharging the ward bed mid-surgery while `theatreOccupancyStatus` never advances, with no UI recovery path.
3. **Defensive backstop**: `acceptTransfer()` now rejects any request whose `theatreTransferType == SEND_TO_THEATRE`, directing the user to "Accept Theatre Patient" instead, in case such a request is ever reached through another path.

## Files changed

- `src/main/java/com/divudi/bean/inward/PatientTransferController.java` — new getter, JPQL filter on two existing methods, guard in `acceptTransfer()`
- `src/main/webapp/inward/admission_profile.xhtml` — `disabled` binding on "Accept Theatre Patient"
- `src/main/webapp/nurse/index.xhtml` — same binding on the nurse dashboard's equivalent button

## Test plan

Verified end-to-end with Playwright against a local deployment (CareCode Model Hospital demo data) + direct DB checks:

- [x] Created a fresh test admission (BHT/53361) in the **Inward** department
- [x] Confirmed "Accept Theatre Patient" is **disabled** while logged into Inward (no pending theatre request for that department)
- [x] Sent the patient to **Operation Theatre 1** (department: Main Operation Theatre) via "Send to Theatre"
- [x] Confirmed the theatre-bound request does **not** appear in the generic "Pending Patients" list (`inward_patient_accept.xhtml`) — only the unrelated ward-admission-handover request shows there
- [x] Logged into **Main Operation Theatre**; confirmed "Accept Theatre Patient" becomes **enabled**
- [x] Accepted the patient via "Accept Theatre Patient" — regression check confirms the existing flow still works: `theatreoccupancystatus` advances to `RECEIVED_IN_THEATRE`, and the ward room (`patientroom.discharged`) correctly stays `0` (not discharged), preserving the intentional bed-reservation behavior during surgery

Screenshots and full verification detail posted on the issue: https://github.com/hmislk/hmis/issues/22211#issuecomment-5008818483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate handling for standard patient transfers and theatre-bound transfers.
  * Added dedicated detection of pending theatre transfer requests by department.
  * Theatre acceptance actions are now disabled when no pending theatre requests are available.

* **Bug Fixes**
  * Prevented theatre-bound requests from being accepted through standard ward transfer workflows.
  * Improved filtering so standard and theatre transfer queues display the correct requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->