### PR TITLE
fix(admin): recover databases missing AUTO_INCREMENT without requiring login

### DIFF
--- a/docs/superpowers/plans/2026-07-19-pre-login-migration-execution.md
+++ b/docs/superpowers/plans/2026-07-19-pre-login-migration-execution.md
@@ -439,6 +439,21 @@ even when that exact condition is what's blocking login."
 
 ---
 
+**Post-implementation note (Task 4):** live Playwright verification found that
+Task 3's specified feedback markup — `h:outputText escape="false"` wrapping a
+raw `<textarea>#{expr}</textarea>`, copied from this page's sibling tabs —
+never actually rendered its content into the DOM, despite the paired
+`p:outputLabel` correctly appearing. Commit `328498a5d1` replaced it with
+`p:inputTextarea` bound directly via `value`, matching this same page's
+already-working "Combined Errors" field, and changed the feedback-string
+builders from `<br/>` to `\n` accordingly (plain-text rendering, not HTML).
+Scoped to the new tab only — the three pre-existing tabs still use the old
+(also-broken) pattern, left untouched as out of scope. See that commit for
+the exact shipped code; the snippets above reflect the original plan, not
+the final rendering approach.
+
+---
+
 ### Task 4: End-to-end verification
 
 **Files:** none (verification only — no code changes)

