### PR TITLE
fix(inward): bill theatre stays alongside the ward room

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -808,6 +808,35 @@ Run the two commands separately (not chained with `&&`): if the domain is alread
 down, `stop-domain` exits nonzero and a chained `start-domain` would be skipped,
 leaving the app offline.
 
+## 35. Department-scoped dashboards need the department actually switched, not just full privileges
+
+While verifying #22213 (theatre stay billing), the Theatre Dashboard's "Awaiting
+Theatre Acceptance" / "Pending Return to Ward" lists showed **0** rows even though
+a request definitely existed (confirmed via direct DB query) and the logged-in
+user had every relevant privilege. Root cause: `PatientTransferController`'s
+loader methods (`loadPendingForTheatre()`, `loadInTheatreRequests()`, etc.) filter
+on `r.toRoomFacilityCharge.department = sessionController.getDepartment()` — the
+**currently selected** department, not "any department the user has access to."
+Being logged in under "Inward" and merely navigating to a Theatre page renders it
+fine but shows empty lists. Fix: log out and back in, and on the Select Department
+screen explicitly pick the department the workflow actually belongs to (here,
+"THEATRE") before testing department-scoped actions — the app remembers your last
+selection and will silently keep applying it across unrelated page navigations.
+
+## 36. `@SessionScoped` bean data can go stale after a direct URL hit — navigate through the real action chain
+
+Also during #22213 verification: after completing a theatre "return to ward" action
+(via a proper button click with a bound `action="..."` method), directly typing the
+URL for `/inward/inward_patient_room_details.xhtml` showed the just-discharged room
+still as "Active" — the underlying DB was already correct (verified via SQL), but
+`BhtSummeryController` (`@SessionScoped`) lazily caches `patientRooms` on first
+access and only a handful of specific action methods actually refresh it. A raw URL
+navigation skips whatever `action="..."` a genuine button click would have invoked,
+so it reads the stale in-memory list from earlier in the session. Fix: always
+reach the page under test by clicking through the real navigation chain (search →
+dashboard button → target page) rather than pasting/typing the target URL directly,
+especially right after an action that's supposed to change what that page displays.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/docs/superpowers/plans/2026-07-18-theatre-stay-billing.md
+++ b/docs/superpowers/plans/2026-07-18-theatre-stay-billing.md
@@ -1,0 +1,597 @@
+# Theatre Stay Billing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make theatre stays actually appear on the patient's bill by creating a concurrent, closable `TheatreRoom` record — alongside the still-active ward `PatientRoom` — so Room Stay History, the Interim Bill's Room Details tab, the Summary panel, and the Charges panel all pick it up automatically.
+
+**Architecture:** `TheatreRoom extends PatientRoom` (single-table inheritance, same pattern as the existing `GuardianRoom`). `PatientTransferController.acceptInTheatre()` creates it (backdated to the transfer request's `initiatedAt`); `PatientTransferController.returnToWard()` discharges it. No other billing code changes — every billing surface already queries `PatientRoom` with no subclass filter.
+
+**Tech Stack:** Java EE / Jakarta EE (JSF + PrimeFaces, JPA/EclipseLink), Maven, MySQL, Payara. This codebase has no JUnit coverage for `bean.inward`/`entity.inward` classes (22 test files total, none touch this package) — this project's established verification loop is compile → build → local Payara deploy → Playwright + DB verification (see `developer_docs/testing/playwright-e2e-workflow.md` and the project's `dev-issue` skill), not unit-test TDD. Each task below is sized so `mvn clean package -DskipTests` compiles cleanly after it; full functional verification happens once in Task 6, after all wiring is in place, because theatre-visit creation and discharge are two halves of one lifecycle that can't be meaningfully exercised in isolation against a real deployment.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-18-theatre-stay-billing-design.md` — follow it exactly; do not add scope beyond it.
+- **JPQL first, native SQL last** (CLAUDE.md) — not applicable here (no new queries needed; existing queries already have no subclass filter).
+- **Never modify existing constructors** (CLAUDE.md) — `TheatreRoom` has no custom constructor; `PatientTransferRequest`'s existing fields/methods are untouched, only a new field + getter/setter are added.
+- Billing window: `TheatreRoom.admittedAt = request.getInitiatedAt()`, `TheatreRoom.dischargedAt` set the same instant as `request.setReturnedToWardAt(...)` inside `returnToWard()`. Do not use `acceptedAt` for either boundary — confirmed by the user during design.
+- `previousRoom` on the new `TheatreRoom` must be `null` (it is a concurrent addition, not a room-chain link) — do not pass the ward `PatientRoom` as `previousRoom`.
+- No backfill for historical admissions — out of scope per spec.
+
+---
+
+### Task 1: `TheatreRoom` entity + `PatientTransferRequest.theatreRoom` field
+
+**Files:**
+- Create: `src/main/java/com/divudi/core/entity/inward/TheatreRoom.java`
+- Modify: `src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java:33-44` (field block), `:107-129` (getter/setter block)
+
+**Interfaces:**
+- Produces: `TheatreRoom` (public no-arg-constructible entity class, subtype of `PatientRoom`); `PatientTransferRequest.getTheatreRoom(): PatientRoom` / `PatientTransferRequest.setTheatreRoom(PatientRoom): void`.
+
+- [ ] **Step 1: Create the `TheatreRoom` entity**
+
+Write `src/main/java/com/divudi/core/entity/inward/TheatreRoom.java`:
+
+```java
+package com.divudi.core.entity.inward;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+
+/**
+ *
+ * @author buddhika
+ */
+@Entity
+public class TheatreRoom extends PatientRoom implements Serializable {
+
+}
+```
+
+This mirrors `src/main/java/com/divudi/core/entity/inward/GuardianRoom.java` exactly — no new table, no new columns; EclipseLink adds a `DTYPE` discriminator value on the existing `PATIENTROOM` table.
+
+- [ ] **Step 2: Add the `theatreRoom` field to `PatientTransferRequest`**
+
+In `src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java`, the field block currently reads (lines 33-44):
+
+```java
+    @ManyToOne
+    private Admission admission;
+
+    /**
+     * null = admission handover; non-null = ward-to-ward transfer
+     */
+    @ManyToOne
+    private PatientRoom fromPatientRoom;
+
+    @ManyToOne
+    private RoomFacilityCharge toRoomFacilityCharge;
+
+    @Enumerated(EnumType.STRING)
+    private TransferRequestStatus status;
+```
+
+Add a new field directly after `fromPatientRoom`:
+
+```java
+    @ManyToOne
+    private Admission admission;
+
+    /**
+     * null = admission handover; non-null = ward-to-ward transfer
+     */
+    @ManyToOne
+    private PatientRoom fromPatientRoom;
+
+    /**
+     * Set only on accepted SEND_TO_THEATRE requests — the concurrent
+     * TheatreRoom billing record created by acceptInTheatre(), closed by
+     * returnToWard(). Null on all other transfer types.
+     */
+    @ManyToOne
+    private PatientRoom theatreRoom;
+
+    @ManyToOne
+    private RoomFacilityCharge toRoomFacilityCharge;
+
+    @Enumerated(EnumType.STRING)
+    private TransferRequestStatus status;
+```
+
+- [ ] **Step 3: Add the getter/setter**
+
+The existing getter/setter block for `fromPatientRoom` (lines 115-121) reads:
+
+```java
+    public PatientRoom getFromPatientRoom() {
+        return fromPatientRoom;
+    }
+
+    public void setFromPatientRoom(PatientRoom fromPatientRoom) {
+        this.fromPatientRoom = fromPatientRoom;
+    }
+```
+
+Add directly after it:
+
+```java
+    public PatientRoom getFromPatientRoom() {
+        return fromPatientRoom;
+    }
+
+    public void setFromPatientRoom(PatientRoom fromPatientRoom) {
+        this.fromPatientRoom = fromPatientRoom;
+    }
+
+    public PatientRoom getTheatreRoom() {
+        return theatreRoom;
+    }
+
+    public void setTheatreRoom(PatientRoom theatreRoom) {
+        this.theatreRoom = theatreRoom;
+    }
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `mvn clean compile -DskipTests -q`
+Expected: `BUILD SUCCESS`, no errors referencing `TheatreRoom` or `PatientTransferRequest`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/entity/inward/TheatreRoom.java src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
+git commit -m "feat(inward): add TheatreRoom entity and PatientTransferRequest.theatreRoom link
+
+Part of #22213 — foundation for billing theatre stays as a concurrent
+PatientRoom-family record, mirroring the existing GuardianRoom pattern."
+```
+
+---
+
+### Task 2: Create the `TheatreRoom` when theatre accepts the patient
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/inward/PatientTransferController.java:545-563` (`acceptInTheatre`), imports at top of file
+
+**Interfaces:**
+- Consumes: `TheatreRoom` (Task 1, no-arg constructor), `PatientTransferRequest.setTheatreRoom(PatientRoom)` (Task 1), `InwardBeanController.savePatientRoom(PatientRoom, PatientRoom, RoomFacilityCharge, PatientEncounter, Date, WebUser): PatientRoom` (existing, `src/main/java/com/divudi/bean/inward/InwardBeanController.java:2270`).
+- Produces: `acceptInTheatre()` now also persists a `TheatreRoom` row and links it on the request — later tasks (Task 3) read it back via `persisted.getTheatreRoom()`.
+
+- [ ] **Step 1: Add the import**
+
+In `src/main/java/com/divudi/bean/inward/PatientTransferController.java`, the import block currently includes (line 12):
+
+```java
+import com.divudi.core.entity.inward.PatientRoom;
+```
+
+Add directly after it:
+
+```java
+import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.entity.inward.TheatreRoom;
+```
+
+- [ ] **Step 2: Wire creation into `acceptInTheatre()`**
+
+The current method (lines 545-563) reads:
+
+```java
+    public void acceptInTheatre(PatientTransferRequest req) {
+        if (req == null || req.getId() == null) {
+            return;
+        }
+        PatientTransferRequest persisted = patientTransferRequestFacade.find(req.getId());
+        if (persisted == null || persisted.getStatus() != TransferRequestStatus.PENDING) {
+            JsfUtil.addErrorMessage("This request is no longer pending.");
+            loadPendingForTheatre();
+            return;
+        }
+        persisted.setStatus(TransferRequestStatus.ACCEPTED);
+        persisted.setAcceptedAt(new Date());
+        persisted.setAcceptedBy(sessionController.getLoggedUser());
+        persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RECEIVED_IN_THEATRE);
+        patientTransferRequestFacade.edit(persisted);
+        loadPendingForTheatre();
+        loadInTheatreRequests();
+        JsfUtil.addSuccessMessage("Patient accepted in theatre.");
+    }
+```
+
+Replace it with:
+
+```java
+    public void acceptInTheatre(PatientTransferRequest req) {
+        if (req == null || req.getId() == null) {
+            return;
+        }
+        PatientTransferRequest persisted = patientTransferRequestFacade.find(req.getId());
+        if (persisted == null || persisted.getStatus() != TransferRequestStatus.PENDING) {
+            JsfUtil.addErrorMessage("This request is no longer pending.");
+            loadPendingForTheatre();
+            return;
+        }
+        persisted.setStatus(TransferRequestStatus.ACCEPTED);
+        persisted.setAcceptedAt(new Date());
+        persisted.setAcceptedBy(sessionController.getLoggedUser());
+        persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RECEIVED_IN_THEATRE);
+
+        TheatreRoom theatreRoom = new TheatreRoom();
+        theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
+                theatreRoom,
+                null,
+                persisted.getToRoomFacilityCharge(),
+                persisted.getAdmission(),
+                persisted.getInitiatedAt(),
+                sessionController.getLoggedUser());
+        persisted.setTheatreRoom(theatreRoom);
+
+        patientTransferRequestFacade.edit(persisted);
+        loadPendingForTheatre();
+        loadInTheatreRequests();
+        JsfUtil.addSuccessMessage("Patient accepted in theatre.");
+    }
+```
+
+Note: `previousRoom` is passed as `null` (not `persisted.getFromPatientRoom()`) — the ward room is not being replaced, so this must not be chained via `previousRoom`/`nextRoom`.
+
+- [ ] **Step 3: Compile**
+
+Run: `mvn clean compile -DskipTests -q`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/inward/PatientTransferController.java
+git commit -m "feat(inward): create TheatreRoom billing record on theatre acceptance
+
+Part of #22213 — acceptInTheatre() now opens a concurrent TheatreRoom
+record backdated to the transfer request's initiatedAt, so the
+theatre's RoomFacilityCharge rate starts accruing alongside the still-
+active ward room charge."
+```
+
+---
+
+### Task 3: Discharge the `TheatreRoom` when the patient returns to ward
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/inward/PatientTransferController.java:609-651` (`returnToWard`)
+
+**Interfaces:**
+- Consumes: `PatientTransferRequest.getTheatreRoom(): PatientRoom` (Task 1), `PatientRoom.setDischarged(boolean)` / `setDischargedAt(Date)` / `setDischargedBy(WebUser)` / `isDischarged(): boolean` (existing, `PatientRoom.java`).
+- Produces: a fully closed `TheatreRoom` row with `discharged=true` — the billing window is now bounded, matching what `getCharge()` in `BhtSummeryController` needs to stop accruing.
+
+- [ ] **Step 1: Wire discharge into `returnToWard()`**
+
+The current method (lines 609-651) reads:
+
+```java
+    public void returnToWard(PatientTransferRequest theatreReq) {
+        if (theatreReq == null || theatreReq.getId() == null) {
+            return;
+        }
+        PatientTransferRequest persisted = patientTransferRequestFacade.find(theatreReq.getId());
+        if (persisted == null) {
+            return;
+        }
+        TheatreOccupancyStatus currentStatus = persisted.getTheatreOccupancyStatus();
+        if (currentStatus != TheatreOccupancyStatus.PROCEDURE_COMPLETED
+                && currentStatus != TheatreOccupancyStatus.IN_RECOVERY) {
+            JsfUtil.addErrorMessage("Patient must have completed the procedure before returning to ward.");
+            return;
+        }
+        if (persisted.getFromPatientRoom() == null || persisted.getFromPatientRoom().getRoomFacilityCharge() == null) {
+            JsfUtil.addErrorMessage("Cannot determine the ward room to return patient to.");
+            return;
+        }
+        PatientTransferRequest returnReq = new PatientTransferRequest();
+        returnReq.setAdmission(persisted.getAdmission());
+        returnReq.setFromPatientRoom(persisted.getFromPatientRoom());
+        returnReq.setToRoomFacilityCharge(persisted.getFromPatientRoom().getRoomFacilityCharge());
+        returnReq.setTheatreTransferType(TheatreTransferType.RETURN_TO_WARD);
+        returnReq.setSurgeryBill(persisted.getSurgeryBill());
+        returnReq.setStatus(TransferRequestStatus.PENDING);
+        returnReq.setNotes(notes);
+        returnReq.setInitiatedAt(new Date());
+        returnReq.setInitiatedBy(sessionController.getLoggedUser());
+        returnReq.setCreatedAt(new Date());
+        returnReq.setCreater(sessionController.getLoggedUser());
+        patientTransferRequestFacade.create(returnReq);
+
+        persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
+        if (persisted.getReturnedToWardAt() == null) {
+            persisted.setReturnedToWardAt(new Date());
+        }
+        patientTransferRequestFacade.edit(persisted);
+
+        notes = null;
+        loadPendingForTheatre();
+        loadInTheatreRequests();
+        JsfUtil.addSuccessMessage("Patient return to ward initiated.");
+    }
+```
+
+Replace the tail (from `persisted.setTheatreOccupancyStatus(...)` onward) so the full method reads:
+
+```java
+    public void returnToWard(PatientTransferRequest theatreReq) {
+        if (theatreReq == null || theatreReq.getId() == null) {
+            return;
+        }
+        PatientTransferRequest persisted = patientTransferRequestFacade.find(theatreReq.getId());
+        if (persisted == null) {
+            return;
+        }
+        TheatreOccupancyStatus currentStatus = persisted.getTheatreOccupancyStatus();
+        if (currentStatus != TheatreOccupancyStatus.PROCEDURE_COMPLETED
+                && currentStatus != TheatreOccupancyStatus.IN_RECOVERY) {
+            JsfUtil.addErrorMessage("Patient must have completed the procedure before returning to ward.");
+            return;
+        }
+        if (persisted.getFromPatientRoom() == null || persisted.getFromPatientRoom().getRoomFacilityCharge() == null) {
+            JsfUtil.addErrorMessage("Cannot determine the ward room to return patient to.");
+            return;
+        }
+        PatientTransferRequest returnReq = new PatientTransferRequest();
+        returnReq.setAdmission(persisted.getAdmission());
+        returnReq.setFromPatientRoom(persisted.getFromPatientRoom());
+        returnReq.setToRoomFacilityCharge(persisted.getFromPatientRoom().getRoomFacilityCharge());
+        returnReq.setTheatreTransferType(TheatreTransferType.RETURN_TO_WARD);
+        returnReq.setSurgeryBill(persisted.getSurgeryBill());
+        returnReq.setStatus(TransferRequestStatus.PENDING);
+        returnReq.setNotes(notes);
+        returnReq.setInitiatedAt(new Date());
+        returnReq.setInitiatedBy(sessionController.getLoggedUser());
+        returnReq.setCreatedAt(new Date());
+        returnReq.setCreater(sessionController.getLoggedUser());
+        patientTransferRequestFacade.create(returnReq);
+
+        Date returnedAt = new Date();
+        persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
+        if (persisted.getReturnedToWardAt() == null) {
+            persisted.setReturnedToWardAt(returnedAt);
+        }
+        if (persisted.getTheatreRoom() != null && !persisted.getTheatreRoom().isDischarged()) {
+            PatientRoom theatreRoom = persisted.getTheatreRoom();
+            theatreRoom.setDischarged(true);
+            theatreRoom.setDischargedAt(returnedAt);
+            theatreRoom.setDischargedBy(sessionController.getLoggedUser());
+            patientRoomFacade.edit(theatreRoom);
+        }
+        patientTransferRequestFacade.edit(persisted);
+
+        notes = null;
+        loadPendingForTheatre();
+        loadInTheatreRequests();
+        JsfUtil.addSuccessMessage("Patient return to ward initiated.");
+    }
+```
+
+Note: `returnedAt` is computed once and reused for both `persisted.setReturnedToWardAt(...)` and `theatreRoom.setDischargedAt(...)` so the two timestamps stay identical, per the spec's confirmed billing window.
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn clean compile -DskipTests -q`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/inward/PatientTransferController.java
+git commit -m "feat(inward): discharge TheatreRoom when patient returns to ward
+
+Part of #22213 — returnToWard() now closes the TheatreRoom billing
+record at the same instant returnedToWardAt is stamped, so the
+theatre charge window matches the Patient Room & Theatre Timeline
+exactly."
+```
+
+---
+
+### Task 4: Add a "Theatre" badge in Room Stay History and the Interim Bill
+
+**Files:**
+- Modify: `src/main/webapp/inward/inward_patient_room_details.xhtml:115-137` (Room column)
+- Modify: `src/main/webapp/inward/inward_bill_intrim.xhtml:458-471` (Room column)
+
+**Interfaces:**
+- Consumes: `PatientRoom.getPatientRoomClass(): String` (existing, returns `this.getClass().toString()`), already used by the existing `GuardianRoom` badge check.
+
+- [ ] **Step 1: Add the badge in `inward_patient_room_details.xhtml`**
+
+The current "Room" column (lines 115-137) reads:
+
+```xml
+                                        <p:column headerText="Room" style="min-width:220px;">
+                                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                                <p:autoComplete
+                                                    forceSelection="true"
+                                                    readonly="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    value="#{rm.roomFacilityCharge}"
+                                                    completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
+                                                    var="rf"
+                                                    itemLabel="#{rf.name}"
+                                                    itemValue="#{rf}"
+                                                    style="width:160px;"
+                                                    minQueryLength="1"/>
+                                                <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
+                                                    <p:badge value="Guardian" severity="success"/>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{rm.discharged}">
+                                                    <p:badge value="Left" severity="info"/>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{not rm.discharged}">
+                                                    <p:badge value="Active" severity="warning"/>
+                                                </h:panelGroup>
+                                            </div>
+                                        </p:column>
+```
+
+Add a second badge check directly after the `GuardianRoom` one:
+
+```xml
+                                        <p:column headerText="Room" style="min-width:220px;">
+                                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                                <p:autoComplete
+                                                    forceSelection="true"
+                                                    readonly="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    value="#{rm.roomFacilityCharge}"
+                                                    completeMethod="#{roomFacilityChargeController.completeRoomChargeAll}"
+                                                    var="rf"
+                                                    itemLabel="#{rf.name}"
+                                                    itemValue="#{rf}"
+                                                    style="width:160px;"
+                                                    minQueryLength="1"/>
+                                                <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
+                                                    <p:badge value="Guardian" severity="success"/>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.TheatreRoom'}">
+                                                    <p:badge value="Theatre" severity="danger"/>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{rm.discharged}">
+                                                    <p:badge value="Left" severity="info"/>
+                                                </h:panelGroup>
+                                                <h:panelGroup rendered="#{not rm.discharged}">
+                                                    <p:badge value="Active" severity="warning"/>
+                                                </h:panelGroup>
+                                            </div>
+                                        </p:column>
+```
+
+- [ ] **Step 2: Add the badge in `inward_bill_intrim.xhtml`**
+
+The current "Room" column (lines 458-471) reads:
+
+```xml
+                                            <p:column headerText="Room" styleClass="text-start">
+                                                <div class="d-flex align-items-center gap-2">
+                                                    <h:outputLabel value="#{rm.roomFacilityCharge.name}" style="display: inline;"/>
+                                                    <h:panelGroup rendered="#{rm.discharged}">
+                                                        <p:badge value="Left" severity="info"/>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{not rm.discharged}">
+                                                        <p:badge value="Active" severity="warning"/>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
+                                                        <p:badge value="Guardian" severity="success"/>
+                                                    </h:panelGroup>
+                                                </div>
+                                            </p:column>
+```
+
+Add the same "Theatre" badge check directly after the `GuardianRoom` one:
+
+```xml
+                                            <p:column headerText="Room" styleClass="text-start">
+                                                <div class="d-flex align-items-center gap-2">
+                                                    <h:outputLabel value="#{rm.roomFacilityCharge.name}" style="display: inline;"/>
+                                                    <h:panelGroup rendered="#{rm.discharged}">
+                                                        <p:badge value="Left" severity="info"/>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{not rm.discharged}">
+                                                        <p:badge value="Active" severity="warning"/>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
+                                                        <p:badge value="Guardian" severity="success"/>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.TheatreRoom'}">
+                                                        <p:badge value="Theatre" severity="danger"/>
+                                                    </h:panelGroup>
+                                                </div>
+                                            </p:column>
+```
+
+- [ ] **Step 3: Commit**
+
+XHTML-only change — per CLAUDE.md, JSF-only changes don't require compilation, but Task 6's full build will still compile the whole webapp, so any typo surfaces there.
+
+```bash
+git add src/main/webapp/inward/inward_patient_room_details.xhtml src/main/webapp/inward/inward_bill_intrim.xhtml
+git commit -m "feat(inward): badge TheatreRoom rows in Room Stay History and Interim Bill
+
+Part of #22213 — visually distinguishes a theatre charge row from a
+real room change/admission, same pattern as the existing Guardian badge."
+```
+
+---
+
+### Task 5: Regenerate DDL
+
+**Files:**
+- Regenerated by the `generate-ddl` skill (do not hand-edit): `tmp/createDDL.jdbc`, the `Database-Schema-DDL-Generation-Guide` wiki page.
+
+**Interfaces:**
+- Consumes: the new `TheatreRoom` entity and `PatientTransferRequest.theatreRoom` field from Task 1 (new entity class → new `DTYPE` value; new `@ManyToOne` field → new FK column on `PATIENTTRANSFERREQUEST`).
+
+- [ ] **Step 1: Run the DDL generator**
+
+Invoke the project's `generate-ddl` skill (per `CLAUDE.md` § "When Working on Database" and the `dev-issue` skill's step 5a — this entity/field addition is exactly the trigger condition for that step).
+
+- [ ] **Step 2: Review the diff**
+
+Confirm the generated DDL includes a new nullable FK column for `theatreRoom` on `PATIENTTRANSFERREQUEST` (referencing `PATIENTROOM`), and nothing else changed unexpectedly (no `DTYPE` column changes needed — `TheatreRoom` reuses `PatientRoom`'s existing single-table-inheritance discriminator).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tmp/createDDL.jdbc
+git commit -m "chore(db): regenerate DDL for TheatreRoom entity (#22213)"
+```
+
+(If the skill also updates the wiki page, that's committed/pushed separately from `../hmis.wiki` per its own instructions — not part of this repo's commit.)
+
+---
+
+### Task 6: Build, deploy, and verify end-to-end
+
+**Files:** none (verification only).
+
+**Interfaces:** none — this task exercises everything built in Tasks 1-5 together.
+
+- [ ] **Step 1: Full build**
+
+Run: `mvn clean package -DskipTests`
+Expected: `BUILD SUCCESS`, `target/rh-3.0.0.war` produced.
+
+- [ ] **Step 2: Local redeploy**
+
+Per this machine's deploy command (see the `local-carecode-dev-credentials` memory):
+```bash
+/home/carecode/payara/bin/asadmin --port 9048 undeploy rh-3.0.0 2>/dev/null; \
+/home/carecode/payara/bin/asadmin --port 9048 deploy --force=true target/rh-3.0.0.war
+```
+Expected: deploy succeeds; check `/home/carecode/payara/glassfish/domains/rh/logs/server.log` for no `TheatreRoom`/EclipseLink mapping errors on startup.
+
+- [ ] **Step 3: Playwright — reproduce the original bug scenario end-to-end**
+
+Using the `playwright-e2e` skill against `http://localhost:9080/rh/`: log in, select department, admit a test patient to a ward room, send them to theatre, accept in theatre, mark procedure completed, return to ward. Confirm:
+- Room Stay History now shows **two rows** — the ward room (no badge) and the theatre visit (**"Theatre"** badge) — with the theatre row's charge columns populated from its `RoomFacilityCharge` rate, not zero.
+- Interim Bill → Fees and Details → Room Details tab shows both rows with the same badge.
+- Summary panel's Gross Total / Total Charges now includes both amounts.
+- Charges panel's "Room Charges" row sums both amounts.
+
+Per the [No PII in public GitHub content](../../../CLAUDE.md) rule reinforced during this issue's filing: do not use real patient/institution names in any screenshot or note taken during this verification; use test/synthetic data only, and if screenshots are published later, genericize any identifying labels first.
+
+- [ ] **Step 4: DB verification**
+
+Query the local test database (credentials per the project's local MySQL credentials reference) to confirm a new `PATIENTROOM` row exists with `DTYPE = 'TheatreRoom'`, `ADMITTEDAT` equal to the transfer request's `INITIATEDAT`, and (after returning to ward) `DISCHARGEDAT` populated and equal to the request's `RETURNEDTOWARDAT`.
+
+- [ ] **Step 5: Regression check**
+
+Repeat the same admission flow *without* a theatre visit (ward room only) and confirm Room Stay History, Summary, and Charges are unchanged from current behavior — no phantom theatre row, no altered totals.
+
+- [ ] **Step 6: Restore local persistence.xml**
+
+Per CLAUDE.md's persistence.xml lifecycle rule — after the eventual `git push` for this branch (not part of this plan; happens in the `dev-issue` workflow's later steps), restore `persistence.xml` to local JNDI values (`jdbc/coop` / `jdbc/ruhunuAudit`) and leave that change unstaged.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: every section of the design spec maps to a task — entity/field (Task 1), creation trigger (Task 2), closing trigger (Task 3), UI badges (Task 4), DDL (Task 5), verification plan (Task 6, mirrors the spec's "Testing plan" section exactly).
+- **No placeholders**: every step shows complete, exact code — no "add appropriate handling" language.
+- **Type/name consistency checked**: `TheatreRoom` (Task 1) is the exact type used in `PatientTransferController` (Tasks 2-3) and the exact string literal (`class com.divudi.core.entity.inward.TheatreRoom`) used in both XHTML files (Task 4). `PatientTransferRequest.getTheatreRoom()`/`setTheatreRoom()` (Task 1) match the calls made in Tasks 2 and 3 exactly.
+- **Out of scope, confirmed with user**: historical backfill, changing the Gantt timeline's own data source (it already works, untouched), and the manual discharge-and-readmit workaround workflow (already bills correctly today).

--- a/docs/superpowers/specs/2026-07-18-theatre-stay-billing-design.md
+++ b/docs/superpowers/specs/2026-07-18-theatre-stay-billing-design.md
@@ -1,0 +1,116 @@
+# Theatre Stay Billing — Design Spec
+
+**Issue**: [hmislk/hmis#22213](https://github.com/hmislk/hmis/issues/22213)
+**Date**: 2026-07-18
+**Status**: Approved
+
+## Problem
+
+When an inpatient is sent to theatre (`PatientTransferRequest` with `theatreTransferType = SEND_TO_THEATRE`), the theatre stay is never billed. The theatre's `RoomFacilityCharge` has a real, configured rate (room/MO/nursing/linen/admin/medical-care components), but that rate is never applied to the patient's bill. Room Stay History, the Interim Bill's Room Details tab, the Summary panel, and the Charges panel all silently omit the theatre visit — only the Patient Room & Theatre Timeline widget is aware it happened.
+
+**Confirmed business rule**: during a theatre stay, both the ward room charge AND the theatre charge apply concurrently. The hospital does not reallocate the ward room for another patient during surgery, and the patient's relatives/guardians may continue occupying it. So the fix must add the theatre charge on top of the still-active room charge for the overlap period — not replace it.
+
+**Exception (out of scope)**: some hospitals manually discharge the patient from the ward room and re-admit once theatre is finished. That workflow already bills correctly today via normal Room Change / discharge-readmit `PatientRoom` mechanics and needs no change.
+
+## Root cause
+
+- `PatientRoom` (`src/main/java/com/divudi/core/entity/inward/PatientRoom.java`) carries a full set of charge fields (`current*Charge`, `discount*Charge`, `adjusted*Charge`, etc.) and is the sole source for every billing surface, via `BhtSummeryController.getPatientRooms()`/`createPatientRooms()` and `InwardBeanController.fetchPatientRoomAll()`/`getPatientRoomChargeSumsBulk()`.
+- `PatientTransferRequest` (`src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java`), the entity used for theatre visits, has no charge fields at all — only a pointer (`toRoomFacilityCharge`) to the rate.
+- `PatientTransferController.acceptInTheatre()` deliberately never creates a `PatientRoom` row (per issue #22211 investigation) — the ward bed stays reserved during surgery, which is correct, but leaves the theatre's rate structurally unreachable by any billing code path.
+
+## Existing precedent
+
+`GuardianRoom extends PatientRoom` (single-table inheritance, no new table/columns, just a `DTYPE` discriminator) already lets two concurrent billable "room" records exist for one admission — the patient's ward room and a guardian's accompanying bed. Every billing surface queries `PatientRoom` generically with **no subclass filter**, so a `GuardianRoom` row is automatically included in Room Stay History, the Interim Bill, and the bulk-sum totals. The XHTML already special-cases it with a "Guardian" badge (`inward_patient_room_details.xhtml` line ~127: `rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'`).
+
+A reusable creation helper already exists: `InwardBeanController.savePatientRoom(PatientRoom, previousRoom, RoomFacilityCharge, PatientEncounter, admittedAt, WebUser)`, used today by the ward-to-ward Room Change flow.
+
+## Approaches considered
+
+1. **New `TheatreRoom extends PatientRoom` subclass, created/closed by the theatre workflow controller (chosen).** Reuses the `GuardianRoom` pattern exactly. Zero changes needed to Room Stay History, Interim Bill Room Details, Summary, or Charges — they inherit the new row for free. Smallest, lowest-risk surface area.
+2. **Reuse plain `PatientRoom` directly, no subclass.** Same lifecycle, but staff can't visually distinguish a theatre charge from a real room change in Room Stay History, and there's no `instanceof` hook for theatre-specific UI/behavior.
+3. **Add charge fields to `PatientTransferRequest` itself, merge into every billing surface.** Avoids a second concurrent room record, but requires duplicating all charge-calculation logic (discount %, price matrix, timed items) currently centralized around `PatientRoom`, and touching every billing surface individually to union two different entity types. Much larger, riskier surface area; diverges from the pattern the codebase already uses for this exact kind of problem.
+
+**Chosen: Approach 1.**
+
+## Design
+
+### New entity
+
+`src/main/java/com/divudi/core/entity/inward/TheatreRoom.java`:
+```java
+@Entity
+public class TheatreRoom extends PatientRoom implements Serializable { }
+```
+
+### `PatientTransferRequest` — new field
+
+Add `theatreRoom` (`@ManyToOne PatientRoom theatreRoom`) to `PatientTransferRequest`, mirroring the existing `fromPatientRoom` field. Links a `SEND_TO_THEATRE` request to the `TheatreRoom` row it created, so `returnToWard()` can close the right row without a lookup query.
+
+### Creation — billing window start
+
+**Trigger**: `PatientTransferController.acceptInTheatre(PatientTransferRequest req)` — only once theatre formally accepts the patient (status → `ACCEPTED`, `theatreOccupancyStatus` → `RECEIVED_IN_THEATRE`). A request cancelled before acceptance never creates a billable row.
+
+**Backdated window start**: the created row's `admittedAt = req.getInitiatedAt()`, not the acceptance instant — per the confirmed requirement that billing should match the Timeline widget exactly (which already uses `initiatedAt` as its bar start).
+
+Implementation, appended inside the existing `acceptInTheatre()` method after the current status/occupancy updates:
+```java
+TheatreRoom theatreRoom = new TheatreRoom();
+theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
+        theatreRoom,
+        /* previousRoom */ null,
+        persisted.getToRoomFacilityCharge(),
+        persisted.getAdmission(),
+        persisted.getInitiatedAt(),
+        sessionController.getLoggedUser());
+persisted.setTheatreRoom(theatreRoom);
+```
+`previousRoom = null` — this is a concurrent addition, not a chain link. The ward `PatientRoom` is untouched and remains `admission.currentPatientRoom` throughout.
+
+### Closing — billing window end
+
+**Trigger**: `PatientTransferController.returnToWard(PatientTransferRequest theatreReq)` — the same instant `returnedToWardAt` is stamped on the request (OT-side initiation of the return, not the ward's later confirmation — matches the chosen billing-window answer and the existing Timeline bar end).
+
+```java
+PatientRoom theatreRoom = persisted.getTheatreRoom();
+if (theatreRoom != null && !theatreRoom.isDischarged()) {
+    theatreRoom.setDischarged(true);
+    theatreRoom.setDischargedAt(new Date());
+    theatreRoom.setDischargedBy(sessionController.getLoggedUser());
+    patientRoomFacade.edit(theatreRoom);
+}
+```
+
+### Why no other billing code changes
+
+- `InwardBeanController.fetchPatientRoomAll()`: `SELECT pr FROM PatientRoom pr WHERE pr.retired=false AND pr.patientEncounter IN :pe` — no `DTYPE` filter, picks up `TheatreRoom` rows automatically. Drives Room Stay History and the Interim Bill Room Details tab.
+- `InwardBeanController.getPatientRoomChargeSumsBulk()`: same — `FROM PatientRoom p WHERE ...`, no subclass filter. Drives the "Room Charges" line in the Charges panel and the Summary totals.
+- `BhtSummeryController.setPatientRoomData()`/`calculateRoomCharge()`/`getCharge()`: iterate `patientRooms` generically; confirmed `getCharge()` falls back to `new Date()` when `dischargedAt == null`, so an in-progress (not yet returned) theatre visit already shows a live, growing charge on the interim bill — same behavior as an active ward stay. No change needed.
+- The `GuardianRoom` charge-field exclusion (`if (!(p instanceof GuardianRoom)) { ...nursing/MO/admin/medicalCare... }` in `setPatientRoomData()`) does **not** apply to `TheatreRoom` — a theatre visit should charge all configured components (room, MO, nursing, etc.), unlike a guardian bed.
+
+### UI changes
+
+- `inward_patient_room_details.xhtml` (~line 127): add a "Theatre" badge alongside the existing "Guardian" badge check, using `rm.patientRoomClass eq 'class com.divudi.core.entity.inward.TheatreRoom'`.
+- `inward_bill_intrim.xhtml` Fees and Details → Room Details tab: same badge treatment for consistency.
+
+### Edge cases
+
+- **Cancelled/rejected `SEND_TO_THEATRE` requests**: no `TheatreRoom` ever created (creation only happens in `acceptInTheatre()`), so nothing is billed for a visit that never happened.
+- **Multiple theatre visits per admission**: each `acceptInTheatre()`/`returnToWard()` pair creates and closes its own `TheatreRoom` row via the per-request `theatreRoom` FK — no shared state, no special-casing needed.
+- **`BhtSummeryController.updatePatientRoom()` sequential-order guard**: rejects a manually-edited row's `admittedAt` only if the previous list-ordered row's `dischargedAt` is non-null. Since the ward room stays open (`dischargedAt == null`) throughout the theatre visit, this guard does not false-positive. Verify with a regression test.
+- **Manual edit of a `TheatreRoom` row**: Room Stay History's existing action buttons (Save Changes, Update Charges from Room Rates, Discharge from Room, Remove Room) remain available, matching current `GuardianRoom` behavior — no special lockdown.
+- **Historical/already-completed admissions**: out of scope. This fix is forward-only; no automatic backfill for encounters that already went through theatre before this ships, since retroactively adjusting historical bills is a financial decision outside this issue.
+
+## Testing plan
+
+1. **DB-level reproduction**: replay the original repro (admit → send to theatre → accept in theatre → return to ward) against local test data; verify a `TheatreRoom` row appears in `PATIENTROOM` carrying the theatre's `RoomFacilityCharge` rate.
+2. **UI/Playwright**: Room Stay History shows two rows (ward + "Theatre" badge); Interim Bill Room Details tab shows both; Summary/Charges totals include both amounts.
+3. **Regression**: existing ward-only admissions (no theatre visit) and existing guardian-room admissions still compute unchanged totals.
+
+## Files touched
+
+- `src/main/java/com/divudi/core/entity/inward/TheatreRoom.java` (new)
+- `src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java` (new `theatreRoom` field + getter/setter)
+- `src/main/java/com/divudi/bean/inward/PatientTransferController.java` (`acceptInTheatre()`, `returnToWard()`)
+- `src/main/webapp/inward/inward_patient_room_details.xhtml` (badge)
+- `src/main/webapp/inward/inward_bill_intrim.xhtml` (badge)
+- DDL regeneration required (new entity, new FK column) — run the `generate-ddl` skill per dev-issue step 5a.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -250,6 +250,9 @@ public class BhtSummeryController implements Serializable {
             if (r.getAdmittedAt() == null) {
                 continue;
             }
+            if (r instanceof TheatreRoom) {
+                continue;
+            }
             Date barEnd = r.getDischargedAt() != null ? r.getDischargedAt() : now;
             long offsetMs = r.getAdmittedAt().getTime() - spanStart.getTime();
             long durationMs = barEnd.getTime() - r.getAdmittedAt().getTime();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -48,6 +48,7 @@ import com.divudi.core.entity.inward.GuardianRoom;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.inward.PatientRoomTimedItemCharge;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
+import com.divudi.core.entity.inward.TheatreRoom;
 import com.divudi.core.entity.inward.TimedItem;
 import com.divudi.core.entity.inward.TimedItemFee;
 import com.divudi.core.entity.membership.InwardMemberShipDiscount;
@@ -328,6 +329,9 @@ public class BhtSummeryController implements Serializable {
         // Ward room bars (same colour logic as getRoomGanttBars)
         for (PatientRoom r : rooms) {
             if (r.getAdmittedAt() == null) {
+                continue;
+            }
+            if (r instanceof TheatreRoom) {
                 continue;
             }
             Date barEnd = r.getDischargedAt() != null ? r.getDischargedAt() : now;

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -652,7 +652,7 @@ public class PatientTransferController implements Serializable {
         returnReq.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(returnReq);
 
-        Date returnedAt = new Date();
+        Date returnedAt = persisted.getReturnedToWardAt() != null ? persisted.getReturnedToWardAt() : new Date();
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
         if (persisted.getReturnedToWardAt() == null) {
             persisted.setReturnedToWardAt(returnedAt);

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -10,6 +10,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.entity.inward.TheatreRoom;
 import com.divudi.core.entity.inward.PatientTransferRequest;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.facade.AdmissionFacade;
@@ -556,6 +557,17 @@ public class PatientTransferController implements Serializable {
         persisted.setAcceptedAt(new Date());
         persisted.setAcceptedBy(sessionController.getLoggedUser());
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RECEIVED_IN_THEATRE);
+
+        TheatreRoom theatreRoom = new TheatreRoom();
+        theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
+                theatreRoom,
+                null,
+                persisted.getToRoomFacilityCharge(),
+                persisted.getAdmission(),
+                persisted.getInitiatedAt(),
+                sessionController.getLoggedUser());
+        persisted.setTheatreRoom(theatreRoom);
+
         patientTransferRequestFacade.edit(persisted);
         loadPendingForTheatre();
         loadInTheatreRequests();

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -558,15 +558,17 @@ public class PatientTransferController implements Serializable {
         persisted.setAcceptedBy(sessionController.getLoggedUser());
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RECEIVED_IN_THEATRE);
 
-        TheatreRoom theatreRoom = new TheatreRoom();
-        theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
-                theatreRoom,
-                null,
-                persisted.getToRoomFacilityCharge(),
-                persisted.getAdmission(),
-                persisted.getInitiatedAt(),
-                sessionController.getLoggedUser());
-        persisted.setTheatreRoom(theatreRoom);
+        if (persisted.getTheatreRoom() == null) {
+            TheatreRoom theatreRoom = new TheatreRoom();
+            theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
+                    theatreRoom,
+                    null,
+                    persisted.getToRoomFacilityCharge(),
+                    persisted.getAdmission(),
+                    persisted.getInitiatedAt(),
+                    sessionController.getLoggedUser());
+            persisted.setTheatreRoom(theatreRoom);
+        }
 
         patientTransferRequestFacade.edit(persisted);
         loadPendingForTheatre();

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -650,9 +650,17 @@ public class PatientTransferController implements Serializable {
         returnReq.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(returnReq);
 
+        Date returnedAt = new Date();
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
         if (persisted.getReturnedToWardAt() == null) {
-            persisted.setReturnedToWardAt(new Date());
+            persisted.setReturnedToWardAt(returnedAt);
+        }
+        if (persisted.getTheatreRoom() != null && !persisted.getTheatreRoom().isDischarged()) {
+            PatientRoom theatreRoom = persisted.getTheatreRoom();
+            theatreRoom.setDischarged(true);
+            theatreRoom.setDischargedAt(returnedAt);
+            theatreRoom.setDischargedBy(sessionController.getLoggedUser());
+            patientRoomFacade.edit(theatreRoom);
         }
         patientTransferRequestFacade.edit(persisted);
 

--- a/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
@@ -39,6 +39,14 @@ public class PatientTransferRequest implements Serializable {
     @ManyToOne
     private PatientRoom fromPatientRoom;
 
+    /**
+     * Set only on accepted SEND_TO_THEATRE requests — the concurrent
+     * TheatreRoom billing record created by acceptInTheatre(), closed by
+     * returnToWard(). Null on all other transfer types.
+     */
+    @ManyToOne
+    private PatientRoom theatreRoom;
+
     @ManyToOne
     private RoomFacilityCharge toRoomFacilityCharge;
 
@@ -118,6 +126,14 @@ public class PatientTransferRequest implements Serializable {
 
     public void setFromPatientRoom(PatientRoom fromPatientRoom) {
         this.fromPatientRoom = fromPatientRoom;
+    }
+
+    public PatientRoom getTheatreRoom() {
+        return theatreRoom;
+    }
+
+    public void setTheatreRoom(PatientRoom theatreRoom) {
+        this.theatreRoom = theatreRoom;
     }
 
     public RoomFacilityCharge getToRoomFacilityCharge() {

--- a/src/main/java/com/divudi/core/entity/inward/TheatreRoom.java
+++ b/src/main/java/com/divudi/core/entity/inward/TheatreRoom.java
@@ -1,0 +1,13 @@
+package com.divudi.core.entity.inward;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+
+/**
+ *
+ * @author buddhika
+ */
+@Entity
+public class TheatreRoom extends PatientRoom implements Serializable {
+
+}

--- a/src/main/resources/db/migrations/v2.15.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.15.0/migration.sql
@@ -1,0 +1,92 @@
+-- Migration v2.15.0: Add patienttransferrequest.THEATREROOM_ID for theatre stay billing
+-- Issue: hmislk/hmis#22213
+--
+-- Background:
+--   PatientTransferRequest gained a new @ManyToOne field `theatreRoom` (a PatientRoom
+--   subtype, TheatreRoom) so theatre stays get billed alongside the still-active ward
+--   room, instead of being silently dropped from Room Stay History / Interim Bill /
+--   Summary / Charges. Production persistence.xml has no DDL generation, so the
+--   column and its FK must be created explicitly here.
+--
+-- UNIVERSAL: Detects actual table name case via INFORMATION_SCHEMA so this script
+--   works on both case-sensitive (Linux) and case-insensitive (Windows) MySQL.
+--
+-- IDEMPOTENT: The ADD COLUMN and ADD FOREIGN KEY statements are gated on
+--   INFORMATION_SCHEMA existence checks so the script can be safely re-run.
+
+SELECT 'Migration v2.15.0 - Add patienttransferrequest.THEATREROOM_ID' AS status;
+
+-- ==========================================
+-- STEP 0: RESOLVE ACTUAL TABLE NAMES
+-- ==========================================
+
+SET @transferrequest_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTTRANSFERREQUEST'
+    LIMIT 1
+);
+
+SET @patientroom_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTROOM'
+    LIMIT 1
+);
+
+SELECT CONCAT('Resolved patienttransferrequest table as: ', IFNULL(@transferrequest_table, '(not found)')) AS info;
+SELECT CONCAT('Resolved patientroom table as: ', IFNULL(@patientroom_table, '(not found)')) AS info;
+
+SELECT IF(@transferrequest_table IS NULL,
+          'patienttransferrequest table not found; v2.15.0 is not applicable and completes as a successful no-op',
+          'patienttransferrequest table found; ensuring THEATREROOM_ID column and FK exist') AS applicability;
+
+-- ==========================================
+-- STEP 1: ADD COLUMN THEATREROOM_ID (if missing)
+-- ==========================================
+
+SET @col_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @transferrequest_table
+      AND UPPER(COLUMN_NAME) = 'THEATREROOM_ID'
+);
+
+SET @sql_add_col = IF(@transferrequest_table IS NOT NULL AND @col_exists = 0,
+    CONCAT('ALTER TABLE ', @transferrequest_table, ' ADD COLUMN THEATREROOM_ID BIGINT NULL'),
+    'SELECT ''patienttransferrequest.THEATREROOM_ID already exists or table missing — skipping column add'' AS info'
+);
+PREPARE stmt FROM @sql_add_col;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 2: ADD FOREIGN KEY to patientroom(ID) (if missing)
+-- ==========================================
+
+SET @fk_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @transferrequest_table
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      AND CONSTRAINT_NAME = 'FK_patienttransferrequest_theatreroom'
+);
+
+SET @sql_add_fk = IF(
+    @transferrequest_table IS NOT NULL
+    AND @patientroom_table IS NOT NULL
+    AND @fk_exists = 0,
+    CONCAT('ALTER TABLE ', @transferrequest_table,
+           ' ADD CONSTRAINT FK_patienttransferrequest_theatreroom',
+           ' FOREIGN KEY (THEATREROOM_ID) REFERENCES ', @patientroom_table, '(ID)'),
+    'SELECT ''FK_patienttransferrequest_theatreroom already exists or a table is missing — skipping FK add'' AS info'
+);
+PREPARE stmt FROM @sql_add_fk;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.15.0 complete' AS status;

--- a/src/main/resources/db/migrations/v2.15.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.15.0/rollback.sql
@@ -1,0 +1,49 @@
+-- Rollback v2.15.0
+-- Drops the FK and THEATREROOM_ID column added to patienttransferrequest in v2.15.0.
+-- Idempotent and case-insensitive: only drops what exists.
+
+SET @transferrequest_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTTRANSFERREQUEST'
+    LIMIT 1
+);
+
+-- STEP 1: DROP FOREIGN KEY (if present)
+SET @fk_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @transferrequest_table
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      AND CONSTRAINT_NAME = 'FK_patienttransferrequest_theatreroom'
+);
+
+SET @sql_drop_fk = IF(@transferrequest_table IS NOT NULL AND @fk_exists > 0,
+    CONCAT('ALTER TABLE ', @transferrequest_table, ' DROP FOREIGN KEY FK_patienttransferrequest_theatreroom'),
+    'SELECT ''FK_patienttransferrequest_theatreroom not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_fk;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- STEP 2: DROP COLUMN THEATREROOM_ID (if present)
+SET @col = (
+    SELECT COLUMN_NAME
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @transferrequest_table
+      AND UPPER(COLUMN_NAME) = 'THEATREROOM_ID'
+    LIMIT 1
+);
+
+SET @sql_drop_col = IF(@transferrequest_table IS NOT NULL AND @col IS NOT NULL,
+    CONCAT('ALTER TABLE ', @transferrequest_table, ' DROP COLUMN ', @col),
+    'SELECT ''patienttransferrequest.THEATREROOM_ID not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_col;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.15.0 complete' AS status;

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -467,6 +467,9 @@
                                                     <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
                                                         <p:badge value="Guardian" severity="success"/>
                                                     </h:panelGroup>
+                                                    <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.TheatreRoom'}">
+                                                        <p:badge value="Theatre" severity="danger"/>
+                                                    </h:panelGroup>
                                                 </div>
                                             </p:column>
                                             <p:column headerText="Admission" style="min-width:10em;" styleClass="text-start">

--- a/src/main/webapp/inward/inward_patient_room_details.xhtml
+++ b/src/main/webapp/inward/inward_patient_room_details.xhtml
@@ -127,6 +127,9 @@
                                                 <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.GuardianRoom'}">
                                                     <p:badge value="Guardian" severity="success"/>
                                                 </h:panelGroup>
+                                                <h:panelGroup rendered="#{rm.patientRoomClass eq 'class com.divudi.core.entity.inward.TheatreRoom'}">
+                                                    <p:badge value="Theatre" severity="danger"/>
+                                                </h:panelGroup>
                                                 <h:panelGroup rendered="#{rm.discharged}">
                                                     <p:badge value="Left" severity="info"/>
                                                 </h:panelGroup>


### PR DESCRIPTION
## Summary

Theatre stays for inpatient admissions were never billed. When a patient was sent to an operating theatre during an admission, the theatre's configured `RoomFacilityCharge` rate (room/MO/nursing/etc.) never appeared on the patient's bill — Room Stay History, the Interim Bill's Room Details tab, the Summary panel, and the Charges panel all silently omitted it, because `PatientTransferRequest` (the entity used for theatre transfers) has no charge fields, and no billable room record was ever created for the theatre visit.

Confirmed with the user: during a theatre stay, both the ward room charge **and** the theatre charge apply concurrently (the ward room stays reserved/billable — the hospital doesn't reallocate it during surgery, and relatives may occupy it).

- New `TheatreRoom extends PatientRoom` entity, mirroring the existing `GuardianRoom` pattern (concurrent second billable room for one admission).
- `PatientTransferController.acceptInTheatre()` creates it, backdated to the transfer request's `initiatedAt` (matching what the Patient Room & Theatre Timeline widget already displays).
- `PatientTransferController.returnToWard()` discharges it, with `dischargedAt` set to the same instant as `returnedToWardAt`.
- Because every existing billing surface already queries `PatientRoom` generically (no subclass filter), this required **zero changes** to Room Stay History, Interim Bill, Summary, or Charges beyond a "Theatre" badge, matching the existing "Guardian" badge pattern.
- DB migration `v2.15.0` adds the new `theatreRoom` FK column + constraint (idempotent, case-insensitive, following the `v2.12.0` pattern — this project has no auto-DDL).

A whole-branch review caught two issues before merge, both now fixed:
- Missing DB migration for the new FK column (added as `v2.15.0`).
- The Patient Room & Theatre Timeline widget double-rendered the theatre visit, since it now also picks up the new `TheatreRoom` row through the general room-fetch path — fixed by excluding `TheatreRoom` from the ward-bars loop in `getUnifiedGanttBars()`.
- Also added a defensive `getTheatreRoom() == null` guard against a narrow concurrent-double-accept race (full fix would need optimistic locking, explicitly deferred as a separate decision).

Design spec and implementation plan are included in the diff (`docs/superpowers/specs/`, `docs/superpowers/plans/`) for full context/rationale.

Closes #22213

## Test plan

Verified end-to-end against a local test admission (test/synthetic data) after applying the migration:

- [x] Sent a test patient to theatre, accepted in theatre, confirmed via DB query that a `TheatreRoom` row was created with `admittedAt` exactly equal to the transfer request's `initiatedAt` and the theatre's configured rate (room/MO/nursing).
- [x] Confirmed the ward room's own `PatientRoom` row was untouched (still open) throughout the theatre visit.
- [x] Room Stay History now shows both rooms, with a "Theatre" badge on the theatre row.
- [x] Interim Bill: Summary panel's Gross/Total Charges now includes the theatre charge; Charges panel correctly splits MO/Nursing/Room lines across both rooms; Fees & Details → Room Details tab shows both rows.
- [x] Completed the full theatre workflow (accept → in theatre → procedure done → return to ward); confirmed via DB that the `TheatreRoom`'s `dischargedAt` is byte-identical to the request's `returnedToWardAt`, and the UI correctly shows "Theatre" + "Left" badges with the charge retained.
- [x] Verified the Patient Room & Theatre Timeline widget shows exactly one bar per theatre visit (not duplicated) after the regression fix.
- [x] Ran the `v2.15.0` migration against the local test database twice — confirmed it creates the column/FK correctly and the second run is a safe no-op.
- [x] Server log clean (no errors) after the migration was applied and after the full workflow.

Screenshots (redacted, no patient-identifying data):

![Room Stay History after fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22213_room_stay_history_fixed.png)

![Interim Bill after fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22213_interim_bill_fixed.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theatre stays are now tracked and billed as separate theatre-room records, while the ward stay remains active.
  * Room history and interim billing now display a **“Theatre”** badge for theatre-room stays.
* **Bug Fixes**
  * Theatre stays no longer render as ward stays on patient timelines/Gantt views, preventing duplicate or incorrect bars.
* **Documentation**
  * Added implementation, design, and end-to-end verification guidance for theatre-stay billing, including Playwright workflow notes.
* **Chores**
  * Added database migration support for the new theatre-room linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->