### PR TITLE
feat(audit): patientEncounterId on AuditEvent + logEncounterAudit helper (foundation for #22232)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -220,7 +220,11 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
         }
 
         try {
-            // Create audit record BEFORE making the change
+            // Update the admission's patient reference
+            current.setPatient(newPatient);
+            admissionFacade.edit(current);
+
+            // Record audit only after the change has successfully persisted
             auditService.logEncounterAudit(
                 current,
                 "Patient changed for BHT: " + current.getBhtNo() +
@@ -234,10 +238,6 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
                 "Admission Patient Change",
                 current.getId()
             );
-
-            // Update the admission's patient reference
-            current.setPatient(newPatient);
-            admissionFacade.edit(current);
 
             JsfUtil.addSuccessMessage("Patient changed successfully. " +
                 "BHT: " + current.getBhtNo() +

--- a/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionPatientChangeController.java
@@ -221,16 +221,18 @@ public class AdmissionPatientChangeController implements Serializable, Controlle
 
         try {
             // Create audit record BEFORE making the change
-            auditService.logAudit(
-                originalPatient,
-                newPatient,
-                sessionController.getLoggedUser(),
-                "Admission Patient Change",
+            auditService.logEncounterAudit(
+                current,
                 "Patient changed for BHT: " + current.getBhtNo() +
                 " from " + originalPatient.getPerson().getName() +
                 " (ID: " + originalPatient.getId() + ")" +
                 " to " + newPatient.getPerson().getName() +
-                " (ID: " + newPatient.getId() + ")"
+                " (ID: " + newPatient.getId() + ")",
+                originalPatient,
+                newPatient,
+                sessionController.getLoggedUser(),
+                "Admission Patient Change",
+                current.getId()
             );
 
             // Update the admission's patient reference

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -568,7 +568,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             
             getEjbFacade().editAndFlush(current);    // SINGLE flush for ALL entities
             
-            auditService.logAudit(originalAdmission, updatedAdmission, sessionController.getLoggedUser(), "PatientEncounter", "UpdateAdmission", current.getId());
+            auditService.logEncounterAudit(current, "UpdateAdmission", originalAdmission, updatedAdmission, sessionController.getLoggedUser());
             if (originalAdmission == null) {
                 originalAdmission = new HashMap<>();
             }

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -417,7 +417,8 @@ public class RoomChangeController implements Serializable {
                     sessionController.getInstitution() != null ? sessionController.getInstitution().getId() : null,
                     sessionController.getDepartment() != null ? sessionController.getDepartment().getId() : null);
         } catch (Exception e) {
-            // Silently fail - audit failure should not block the user action
+            // Audit failure should not block the user action, but leave a trace
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -27,12 +27,15 @@ import com.divudi.core.facade.PersonFacade;
 import com.divudi.core.facade.RoomFacade;
 import com.divudi.core.facade.RoomFacilityChargeFacade;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.service.AuditService;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.component.UIComponent;
@@ -66,9 +69,8 @@ public class RoomChangeController implements Serializable {
     NotificationController notificationController;
     @Inject
     private InwardBeanController inwardBean;
-    @Inject
-    private com.divudi.bean.common.AuditEventApplicationController auditEventApplicationController;
-
+    @EJB
+    private AuditService auditService;
     @EJB
     private AdmissionFacade ejbFacade;
     @EJB
@@ -287,9 +289,7 @@ public class RoomChangeController implements Serializable {
             return;
         }
 
-        String beforeState = "roomFacilityCharge=" + (pR.getRoomFacilityCharge() != null ? pR.getRoomFacilityCharge().getName() : "null")
-                + ", admittedAt=" + pR.getAdmittedAt()
-                + ", discharged=" + pR.isDischarged();
+        Map<String, Object> beforeState = roomStateMap(pR);
 
         pR.setRetirer(getSessionController().getLoggedUser());
         pR.setRetired(true);
@@ -314,6 +314,8 @@ public class RoomChangeController implements Serializable {
             return;
         }
 
+        Map<String, Object> beforeState = roomStateMap(pR);
+
         pR.setDischarged(true);
         pR.setDischargedBy(getSessionController().getLoggedUser());
         getPatientRoomFacade().edit(pR);
@@ -327,7 +329,7 @@ public class RoomChangeController implements Serializable {
             patientEncounterFacade.edit(encounter);
         }
 
-        recordRoomAuditEvent(pR, "Room Discharged", null);
+        recordRoomAuditEvent(pR, "Room Discharged", beforeState);
     }
 
     public void dischargeWithCurrentTime(PatientRoom pR) {
@@ -351,6 +353,8 @@ public class RoomChangeController implements Serializable {
             }
         }
 
+        Map<String, Object> beforeState = roomStateMap(pR);
+
         pR.setDischarged(true);
         pR.setDischargedBy(getSessionController().getLoggedUser());
         getPatientRoomFacade().edit(pR);
@@ -365,7 +369,7 @@ public class RoomChangeController implements Serializable {
         }
 
         // Record audit event
-        recordRoomAuditEvent(pR, "Room Discharged", null);
+        recordRoomAuditEvent(pR, "Room Discharged", beforeState);
 
         JsfUtil.addSuccessMessage("Successfully Discharged from Room");
     }
@@ -375,8 +379,7 @@ public class RoomChangeController implements Serializable {
             return;
         }
         // Capture state before cancel for audit
-        String beforeState = "discharged=true, dischargedAt=" + pR.getDischargedAt()
-                + ", dischargedBy=" + (pR.getDischargedBy() != null ? pR.getDischargedBy().getName() : "null");
+        Map<String, Object> beforeState = roomStateMap(pR);
 
         pR.setDischarged(false);
         pR.setDischargedBy(null);
@@ -390,38 +393,31 @@ public class RoomChangeController implements Serializable {
         JsfUtil.addSuccessMessage("Room Discharge Cancelled");
     }
 
-    private void recordRoomAuditEvent(PatientRoom pr, String trigger, String beforeState) {
+    private Map<String, Object> roomStateMap(PatientRoom pr) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        if (pr == null) {
+            return m;
+        }
+        m.put("room", pr.getRoomFacilityCharge() != null ? pr.getRoomFacilityCharge().getName() : null);
+        m.put("admittedAt", pr.getAdmittedAt());
+        m.put("discharged", pr.isDischarged());
+        m.put("dischargedAt", pr.getDischargedAt());
+        m.put("dischargedBy", pr.getDischargedBy() != null ? pr.getDischargedBy().getName() : null);
+        m.put("retired", pr.isRetired());
+        return m;
+    }
+
+    private void recordRoomAuditEvent(PatientRoom pr, String trigger, Map<String, Object> beforeState) {
         try {
-            com.divudi.core.entity.AuditEvent auditEvent = new com.divudi.core.entity.AuditEvent();
-            auditEvent.setEventDataTime(new Date());
-            auditEvent.setEventTrigger(trigger);
-            auditEvent.setEntityType(pr.getClass().getSimpleName());
-            auditEvent.setObjectId(pr.getId());
-            if (pr.getPatientEncounter() != null) {
-                auditEvent.setUrl("BHT: " + pr.getPatientEncounter().getBhtNo()
-                        + " | Room: " + (pr.getRoomFacilityCharge() != null ? pr.getRoomFacilityCharge().getName() : "N/A"));
-            }
-            if (sessionController.getLoggedUser() != null) {
-                auditEvent.setWebUserId(sessionController.getLoggedUser().getId());
-            }
-            if (sessionController.getInstitution() != null) {
-                auditEvent.setInstitutionId(sessionController.getInstitution().getId());
-            }
-            if (sessionController.getDepartment() != null) {
-                auditEvent.setDepartmentId(sessionController.getDepartment().getId());
-            }
-            if (beforeState != null) {
-                auditEvent.setBeforeJson(beforeState);
-            }
-            String afterState = "discharged=" + pr.isDischarged()
-                    + ", dischargedAt=" + pr.getDischargedAt()
-                    + ", dischargedBy=" + (pr.getDischargedBy() != null ? pr.getDischargedBy().getName() : "null");
-            auditEvent.setAfterJson(afterState);
-            auditEvent.setEventStatus("Completed");
-            auditEvent.setEventDuration(new Date().getTime() - auditEvent.getEventDataTime().getTime());
-            auditEventApplicationController.logAuditEvent(auditEvent);
+            auditService.logEncounterAudit(
+                    pr.getPatientEncounter(), trigger,
+                    beforeState, roomStateMap(pr),
+                    sessionController.getLoggedUser(),
+                    pr.getClass().getSimpleName(), pr.getId(),
+                    sessionController.getInstitution() != null ? sessionController.getInstitution().getId() : null,
+                    sessionController.getDepartment() != null ? sessionController.getDepartment().getId() : null);
         } catch (Exception e) {
-            // Silently fail â€" audit failure should not block the user action
+            // Silently fail - audit failure should not block the user action
         }
     }
 
@@ -447,7 +443,7 @@ public class RoomChangeController implements Serializable {
             JsfUtil.addErrorMessage("No Patient Room Detected");
             return;
         }
-        String beforeState = "room=" + (pR.getRoomFacilityCharge() != null ? pR.getRoomFacilityCharge().getName() : "null");
+        Map<String, Object> beforeState = roomStateMap(pR);
         pR.setRetired(true);
         pR.setRetiredAt(new Date());
         pR.setRetirer(sessionController.getWebUser());
@@ -463,7 +459,7 @@ public class RoomChangeController implements Serializable {
             return;
         }
 
-        String beforeState = "room=" + (pR.getRoomFacilityCharge() != null ? pR.getRoomFacilityCharge().getName() : "null");
+        Map<String, Object> beforeState = roomStateMap(pR);
         pR.setRetirer(getSessionController().getLoggedUser());
         pR.setRetired(true);
         pR.setRetiredAt(new Date());
@@ -545,7 +541,8 @@ public class RoomChangeController implements Serializable {
         // Save consultant information
         saveConsultantInfo(newPatientRoom);
 
-        recordRoomAuditEvent(newPatientRoom, "Room Changed", "previousRoom=" + (oldPatientRoom.getRoomFacilityCharge() != null ? oldPatientRoom.getRoomFacilityCharge().getName() : "null"));
+        Map<String, Object> beforeState = roomStateMap(oldPatientRoom);
+        recordRoomAuditEvent(newPatientRoom, "Room Changed", beforeState);
         notificationController.createNotification(newPatientRoom, "Change");
 
         if (newConsultant != null || newPrimeConsultant != null) {
@@ -631,7 +628,7 @@ public class RoomChangeController implements Serializable {
             getPatientRoomFacade().edit(oldGaurdianRoom);
         }
 
-        recordRoomAuditEvent(newGuardianRoom, "Guardian Room Changed", oldGaurdianRoom != null ? "previousRoom=" + (oldGaurdianRoom.getRoomFacilityCharge() != null ? oldGaurdianRoom.getRoomFacilityCharge().getName() : "null") : "first guardian room");
+        recordRoomAuditEvent(newGuardianRoom, "Guardian Room Changed", oldGaurdianRoom != null ? roomStateMap(oldGaurdianRoom) : null);
         notificationController.createNotification(newGuardianRoom, "Change");
 
         JsfUtil.addSuccessMessage("Successfully Guardian Room Changed");

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -39,12 +39,15 @@ import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PatientItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.facade.StaffFacade;
+import com.divudi.service.AuditService;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
@@ -110,6 +113,8 @@ public class SurgeryBillController implements Serializable {
     BhtSummeryController bhtSummeryController;
     @Inject
     AuditEventController auditEventController;
+    @EJB
+    private AuditService auditService;
 
     public InwardTimedItemController getInwardTimedItemController() {
         return inwardTimedItemController;
@@ -587,9 +592,8 @@ public class SurgeryBillController implements Serializable {
                 beforeName = nameResult.get(0);
             }
         }
-        String beforeJson = "{\"surgeryName\": \"" + beforeName.replace("\"", "\\\"") + "\"}";
-        com.divudi.core.entity.AuditEvent auditEvent = auditEventController.createNewAuditEvent(
-                "Edit Surgery", beforeJson, billId, "Bill");
+        Map<String, Object> beforeState = new LinkedHashMap<>();
+        beforeState.put("surgeryName", beforeName);
 
         saveProcedure();
         saveSurgeryBill();
@@ -598,8 +602,12 @@ public class SurgeryBillController implements Serializable {
         String afterName = (surgeryBill != null && surgeryBill.getProcedure() != null
                 && surgeryBill.getProcedure().getItem() != null)
                 ? surgeryBill.getProcedure().getItem().getName() : "";
-        String afterJson = "{\"surgeryName\": \"" + afterName.replace("\"", "\\\"") + "\"}";
-        auditEventController.completeAuditEvent(auditEvent, afterJson);
+        Map<String, Object> afterState = new LinkedHashMap<>();
+        afterState.put("surgeryName", afterName);
+        auditService.logEncounterAudit(
+                surgeryBill != null ? surgeryBill.getPatientEncounter() : null,
+                "Edit Surgery", beforeState, afterState,
+                sessionController.getLoggedUser(), "Bill", billId);
 
         return auditEventController.navigateToAllAuditEventsForBill(billId);
     }

--- a/src/main/java/com/divudi/core/entity/AuditEvent.java
+++ b/src/main/java/com/divudi/core/entity/AuditEvent.java
@@ -44,7 +44,10 @@ public class AuditEvent implements Serializable {
     private Long institutionId;
     private Long departmentId;
     private Long objectId;
-    
+    // Links the event to a PatientEncounter (BHT) regardless of which entity
+    // objectId points at, so all events for an admission can be queried together
+    private Long patientEncounterId;
+
     @Lob
     private String beforeJson;
     @Lob
@@ -326,6 +329,14 @@ public class AuditEvent implements Serializable {
 
     public void setObjectId(Long objectId) {
         this.objectId = objectId;
+    }
+
+    public Long getPatientEncounterId() {
+        return patientEncounterId;
+    }
+
+    public void setPatientEncounterId(Long patientEncounterId) {
+        this.patientEncounterId = patientEncounterId;
     }
 
 }

--- a/src/main/java/com/divudi/service/AuditService.java
+++ b/src/main/java/com/divudi/service/AuditService.java
@@ -1,6 +1,7 @@
 package com.divudi.service;
 
 import com.divudi.core.entity.AuditEvent;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.AuditEventFacade;
 import com.google.gson.Gson;
@@ -107,6 +108,56 @@ public class AuditService {
             audit.setEventStatus(eventStatus != null ? eventStatus : "Completed");
             audit.setIpAddress(getClientIpAddress());
 
+            auditEventFacade.create(audit);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Records an audit event linked to a PatientEncounter so all events of an
+     * admission can be fetched with
+     * {@code select a from AuditEvent a where a.patientEncounterId=:peid}.
+     * entityType defaults to "PatientEncounter" and objectId to the encounter id.
+     */
+    public void logEncounterAudit(PatientEncounter pe, String eventTrigger,
+            Object before, Object after, WebUser user) {
+        logEncounterAudit(pe, eventTrigger, before, after, user, "PatientEncounter",
+                pe != null ? pe.getId() : null, null, null);
+    }
+
+    public void logEncounterAudit(PatientEncounter pe, String eventTrigger,
+            Object before, Object after, WebUser user, String entityType, Long objectId) {
+        logEncounterAudit(pe, eventTrigger, before, after, user, entityType, objectId, null, null);
+    }
+
+    /**
+     * Full form for callers that audit a related entity (e.g. PatientRoom, Bill)
+     * while still linking the event to the encounter, optionally recording the
+     * acting institution/department (session data the EJB cannot reach itself).
+     */
+    public void logEncounterAudit(PatientEncounter pe, String eventTrigger,
+            Object before, Object after, WebUser user, String entityType, Long objectId,
+            Long institutionId, Long departmentId) {
+        try {
+            AuditEvent audit = new AuditEvent();
+            audit.setEventDataTime(new Date());
+            if (user != null) {
+                audit.setWebUserId(user.getId());
+            }
+            audit.setEntityType(entityType);
+            audit.setEventTrigger(eventTrigger);
+            audit.setObjectId(objectId);
+            if (pe != null) {
+                audit.setPatientEncounterId(pe.getId());
+                audit.setUrl("BHT: " + pe.getBhtNo());
+            }
+            audit.setInstitutionId(institutionId);
+            audit.setDepartmentId(departmentId);
+            audit.setBeforeJson(before != null ? gson.toJson(before) : null);
+            audit.setAfterJson(after != null ? gson.toJson(after) : null);
+            audit.setEventStatus("Completed");
+            audit.setIpAddress(getClientIpAddress());
             auditEventFacade.create(audit);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Closes #22234. Part of #22232 (Inpatient Event History — Patient Story). **Foundation PR — the other #22232 sub-issues build on this.**

## What was implemented

- **`AuditEvent.patientEncounterId`** — new nullable `Long` column so all audit events of an admission are queryable with `select a from AuditEvent a where a.patientEncounterId=:peid`, regardless of which entity `objectId` points at (`PatientRoom`, `Bill`, encounter).
- **`AuditService.logEncounterAudit(...)`** — 3 overloads. Short form defaults `entityType=PatientEncounter` and `objectId`=encounter id; full form takes `entityType`/`objectId`/`institutionId`/`departmentId` for callers auditing a related entity while linking to the encounter. Gson snapshots, never throws (same pattern as existing `logAudit`).
- **Retrofitted all 4 existing inward audit recordings**:
  - `RoomChangeController` — all 11 `recordRoomAuditEvent` call sites now capture **JSON maps** (room, admittedAt, discharged, dischargedAt, dischargedBy, retired) instead of the previous plain strings that bypassed `AuditEvent.calculateDifference()`; before-states are captured prior to mutation (discharge paths previously recorded no before-state at all)
  - `BhtEditController.saveCurrent()` (UpdateAdmission)
  - `AdmissionPatientChangeController.confirmPatientChange()`
  - `SurgeryBillController.edit()` (Edit Surgery) — replaces hand-built JSON strings + two-phase `AuditEventController` calls with the helper

## Schema

`AUDITEVENT.PATIENTENCOUNTERID BIGINT` (nullable). DDL regenerated and published to the [Database-Schema-DDL-Generation-Guide](https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide) wiki page.

## Verification (local Payara + Playwright + MySQL)

Exercised against BHT/53362 (encounter 9596629) on a local deployment:

| Action | Audit row | patientEncounterId | Diff rendered |
|---|---|---|---|
| Edit Admission (guardian name) | UpdateAdmission / PatientEncounter | 9596629 ✔ | `guardian_name: Before: Saman, After: Saman Kumara` |
| Discharge from Room | Room Discharged / PatientRoom | 9596629 ✔ | `discharged: false→true, dischargedBy: null→buddhika` |
| Cancel Room Discharge | Room Discharge Cancelled / PatientRoom | 9596629 ✔ | `discharged: true→false, dischargedAt/By→null` |

- Single query on `PATIENTENCOUNTERID=9596629` returns all 3 rows across both entity types (acceptance criterion).
- Room state verified restored after cancel (`discharged=0`, `dischargedat=NULL`).
- Audit viewer `/audit/all_audit_events.xhtml` now renders field-by-field diffs for room events:

![Audit events with encounter-linked diffs](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22234-audit-events-encounter-diff.png)

Full E2E details in the [issue comment](https://github.com/hmislk/hmis/issues/22234#issuecomment-5014305093).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit records can now be linked directly to patient encounters for clearer tracking, including dedicated encounter context fields.
* **Improvements**
  * Admission, room, patient-change, and surgery edits now write more structured before-and-after snapshots.
  * Audit entries now consistently use encounter-based logging (with improved user, entity, and location context), and ensure updates are audited after successful changes.
  * Room and surgery audit events now capture richer state details for easier review of history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->