### PR TITLE
feat(inward): add comment field when adding inward timed service

### DIFF
--- a/src/main/java/com/divudi/core/entity/PatientItem.java
+++ b/src/main/java/com/divudi/core/entity/PatientItem.java
@@ -39,6 +39,7 @@ public class PatientItem implements Serializable, RetirableEntity {
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date retiredAt;
     String retireComments;
+    String comment;
     @ManyToOne
     Patient patient;
     @ManyToOne
@@ -242,6 +243,14 @@ public class PatientItem implements Serializable, RetirableEntity {
 
     public void setRetireComments(String retireComments) {
         this.retireComments = retireComments;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
     }
 
     public Double getServiceValue() {

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -238,6 +238,20 @@
                                     </div>
                                 </div>
 
+                                <div class="row m-1">
+                                    <div class="col-4">
+                                        <p:outputLabel value="Comment"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputTextarea
+                                            class="mx-2 w-100"
+                                            id="itemComment"
+                                            rows="2"
+                                            value="#{inwardTimedItemController.current.comment}">
+                                        </p:inputTextarea>
+                                    </div>
+                                </div>
+
                                 <div class="row">
                                     <div class="col-4">
                                         <p:commandButton
@@ -261,11 +275,17 @@
                         <h:outputLabel value="Consumed Timed Service" class="mx-4"></h:outputLabel>
                     </f:facet>
 
-                    <p:dataTable id="list" class="w-100" value="#{inwardTimedItemController.items}" var="ti">
-                        <p:column headerText="Service Name">
+                    <p:dataTable 
+                        id="list" 
+                        class="w-100" 
+                        value="#{inwardTimedItemController.items}" 
+                        var="ti">
+                        
+                        <p:column headerText="Service Name" style="padding: 8px;">
                             #{ti.item.name}
                         </p:column>
-                        <p:column headerText="Start Time">
+                        
+                        <p:column headerText="Start Time" style="padding: 8px;">
                             <p:datePicker
                                 showTime="true"
                                 timeInput="true"
@@ -273,9 +293,9 @@
                                 disabled="#{ti.billItem.fromPackage}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
                             </p:datePicker>
-
                         </p:column>
-                        <p:column headerText="Stopped Time">
+                        
+                        <p:column headerText="Stopped Time" style="padding: 8px;">
                             <p:datePicker
                                 showTime="true"
                                 timeInput="true"
@@ -284,21 +304,25 @@
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
                             </p:datePicker>
                         </p:column>
-                        <p:column headerText="Total" styleClass="averageNumericColumn" rendered="#{webUserController.hasPrivilege('ShowTimeServiceCharges')}">
+
+                        <p:column headerText="Comments" style="padding: 8px;">
+                            <h:outputLabel value="#{ti.comment}" />
+                        </p:column>
+                        
+                        <p:column headerText="Added By" style="padding: 8px;">
+                            <h:outputLabel value="#{ti.creater.webUserPerson.nameWithTitle}"/><br/>
+                            <h:outputLabel value="#{ti.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            </h:outputLabel>
+                        </p:column>
+                        
+                        <p:column headerText="Total Charges" styleClass="averageNumericColumn" rendered="#{webUserController.hasPrivilege('ShowTimeServiceCharges')}"  style="padding: 8px;">
                             <h:outputLabel  value="#{ti.serviceValue}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
                         </p:column>
-                        <p:column headerText="Comments">
-                            <h:outputLabel value="Added by #{ti.creater.webUserPerson.name}"/>     
-                            <br/>
-                            <h:panelGroup rendered="#{ti.retired}" >
-                                <h:outputLabel style="color: red;" value="Deleted By " />
-                                <h:outputLabel style="color: red;"  value="#{ti.retirer.webUserPerson.name}"  class="mx-1">                                       
-                                </h:outputLabel>
-                            </h:panelGroup>
-                        </p:column>     
-                        <p:column headerText="Action" >
+
+                        <p:column headerText="Action" width="14em;" style="padding: 8px;">
                             <div class="d-flex gap-2">
                                 <p:commandButton
                                     value="Update"


### PR DESCRIPTION
## Summary
- Adds a Comment field to the Add Service panel in Manage Inward Timed Services, so a note can be captured item wise at the time a timed service is billed.
- Stores the comment on `PatientItem` and shows it against that entry in the Consumed Timed Service table (with reworked column layout: Added By, Total Charges, styled padding).

Closes #22222

## Test plan
- [ ] Open Manage Inward Timed Services for a patient with an active encounter
- [ ] Select a Service, set Start Time, enter a Comment, click Add Service
- [ ] Confirm the entry appears in Consumed Timed Service with the comment shown
- [ ] Confirm existing Update/Remove actions still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comment field when consuming inward timed services.
  * Added a dedicated Comments column to the consumed timed services table.
  * Added separate Added By details, including the creator and creation date/time.
  * Renamed and reformatted the Total Charges column for clearer presentation.
  * Improved table spacing and action-column layout for easier viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->