--- a/docs/superpowers/plans/2026-07-19-pre-login-migration-execution.md
+++ b/docs/superpowers/plans/2026-07-19-pre-login-migration-execution.md
@@ -1,0 +1,558 @@
+# Pre-Login AUTO_INCREMENT Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an administrator fix a database missing `AUTO_INCREMENT` on `ID` primary keys — which otherwise blocks login itself — from the existing no-login `mf.xhtml` bootstrap page, without needing to log in first.
+
+**Architecture:** Harden two already-written-but-unused methods,
+`DatabaseMigrationFacade.applyAutoIncrementToAllEntityTables()` and
+`AuditDatabaseFacade.applyAutoIncrementToAllEntityTables()`, to match the
+correctness properties of the existing `v2.9.0` migration script (PK-only
+filter, preserve column type, relax `sql_mode`, fail loudly on partial
+failure). Wire them into a new tab on `midding_data_fields.xhtml` (rendered on
+`mf.xhtml`, already `@PermitAll`), backed by a new method on
+`DataAdministrationController` (which already injects both facades and
+already has the `runOnMainDatabase`/`runOnAuditDatabase` checkbox pattern
+used by its sibling tabs).
+
+**Tech Stack:** Java EE 8 (Payara 5, EJB `@Stateless`, JPA/EclipseLink), JSF 2.3 + PrimeFaces (XHTML), raw JDBC via `INFORMATION_SCHEMA`, MySQL.
+
+## Global Constraints
+
+- No new SQL migration script — this reuses the existing `v2.9.0` correctness properties in Java, it does not touch `src/main/resources/db/migrations/`.
+- No changes to `SessionController.recordLogin()`, `ConfigOptionApplicationController`, `DatabaseMigrationController`, or `database_migration.xhtml` — out of scope per the approved spec.
+- `mf.xhtml` must remain reachable without authentication for this feature to work — do not add any login/privilege check to the new controller method or tab.
+- Follow this codebase's existing duplication convention for these two facades (see `executeDdlNative()`, already duplicated verbatim in both) — apply the identical fix to both files rather than extracting a shared helper.
+- JSF/XHTML-only portions of this change (Task 3) do not require compilation, per this project's CLAUDE.md; the Java portions (Tasks 1, 2) do.
+- Spec: `docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md`
+
+---
+
+### Task 1: Harden `DatabaseMigrationFacade.applyAutoIncrementToAllEntityTables()`
+
+**Files:**
+- Modify: `src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java:196-247`
+
+**Interfaces:**
+- Consumes: nothing new — uses the existing private `getRawJdbcConnection()` (line 178-183) and the existing `LOGGER` field (line 172), both already present in this file.
+- Produces: `public List<String> applyAutoIncrementToAllEntityTables() throws Exception` — same signature as before (no caller-visible change), but now throws `SQLException` (a subtype of the declared `Exception`) if any table still lacks `AUTO_INCREMENT` after the fix loop. Task 3 will call this method and must catch `Exception`.
+
+- [ ] **Step 1: Replace the method body**
+
+Replace lines 196-247 (the full existing `applyAutoIncrementToAllEntityTables()` method, from its `@TransactionAttribute` annotation down to its closing `}`) with:
+
+```java
+    /**
+     * Scan every table in the current schema for a BIGINT ID primary key that
+     * lacks AUTO_INCREMENT and apply it, preserving each column's exact type.
+     * Runs outside JTA so DDL implicit COMMITs cannot desync the transaction
+     * manager. Relaxes sql_mode for the duration of the rebuild so a table
+     * whose OTHER columns carry legacy invalid defaults (e.g. TIMESTAMP
+     * DEFAULT '0000-00-00 00:00:00') does not fail with error 1067 when
+     * MODIFY COLUMN re-validates every column.
+     *
+     * Safe to call at every startup: tables that already have AUTO_INCREMENT
+     * are skipped by the information_schema query. FK checks are disabled for
+     * the duration so child-table ALTER statements do not fail.
+     *
+     * @return list of table names that were altered (empty when nothing needed)
+     * @throws Exception (specifically SQLException) if any detected table still
+     *         lacks AUTO_INCREMENT after the fix loop (e.g. lock timeout or
+     *         missing privilege) — callers must not treat a silent partial
+     *         failure as success.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
+        List<String> altered = new ArrayList<>();
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            String detectQuery = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+                    + "WHERE TABLE_SCHEMA = DATABASE() "
+                    + "AND UPPER(COLUMN_NAME) = 'ID' "
+                    + "AND COLUMN_KEY = 'PRI' "
+                    + "AND DATA_TYPE = 'bigint' "
+                    + "AND EXTRA NOT LIKE '%auto_increment%' "
+                    + "ORDER BY TABLE_NAME";
+
+            List<String[]> rows = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    rows.add(new String[]{rs.getString(1), rs.getString(2), rs.getString(3)});
+                }
+            }
+            if (rows.isEmpty()) {
+                return altered;
+            }
+
+            String originalSqlMode;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT @@SESSION.sql_mode")) {
+                originalSqlMode = rs.next() ? rs.getString(1) : "";
+            }
+            try (Statement relaxMode = conn.createStatement()) {
+                relaxMode.execute("SET SESSION sql_mode = ''");
+            }
+            try (Statement fkOff = conn.createStatement()) {
+                fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
+            }
+            try {
+                for (String[] row : rows) {
+                    String tableName = row[0];
+                    String columnName = row[1];
+                    String columnType = row[2];
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN `" + columnName
+                                + "` " + columnType + " NOT NULL AUTO_INCREMENT");
+                        altered.add(tableName);
+                        LOGGER.info("AutoIncrement: applied to table `" + tableName + "`");
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "AutoIncrement: could not alter `" + tableName + "` — skipping", e);
+                    }
+                }
+            } finally {
+                try (Statement fkOn = conn.createStatement()) {
+                    fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
+                }
+                try (PreparedStatement restoreMode = conn.prepareStatement("SET SESSION sql_mode = ?")) {
+                    restoreMode.setString(1, originalSqlMode);
+                    restoreMode.execute();
+                }
+            }
+
+            List<String> remaining = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    remaining.add(rs.getString(1));
+                }
+            }
+            if (!remaining.isEmpty()) {
+                throw new java.sql.SQLException("AUTO_INCREMENT could not be applied to: " + String.join(", ", remaining));
+            }
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            // Without this, the pool hands the connection (with autoCommit=true) to the
+            // next JTA operation, which breaks JTA enlistment and causes
+            // java.lang.reflect.UndeclaredThrowableException wrapped in SQLException.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+        return altered;
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q compile -DskipTests`
+Expected: `BUILD SUCCESS`, no errors referencing `DatabaseMigrationFacade.java`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+git commit -m "fix(migration): harden main-DB AUTO_INCREMENT repair to match v2.9.0
+
+Restrict the scan to primary-key ID columns, preserve each column's exact
+type instead of hardcoding BIGINT, relax sql_mode for the rebuild, and fail
+loudly if any table still lacks AUTO_INCREMENT afterward."
+```
+
+---
+
+### Task 2: Harden `AuditDatabaseFacade.applyAutoIncrementToAllEntityTables()`
+
+**Files:**
+- Modify: `src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java:1-135` (add one import, replace the method body)
+
+**Interfaces:**
+- Consumes: the existing private `getRawJdbcConnection()` (line 129-134) and `LOGGER` field (line 35), both already present.
+- Produces: `public List<String> applyAutoIncrementToAllEntityTables() throws Exception` — identical contract to Task 1's method, same exception-on-partial-failure behavior, applied to the `hmisAuditPU` persistence unit instead of `hmisPU`.
+
+- [ ] **Step 1: Add the `SQLException` import**
+
+In `src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java`, find:
+
+```java
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+```
+
+Replace with:
+
+```java
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+```
+
+- [ ] **Step 2: Replace the method body**
+
+Replace the existing `applyAutoIncrementToAllEntityTables()` method (lines 82-127, from its `@TransactionAttribute` annotation down to its closing `}`) with:
+
+```java
+    /**
+     * Scan every table in the audit database schema for a BIGINT ID primary
+     * key that lacks AUTO_INCREMENT and apply it, preserving each column's
+     * exact type. See DatabaseMigrationFacade.applyAutoIncrementToAllEntityTables()
+     * for the full rationale — this is the identical fix applied to the audit
+     * persistence unit (hmisAuditPU) instead of the main one.
+     *
+     * @return list of table names that were altered (empty when nothing needed)
+     * @throws Exception (specifically SQLException) if any detected table still
+     *         lacks AUTO_INCREMENT after the fix loop.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
+        List<String> altered = new ArrayList<>();
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            String detectQuery = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+                    + "WHERE TABLE_SCHEMA = DATABASE() "
+                    + "AND UPPER(COLUMN_NAME) = 'ID' "
+                    + "AND COLUMN_KEY = 'PRI' "
+                    + "AND DATA_TYPE = 'bigint' "
+                    + "AND EXTRA NOT LIKE '%auto_increment%' "
+                    + "ORDER BY TABLE_NAME";
+
+            List<String[]> rows = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    rows.add(new String[]{rs.getString(1), rs.getString(2), rs.getString(3)});
+                }
+            }
+            if (rows.isEmpty()) {
+                return altered;
+            }
+
+            String originalSqlMode;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT @@SESSION.sql_mode")) {
+                originalSqlMode = rs.next() ? rs.getString(1) : "";
+            }
+            try (Statement relaxMode = conn.createStatement()) {
+                relaxMode.execute("SET SESSION sql_mode = ''");
+            }
+            try (Statement fkOff = conn.createStatement()) {
+                fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
+            }
+            try {
+                for (String[] row : rows) {
+                    String tableName = row[0];
+                    String columnName = row[1];
+                    String columnType = row[2];
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN `" + columnName
+                                + "` " + columnType + " NOT NULL AUTO_INCREMENT");
+                        altered.add(tableName);
+                        LOGGER.info("AuditDB AutoIncrement: applied to table `" + tableName + "`");
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "AuditDB AutoIncrement: could not alter `" + tableName + "` — skipping", e);
+                    }
+                }
+            } finally {
+                try (Statement fkOn = conn.createStatement()) {
+                    fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
+                }
+                try (PreparedStatement restoreMode = conn.prepareStatement("SET SESSION sql_mode = ?")) {
+                    restoreMode.setString(1, originalSqlMode);
+                    restoreMode.execute();
+                }
+            }
+
+            List<String> remaining = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    remaining.add(rs.getString(1));
+                }
+            }
+            if (!remaining.isEmpty()) {
+                throw new SQLException("AUTO_INCREMENT could not be applied to: " + String.join(", ", remaining));
+            }
+        } finally {
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+        return altered;
+    }
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q compile -DskipTests`
+Expected: `BUILD SUCCESS`, no errors referencing `AuditDatabaseFacade.java`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
+git commit -m "fix(migration): harden audit-DB AUTO_INCREMENT repair to match v2.9.0
+
+Identical fix to DatabaseMigrationFacade's main-DB version: restrict to
+primary-key ID columns, preserve exact column type, relax sql_mode, fail
+loudly on partial failure."
+```
+
+---
+
+### Task 3: Wire the fix into `DataAdministrationController` and `mf.xhtml`
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/common/DataAdministrationController.java` (add one public method + two private helpers)
+- Modify: `src/main/webapp/resources/ezcomp/midding_data_fields.xhtml` (add one new `p:tab`)
+
+**Interfaces:**
+- Consumes: `databaseMigrationFacade.applyAutoIncrementToAllEntityTables()` and `auditDatabaseFacade.applyAutoIncrementToAllEntityTables()` from Tasks 1 and 2 (both already `@EJB`-injected in this controller at lines 238-239 and 283). Also reuses the existing `runOnMainDatabase`/`runOnAuditDatabase` fields (lines 331-332) and existing `getExceptionMessage(Exception)` private helper (already used elsewhere in this file, e.g. line 2877).
+- Produces: `public void fixMissingAutoIncrement()` — the JSF action method the new button calls. Populates the existing `mainDatabaseExecutionFeedback`/`auditDatabaseExecutionFeedback` String fields (already have getters at lines 4374 and 4382, already rendered read-only in the XHTML tab family this new tab copies from).
+
+- [ ] **Step 1: Add the controller method**
+
+In `src/main/java/com/divudi/bean/common/DataAdministrationController.java`, immediately after the closing `}` of the existing `fixMissingFields()` method (ends at line 2822, right before the `private void fixMissingFieldsForDatabase(...)` method that starts at line 2824), insert:
+
+```java
+
+    /**
+     * Fix any table whose BIGINT ID primary key is missing AUTO_INCREMENT.
+     * Available on the no-login mf.xhtml bootstrap page because this exact
+     * condition can block login itself: SessionController.recordLogin()
+     * inserts a Logins audit row on every login, and ConfigOptionApplicationController's
+     * @PostConstruct creates missing ConfigOption rows on nearly every page —
+     * both fail with MySQL error 1364 on a database missing AUTO_INCREMENT,
+     * which otherwise makes it impossible to log in and reach the normal
+     * authenticated admin tooling to fix it.
+     */
+    public void fixMissingAutoIncrement() {
+        executionFeedback = "";
+        mainDatabaseExecutionFeedback = "";
+        auditDatabaseExecutionFeedback = "";
+
+        if (runOnMainDatabase) {
+            mainDatabaseExecutionFeedback = fixAutoIncrementForMainDatabase();
+        }
+        if (runOnAuditDatabase) {
+            auditDatabaseExecutionFeedback = fixAutoIncrementForAuditDatabase();
+        }
+    }
+
+    private String fixAutoIncrementForMainDatabase() {
+        try {
+            List<String> altered = databaseMigrationFacade.applyAutoIncrementToAllEntityTables();
+            return formatAutoIncrementResult("Main Database", altered);
+        } catch (Exception e) {
+            return "=== Main Database ===<br/>ERROR: " + getExceptionMessage(e);
+        }
+    }
+
+    private String fixAutoIncrementForAuditDatabase() {
+        try {
+            List<String> altered = auditDatabaseFacade.applyAutoIncrementToAllEntityTables();
+            return formatAutoIncrementResult("Audit Database", altered);
+        } catch (Exception e) {
+            return "=== Audit Database ===<br/>ERROR: " + getExceptionMessage(e);
+        }
+    }
+
+    private String formatAutoIncrementResult(String databaseName, List<String> altered) {
+        if (altered.isEmpty()) {
+            return "=== " + databaseName + " ===<br/>No tables needed fixing — AUTO_INCREMENT already present on every ID primary key.";
+        }
+        return "=== " + databaseName + " ===<br/>Fixed AUTO_INCREMENT on: " + String.join(", ", altered);
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q compile -DskipTests`
+Expected: `BUILD SUCCESS`, no errors referencing `DataAdministrationController.java`.
+
+- [ ] **Step 3: Add the new tab to the XHTML**
+
+In `src/main/webapp/resources/ezcomp/midding_data_fields.xhtml`, immediately after the closing `</p:tab>` of the "Check Missing Fields and Add Fields" tab (the tab that starts `<p:tab title="Check Missing Fields and Add Fields" >` and ends just before `<p:tab title="Run Custom SQL Commands" >`), insert this new tab:
+
+```xml
+                <p:tab title="Fix Missing AUTO_INCREMENT" >
+                    <p:panelGrid columns="2" class="mt-1 w-100" style="border: 10px green;">
+                        <f:facet name="header">
+                            <i class="fa fa-search"/>
+                            <h:outputLabel value="Fix Missing AUTO_INCREMENT" class="mx-2"/>
+                            <p:spacer height="2" width="20" ></p:spacer>
+                            <p:commandButton
+                                ajax="false"
+                                action="#{dataAdministrationController.fixMissingAutoIncrement()}"
+                                value="Fix AUTO_INCREMENT"
+                                styleClass="ui-button-success w-25 ml-2"
+                                title="Scans every table for a BIGINT ID primary key missing AUTO_INCREMENT and re-adds it. Safe to run repeatedly — a no-op on a healthy database."
+                                />
+                        </f:facet>
+
+                        <p:outputLabel value="Instructions" />
+                        <p>A database restored from a dump can lose the AUTO_INCREMENT attribute on ID primary keys, which makes every INSERT into the affected table fail with MySQL error 1364 ("Field 'ID' doesn't have a default value") — including the login-audit insert, which blocks login itself. Click "Fix AUTO_INCREMENT" to scan and repair every affected table on the selected database(s) below.</p>
+
+                        <p:outputLabel value="Database Selection" />
+                        <h:panelGroup layout="block" class="d-flex">
+                            <p:selectBooleanCheckbox
+                                value="#{dataAdministrationController.runOnMainDatabase}"
+                                class="mr-2"/>
+                            <h:outputText value="Main Database (hmisPU)" class="mr-3"/>
+                            <p:selectBooleanCheckbox
+                                value="#{dataAdministrationController.runOnAuditDatabase}"
+                                class="mr-2"/>
+                            <h:outputText value="Audit Database (hmisAuditPU)"/>
+                        </h:panelGroup>
+
+                        <p:outputLabel value="Main Database Results" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}"/>
+                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}">
+                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.mainDatabaseExecutionFeedback}</textarea>
+                        </h:outputText>
+
+                        <p:outputLabel value="Audit Database Results" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}"/>
+                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}">
+                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.auditDatabaseExecutionFeedback}</textarea>
+                        </h:outputText>
+                    </p:panelGrid>
+
+                </p:tab>
+
+```
+
+This is JSF/XHTML-only (no Java touched in this step), so per CLAUDE.md it does not require compilation — but it must still be verified end-to-end in Task 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/common/DataAdministrationController.java src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+git commit -m "feat(admin): add no-login AUTO_INCREMENT fix tab to mf.xhtml
+
+Wires the hardened DatabaseMigrationFacade/AuditDatabaseFacade repair
+methods into a new tab on the existing PermitAll bootstrap page, so an
+admin can recover a database missing AUTO_INCREMENT on ID primary keys
+even when that exact condition is what's blocking login."
+```
+
+---
+
+### Task 4: End-to-end verification
+
+**Files:** none (verification only — no code changes)
+
+**Interfaces:**
+- Consumes: the running local Payara deployment with Tasks 1-3 built and redeployed, and direct MySQL access to the local dev database (credentials in `C:\Credentials\`, per this project's `database-guide` skill).
+
+- [ ] **Step 1: Rebuild and redeploy locally**
+
+Follow this project's `playwright-e2e` skill §0a (rebuild and redeploy local code changes) to package and redeploy the WAR to the local Payara domain so Tasks 1-3's changes are live.
+
+- [ ] **Step 2: Reproduce the blocking condition on a disposable table**
+
+Pick a low-traffic table with a `BIGINT` `ID` primary key on the local dev database (e.g. a lookup/reference table, NOT `webuser`, `bill`, or anything with live data). Confirm its current `AUTO_INCREMENT` state, strip it, and confirm the break:
+
+```sql
+SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, EXTRA
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '<chosen_table>' AND COLUMN_NAME = 'ID';
+
+ALTER TABLE <chosen_table> MODIFY COLUMN ID BIGINT NOT NULL;
+
+SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, EXTRA
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '<chosen_table>' AND COLUMN_NAME = 'ID';
+```
+
+Expected: the `EXTRA` column no longer contains `auto_increment` after the `ALTER TABLE`.
+
+- [ ] **Step 3: Verify `mf.xhtml` is reachable without login and shows the new tab**
+
+Using Playwright MCP (per the `playwright-e2e` skill), in a fresh browser context with no prior session:
+
+1. Navigate directly to `http://localhost:8080/rh/faces/mf.xhtml` (adjust context path per local deployment) without logging in first.
+2. Take a snapshot and confirm the page loads (not redirected to login) and the "Fix Missing AUTO_INCREMENT" tab is present in the accordion.
+3. Click into that tab and confirm the "Fix AUTO_INCREMENT" button and both database checkboxes are visible.
+
+- [ ] **Step 4: Execute the fix and verify via database**
+
+1. With only "Main Database (hmisPU)" checked, click "Fix AUTO_INCREMENT".
+2. Confirm the "Main Database Results" panel appears and lists the chosen table name (e.g. "Fixed AUTO_INCREMENT on: `<chosen_table>`").
+3. Re-run the verification query from Step 2 and confirm `EXTRA` now contains `auto_increment` again.
+
+- [ ] **Step 5: Verify idempotency**
+
+Click "Fix AUTO_INCREMENT" again with the database already healthy. Confirm the result panel now reads "No tables needed fixing — AUTO_INCREMENT already present on every ID primary key." (no errors, no duplicate ALTER attempts visible in `server.log`).
+
+- [ ] **Step 6: Verify the original symptom is resolved**
+
+If feasible in the local environment, reproduce the original login-blocking scenario by stripping `AUTO_INCREMENT` specifically from the `LOGINS` and `CONFIG_OPTION` tables (the two confirmed affected on qa4), confirm login fails with the MySQL 1364 error (matching the original qa4 symptom), then use the new tab to fix both tables and confirm a normal login now succeeds.
+
+- [ ] **Step 7: Restore local state**
+
+Confirm no other local tables were altered unexpectedly (the disposable test table from Step 2 is now correctly back to a healthy `AUTO_INCREMENT` state — no restoration needed, since the fix is the intended end state, not a temporary change to revert).
+
+---
+
+### Task 5: Push and open PR
+
+**Files:** none (git/GitHub operations only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin 22314-pre-login-migration-execution
+```
+
+- [ ] **Step 2: Open the PR against `development`**
+
+```bash
+gh pr create --base development --title "fix(admin): recover databases missing AUTO_INCREMENT without requiring login" --body "$(cat <<'EOF'
+## Summary
+- Hardens two already-written-but-unused facade methods (`DatabaseMigrationFacade`/`AuditDatabaseFacade`.`applyAutoIncrementToAllEntityTables()`) to match `v2.9.0`'s correctness: primary-key-only filter, preserve each column's exact type, relax `sql_mode` for the rebuild, and fail loudly on partial failure instead of silently logging a warning.
+- Wires them into a new tab on the existing no-login `mf.xhtml` bootstrap page, so an admin can recover a database that's missing `AUTO_INCREMENT` on `ID` primary keys even when that exact condition is what's blocking login (`SessionController.recordLogin()` inserts an audit row on every login and fails the same way).
+- Design: `docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md`
+
+## Test plan
+- [x] Reproduced the blocking condition locally by stripping AUTO_INCREMENT from a disposable table
+- [x] Verified `mf.xhtml` is reachable without login and the new tab renders
+- [x] Verified the fix via direct `INFORMATION_SCHEMA` queries before/after
+- [x] Verified idempotency (re-running reports no tables needed fixing)
+- [x] Verified login succeeds again after fixing `LOGINS`/`CONFIG_OPTION`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Record the PR URL**
+
+Note the PR URL returned by `gh pr create` for tracking through the review loop in Task 6.
+
+---
+
+### Task 6: Loop on CI and automated review until mergeable
+
+**Files:** varies — whatever CI/CodeRabbit/Codex flags
+
+- [ ] **Step 1: Check CI status**
+
+Run: `gh pr checks <PR-number>`
+If any check fails, read the failure log (`gh run view <run-id> --log-failed` or equivalent), diagnose the root cause, fix it in a new commit, and push. Repeat until all checks pass.
+
+- [ ] **Step 2: Address automated review comments**
+
+Use this project's `review-pr` skill workflow: fetch CodeRabbit/Codex comments on the PR, investigate each against the actual code (per this project's CLAUDE.md §"After applying any CodeRabbit/Codex fix" — verify method names against the real entity/class before pushing), apply valid fixes, push, and repeat until no unresolved actionable comments remain.
+
+- [ ] **Step 3: Confirm mergeable state**
+
+Run: `gh pr view <PR-number> --json mergeable,mergeStateStatus,statusCheckRollup`
+Expected: `"mergeable": "MERGEABLE"` and all status checks green. Do not merge — this is the user's call at PR review.
+
+## Self-Review Notes
+
+- **Spec coverage:** Design decisions 1-7 in the spec are all covered — 1-2 by Tasks 1-2, 3-4 by Task 3, 5 requires no code change (verified by inspection: the new tab adds no new authorization check, matching decision 5), 6 is explicitly a non-goal (no task touches `recordLogin`/`ConfigOptionApplicationController`), 7 is explicitly a non-goal (no task touches `DatabaseMigrationController`/`database_migration.xhtml`/the `DatabaseMigration` entity).
+- **Type consistency:** `applyAutoIncrementToAllEntityTables()` returns `List<String>` and throws `Exception` in both Task 1 and Task 2, matching what Task 3's `fixAutoIncrementForMainDatabase()`/`fixAutoIncrementForAuditDatabase()` expect (`catch (Exception e)`). `mainDatabaseExecutionFeedback`/`auditDatabaseExecutionFeedback` are `String` fields with existing getters already rendered by the XHTML pattern Task 3 copies.
+- **No placeholders:** all code blocks are complete; no TBD/TODO markers.

--- a/docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md
+++ b/docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md
@@ -1,0 +1,119 @@
+# Execute Pending Migrations from the No-Login Bootstrap Page
+
+## Context
+
+On the qa4 environment, every login attempt fails with a 500
+(`javax.ejb.EJBException: Transaction aborted`, ultimately
+`java.sql.SQLException: Field 'ID' doesn't have a default value`, MySQL 1364).
+Root cause: several tables (at least `LOGINS`, `CONFIG_OPTION`) lost
+`AUTO_INCREMENT` on their `ID` primary key, likely during a database restore.
+Entities map `@GeneratedValue(strategy = IDENTITY)`, which requires the
+underlying column to be `AUTO_INCREMENT` — without it, every `INSERT` into an
+affected table fails.
+
+This blocks the app in two places:
+
+1. `SessionController.recordLogin()` (`SessionController.java:307-335`) inserts
+   a `Logins` audit row during `selectDepartment()`/
+   `loginActionWithoutDepartment()`. When that insert fails, the exception is
+   not caught and the whole login/department-selection action fails — **no
+   user, including an admin, can complete login** on an affected database.
+2. `ConfigOptionApplicationController.init()` (`@PostConstruct`,
+   `@ApplicationScoped`) creates missing `ConfigOption` rows on nearly every
+   page load via `createOptionIfNotExists()`. On an affected database this
+   insert also fails, and since it's uncaught, it breaks page rendering
+   application-wide.
+
+A migration to fix exactly this already exists and requires no new SQL:
+`src/main/resources/db/migrations/v2.9.0/migration.sql` dynamically scans
+`INFORMATION_SCHEMA` for every table whose single-column `BIGINT` `ID` primary
+key lacks `AUTO_INCREMENT` and re-adds it. It's idempotent and a no-op on
+healthy databases.
+
+The problem is reachability, not tooling: `v2.9.0` can only be executed today
+through `database_migration.xhtml`, which is gated by
+`DatabaseMigrationController.isAuthorized()` — requiring a logged-in SuperAdmin.
+On an affected database, login never completes, so this page can never be
+reached.
+
+Separately, `mf.xhtml` (backed by `midding_data_fields.xhtml`) already exists
+as a **no-login bootstrap page** — it's `@PermitAll`
+(`DatabaseMigrationService`, a `@Singleton @Startup` EJB, defaults
+`migrationPending = true` on every deploy/restart until an admin explicitly
+marks it complete or not-necessary). It currently offers DDL-based table/field
+creation, a "missing fields" checker, and a raw "Run Custom SQL" box — but has
+no awareness of the versioned migration-tracking system
+(`DatabaseMigration` entity / `DatabaseMigrationFacade` /
+`MigrationDiscoveryService`) that `database_migration.xhtml` uses.
+
+## Decisions
+
+1. **No new SQL or detection logic.** Reuse `v2.9.0/migration.sql` as-is via
+   the existing migration-tracking system. This design is purely about
+   reachability.
+
+2. **Extract the execution engine into a shared, stateless service.**
+   `DatabaseMigrationController` currently owns
+   `executeSingleMigration()`, `executeSqlScript()`, `splitSqlStatements()`,
+   `isDdlStatement()`, `usesMysqlConnectionScopedState()`,
+   `getIdempotentSkipReason()`, etc. as private methods on a `@SessionScoped`
+   bean that reads `sessionController.getLoggedUser()` directly. Move these
+   into a new `@Stateless` EJB, `com.divudi.service.MigrationExecutionService`,
+   parameterized with a nullable `WebUser executedBy` instead of reading the
+   session directly. `DatabaseMigrationController` keeps its
+   `isAuthorized()` gate and delegates to the shared service, passing the
+   logged-in user. This avoids duplicating the SQL-execution engine (needed
+   intact, including the DELIMITER/stored-procedure handling `v2.9.0`
+   requires) across two code paths.
+
+3. **New UI: 4th tab on the existing no-login page.** Add a "Pending Schema/
+   Data Migrations" tab to `midding_data_fields.xhtml` (rendered on `mf.xhtml`,
+   already reachable without login while `databaseMigrationPending` is true).
+   It lists migrations from `MigrationDiscoveryService`/
+   `DatabaseMigrationFacade` that are not yet `SUCCESS`, each with an
+   "Execute" button, plus an "Execute All Pending" button — mirroring
+   `database_migration.xhtml`'s existing UX (list, per-item execute, execute-
+   all, live log/status per migration).
+
+4. **Backing controller: `DataAdministrationController`** (already backs
+   `mf.xhtml`). Add `pendingMigrations` (list), `executeMigration(MigrationInfo)`,
+   and `executeAllPendingMigrations()`, delegating to
+   `MigrationExecutionService` with `executedBy = null` (the
+   `DatabaseMigration.executed_by_id` column is already a nullable FK, per
+   `MIGRATION_SYSTEM_DEPLOYMENT.md`'s `CREATE TABLE database_migration`
+   definition).
+
+5. **No new authorization exposure.** `mf.xhtml` already self-locks (an admin
+   clicks "Mark Migration as Complete"/"Mark as Not Necessary" once the
+   database is healthy, setting `databaseMigrationPending = false` and
+   restricting the page to admins again). It also already exposes a raw
+   arbitrary-SQL executor (existing Tab 3, "Run Custom SQL Commands").
+   Executing only vetted, repo-shipped migration files by version number is
+   strictly narrower than that existing capability, so this does not widen
+   the pre-login attack surface.
+
+6. **No changes to `recordLogin()`/`ConfigOptionApplicationController.init()`
+   resiliency.** Out of scope per explicit decision: the mf.xhtml route is the
+   sanctioned bootstrap-recovery path; login/config-option code stays as-is.
+
+## Non-goals
+
+- Does not fix `SessionController.recordLogin()`'s uncaught exception path or
+  `ConfigOptionApplicationController.init()`'s lack of per-option error
+  isolation. Those remain unchanged.
+- Does not add a new migration script — `v2.9.0` is reused verbatim.
+- Does not change `database_migration.xhtml` or `DatabaseMigrationController`'s
+  authorization model.
+
+## Testing
+
+Local verification: temporarily strip `AUTO_INCREMENT` from a test table's
+`ID` column (e.g. via `ALTER TABLE ... MODIFY id BIGINT NOT NULL`), confirm:
+
+1. Login fails with the same 1364 error, reproducing the qa4 symptom.
+2. `mf.xhtml` is reachable without logging in, and the new tab shows `v2.9.0`
+   (or the then-current AUTO_INCREMENT-fix migration) as pending.
+3. Clicking "Execute" runs it successfully and the migration is recorded with
+   `executed_by = null`.
+4. After execution, login succeeds and `ConfigOption` auto-creation no longer
+   throws.

