### PR TITLE
feat(inward): hold professional payments on a BHT (#16473)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -837,6 +837,40 @@ reach the page under test by clicking through the real navigation chain (search 
 dashboard button → target page) rather than pasting/typing the target URL directly,
 especially right after an action that's supposed to change what that page displays.
 
+## 37. A required `p:selectOneMenu` with no default silently swallows an entire non-AJAX submit — no network request, no error
+
+On `inward/inward_bill_professional_payment.xhtml` (and likely the surgery
+equivalent), the "Find Due Payments" button (`type="submit"`, `onclick=""`,
+plain `ajax="false"` postback — verified via `outerHTML`) does **nothing
+at all** when the "WHT Calculation" dropdown is left at its default empty
+"Select" option — no `browser_network_requests` entry appears, no MySQL
+`general_log` query fires, no visible error, and the page doesn't even
+reload. `browser_click` and a JS `.click()` on the button both silently
+no-op. The accessibility snapshot's only tell is the dropdown rendering as
+`combobox "Select" [invalid]` — client-side JSF validation
+(`PrimeFaces.settings.validateEmptyFields=true`) blocks the *entire* form
+submit before it reaches the network layer, exactly like the required-field
+gotcha in §5/§12 but with **zero observable signal** beyond that one
+`[invalid]` accessibility attribute (this button isn't even in the same
+visual section as the required field, so it's easy to miss).
+
+**Diagnosis technique that worked**: enable the MySQL general query log
+(`SET GLOBAL log_output='TABLE'; SET GLOBAL general_log='ON';`,
+`TRUNCATE TABLE mysql.general_log;`), click the button, then check
+`SELECT event_time, argument FROM mysql.general_log ORDER BY event_time DESC`
+— if the expected query never appears at all (not even a failed one), the
+submit never reached the server, which points at client-side validation
+rather than a bean/JPQL bug. Remember to `SET GLOBAL general_log='OFF'`
+afterward.
+
+**Fix**: before clicking any non-AJAX submit button on this page, first
+select a real option in every required dropdown on the same form (here:
+click the "WHT Calculation" combobox → click e.g. "Include Withholding
+Tax" from the listbox), even if that dropdown looks unrelated to the
+button you're about to click — required-field validation on a JSF
+`ajax="false"` postback applies to the whole `<h:form>`, not just the
+fields near the button.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -854,14 +854,19 @@ gotcha in §5/§12 but with **zero observable signal** beyond that one
 `[invalid]` accessibility attribute (this button isn't even in the same
 visual section as the required field, so it's easy to miss).
 
-**Diagnosis technique that worked**: enable the MySQL general query log
-(`SET GLOBAL log_output='TABLE'; SET GLOBAL general_log='ON';`,
-`TRUNCATE TABLE mysql.general_log;`), click the button, then check
+**Diagnosis technique for local dev DBs only — never on staging/production**:
+`mysql.general_log` captures every statement verbatim, including patient
+identifiers and payment values, and adds real overhead while active, so only
+enable it against your own local dev database, for the shortest possible
+window. Enable it (`SET GLOBAL log_output='TABLE'; SET GLOBAL
+general_log='ON';`, `TRUNCATE TABLE mysql.general_log;`), click the button,
+then check
 `SELECT event_time, argument FROM mysql.general_log ORDER BY event_time DESC`
 — if the expected query never appears at all (not even a failed one), the
 submit never reached the server, which points at client-side validation
-rather than a bean/JPQL bug. Remember to `SET GLOBAL general_log='OFF'`
-afterward.
+rather than a bean/JPQL bug. Immediately run `SET GLOBAL general_log='OFF'`
+afterward and truncate the table again to avoid leaving captured rows
+sitting around.
 
 **Fix**: before clicking any non-AJAX submit button on this page, first
 select a real option in every required dropdown on the same form (here:

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -194,6 +194,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddProfessionalFee, "Add Professional Fee"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddTimedServices, "Add Timed Services"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAddChargesAfterNursingDischarge, "Add Charges After Nursing Discharge"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardHoldProfessionalPayments, "Hold Professional Payments"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPayProfessionalFeesWhileOnHold, "Pay Professional Fees While On Hold"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestApproval, "Approve Service/Item Requests"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestRejection, "Reject Service/Item Requests"), servicesItemsNode);
 

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -3,6 +3,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.cashTransaction.DrawerController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.PaymentMethod;
@@ -97,6 +98,8 @@ public class InwardStaffPaymentBillController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     DrawerController drawerController;
+    @Inject
+    private WebUserController webUserController;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
     private List<BillComponent> billComponents;
@@ -1464,6 +1467,16 @@ public class InwardStaffPaymentBillController implements Serializable {
     }
 
     private boolean errorCheck() {
+        if (getPayingBillFees() != null) {
+            for (BillFee bf : getPayingBillFees()) {
+                com.divudi.core.entity.PatientEncounter pe = bf.getPatienEncounter();
+                if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
+                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
+                    JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
+                    return true;
+                }
+            }
+        }
         if (currentStaff == null) {
             JsfUtil.addErrorMessage("Please select a Staff Memeber");
             return true;

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -3,6 +3,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.cashTransaction.DrawerController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.PaymentMethod;
@@ -93,6 +94,8 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     DrawerController drawerController;
+    @Inject
+    private WebUserController webUserController;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
@@ -333,6 +336,16 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     }
 
     private boolean errorCheck() {
+        if (getPayingSurgeryFees() != null) {
+            for (BillFee bf : getPayingSurgeryFees()) {
+                com.divudi.core.entity.PatientEncounter pe = bf.getPatienEncounter();
+                if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
+                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
+                    JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
+                    return true;
+                }
+            }
+        }
         if (currentSurgeon == null) {
             JsfUtil.addErrorMessage("Please select a Surgeon");
             return true;

--- a/src/main/java/com/divudi/bean/inward/ProfessionalPaymentHoldController.java
+++ b/src/main/java/com/divudi/bean/inward/ProfessionalPaymentHoldController.java
@@ -1,0 +1,111 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Date;
+
+/**
+ * Handles holding and releasing the hold on professional fee payments for a
+ * BHT (PatientEncounter). This is BHT-level only (no per-fee hold).
+ * <p>
+ * Holding a BHT does NOT block charge entry — {@code BillBhtController} and
+ * {@code InwardProfessionalBillController} continue to add charges normally
+ * regardless of hold state. Only the payment pages
+ * ({@code InwardStaffPaymentBillController},
+ * {@code InwardSurgeryPaymentBillController}) check this flag before allowing
+ * professional fees to be paid out. (Issue #16473)
+ * <p>
+ * Mirrors the shape of {@link NursingDischargeController}, applying the guard
+ * at payment time instead of charge-entry time.
+ */
+@Named
+@SessionScoped
+public class ProfessionalPaymentHoldController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+
+    @Inject
+    private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
+
+    private PatientEncounter currentEncounter;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String navigateToProfessionalPaymentHold(PatientEncounter pe) {
+        this.currentEncounter = pe;
+        return "/inward/inward_professional_payment_hold?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Hold / Release
+    // -------------------------------------------------------------------------
+
+    public void confirmHold() {
+        if (currentEncounter == null) {
+            JsfUtil.addErrorMessage("No patient encounter loaded.");
+            return;
+        }
+        if (!webUserController.hasPrivilege("InwardHoldProfessionalPayments")) {
+            JsfUtil.addErrorMessage("You do not have privileges to hold professional payments.");
+            return;
+        }
+        if (currentEncounter.isProfessionalPaymentsOnHold()) {
+            JsfUtil.addErrorMessage("Professional payments are already on hold for this BHT.");
+            return;
+        }
+        currentEncounter.setProfessionalPaymentsOnHold(Boolean.TRUE);
+        currentEncounter.setProfessionalPaymentsHoldDateTime(new Date());
+        currentEncounter.setProfessionalPaymentsHoldBy(sessionController.getLoggedUser());
+        patientEncounterFacade.edit(currentEncounter);
+        JsfUtil.addSuccessMessage("Professional payments held for BHT " + currentEncounter.getBhtNo() + ".");
+    }
+
+    public void releaseHold() {
+        if (currentEncounter == null) {
+            JsfUtil.addErrorMessage("No patient encounter loaded.");
+            return;
+        }
+        if (!webUserController.hasPrivilege("InwardHoldProfessionalPayments")) {
+            JsfUtil.addErrorMessage("You do not have privileges to release the hold on professional payments.");
+            return;
+        }
+        if (!currentEncounter.isProfessionalPaymentsOnHold()) {
+            JsfUtil.addErrorMessage("Professional payments are not currently on hold for this BHT.");
+            return;
+        }
+        currentEncounter.setProfessionalPaymentsOnHold(Boolean.FALSE);
+        currentEncounter.setProfessionalPaymentsHoldDateTime(null);
+        currentEncounter.setProfessionalPaymentsHoldBy(null);
+        currentEncounter.setProfessionalPaymentsHoldNotes(null);
+        patientEncounterFacade.edit(currentEncounter);
+        JsfUtil.addSuccessMessage("Professional payments hold released for BHT " + currentEncounter.getBhtNo() + ".");
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public PatientEncounter getCurrentEncounter() {
+        return currentEncounter;
+    }
+
+    public void setCurrentEncounter(PatientEncounter currentEncounter) {
+        this.currentEncounter = currentEncounter;
+    }
+}

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -90,6 +90,8 @@ public enum Privileges {
     InwardServiceItemRequestApproval("Inward Service/Item Request Approval"),
     InwardServiceItemRequestRejection("Inward Service/Item Request Rejection"),
     InwardAddChargesAfterNursingDischarge("Inward Add Charges After Nursing Discharge"),
+    InwardHoldProfessionalPayments("Hold Professional Payments"),
+    InwardPayProfessionalFeesWhileOnHold("Pay Professional Fees While On Hold"),
     InwardBilling("Inward Billing"),
     InwardBillingInterimBill("Inward Interim Bill"),
     InwardBillingInterimBillSearch("Inward Interim Bill Search"),
@@ -1219,6 +1221,8 @@ public enum Privileges {
             case InwardNursingDischarge:
             case InwardPhysicalDischarge:
             case InwardAddChargesAfterNursingDischarge:
+            case InwardHoldProfessionalPayments:
+            case InwardPayProfessionalFeesWhileOnHold:
             case InwardDocumentUpload:
             case InpatientLetter:
             case InwardPackageAdministration:

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -130,6 +130,14 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     private WebUser nursingDischargedBy;
     @Lob
     private String nursingDischargeNotes;
+    // Professional payments hold — blocks professional fee payment (not charge entry) for this BHT
+    private Boolean professionalPaymentsOnHold = false;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date professionalPaymentsHoldDateTime;
+    @ManyToOne
+    private WebUser professionalPaymentsHoldBy;
+    @Lob
+    private String professionalPaymentsHoldNotes;
     // Physical discharge (stage 5) — nurse marks time patient physically leaves the hospital
     private Boolean physicalDischarged = false;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
@@ -1032,6 +1040,42 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setNursingDischargeNotes(String nursingDischargeNotes) {
         this.nursingDischargeNotes = nursingDischargeNotes;
+    }
+
+    public Boolean getProfessionalPaymentsOnHold() {
+        return professionalPaymentsOnHold;
+    }
+
+    public boolean isProfessionalPaymentsOnHold() {
+        return Boolean.TRUE.equals(professionalPaymentsOnHold);
+    }
+
+    public void setProfessionalPaymentsOnHold(Boolean professionalPaymentsOnHold) {
+        this.professionalPaymentsOnHold = professionalPaymentsOnHold;
+    }
+
+    public Date getProfessionalPaymentsHoldDateTime() {
+        return professionalPaymentsHoldDateTime;
+    }
+
+    public void setProfessionalPaymentsHoldDateTime(Date professionalPaymentsHoldDateTime) {
+        this.professionalPaymentsHoldDateTime = professionalPaymentsHoldDateTime;
+    }
+
+    public WebUser getProfessionalPaymentsHoldBy() {
+        return professionalPaymentsHoldBy;
+    }
+
+    public void setProfessionalPaymentsHoldBy(WebUser professionalPaymentsHoldBy) {
+        this.professionalPaymentsHoldBy = professionalPaymentsHoldBy;
+    }
+
+    public String getProfessionalPaymentsHoldNotes() {
+        return professionalPaymentsHoldNotes;
+    }
+
+    public void setProfessionalPaymentsHoldNotes(String professionalPaymentsHoldNotes) {
+        this.professionalPaymentsHoldNotes = professionalPaymentsHoldNotes;
     }
 
     public Boolean getPhysicalDischarged() {

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -835,6 +835,18 @@
                                             styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
                                         </p:commandButton>
                                     </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnHoldProfessionalPayments"
+                                            value="Hold Professional Payments"
+                                            ajax="false"
+                                            action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
+                                            icon="fa fa-hand-paper"
+                                            title="Navigate to Hold Professional Payments"
+                                            rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                            styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
 

--- a/src/main/webapp/inward/inward_bill_professional_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional_payment.xhtml
@@ -142,9 +142,12 @@
                                 <p:column headerText="BHT No" filterBy="#{bf.bill.patientEncounter.bhtNo}" filterMatchMode="contains">
                                     <f:facet name="header">
                                         <h:outputLabel value="BHT No"/>
-                                    </f:facet>                                        
+                                    </f:facet>
                                     <h:outputLabel value="#{bf.bill.patientEncounter.bhtNo}">
                                     </h:outputLabel>
+                                    <h:panelGroup layout="block" rendered="#{bf.patienEncounter.professionalPaymentsOnHold}">
+                                        <span class="ui-tag ui-tag-danger" title="Professional payments are on hold for this BHT">On Hold</span>
+                                    </h:panelGroup>
                                 </p:column>
 
                                 <p:column headerText="Charge" width="7em;" class="text-end">

--- a/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
@@ -142,9 +142,12 @@
                                 <p:column headerText="BHT No" filterBy="#{bf.bill.patientEncounter.bhtNo}" filterMatchMode="contains">
                                     <f:facet name="header">
                                         <h:outputLabel value="BHT No"/>
-                                    </f:facet>                                        
+                                    </f:facet>
                                     <h:outputLabel value="#{bf.bill.patientEncounter.bhtNo}">
                                     </h:outputLabel>
+                                    <h:panelGroup layout="block" rendered="#{bf.patienEncounter.professionalPaymentsOnHold}">
+                                        <span class="ui-tag ui-tag-danger" title="Professional payments are on hold for this BHT">On Hold</span>
+                                    </h:panelGroup>
                                 </p:column>
 
                                 <p:column headerText="Surgery Fee" width="7em;" class="text-end">

--- a/src/main/webapp/inward/inward_professional_payment_hold.xhtml
+++ b/src/main/webapp/inward/inward_professional_payment_hold.xhtml
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formProfessionalPaymentHold"
+                        onkeydown="if(event.key==='Enter'&amp;&amp;event.target.tagName!=='TEXTAREA'){event.preventDefault();return false;}">
+
+                    <p:growl id="growl" life="4000"/>
+
+                    <!-- Navigation bar -->
+                    <div class="row">
+                        <div class="col-12 px-4">
+                            <p:commandButton
+                                id="btnDashboard"
+                                value="Inpatient Dashboard"
+                                ajax="false"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"
+                                icon="fa fa-id-card"
+                                class="p-0 m-1">
+                                <f:setPropertyActionListener
+                                    value="#{professionalPaymentHoldController.currentEncounter}"
+                                    target="#{admissionController.current}" />
+                            </p:commandButton>
+                        </div>
+                    </div>
+
+                    <!-- Access denied panel -->
+                    <h:panelGroup id="pnlAccessDenied" layout="block" rendered="#{not webUserController.hasPrivilege('InwardHoldProfessionalPayments')}">
+                        <div class="row px-4">
+                            <div class="col-12">
+                                <p:panel class="m-1">
+                                    <h:outputText value="You do not have permission to hold or release professional payments." />
+                                </p:panel>
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                    <!-- Main content -->
+                    <h:panelGroup id="pnlMain" layout="block" rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}">
+
+                        <!-- Hold status banner -->
+                        <h:panelGroup id="pnlHoldStatusBanner" layout="block"
+                                      rendered="#{professionalPaymentHoldController.currentEncounter.professionalPaymentsOnHold}">
+                            <div class="row px-4 pt-2">
+                                <div class="col-12">
+                                    <div class="alert alert-danger" role="alert">
+                                        <i class="fa fa-lock mr-2"/>
+                                        Professional payments are on hold for BHT
+                                        <strong>#{professionalPaymentHoldController.currentEncounter.bhtNo}</strong>,
+                                        held by
+                                        <strong>#{professionalPaymentHoldController.currentEncounter.professionalPaymentsHoldBy.name}</strong>
+                                        on
+                                        <h:outputText value="#{professionalPaymentHoldController.currentEncounter.professionalPaymentsHoldDateTime}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                        <h:panelGroup layout="block" rendered="#{not empty professionalPaymentHoldController.currentEncounter.professionalPaymentsHoldNotes}">
+                                            <span class="font-weight-bold">Notes:</span>
+                                            <span>#{professionalPaymentHoldController.currentEncounter.professionalPaymentsHoldNotes}</span>
+                                        </h:panelGroup>
+                                    </div>
+                                </div>
+                            </div>
+                        </h:panelGroup>
+
+                        <div class="row px-4 py-2">
+                            <div class="col-12">
+
+                                <!-- Hold panel: shown when NOT currently on hold -->
+                                <h:panelGroup layout="block" rendered="#{not professionalPaymentHoldController.currentEncounter.professionalPaymentsOnHold}">
+                                    <p:panel class="w-100 m-1 p-0 mb-2">
+                                        <f:facet name="header">
+                                            <i class="fa fa-hand-paper mr-2"/>
+                                            <h:outputText value="Hold Professional Payments" />
+                                        </f:facet>
+                                        <div class="container-fluid">
+                                            <div class="row my-2">
+                                                <div class="col-12">
+                                                    <p:outputLabel for="txtProfessionalPaymentHoldNotes" value="Hold Notes:" styleClass="font-weight-bold" />
+                                                    <p:inputTextarea
+                                                        id="txtProfessionalPaymentHoldNotes"
+                                                        value="#{professionalPaymentHoldController.currentEncounter.professionalPaymentsHoldNotes}"
+                                                        class="w-100"
+                                                        autoResize="true"
+                                                        rows="6"
+                                                        placeholder="Reason for holding professional payments on this BHT, e.g. pending investigation, billing dispute, awaiting clarification, etc." />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </p:panel>
+                                </h:panelGroup>
+
+                                <!-- Action buttons -->
+                                <h:panelGroup id="pnlActionButtons" layout="block"
+                                              styleClass="d-flex justify-content-end my-2 mb-4">
+                                    <h:panelGroup rendered="#{not professionalPaymentHoldController.currentEncounter.professionalPaymentsOnHold}">
+                                        <p:commandButton
+                                            id="btnConfirmProfessionalPaymentHold"
+                                            value="Confirm Hold"
+                                            ajax="false"
+                                            action="#{professionalPaymentHoldController.confirmHold()}"
+                                            icon="fa fa-lock"
+                                            class="ui-button-danger mx-1"
+                                            onclick="return confirm('Are you sure you want to hold professional payments for this BHT? Professional fee payments will be blocked until the hold is released.')" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{professionalPaymentHoldController.currentEncounter.professionalPaymentsOnHold}">
+                                        <p:commandButton
+                                            id="btnReleaseProfessionalPaymentHold"
+                                            value="Release Hold"
+                                            ajax="false"
+                                            action="#{professionalPaymentHoldController.releaseHold()}"
+                                            icon="fa fa-unlock"
+                                            class="ui-button-success mx-1"
+                                            onclick="return confirm('Are you sure you want to release the hold on professional payments for this BHT?')" />
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -275,6 +275,17 @@
                                                             rendered="#{webUserController.hasPrivilege('InwardPhysicalDischarge')}"
                                                             styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
                                                         </p:commandButton>
+
+                                                        <p:commandButton
+                                                            id="btnHoldProfessionalPayments"
+                                                            value="Hold Professional Payments"
+                                                            ajax="false"
+                                                            action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
+                                                            icon="fa fa-hand-paper"
+                                                            title="Navigate to Hold Professional Payments"
+                                                            rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                                            styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
+                                                        </p:commandButton>
                                                     </div>
                                                 </p:panel>
                                             </div>


### PR DESCRIPTION
## Summary
- Adds a BHT-level "Hold Professional Payments" action (Inpatient Dashboard) that blocks payout of professional/surgery fees for that admission, while charge entry (Add Services/Professional Fees) continues to work normally.
- New `professionalPaymentsOnHold` (+ audit) fields on `PatientEncounter`, a new `ProfessionalPaymentHoldController` + confirm/release page mirroring the existing `nursingDischarged` pattern.
- Two new privileges: `InwardHoldProfessionalPayments` (toggle the hold) and `InwardPayProfessionalFeesWhileOnHold` (override — lets an authorized user pay anyway).
- Server-side guard added to `InwardStaffPaymentBillController.errorCheck()` and `InwardSurgeryPaymentBillController.errorCheck()` — the single choke point both settle flows already route through — rejects payment for a held BHT unless the user has the override privilege.
- "On Hold" badge added to the due-fee tables on `inward_bill_professional_payment.xhtml` / `inward_bill_surgery_payment.xhtml` (informational; the server-side guard is the real gate).
- No DB migration — new columns handled via `generate-ddl` (EclipseLink DDL regeneration), consistent with plain additive-column changes elsewhere in this codebase.

## Test plan
- [x] Held a real BHT (BHT/56178) via the new Inpatient Dashboard action; confirmed the audit banner (who/when/notes) and DB columns (`PROFESSIONALPAYMENTSONHOLD`, `PROFESSIONALPAYMENTSHOLDBY_ID`, `PROFESSIONALPAYMENTSHOLDDATETIME`, `PROFESSIONALPAYMENTSHOLDNOTES`).
- [x] Confirmed `inward_bill_professional_payment.xhtml`'s due-fee table shows an "On Hold" badge for that BHT's row while sibling BHTs show none.
- [x] Attempted to settle payment for the held BHT as a user **without** `InwardPayProfessionalFeesWhileOnHold` — payment was rejected with `Cannot pay: professional payments are on hold for BHT BHT/56178.`; confirmed via DB that `PAIDVALUE` stayed `0`.
- [x] Re-tested as a user **with** the override privilege — the hold check no longer blocked (request proceeded to the next, unrelated, drawer-balance check).
- [x] Confirmed `inward_bill_professional.xhtml` ("Add Professional Fees") still works normally for the held BHT — charge entry is unaffected by the hold.
- [x] Released the hold and confirmed the audit fields cleared correctly.
- [x] `mvn -o compile -DskipTests` passes; verified server log has no exceptions during the Playwright session.

Screenshots (patient/BHT/professional name redacted) posted on the issue: https://github.com/hmislk/hmis/issues/16473#issuecomment-5012644010

Closes #16473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Hold Professional Payments” workflow with hold/release page and action buttons in admission and nursing screens (privilege-protected).
  * Displayed “On Hold” indicators in professional and surgery billing lists.
  * Captures hold metadata (date/time, staff member, notes).
* **Bug Fixes**
  * Prevented processing of professional payments when an encounter is on hold unless the user has the required privilege.
* **Documentation**
  * Added Playwright e2e guidance for diagnosing blocked non-AJAX form submissions caused by default required dropdown values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->