### PR TITLE
Apply room-category price matrix margin to inward interim bill room charges

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -247,6 +247,64 @@ public class PriceMatrixController implements Serializable {
         return result;
     }
 
+    /**
+     * Inward-margin lookup for room charges themselves (room/maintenance/
+     * linen/nursing/MO/administration/medical-care), as opposed to a service
+     * or pharmacy item. These matrix rows are configured with no category
+     * (category is null) and a room category, via the room-category price
+     * matrix admin page.
+     */
+    public PriceMatrix fetchRoomChargeMargin(Department department, double chargeValue, PaymentMethod paymentMethod,
+            Institution creditCompany, AdmissionType admissionType, RoomCategory roomCategory) {
+        if (department == null) {
+            return null;
+        }
+        boolean isPaymentMethodAllowedInInwardMatrix = configOptionApplicationController.getBooleanValueByKey("Inward Matrix - Allow PaymentMethod for Inward Matrix Calculation", false);
+        PaymentMethod pm = isPaymentMethodAllowedInInwardMatrix ? paymentMethod : null;
+        return getRoomChargePriceAdjustment(department, chargeValue, pm, creditCompany, admissionType, roomCategory);
+    }
+
+    private InwardPriceAdjustment getRoomChargePriceAdjustment(Department department, double dbl, PaymentMethod paymentMethod,
+            Institution creditCompany, AdmissionType admissionType, RoomCategory roomCategory) {
+        StringBuilder sql = new StringBuilder("select a from InwardPriceAdjustment a "
+                + " where a.retired=false"
+                + " and a.category is null "
+                + " and a.department=:dep"
+                + " and (a.fromPrice< :frPrice and a.toPrice >:tPrice)");
+        HashMap hm = new HashMap();
+        hm.put("dep", department);
+        hm.put("frPrice", dbl);
+        hm.put("tPrice", dbl);
+
+        if (paymentMethod != null) {
+            sql.append(" and a.paymentMethod=:pm");
+            hm.put("pm", paymentMethod);
+        }
+
+        if (creditCompany == null) {
+            sql.append(" and a.creditCompany is null");
+        } else {
+            sql.append(" and a.creditCompany=:cc");
+            hm.put("cc", creditCompany);
+        }
+
+        if (admissionType == null) {
+            sql.append(" and a.admissionType is null");
+        } else {
+            sql.append(" and (a.admissionType=:at or a.admissionType is null)");
+            hm.put("at", admissionType);
+        }
+
+        sql.append(roomCategoryPredicate(roomCategory));
+        if (roomCategory != null) {
+            hm.put("rc", roomCategory);
+        }
+
+        sql.append(inwardMatrixOrderBy(admissionType != null, roomCategory != null));
+
+        return firstInwardPriceAdjustment(findInwardPriceAdjustments(sql.toString(), hm));
+    }
+
     public double getItemWithInwardMargin(Item item) {
         if (item == null) {
             return 0.0;

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.Department;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.PriceMatrix;
@@ -47,6 +48,7 @@ import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.GuardianRoom;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.inward.PatientRoomTimedItemCharge;
+import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.entity.inward.TheatreRoom;
 import com.divudi.core.entity.inward.TimedItem;
@@ -3361,10 +3363,38 @@ public class BhtSummeryController implements Serializable {
         p.setAjdustedMedicalCareCharge(p.getCalculatedMedicalCareCharge() - medicalCareDisc);
     }
 
+    /**
+     * Margin (positive or negative) from the room-category price-adjustment
+     * matrix (InwardPriceAdjustment rows configured on the room facility
+     * category price-matrix admin page) for a single room-related charge
+     * amount of a given PatientRoom. Returns 0 when the room has no
+     * department/room-category context or no matching matrix row exists.
+     */
+    private double roomChargeMatrixMargin(PatientRoom p, double chargeValue) {
+        if (p.getRoomFacilityCharge() == null || chargeValue == 0.0) {
+            return 0.0;
+        }
+        Department department = p.getRoomFacilityCharge().getDepartment();
+        if (department == null) {
+            return 0.0;
+        }
+        RoomCategory roomCategory = p.getRoomFacilityCharge().getRoomCategory();
+        PatientEncounter encounter = getPatientEncounter();
+        PaymentMethod paymentMethod = encounter == null ? null : encounter.getPaymentMethod();
+        AdmissionType admissionType = encounter == null ? null : encounter.getAdmissionType();
+        Institution creditCompany = resolveSingleCreditCompany(encounter);
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchRoomChargeMargin(department, chargeValue, paymentMethod, creditCompany, admissionType, roomCategory);
+        if (priceMatrix == null) {
+            return 0.0;
+        }
+        return (chargeValue * priceMatrix.getMargin()) / 100.0;
+    }
+
     private void calculateLinenCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentLinenCharge() == 0.0) {
             p.setCalculatedLinenCharge(0);
+            p.setMarginLinenCharge(0.0);
             return;
         }
 
@@ -3377,88 +3407,107 @@ public class BhtSummeryController implements Serializable {
         }
 
         double extra = p.getAddedLinenCharge();
+        double calculated;
         ////System.out.println("extra = " + extra);
         if (CommonFunctions.checkToDateAreInSameDay(p.getAdmittedAt(), dischargedAt)) {
             if (p.getAdmittedAt().equals(dischargedAt)) {
-                p.setCalculatedLinenCharge(0 + extra);
-                ////System.out.println("1.1 p.getCalculatedLinenCharge() = " + p.getCalculatedLinenCharge());
+                calculated = 0 + extra;
             } else {
-                p.setCalculatedLinenCharge(linen + extra);
-                ////System.out.println("1.2 p.getCalculatedLinenCharge() = " + p.getCalculatedLinenCharge());
+                calculated = linen + extra;
             }
         } else {
-            p.setCalculatedLinenCharge((linen * CommonFunctions.getDayCount(p.getAdmittedAt(), dischargedAt)) + extra);
-            ////System.out.println("2 p.getCalculatedLinenCharge() = " + p.getCalculatedLinenCharge());
+            calculated = (linen * CommonFunctions.getDayCount(p.getAdmittedAt(), dischargedAt)) + extra;
         }
+
+        double linenMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude Linen Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginLinenCharge(linenMargin);
+        p.setCalculatedLinenCharge(calculated + linenMargin);
     }
 
     private void calculateMoCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentMoCharge() == 0.0) {
             p.setCalculatedMoCharge(0);
+            p.setMarginMoCharge(0.0);
             return;
         }
 