--- a/docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md
+++ b/docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md
@@ -24,96 +24,144 @@ This blocks the app in two places:
    insert also fails, and since it's uncaught, it breaks page rendering
    application-wide.
 
-A migration to fix exactly this already exists and requires no new SQL:
-`src/main/resources/db/migrations/v2.9.0/migration.sql` dynamically scans
-`INFORMATION_SCHEMA` for every table whose single-column `BIGINT` `ID` primary
-key lacks `AUTO_INCREMENT` and re-adds it. It's idempotent and a no-op on
-healthy databases.
-
-The problem is reachability, not tooling: `v2.9.0` can only be executed today
+A migration to fix exactly this already exists and requires no new SQL logic
+to design from scratch: `src/main/resources/db/migrations/v2.9.0/migration.sql`
+dynamically scans `INFORMATION_SCHEMA` for every table whose single-column
+`BIGINT` `ID` primary key lacks `AUTO_INCREMENT` and re-adds it, preserving
+each column's exact type, relaxing `sql_mode` for the rebuild, and failing
+loudly (`SIGNAL SQLSTATE '45000'`) if any table couldn't be fixed. It's
+idempotent and a no-op on healthy databases. It can only be executed today
 through `database_migration.xhtml`, which is gated by
-`DatabaseMigrationController.isAuthorized()` — requiring a logged-in SuperAdmin.
-On an affected database, login never completes, so this page can never be
-reached.
+`DatabaseMigrationController.isAuthorized()` — requiring a logged-in
+SuperAdmin. On an affected database, login never completes, so this page can
+never be reached.
 
-Separately, `mf.xhtml` (backed by `midding_data_fields.xhtml`) already exists
-as a **no-login bootstrap page** — it's `@PermitAll`
-(`DatabaseMigrationService`, a `@Singleton @Startup` EJB, defaults
-`migrationPending = true` on every deploy/restart until an admin explicitly
-marks it complete or not-necessary). It currently offers DDL-based table/field
-creation, a "missing fields" checker, and a raw "Run Custom SQL" box — but has
-no awareness of the versioned migration-tracking system
-(`DatabaseMigration` entity / `DatabaseMigrationFacade` /
-`MigrationDiscoveryService`) that `database_migration.xhtml` uses.
+Separately, `mf.xhtml` (backed by `midding_data_fields.xhtml` /
+`DataAdministrationController`) already exists as a **no-login bootstrap
+page** — it's `@PermitAll` (`DatabaseMigrationService`, a `@Singleton
+@Startup` EJB, defaults `migrationPending = true` on every deploy/restart
+until an admin explicitly marks it complete or not-necessary). It currently
+offers DDL-based table/field creation, a "missing fields" checker, and a raw
+"Run Custom SQL" box, gated by the same `runOnMainDatabase`/
+`runOnAuditDatabase` checkboxes and already injecting both
+`DatabaseMigrationFacade` and `AuditDatabaseFacade`.
+
+**Key discovery:** both of those facades already contain an
+`applyAutoIncrementToAllEntityTables()` method — a pure-Java equivalent of the
+`v2.9.0` fix — but neither is called from anywhere in the codebase. They are
+dead code, seemingly written for exactly this scenario and never wired up.
+Their current implementation is rougher than `v2.9.0`: no `COLUMN_KEY='PRI'`
+restriction, no case-insensitive column-name match, hardcodes `BIGINT` instead
+of preserving each column's actual type, doesn't relax `sql_mode`, and
+silently logs-and-continues instead of failing loudly when a table can't be
+fixed.
 
 ## Decisions
 
-1. **No new SQL or detection logic.** Reuse `v2.9.0/migration.sql` as-is via
-   the existing migration-tracking system. This design is purely about
-   reachability.
+1. **No new detection SQL.** Harden the existing (currently unused)
+   `applyAutoIncrementToAllEntityTables()` methods on `DatabaseMigrationFacade`
+   (main DB) and `AuditDatabaseFacade` (audit DB) to match `v2.9.0`'s
+   correctness properties, then call them — rather than extracting a shared
+   execution engine out of `DatabaseMigrationController` and running the SQL
+   file through the versioned migration-tracking system. This is a much
+   smaller change: no new service class, no changes to
+   `DatabaseMigrationController` or its authorization model at all.
 
-2. **Extract the execution engine into a shared, stateless service.**
-   `DatabaseMigrationController` currently owns
-   `executeSingleMigration()`, `executeSqlScript()`, `splitSqlStatements()`,
-   `isDdlStatement()`, `usesMysqlConnectionScopedState()`,
-   `getIdempotentSkipReason()`, etc. as private methods on a `@SessionScoped`
-   bean that reads `sessionController.getLoggedUser()` directly. Move these
-   into a new `@Stateless` EJB, `com.divudi.service.MigrationExecutionService`,
-   parameterized with a nullable `WebUser executedBy` instead of reading the
-   session directly. `DatabaseMigrationController` keeps its
-   `isAuthorized()` gate and delegates to the shared service, passing the
-   logged-in user. This avoids duplicating the SQL-execution engine (needed
-   intact, including the DELIMITER/stored-procedure handling `v2.9.0`
-   requires) across two code paths.
+2. **Harden both `applyAutoIncrementToAllEntityTables()` methods** (identical
+   fix applied to both `DatabaseMigrationFacade.java` and
+   `AuditDatabaseFacade.java`, matching this codebase's existing convention of
+   duplicating this exact kind of native-JDBC helper per facade — see
+   `executeDdlNative()`, already duplicated verbatim between the two):
+   - Restrict the `INFORMATION_SCHEMA.COLUMNS` scan to `COLUMN_KEY = 'PRI'`
+     (primary keys only) and match `COLUMN_NAME` case-insensitively
+     (`UPPER(COLUMN_NAME) = 'ID'`), matching `v2.9.0`.
+   - Select `COLUMN_TYPE` per row and use it verbatim in the `ALTER TABLE ...
+     MODIFY COLUMN` statement instead of hardcoding `BIGINT`, so a table with
+     e.g. `bigint(20) unsigned` keeps its exact type.
+   - Relax `sql_mode` to `''` for the duration of the rebuild (save the
+     original value first, restore it in a `finally`), so a table with a
+     legacy invalid default (e.g. `TIMESTAMP DEFAULT '0000-00-00 00:00:00'`)
+     doesn't fail with error 1067 when `MODIFY COLUMN` re-validates every
+     column.
+   - After the fix loop, re-run the detection query. If any table is still
+     missing `AUTO_INCREMENT`, throw an `SQLException` listing the remaining
+     table names instead of returning silently — callers must be able to
+     detect partial failure.
 
-3. **New UI: 4th tab on the existing no-login page.** Add a "Pending Schema/
-   Data Migrations" tab to `midding_data_fields.xhtml` (rendered on `mf.xhtml`,
-   already reachable without login while `databaseMigrationPending` is true).
-   It lists migrations from `MigrationDiscoveryService`/
-   `DatabaseMigrationFacade` that are not yet `SUCCESS`, each with an
-   "Execute" button, plus an "Execute All Pending" button — mirroring
-   `database_migration.xhtml`'s existing UX (list, per-item execute, execute-
-   all, live log/status per migration).
+3. **New UI: 4th tab on the existing no-login page.** Add a "Fix Missing
+   AUTO_INCREMENT" tab to `midding_data_fields.xhtml` (rendered on `mf.xhtml`,
+   already reachable without login while `databaseMigrationPending` is true),
+   with a single "Fix AUTO_INCREMENT" button gated by the existing
+   `runOnMainDatabase`/`runOnAuditDatabase` checkboxes, mirroring the
+   existing "Fix Missing Fields" tab's structure exactly.
 
 4. **Backing controller: `DataAdministrationController`** (already backs
-   `mf.xhtml`). Add `pendingMigrations` (list), `executeMigration(MigrationInfo)`,
-   and `executeAllPendingMigrations()`, delegating to
-   `MigrationExecutionService` with `executedBy = null` (the
-   `DatabaseMigration.executed_by_id` column is already a nullable FK, per
-   `MIGRATION_SYSTEM_DEPLOYMENT.md`'s `CREATE TABLE database_migration`
-   definition).
+   `mf.xhtml`, already injects both `databaseMigrationFacade` and
+   `auditDatabaseFacade`). Add one new method,
+   `fixMissingAutoIncrement()`, that calls
+   `databaseMigrationFacade.applyAutoIncrementToAllEntityTables()` when
+   `runOnMainDatabase` is checked and
+   `auditDatabaseFacade.applyAutoIncrementToAllEntityTables()` when
+   `runOnAuditDatabase` is checked, reporting the altered-table list (or
+   error) into the existing `mainDatabaseExecutionFeedback`/
+   `auditDatabaseExecutionFeedback` fields already rendered by that tab
+   family.
 
 5. **No new authorization exposure.** `mf.xhtml` already self-locks (an admin
    clicks "Mark Migration as Complete"/"Mark as Not Necessary" once the
    database is healthy, setting `databaseMigrationPending = false` and
    restricting the page to admins again). It also already exposes a raw
    arbitrary-SQL executor (existing Tab 3, "Run Custom SQL Commands").
-   Executing only vetted, repo-shipped migration files by version number is
-   strictly narrower than that existing capability, so this does not widen
-   the pre-login attack surface.
+   Calling a fixed, narrowly-scoped Java method is strictly narrower than
+   that existing capability, so this does not widen the pre-login attack
+   surface.
 
 6. **No changes to `recordLogin()`/`ConfigOptionApplicationController.init()`
    resiliency.** Out of scope per explicit decision: the mf.xhtml route is the
    sanctioned bootstrap-recovery path; login/config-option code stays as-is.
+
+7. **`v2.9.0` stays untouched and unrun by this path.** Since this fix
+   bypasses the `DatabaseMigration` tracking entity entirely, `v2.9.0` will
+   still show as "pending" on `database_migration.xhtml` after this tab is
+   used. That's an accepted, harmless gap: once login works again, an admin
+   who later executes `v2.9.0` through the normal page gets a fast no-op (the
+   scan finds nothing left to fix) and the tracked history is closed out
+   properly then.
 
 ## Non-goals
 
 - Does not fix `SessionController.recordLogin()`'s uncaught exception path or
   `ConfigOptionApplicationController.init()`'s lack of per-option error
   isolation. Those remain unchanged.
-- Does not add a new migration script — `v2.9.0` is reused verbatim.
-- Does not change `database_migration.xhtml` or `DatabaseMigrationController`'s
-  authorization model.
+- Does not touch `database_migration.xhtml`, `DatabaseMigrationController`, or
+  the `DatabaseMigration` tracking entity/table.
+- Does not add a `MigrationExecutionService` or otherwise refactor
+  `DatabaseMigrationController`.
 
 ## Testing
 
-Local verification: temporarily strip `AUTO_INCREMENT` from a test table's
-`ID` column (e.g. via `ALTER TABLE ... MODIFY id BIGINT NOT NULL`), confirm:
+No unit-test harness exists for this subsystem — both facades talk to a live
+JDBC connection pulled from EclipseLink's JNDI datasource, which needs a real
+Payara + MySQL, matching why no existing tests touch
+`DatabaseMigrationFacade`/`AuditDatabaseFacade` today. Verify manually
+instead, per this project's own migration-development-guide.md "Local
+Testing" convention (backup, exercise through the admin UI, restore if
+needed):
 
-1. Login fails with the same 1364 error, reproducing the qa4 symptom.
-2. `mf.xhtml` is reachable without logging in, and the new tab shows `v2.9.0`
-   (or the then-current AUTO_INCREMENT-fix migration) as pending.
-3. Clicking "Execute" runs it successfully and the migration is recorded with
-   `executed_by = null`.
-4. After execution, login succeeds and `ConfigOption` auto-creation no longer
-   throws.
+1. On the local dev database, strip `AUTO_INCREMENT` from a disposable test
+   table's `BIGINT` `ID` primary key (e.g. `ALTER TABLE some_table MODIFY id
+   BIGINT NOT NULL`) and confirm an `INSERT` into it now fails with MySQL
+   1364, reproducing the qa4 symptom.
+2. Confirm `mf.xhtml` is reachable without logging in (fresh session, no
+   prior auth), and the new tab is visible with its Fix button.
+3. Click "Fix AUTO_INCREMENT" with `runOnMainDatabase` checked; confirm the
+   feedback panel lists the affected table and the column is fixed (query
+   `INFORMATION_SCHEMA.COLUMNS` directly to confirm `EXTRA` now contains
+   `auto_increment`).
+4. Re-click the button with the database already healthy; confirm it reports
+   no tables altered (idempotency).
+5. Repeat steps 1 and 3 against the audit database/`runOnAuditDatabase`
+   checkbox.
+6. Confirm a normal login now succeeds (the login-blocking symptom is gone)
+   once the affected tables — `LOGINS`, `CONFIG_OPTION` in the original qa4
+   case — are fixed this way.

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2821,6 +2821,54 @@ public class DataAdministrationController implements Serializable {
         }
     }
 
+    /**
+     * Fix any table whose BIGINT ID primary key is missing AUTO_INCREMENT.
+     * Available on the no-login mf.xhtml bootstrap page because this exact
+     * condition can block login itself: SessionController.recordLogin()
+     * inserts a Logins audit row on every login, and ConfigOptionApplicationController's
+     * @PostConstruct creates missing ConfigOption rows on nearly every page —
+     * both fail with MySQL error 1364 on a database missing AUTO_INCREMENT,
+     * which otherwise makes it impossible to log in and reach the normal
+     * authenticated admin tooling to fix it.
+     */
+    public void fixMissingAutoIncrement() {
+        executionFeedback = "";
+        mainDatabaseExecutionFeedback = "";
+        auditDatabaseExecutionFeedback = "";
+
+        if (runOnMainDatabase) {
+            mainDatabaseExecutionFeedback = fixAutoIncrementForMainDatabase();
+        }
+        if (runOnAuditDatabase) {
+            auditDatabaseExecutionFeedback = fixAutoIncrementForAuditDatabase();
+        }
+    }
+
+    private String fixAutoIncrementForMainDatabase() {
+        try {
+            List<String> altered = databaseMigrationFacade.applyAutoIncrementToAllEntityTables();
+            return formatAutoIncrementResult("Main Database", altered);
+        } catch (Exception e) {
+            return "=== Main Database ===<br/>ERROR: " + getExceptionMessage(e);
+        }
+    }
+
+    private String fixAutoIncrementForAuditDatabase() {
+        try {
+            List<String> altered = auditDatabaseFacade.applyAutoIncrementToAllEntityTables();
+            return formatAutoIncrementResult("Audit Database", altered);
+        } catch (Exception e) {
+            return "=== Audit Database ===<br/>ERROR: " + getExceptionMessage(e);
+        }
+    }
+
+    private String formatAutoIncrementResult(String databaseName, List<String> altered) {
+        if (altered.isEmpty()) {
+            return "=== " + databaseName + " ===<br/>No tables needed fixing — AUTO_INCREMENT already present on every ID primary key.";
+        }
+        return "=== " + databaseName + " ===<br/>Fixed AUTO_INCREMENT on: " + String.join(", ", altered);
+    }
+
     private void fixMissingFieldsForDatabase(AbstractFacade<?> facade, String databaseName) {
         StringBuilder executionResults = new StringBuilder();
         executionResults.append("=== ").append(databaseName).append(" ===<br/>");

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -2849,7 +2849,7 @@ public class DataAdministrationController implements Serializable {
             List<String> altered = databaseMigrationFacade.applyAutoIncrementToAllEntityTables();
             return formatAutoIncrementResult("Main Database", altered);
         } catch (Exception e) {
-            return "=== Main Database ===<br/>ERROR: " + getExceptionMessage(e);
+            return "=== Main Database ===\nERROR: " + getExceptionMessage(e);
         }
     }
 
@@ -2858,15 +2858,15 @@ public class DataAdministrationController implements Serializable {
             List<String> altered = auditDatabaseFacade.applyAutoIncrementToAllEntityTables();
             return formatAutoIncrementResult("Audit Database", altered);
         } catch (Exception e) {
-            return "=== Audit Database ===<br/>ERROR: " + getExceptionMessage(e);
+            return "=== Audit Database ===\nERROR: " + getExceptionMessage(e);
         }
     }
 
     private String formatAutoIncrementResult(String databaseName, List<String> altered) {
         if (altered.isEmpty()) {
-            return "=== " + databaseName + " ===<br/>No tables needed fixing — AUTO_INCREMENT already present on every ID primary key.";
+            return "=== " + databaseName + " ===\nNo tables needed fixing — AUTO_INCREMENT already present on every ID primary key.";
         }
-        return "=== " + databaseName + " ===<br/>Fixed AUTO_INCREMENT on: " + String.join(", ", altered);
+        return "=== " + databaseName + " ===\nFixed AUTO_INCREMENT on: " + String.join(", ", altered);
     }
 
     private void fixMissingFieldsForDatabase(AbstractFacade<?> facade, String databaseName) {

--- a/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
+++ b/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
@@ -8,6 +8,7 @@ import com.divudi.core.entity.Item;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,35 +80,61 @@ public class AuditDatabaseFacade extends AbstractFacade<Item> {
         }
     }
 
+    /**
+     * Scan every table in the audit database schema for a BIGINT ID primary
+     * key that lacks AUTO_INCREMENT and apply it, preserving each column's
+     * exact type. See DatabaseMigrationFacade.applyAutoIncrementToAllEntityTables()
+     * for the full rationale — this is the identical fix applied to the audit
+     * persistence unit (hmisAuditPU) instead of the main one.
+     *
+     * @return list of table names that were altered (empty when nothing needed)
+     * @throws Exception (specifically SQLException) if any detected table still
+     *         lacks AUTO_INCREMENT after the fix loop.
+     */
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
         List<String> altered = new ArrayList<>();
         Connection conn = getRawJdbcConnection();
         try {
             conn.setAutoCommit(true);
-            String query = "SELECT TABLE_NAME FROM information_schema.COLUMNS "
+            String detectQuery = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
                     + "WHERE TABLE_SCHEMA = DATABASE() "
-                    + "AND COLUMN_NAME = 'ID' "
+                    + "AND UPPER(COLUMN_NAME) = 'ID' "
+                    + "AND COLUMN_KEY = 'PRI' "
                     + "AND DATA_TYPE = 'bigint' "
                     + "AND EXTRA NOT LIKE '%auto_increment%' "
                     + "ORDER BY TABLE_NAME";
-            List<String> tables = new ArrayList<>();
-            try (PreparedStatement ps = conn.prepareStatement(query);
+
+            List<String[]> rows = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
                  ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    tables.add(rs.getString(1));
+                    rows.add(new String[]{rs.getString(1), rs.getString(2), rs.getString(3)});
                 }
             }
-            if (tables.isEmpty()) {
+            if (rows.isEmpty()) {
                 return altered;
+            }
+
+            String originalSqlMode;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT @@SESSION.sql_mode")) {
+                originalSqlMode = rs.next() ? rs.getString(1) : "";
+            }
+            try (Statement relaxMode = conn.createStatement()) {
+                relaxMode.execute("SET SESSION sql_mode = ''");
             }
             try (Statement fkOff = conn.createStatement()) {
                 fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
             }
             try {
-                for (String tableName : tables) {
+                for (String[] row : rows) {
+                    String tableName = row[0];
+                    String columnName = row[1];
+                    String columnType = row[2];
                     try (Statement stmt = conn.createStatement()) {
-                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN `" + columnName
+                                + "` " + columnType + " NOT NULL AUTO_INCREMENT");
                         altered.add(tableName);
                         LOGGER.info("AuditDB AutoIncrement: applied to table `" + tableName + "`");
                     } catch (Exception e) {
@@ -118,6 +145,21 @@ public class AuditDatabaseFacade extends AbstractFacade<Item> {
                 try (Statement fkOn = conn.createStatement()) {
                     fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
                 }
+                try (PreparedStatement restoreMode = conn.prepareStatement("SET SESSION sql_mode = ?")) {
+                    restoreMode.setString(1, originalSqlMode);
+                    restoreMode.execute();
+                }
+            }
+
+            List<String> remaining = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    remaining.add(rs.getString(1));
+                }
+            }
+            if (!remaining.isEmpty()) {
+                throw new SQLException("AUTO_INCREMENT could not be applied to: " + String.join(", ", remaining));
             }
         } finally {
             try { conn.setAutoCommit(false); } catch (Exception ignored) { }

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -183,15 +183,23 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
     }
 
     /**
-     * Scan every table in the current schema for a BIGINT column named ID that
-     * lacks AUTO_INCREMENT and apply it.  Runs outside JTA so DDL implicit
-     * COMMITs cannot desync the transaction manager.
+     * Scan every table in the current schema for a BIGINT ID primary key that
+     * lacks AUTO_INCREMENT and apply it, preserving each column's exact type.
+     * Runs outside JTA so DDL implicit COMMITs cannot desync the transaction
+     * manager. Relaxes sql_mode for the duration of the rebuild so a table
+     * whose OTHER columns carry legacy invalid defaults (e.g. TIMESTAMP
+     * DEFAULT '0000-00-00 00:00:00') does not fail with error 1067 when
+     * MODIFY COLUMN re-validates every column.
      *
-     * Safe to call at every startup: tables that already have AUTO_INCREMENT are
-     * skipped by the information_schema query.  FK checks are disabled for the
-     * duration so child-table ALTER statements do not fail.
+     * Safe to call at every startup: tables that already have AUTO_INCREMENT
+     * are skipped by the information_schema query. FK checks are disabled for
+     * the duration so child-table ALTER statements do not fail.
      *
      * @return list of table names that were altered (empty when nothing needed)
+     * @throws Exception (specifically SQLException) if any detected table still
+     *         lacks AUTO_INCREMENT after the fix loop (e.g. lock timeout or
+     *         missing privilege) — callers must not treat a silent partial
+     *         failure as success.
      */
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public List<String> applyAutoIncrementToAllEntityTables() throws Exception {
@@ -199,31 +207,44 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
         Connection conn = getRawJdbcConnection();
         try {
             conn.setAutoCommit(true);
-            // Find all BIGINT ID columns that do NOT yet have auto_increment
-            String query = "SELECT TABLE_NAME FROM information_schema.COLUMNS "
+            String detectQuery = "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
                     + "WHERE TABLE_SCHEMA = DATABASE() "
-                    + "AND COLUMN_NAME = 'ID' "
+                    + "AND UPPER(COLUMN_NAME) = 'ID' "
+                    + "AND COLUMN_KEY = 'PRI' "
                     + "AND DATA_TYPE = 'bigint' "
                     + "AND EXTRA NOT LIKE '%auto_increment%' "
                     + "ORDER BY TABLE_NAME";
-            List<String> tables = new ArrayList<>();
-            try (PreparedStatement ps = conn.prepareStatement(query);
+
+            List<String[]> rows = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
                  ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    tables.add(rs.getString(1));
+                    rows.add(new String[]{rs.getString(1), rs.getString(2), rs.getString(3)});
                 }
             }
-            if (tables.isEmpty()) {
+            if (rows.isEmpty()) {
                 return altered;
             }
-            // Disable FK checks so child-table ALTERs succeed
+
+            String originalSqlMode;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT @@SESSION.sql_mode")) {
+                originalSqlMode = rs.next() ? rs.getString(1) : "";
+            }
+            try (Statement relaxMode = conn.createStatement()) {
+                relaxMode.execute("SET SESSION sql_mode = ''");
+            }
             try (Statement fkOff = conn.createStatement()) {
                 fkOff.execute("SET FOREIGN_KEY_CHECKS=0");
             }
             try {
-                for (String tableName : tables) {
+                for (String[] row : rows) {
+                    String tableName = row[0];
+                    String columnName = row[1];
+                    String columnType = row[2];
                     try (Statement stmt = conn.createStatement()) {
-                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN ID BIGINT NOT NULL AUTO_INCREMENT");
+                        stmt.execute("ALTER TABLE `" + tableName + "` MODIFY COLUMN `" + columnName
+                                + "` " + columnType + " NOT NULL AUTO_INCREMENT");
                         altered.add(tableName);
                         LOGGER.info("AutoIncrement: applied to table `" + tableName + "`");
                     } catch (Exception e) {
@@ -234,6 +255,21 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
                 try (Statement fkOn = conn.createStatement()) {
                     fkOn.execute("SET FOREIGN_KEY_CHECKS=1");
                 }
+                try (PreparedStatement restoreMode = conn.prepareStatement("SET SESSION sql_mode = ?")) {
+                    restoreMode.setString(1, originalSqlMode);
+                    restoreMode.execute();
+                }
+            }
+
+            List<String> remaining = new ArrayList<>();
+            try (PreparedStatement ps = conn.prepareStatement(detectQuery);
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    remaining.add(rs.getString(1));
+                }
+            }
+            if (!remaining.isEmpty()) {
+                throw new java.sql.SQLException("AUTO_INCREMENT could not be applied to: " + String.join(", ", remaining));
             }
         } finally {
             // Restore autoCommit=false before returning connection to Payara's JTA pool.

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -197,6 +197,49 @@
 
                 </p:tab>
 
+                <p:tab title="Fix Missing AUTO_INCREMENT" >
+                    <p:panelGrid columns="2" class="mt-1 w-100" style="border: 10px green;">
+                        <f:facet name="header">
+                            <i class="fa fa-search"/>
+                            <h:outputLabel value="Fix Missing AUTO_INCREMENT" class="mx-2"/>
+                            <p:spacer height="2" width="20" ></p:spacer>
+                            <p:commandButton
+                                ajax="false"
+                                action="#{dataAdministrationController.fixMissingAutoIncrement()}"
+                                value="Fix AUTO_INCREMENT"
+                                styleClass="ui-button-success w-25 ml-2"
+                                title="Scans every table for a BIGINT ID primary key missing AUTO_INCREMENT and re-adds it. Safe to run repeatedly — a no-op on a healthy database."
+                                />
+                        </f:facet>
+
+                        <p:outputLabel value="Instructions" />
+                        <p>A database restored from a dump can lose the AUTO_INCREMENT attribute on ID primary keys, which makes every INSERT into the affected table fail with MySQL error 1364 ("Field 'ID' doesn't have a default value") — including the login-audit insert, which blocks login itself. Click "Fix AUTO_INCREMENT" to scan and repair every affected table on the selected database(s) below.</p>
+
+                        <p:outputLabel value="Database Selection" />
+                        <h:panelGroup layout="block" class="d-flex">
+                            <p:selectBooleanCheckbox
+                                value="#{dataAdministrationController.runOnMainDatabase}"
+                                class="mr-2"/>
+                            <h:outputText value="Main Database (hmisPU)" class="mr-3"/>
+                            <p:selectBooleanCheckbox
+                                value="#{dataAdministrationController.runOnAuditDatabase}"
+                                class="mr-2"/>
+                            <h:outputText value="Audit Database (hmisAuditPU)"/>
+                        </h:panelGroup>
+
+                        <p:outputLabel value="Main Database Results" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}"/>
+                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}">
+                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.mainDatabaseExecutionFeedback}</textarea>
+                        </h:outputText>
+
+                        <p:outputLabel value="Audit Database Results" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}"/>
+                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}">
+                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.auditDatabaseExecutionFeedback}</textarea>
+                        </h:outputText>
+                    </p:panelGrid>
+
+                </p:tab>
+
                 <p:tab title="Run Custom SQL Commands" >
 
                     <p:panelGrid columns="2" class="mt-1 w-100" style="border: 10px green;">

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -228,14 +228,22 @@
                         </h:panelGroup>
 
                         <p:outputLabel value="Main Database Results" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}"/>