+        double calculated;
         if (!sessionController.getApplicationPreference().isInwardMoChargeCalculateInitialTime()) {
             double mo = p.getCurrentMoCharge();
-            double calculated = getCharge(p, mo) + p.getAddedMoCharge();
-            p.setCalculatedMoCharge(calculated);
+            calculated = getCharge(p, mo) + p.getAddedMoCharge();
         } else {
             Date dischargedAt = p.getDischargedAt();
             long dCount = CommonFunctions.getDayCount(p.getAdmittedAt(), dischargedAt);
 
             if (dCount <= p.getRoomFacilityCharge().getTimedItemFee().getDurationDaysForMoCharge()) {
-                double calculated = p.getCurrentMoCharge() + p.getAddedMoCharge();
-                p.setCalculatedMoCharge(calculated);
+                calculated = p.getCurrentMoCharge() + p.getAddedMoCharge();
             } else {
                 long extra = dCount - p.getRoomFacilityCharge().getTimedItemFee().getDurationDaysForMoCharge();
-                double calculated = (p.getCurrentMoChargeForAfterDuration() * extra) + p.getCurrentMoCharge();
-                p.setCalculatedMoCharge(calculated);
+                calculated = (p.getCurrentMoChargeForAfterDuration() * extra) + p.getCurrentMoCharge();
             }
         }
+
+        double moMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude MO Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginMoCharge(moMargin);
+        p.setCalculatedMoCharge(calculated + moMargin);
     }
 
     private void calculateAdministrationCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentAdministrationCharge() == 0.0) {
             p.setCalculatedAdministrationCharge(0);
+            p.setMarginAdministrationCharge(0.0);
             return;
         }
 
         double adm = p.getCurrentAdministrationCharge();
         double calculated = getCharge(p, adm) + p.getAddedAdministrationCharge();
-        p.setCalculatedAdministrationCharge(calculated);
+        double adminMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude Administration Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginAdministrationCharge(adminMargin);
+        p.setCalculatedAdministrationCharge(calculated + adminMargin);
     }
 
     private void calculateMedicalCareCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentMedicalCareCharge() == 0.0) {
             p.setCalculatedMedicalCareCharge(0);
+            p.setMarginMedicalCareCharge(0.0);
             return;
         }
 
         double med = p.getCurrentMedicalCareCharge();
         double calculated = getCharge(p, med) + p.getAddedMedicalCareCharge();
-        p.setCalculatedMedicalCareCharge(calculated);
+        double medicalCareMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude Medical Care Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginMedicalCareCharge(medicalCareMargin);
+        p.setCalculatedMedicalCareCharge(calculated + medicalCareMargin);
     }
 
     private void calculateNursingCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentNursingCharge() == 0) {
             p.setCalculatedNursingCharge(0);
+            p.setMarginNursingCharge(0.0);
             return;
         }
 
         double nursing = p.getCurrentNursingCharge();
         double calculated = getCharge(p, nursing) + p.getAddedNursingCharge();
-
-        p.setCalculatedNursingCharge(calculated);
+        double nursingMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude Nursing Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginNursingCharge(nursingMargin);
+        p.setCalculatedNursingCharge(calculated + nursingMargin);
     }
 
     private void calculateRoomCharge(PatientRoom p) {
 
         if (p.getRoomFacilityCharge() == null || p.getCurrentRoomCharge() == 0) {
             p.setCalculatedRoomCharge(0);
+            p.setMarginRoomCharge(0.0);
             return;
         }
 
@@ -3467,6 +3516,7 @@ public class BhtSummeryController implements Serializable {
             // fixed total for the room, not a per-block rate — do not multiply
             // it by elapsed TimedItemFee blocks while within the included duration.
             p.setCalculatedRoomCharge(p.getCurrentRoomCharge() + p.getAddedRoomCharge());
+            p.setMarginRoomCharge(0.0);
             return;
         }
 
@@ -3475,7 +3525,10 @@ public class BhtSummeryController implements Serializable {
         double calculated = getCharge(p, roomCharge) + p.getAddedRoomCharge();
         ////System.out.println("calculated = " + calculated);
 
-        p.setCalculatedRoomCharge(calculated);
+        double roomMargin = roomChargeMatrixMargin(p, calculated);
+        p.setMarginRoomCharge(roomMargin);
+
+        p.setCalculatedRoomCharge(calculated + roomMargin);
     }
 
     private double getCharge(PatientRoom patientRoom, double value) {
@@ -3506,12 +3559,15 @@ public class BhtSummeryController implements Serializable {
     private void calculateMaintananceCharge(PatientRoom p) {
         if (p.getRoomFacilityCharge() == null || p.getCurrentMaintananceCharge() == 0) {
             p.setCalculatedMaintainCharge(0);
+            p.setMarginMaintainCharge(0.0);
             return;
         }
         double maintanance = p.getCurrentMaintananceCharge();
         double calculated = getCharge(p, maintanance) + p.getAddedMaintainCharge();
-
-        p.setCalculatedMaintainCharge(calculated);
+        double maintainMargin = configOptionApplicationController.getBooleanValueByKey("Inward Room Price Matrix - Exclude Maintenance Charge", false)
+                ? 0.0 : roomChargeMatrixMargin(p, calculated);
+        p.setMarginMaintainCharge(maintainMargin);
+        p.setCalculatedMaintainCharge(calculated + maintainMargin);
     }
 
     private void calculateTimedItemCharges(PatientRoom p) {
@@ -4431,6 +4487,22 @@ public class BhtSummeryController implements Serializable {
 
         return new RoomDurationBreakdown(totalMinutes, slotMinutes, completeSlots,
                 remainderMinutes, overshootMinutes, extraSlotCharged, billedSlots);
+    }
+
+    /**
+     * The room-category price-matrix margin percentage applied to this room's
+     * Room Charge, derived from the already-computed calculated/margin fields
+     * (set by calculateRoomCharge()). Returns null when no matrix row applied.
+     */
+    public Double getRoomMatrixPercent(PatientRoom pr) {
+        if (pr == null || pr.getMarginRoomCharge() == 0.0) {
+            return null;
+        }
+        double slotRate = pr.getCalculatedRoomCharge() - pr.getMarginRoomCharge();
+        if (slotRate == 0.0) {
+            return null;
+        }
+        return (pr.getMarginRoomCharge() / slotRate) * 100.0;
     }
 
     public List<BillFee> getAllDoctorCharges() {

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -170,6 +170,53 @@ public class InwardPriceAdjustmntController implements Serializable {
         recreateModel();
 //        createItems();
     }
+    
+    public void savePriceMetrixforRoomCategory() {
+
+        if (fromPrice == toPrice) {
+            JsfUtil.addErrorMessage("Check prices");
+            return;
+        }
+        if (toPrice == 0) {
+            JsfUtil.addErrorMessage("Check prices");
+            return;
+        }
+
+        if (department == null) {
+            JsfUtil.addErrorMessage("Please select a department");
+            return;
+        }
+
+        if (roomCategory == null) {
+            JsfUtil.addErrorMessage("Please select a Room Category");
+            return;
+        }
+
+        PriceMatrix a = new InwardPriceAdjustment();
+
+        a.setInstitution(department.getInstitution());
+        a.setDepartment(department);
+        a.setAdmissionType(admissionType);
+        a.setRoomCategory(roomCategory);
+        a.setPaymentMethod(paymentMethod);
+        a.setFromPrice(fromPrice);
+        a.setToPrice(toPrice);
+        a.setMargin(margin);
+        a.setCreatedAt(new Date());
+        a.setCreater(getSessionController().getLoggedUser());
+        if (a.getId() == null) {
+            getFacade().create(a);
+        }
+        JsfUtil.addSuccessMessage("Saved Successfully");
+        recreateModel();
+        fillPriceMetrixforRoomCategory();
+
+    }
+
+    public void prepareRoomCategoryPriceMatrixPage() {
+        preparedAdd();
+        fillPriceMetrixforRoomCategory();
+    }
 
     public void addForAllCategory() {
 
@@ -364,6 +411,18 @@ public class InwardPriceAdjustmntController implements Serializable {
         hm.put("sub", ServiceSubCategory.class);
         items = getFacade().findByJpql(sql, hm);
 
+    }
+    
+    public void fillPriceMetrixforRoomCategory() {
+        filterItems = null;
+        String sql;
+        HashMap hm = new HashMap();
+        sql = "select a from InwardPriceAdjustment a"
+                + " where a.retired=false "
+                + " and a.category is null "
+                + " and a.roomCategory is not null "
+                + " order by a.department.name,a.fromPrice";
+        items = getFacade().findByJpql(sql, hm);
     }
 
     public void createCategroyServicePharmacy() {

--- a/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
@@ -136,6 +136,21 @@ public class PatientRoom implements Serializable, RetirableEntity {
     private long tmpStayedTime;
     @Transient
     private double tmpTotalRoomCharge;
+    //Room-category price-matrix margin (display-only, recomputed on every calculation)
+    @Transient
+    private double marginRoomCharge;
+    @Transient
+    private double marginMaintainCharge;
+    @Transient
+    private double marginMoCharge;
+    @Transient
+    private double marginNursingCharge;
+    @Transient
+    private double marginLinenCharge;
+    @Transient
+    private double marginAdministrationCharge;
+    @Transient
+    private double marginMedicalCareCharge;
 
     public double getAddedRoomCharge() {
         return addedRoomCharge;
@@ -691,6 +706,62 @@ public class PatientRoom implements Serializable, RetirableEntity {
 
     public void setAjdustedNursingCharge(double ajdustedNursingCharge) {
         this.ajdustedNursingCharge = ajdustedNursingCharge;
+    }
+
+    public double getMarginRoomCharge() {
+        return marginRoomCharge;
+    }
+
+    public void setMarginRoomCharge(double marginRoomCharge) {
+        this.marginRoomCharge = marginRoomCharge;
+    }
+
+    public double getMarginMaintainCharge() {
+        return marginMaintainCharge;
+    }
+
+    public void setMarginMaintainCharge(double marginMaintainCharge) {
+        this.marginMaintainCharge = marginMaintainCharge;
+    }
+
+    public double getMarginMoCharge() {
+        return marginMoCharge;
+    }
+
+    public void setMarginMoCharge(double marginMoCharge) {
+        this.marginMoCharge = marginMoCharge;
+    }
+
+    public double getMarginNursingCharge() {
+        return marginNursingCharge;
+    }
+
+    public void setMarginNursingCharge(double marginNursingCharge) {
+        this.marginNursingCharge = marginNursingCharge;
+    }
+
+    public double getMarginLinenCharge() {
+        return marginLinenCharge;
+    }
+
+    public void setMarginLinenCharge(double marginLinenCharge) {
+        this.marginLinenCharge = marginLinenCharge;
+    }
+
+    public double getMarginAdministrationCharge() {
+        return marginAdministrationCharge;
+    }
+
+    public void setMarginAdministrationCharge(double marginAdministrationCharge) {
+        this.marginAdministrationCharge = marginAdministrationCharge;
+    }
+
+    public double getMarginMedicalCareCharge() {
+        return marginMedicalCareCharge;
+    }
+
+    public void setMarginMedicalCareCharge(double marginMedicalCareCharge) {
+        this.marginMedicalCareCharge = marginMedicalCareCharge;
     }
 
     public double getCurrentMoChargeForAfterDuration() {

--- a/src/main/webapp/inward/inward_administration.xhtml
+++ b/src/main/webapp/inward/inward_administration.xhtml
@@ -68,11 +68,47 @@
 
                                     <p:tab title="Price Matrix">
                                         <div class="d-grid gap-2">
-                                            <p:commandButton ajax="false" value="Inward Price Adjustment - Service " class="w-100" action="/inward/inward_price_adjustment_service?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
-                                            <p:commandButton ajax="false" value="Inward Price Adjustment - Investigation " class="w-100" action="/inward/inward_price_adjustment_investigation?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
-                                            <p:commandButton ajax="false" value="Inward Price Adjustment - Pharmacy " class="w-100" action="/inward/inward_price_adjustment_pharmacy?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
-                                            <p:commandButton ajax="false" value="Inward Price Adjustment - Store " class="w-100" action="/inward/inward_price_adjustment_store?faces-redirect=true" actionListener="#{inwardPriceAdjustmntController.preparedAdd()}"></p:commandButton>
-                                            <p:commandButton ajax="false" value="Service Charge Allowed - Fee Update " class="w-100" action="#{feeMarginAllowedController.navigateToManageFeeMarginAllowed()}"></p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Inward Price Adjustment - Room Facility Category " 
+                                                class="w-100" 
+                                                action="/inward/inward_price_adjustment_room_category?faces-redirect=true"
+                                                actionListener="#{inwardPriceAdjustmntController.prepareRoomCategoryPriceMatrixPage()}">
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Inward Price Adjustment - Service " 
+                                                class="w-100" 
+                                                action="/inward/inward_price_adjustment_service?faces-redirect=true" 
+                                                actionListener="#{inwardPriceAdjustmntController.preparedAdd()}">
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Inward Price Adjustment - Investigation " 
+                                                class="w-100" 
+                                                action="/inward/inward_price_adjustment_investigation?faces-redirect=true" 
+                                                actionListener="#{inwardPriceAdjustmntController.preparedAdd()}">
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Inward Price Adjustment - Pharmacy " 
+                                                class="w-100" 
+                                                action="/inward/inward_price_adjustment_pharmacy?faces-redirect=true" 
+                                                actionListener="#{inwardPriceAdjustmntController.preparedAdd()}">
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Inward Price Adjustment - Store " 
+                                                class="w-100" 
+                                                action="/inward/inward_price_adjustment_store?faces-redirect=true" 
+                                                actionListener="#{inwardPriceAdjustmntController.preparedAdd()}">
+                                            </p:commandButton>
+                                            <p:commandButton 
+                                                ajax="false" 
+                                                value="Service Charge Allowed - Fee Update " 
+                                                class="w-100" 
+                                                action="#{feeMarginAllowedController.navigateToManageFeeMarginAllowed()}">
+                                            </p:commandButton>
                                         </div>
                                     </p:tab>
 

--- a/src/main/webapp/inward/inward_patient_room_details.xhtml
+++ b/src/main/webapp/inward/inward_patient_room_details.xhtml
@@ -196,6 +196,7 @@
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputText>
                                         </p:column>
+
                                         <p:column headerText="Discount" style="width:80px; text-align:right; color:#c0392b;">
                                             <h:outputText value="#{rm.discountRoomCharge + rm.discountMaintainCharge + rm.discountLinenCharge + rm.discountNursingCharge + rm.discountMoCharge + rm.discountAdministrationCharge + rm.discountMedicalCareCharge}">
                                                 <f:convertNumber pattern="#,##0.00"/>
@@ -318,6 +319,7 @@
                                                                     <th>Overshoot Limit</th>
                                                                     <th>Extra Slot?</th>
                                                                     <th class="text-primary">Billed Slots</th>
+                                                                    <th style="color:#0d6efd;">Matrix %</th>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
@@ -368,6 +370,13 @@
                                                                     <td class="text-primary fw-bold" style="font-size:1.05rem;">
                                                                         <h:outputText value="#{bhtSummeryController.getRoomDurationBreakdown(rm).billedSlots}"/>
                                                                     </td>
+                                                                    <td class="fw-semibold" style="color:#0d6efd;">
+                                                                        <h:outputText value="#{bhtSummeryController.getRoomMatrixPercent(rm)}" rendered="#{bhtSummeryController.getRoomMatrixPercent(rm) ne null}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                        <h:outputText value="%" rendered="#{bhtSummeryController.getRoomMatrixPercent(rm) ne null}"/>
+                                                                        <h:outputText value="—" rendered="#{bhtSummeryController.getRoomMatrixPercent(rm) eq null}" styleClass="text-muted"/>
+                                                                    </td>
                                                                 </tr>
                                                             </tbody>
                                                         </table>
@@ -389,6 +398,8 @@
                                                         <tr>
                                                             <th>Charge Type</th>
                                                             <th class="text-end">Rate / Slot</th>
+                                                            <th class="text-end">Slot Rate</th>
+                                                            <th class="text-end" style="color:#0d6efd;">Matrix Value</th>
                                                             <th class="text-end">Calculated</th>
                                                             <th class="text-end" style="color:#c0392b;">Discount</th>
                                                             <th class="text-end fw-bold">Net</th>
@@ -399,6 +410,12 @@
                                                             <td><i class="fa-solid fa-bed me-1 text-primary"/>Room</td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.currentRoomCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedRoomCharge - rm.marginRoomCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginRoomCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedRoomCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
@@ -416,6 +433,12 @@
                                                                 <h:outputText value="#{rm.currentMaintananceCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedMaintainCharge - rm.marginMaintainCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginMaintainCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedMaintainCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end" style="color:#c0392b;">
@@ -429,6 +452,12 @@
                                                             <td><i class="fa-solid fa-user-doctor me-1 text-info"/>Medical Officer</td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.currentMoCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedMoCharge - rm.marginMoCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginMoCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedMoCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
@@ -446,6 +475,12 @@
                                                                 <h:outputText value="#{rm.currentNursingCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedNursingCharge - rm.marginNursingCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginNursingCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedNursingCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end" style="color:#c0392b;">
@@ -459,6 +494,12 @@
                                                             <td><i class="fa-solid fa-sheet-plastic me-1 text-warning"/>Linen</td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.currentLinenCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedLinenCharge - rm.marginLinenCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginLinenCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedLinenCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
@@ -476,6 +517,12 @@
                                                                 <h:outputText value="#{rm.currentAdministrationCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedAdministrationCharge - rm.marginAdministrationCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginAdministrationCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedAdministrationCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end" style="color:#c0392b;">
@@ -491,6 +538,12 @@
                                                                 <h:outputText value="#{rm.currentMedicalCareCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end">
+                                                                <h:outputText value="#{rm.calculatedMedicalCareCharge - rm.marginMedicalCareCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginMedicalCareCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                                            </td>
+                                                            <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedMedicalCareCharge}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
                                                             </td>
                                                             <td class="text-end" style="color:#c0392b;">
@@ -504,6 +557,16 @@
                                                         <tr class="table-secondary fw-bold">
                                                             <td>Total</td>
                                                             <td></td>
+                                                            <td class="text-end">
+                                                                <h:outputText value="#{(rm.calculatedRoomCharge - rm.marginRoomCharge) + (rm.calculatedMaintainCharge - rm.marginMaintainCharge) + (rm.calculatedMoCharge - rm.marginMoCharge) + (rm.calculatedNursingCharge - rm.marginNursingCharge) + (rm.calculatedLinenCharge - rm.marginLinenCharge) + (rm.calculatedAdministrationCharge - rm.marginAdministrationCharge) + (rm.calculatedMedicalCareCharge - rm.marginMedicalCareCharge)}">
+                                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                                </h:outputText>
+                                                            </td>
+                                                            <td class="text-end" style="color:#0d6efd;">
+                                                                <h:outputText value="#{rm.marginRoomCharge + rm.marginMaintainCharge + rm.marginLinenCharge + rm.marginNursingCharge + rm.marginMoCharge + rm.marginAdministrationCharge + rm.marginMedicalCareCharge}">
+                                                                    <f:convertNumber pattern="#,##0.00"/>
+                                                                </h:outputText>
+                                                            </td>
                                                             <td class="text-end">
                                                                 <h:outputText value="#{rm.calculatedRoomCharge + rm.calculatedMaintainCharge + rm.calculatedMoCharge + rm.calculatedNursingCharge + rm.calculatedLinenCharge + rm.calculatedAdministrationCharge + rm.calculatedMedicalCareCharge}">
                                                                     <f:convertNumber pattern="#,##0.00"/>

--- a/src/main/webapp/inward/inward_price_adjustment_room_category.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_room_category.xhtml
@@ -1,0 +1,377 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      >
+
+    <h:body>
+
+        <ui:composition template="/inward/inward_administration.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="mainForm">
+                    <p:panel header="Inward Price Adjustment Matrix - Room Facility Category" id="reportPrint" class="row w-100">
+                        <p:panel>
+                            <f:facet name="header">
+                                <h:outputLabel value="Add new Matrix"  class="mt-2"/>
+                                <p:commandButton
+                                    id="btnAdd"
+                                    value="Add"
+                                    class="ui-button-success"
+                                    icon="fa fa-plus"
+                                    style="float: right;"
+                                    ajax="false"
+                                    update="inwd"
+                                    action="#{inwardPriceAdjustmntController.savePriceMetrixforRoomCategory()}"  >
+                                </p:commandButton>
+
+                            </f:facet>
+
+                            <div class="row w-100 d-flex ml-2">
+                                <div class="row">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Department " class="mt-1"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:autoComplete
+                                            value="#{inwardPriceAdjustmntController.department}"
+                                            forceSelection="true"
+                                            completeMethod="#{departmentController.completeDept}"
+                                            var="dep"
+                                            placeholder="Select the Room Department"
+                                            inputStyleClass="form-control"
+                                            class="w-100"
+                                            maxResults="20"
+                                            itemLabel="#{dep.name}"
+                                            itemValue="#{dep}" >
+                                            <p:column style="padding: 6px; width: 8em;">
+                                                <h:outputLabel value="#{dep.name}"/>
+                                            </p:column>
+                                            <p:column style="padding: 6px; width: 12em;">
+                                                <h:outputLabel value="#{dep.institution.name}"/>
+                                            </p:column>
+                                        </p:autoComplete>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Payment Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbPs"
+                                            value="#{inwardPriceAdjustmntController.paymentMethod}"  >
+                                            <f:selectItem itemLabel="Select" />
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Admission Type" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbAdmissionType"
+                                            value="#{inwardPriceAdjustmntController.admissionType}">
+                                            <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                            <f:selectItems 
+                                                value="#{admissionTypeController.items}"
+                                                var="at" 
+                                                itemValue="#{at}" 
+                                                itemLabel="#{at.name}" >
+                                            </f:selectItems>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Room Category" class="mt-2"/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="w-100"
+                                            id="cmbRoomCategory"
+                                            value="#{inwardPriceAdjustmntController.roomCategory}">
+                                            <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                            <f:selectItems 
+                                                value="#{roomCategoryController.items}" 
+                                                var="rc"
+                                                itemValue="#{rc}" 
+                                                itemLabel="#{rc.name}" >
+                                            </f:selectItems>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="From" class="mt-2"></h:outputLabel>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputText
+                                            class="w-100"
+                                            autocomplete="off"
+                                            onfocus="this.select()"
+                                            value="#{inwardPriceAdjustmntController.fromPrice}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:inputText>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="To" class="mt-2"></h:outputLabel>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputText
+                                            class="w-100"
+                                            onfocus="this.select()"
+                                            autocomplete="off"
+                                            value="#{inwardPriceAdjustmntController.toPrice}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:inputText>
+                                    </div>
+                                </div>
+
+                                <div class="row mt-1">
+                                    <div class="col-2">
+                                        <h:outputLabel value="Margin" class="mt-2"></h:outputLabel>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:inputText
+                                            class="w-100"
+                                            onfocus="this.select()"
+                                            autocomplete="off"
+                                            value="#{inwardPriceAdjustmntController.margin}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </p:inputText>
+                                    </div>
+                                </div>
+
+                            </div>
+
+                        </p:panel>
+
+                        <p:panel class="mt-2" id="priceMatrixDataPreview">
+                            <f:facet name="header">
+                                <h:outputLabel value="Price Matrix"  class="mt-2"/>
+                                <div class="d-flex" style="float: right">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-fill"
+                                        class="ui-button-warning"
+                                        value="Fill"
+                                        action="#{inwardPriceAdjustmntController.fillPriceMetrixforRoomCategory()}">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        class="ui-button-success mx-2"
+                                        actionListener="#{inwardPriceAdjustmntController.createCategroyService()}"
+                                        ajax="false"
+                                        value="Excel"
+                                        icon="fa-solid fa-file-excel">
+                                        <p:dataExporter
+                                            type="xlsx"
+                                            target="inwd"
+                                            fileName="Price_metrix_room_category"  />
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        class="w-100 ui-button-info"
+                                        ajax="false"
+                                        icon="fa fa-print"
+                                        value="Print">
+                                        <p:printer target="priceMatrixDataPreview"/>
+                                    </p:commandButton>
+                                </div>
+
+                            </f:facet>
+
+                            <p:dataTable
+                                id="inwd"
+                                value="#{inwardPriceAdjustmntController.items}"
+                                filteredValue="#{inwardPriceAdjustmntController.filterItems}"
+                                var="a"
+                                editable="true"
+                                scrollable="true">
+
+                                <p:column headerText="ID" style="width: 5em;">
+                                    #{a.id}
+                                </p:column>
+
+                                <p:column
+                                    filterBy="#{a.department.name}"
+                                    filterMatchMode="contains"
+                                    headerText="Department Name"
+                                    exportable="false">
+                                    <p:outputLabel value="#{a.department.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Payment Method"
+                                    width="10%"
+                                    filterMatchMode="contains"
+                                    filterBy="#{a.paymentMethod}">
+                                    <p:outputLabel value="#{a.paymentMethod}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Admission Type"
+                                    filterBy="#{empty a.admissionType ? '' : a.admissionType.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}">
+                                    <h:outputText value="#{empty a.admissionType ? 'All Admission Types' : a.admissionType.name}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Room Category"
+                                    filterBy="#{empty a.roomCategory ? '' : a.roomCategory.name}"
+                                    filterMatchMode="contains"
+                                    exportValue="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}">
+                                    <h:outputText value="#{empty a.roomCategory ? 'All Room Categories' : a.roomCategory.name}"/>
+                                </p:column>
+
+                                <p:column headerText="From Price" width="8%">
+                                    <h:outputText value="#{a.fromPrice}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column  headerText="To Price" width="8%">
+                                    <h:outputText value="#{a.toPrice}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column  headerText="Margin" width="8%">
+                                    <h:outputText value="#{a.margin}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Action" width="5em;" >
+                                    <div class="d-flex">
+                                        <p:commandButton
+                                            id="edit"
+                                            icon="fa fa-pencil"
+                                            class="ui-button-success mx-1"
+                                            process="@this"
+                                            update=":dlgEditForm"
+                                            oncomplete="PF('dlgEdit').show()"
+                                            action="#{inwardPriceAdjustmntController.prepareEdit(a)}" >
+                                        </p:commandButton>
+
+                                        <p:commandButton
+                                            id="delete"
+                                            class="ui-button-danger"
+                                            icon=" fa-solid fa-trash"
+                                            action="#{inwardPriceAdjustmntController.delete}" >
+                                            <f:setPropertyActionListener value="#{a}" target="#{inwardPriceAdjustmntController.current}"/>
+                                        </p:commandButton>
+                                    </div>
+
+                                    <p:tooltip for="edit" value="Edit"  showDelay="0" hideDelay="0"></p:tooltip>
+                                    <p:tooltip for="delete" value="Delete"  showDelay="0" hideDelay="0"></p:tooltip>
+                                </p:column>
+
+                            </p:dataTable>
+                        </p:panel>
+                    </p:panel>
+                </h:form>
+
+                <p:dialog 
+                    header="Edit Price Matrix" 
+                    widgetVar="dlgEdit" 
+                    modal="true"
+                    resizable="false" 
+                    width="680" 
+                    id="dlgEdit">
+
+                    <h:form id="dlgEditForm">
+                        <h:panelGrid columns="3" cellpadding="5" rendered="#{not empty inwardPriceAdjustmntController.current}">
+                            <h:outputLabel value="Department"/>
+                            <p:spacer width="40"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.department.name}"/>
+
+                            <h:outputLabel value="Payment Method"/>
+                            <p:spacer width="40"/>
+                            <h:outputText value="#{inwardPriceAdjustmntController.current.paymentMethod}"/>
+
+                            <h:outputLabel value="Admission Type"/>
+                            <p:spacer width="40"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.admissionType}" class="w-100">
+                                <f:selectItem itemLabel="All Admission Types" itemValue="#{null}" />
+                                <f:selectItems 
+                                    value="#{admissionTypeController.items}" 
+                                    var="at"
+                                    itemValue="#{at}" 
+                                    itemLabel="#{at.name}" />
+                            </p:selectOneMenu>
+
+                            <h:outputLabel value="Room Category"/>
+                            <p:spacer width="40"/>
+                            <p:selectOneMenu value="#{inwardPriceAdjustmntController.current.roomCategory}" class="w-100">
+                                <f:selectItem itemLabel="All Room Categories" itemValue="#{null}" />
+                                <f:selectItems 
+                                    value="#{roomCategoryController.items}" 
+                                    var="rc"
+                                    itemValue="#{rc}" 
+                                    itemLabel="#{rc.name}" />
+                            </p:selectOneMenu>
+
+                            <h:outputLabel value="From Price"/>
+                            <p:spacer width="40"/>
+                            <p:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.fromPrice}" onfocus="this.select()">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:inputText>
+
+                            <h:outputLabel value="To Price"/>
+                            <p:spacer width="40"/>
+                            <p:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.toPrice}" onfocus="this.select()">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:inputText>
+
+                            <h:outputLabel value="Margin"/>
+                            <p:spacer width="20"/>
+                            <p:inputText autocomplete="off" value="#{inwardPriceAdjustmntController.current.margin}" onfocus="this.select()">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </p:inputText>
+
+
+                        </h:panelGrid>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <p:commandButton 
+                                id="dlgSave" 
+                                value="Save" 
+                                icon="fa fa-save"
+                                class="ui-button-success mx-1"
+                                action="#{inwardPriceAdjustmntController.saveEdit}"
+                                update=":dlgEditForm :mainForm:inwd"
+                                oncomplete="PF('dlgEdit').hide()">
+                            </p:commandButton>
+
+                            <p:commandButton 
+                                id="dlgCancel" 
+                                value="Cancel" 
+                                icon="fa fa-times"
+                                class="ui-button-secondary mx-1"
+                                type="button"
+                                onclick="PF('dlgEdit').hide()">
+                            </p:commandButton>
+                        </div>
+                    </h:form>
+                </p:dialog>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_price_adjustment_room_category.xhtml
+++ b/src/main/webapp/inward/inward_price_adjustment_room_category.xhtml
@@ -175,7 +175,7 @@
 
                                     <p:commandButton
                                         class="ui-button-success mx-2"
-                                        actionListener="#{inwardPriceAdjustmntController.createCategroyService()}"
+                                        actionListener="#{inwardPriceAdjustmntController.fillPriceMetrixforRoomCategory()}"
                                         ajax="false"
                                         value="Excel"
                                         icon="fa-solid fa-file-excel">
@@ -274,6 +274,7 @@
                                             id="delete"
                                             class="ui-button-danger"
                                             icon=" fa-solid fa-trash"
+                                            ajax="false"
                                             action="#{inwardPriceAdjustmntController.delete}" >
                                             <f:setPropertyActionListener value="#{a}" target="#{inwardPriceAdjustmntController.current}"/>
                                         </p:commandButton>


### PR DESCRIPTION
## Summary
- Adds a room-category price-matrix margin lookup to `PriceMatrixController` (`fetchRoomChargeMargin`) for room-related charges (as opposed to a service/pharmacy item).
- `BhtSummeryController` folds this margin into each `calculate*Charge()` for `PatientRoom` (Room, Maintenance, Linen, Nursing, MO, Administration, Medical Care), stacked on top of the existing `InwardDiscountMatrix` percentage discount. Room Charge always applies it; the rest each have a config toggle to exclude (default: applied).
- `PatientRoom` gets transient (non-persisted) margin fields per charge type, so the applied margin can be shown without a DB migration.
- `inward_patient_room_details.xhtml` (Room Stay History) now shows a full breakdown per charge type — Rate/Slot, Slot Rate, Matrix Value, Calculated, Discount, Net — plus a Matrix % column on the slot-calculation detail table.
- Also includes an earlier fix in this branch: the room facility category price-matrix admin page (`inward_price_adjustment_room_category.xhtml`) wasn't populating its bottom table on page load or after adding a new row.

## Config Options Added
- `Inward Room Price Matrix - Exclude Maintenance Charge` (default false)
- `Inward Room Price Matrix - Exclude Linen Charge` (default false)
- `Inward Room Price Matrix - Exclude Nursing Charge` (default false)
- `Inward Room Price Matrix - Exclude MO Charge` (default false)
- `Inward Room Price Matrix - Exclude Administration Charge` (default false)
- `Inward Room Price Matrix - Exclude Medical Care Charge` (default false)

## Test plan
- [ ] Configure a room-category price-adjustment matrix row (department + room category + margin %) via Inward Administration → Price Matrix → Room Facility Category.
- [ ] Admit a patient into a room in that department/category, open the interim bill / Patient Room Details page, and confirm the Room/Maintain/MO/Nursing/Linen/Admin/Medical Care columns reflect the margin.
- [ ] Expand a room row and confirm Rate/Slot, Slot Rate, Matrix Value, Calculated, Discount, Net all reconcile (Calculated = Slot Rate + Matrix Value; Net = Calculated - Discount).
- [ ] Confirm the Matrix % column shows the correct percentage for the room charge.
- [ ] Toggle one of the "Exclude ... Charge" config options and confirm that charge type stops receiving the margin while Room Charge still does.
- [ ] Confirm package-locked rooms are unaffected.

Closes #22226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added room facility category price matrices (by department, room category, payment type, admission type, and charge range) with configurable margins.
  * Added a dedicated screen to add, edit, filter, export, and print room-category pricing rules.
  * Added room matrix details to patient room charge breakdowns, including matrix value and matrix %.
* **Improvements**
  * Applied room-category margins across room-related charge types and split totals into slot-rate vs matrix components.
  * Preserved fixed pricing for package-locked rooms, with matrix margin set to zero.
  * Added a new entry point for the room-category price matrix from the inward administration area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->