-                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}">
-                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.mainDatabaseExecutionFeedback}</textarea>
-                        </h:outputText>
+                        <p:inputTextarea
+                            value="#{dataAdministrationController.mainDatabaseExecutionFeedback}"
+                            readonly="true"
+                            rows="4"
+                            autoResize="false"
+                            class="w-100"
+                            rendered="#{dataAdministrationController.runOnMainDatabase and not empty dataAdministrationController.mainDatabaseExecutionFeedback}"/>
 
                         <p:outputLabel value="Audit Database Results" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}"/>
-                        <h:outputText escape="false" rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}">
-                            <textarea readonly="readonly" rows="4" class="form-control w-100" style="resize: none;">#{dataAdministrationController.auditDatabaseExecutionFeedback}</textarea>
-                        </h:outputText>
+                        <p:inputTextarea
+                            value="#{dataAdministrationController.auditDatabaseExecutionFeedback}"
+                            readonly="true"
+                            rows="4"
+                            autoResize="false"
+                            class="w-100"
+                            rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseExecutionFeedback}"/>
                     </p:panelGrid>
 
                 </p:tab>


### PR DESCRIPTION
## Summary
- Hardens two already-written-but-unused facade methods (`DatabaseMigrationFacade`/`AuditDatabaseFacade`.`applyAutoIncrementToAllEntityTables()`) to match the existing `v2.9.0` migration's correctness properties: primary-key-only filter, case-insensitive column-name match, preserve each column's exact type, relax `sql_mode` for the rebuild, and fail loudly on partial failure instead of silently logging a warning.
- Wires them into a new "Fix Missing AUTO_INCREMENT" tab on the existing no-login `mf.xhtml` bootstrap page, so an admin can recover a database that's missing `AUTO_INCREMENT` on `ID` primary keys even when that exact condition is what's blocking login (`SessionController.recordLogin()` inserts an audit row on every login and fails the same way; `ConfigOptionApplicationController`'s `@PostConstruct` can too).
- Live E2E verification (see Test plan) found the plan's originally-specified feedback markup never actually rendered its content — fixed by switching to a `p:inputTextarea` binding, scoped to only the new tab.
- Design: `docs/superpowers/specs/2026-07-19-pre-login-migration-execution-design.md`
- Plan: `docs/superpowers/plans/2026-07-19-pre-login-migration-execution.md`

## Known follow-up (non-blocking)
The new tab's feedback fields (`mainDatabaseExecutionFeedback`/`auditDatabaseExecutionFeedback`) are shared `DataAdministrationController` bean fields also written by this page's three pre-existing tabs. Since tab-switching is AJAX (no action re-run) and each tab's action only clears these fields at its own start, switching to the new tab without clicking its button can briefly show stale content left over from a different tab's earlier action (cosmetic only — a real `<br/>`-vs-`\n` formatting mismatch between tabs, no functional or security impact). Pre-existing architectural coupling, exposed rather than introduced by this change.

## Test plan
- [x] Reproduced the blocking condition locally against the local `coop` database: stripped `AUTO_INCREMENT` from a disposable table, confirmed MySQL error 1364
- [x] Confirmed `mf.xhtml` is reachable without any login session and the new tab renders correctly positioned
- [x] Executed the fix via the new tab; confirmed via direct `INFORMATION_SCHEMA` query that `AUTO_INCREMENT` was restored with the correct original column type
- [x] Confirmed idempotency (re-running reports "no tables needed fixing")
- [x] Reproduced and fixed the actual qa4-affected tables (`logins`, `configoption`) in one pass, confirmed via direct SQL
- [x] All 4 implementation tasks passed individual code review (spec compliance + quality); a final whole-branch review found no Critical/Important issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)