### PR TITLE
feat(audit): admission lifecycle audit events (#22232 sub-issue 2)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -76,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
@@ -123,6 +124,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     PageMetadataRegistry pageMetadataRegistry;
 
     ////////////
+    @EJB
+    private com.divudi.service.AuditService auditService;
     @EJB
     private AdmissionFacade ejbFacade;
     @EJB
@@ -1598,10 +1601,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     public void delete() {
 
         if (getCurrent() != null) {
+            Map<String, Object> before = admissionSnapshotMap(getCurrent());
             getCurrent().setRetired(true);
             getCurrent().setRetiredAt(new Date());
             getCurrent().setRetirer(getSessionController().getLoggedUser());
             getFacade().edit(getCurrent());
+            auditService.logEncounterAudit(getCurrent(), "Admission Deleted",
+                    before, admissionSnapshotMap(getCurrent()),
+                    getSessionController().getLoggedUser());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
             JsfUtil.addErrorMessage("Nothing to Delete");
@@ -2202,10 +2209,28 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             JsfUtil.addErrorMessage("Admission Type.");
             return;
         }
+        String oldBhtNo = null;
+        if (current.getId() != null) {
+            HashMap<String, Object> bhtParams = new HashMap<>();
+            bhtParams.put("id", current.getId());
+            List<String> persisted = getFacade().findString(
+                    "select a.bhtNo from Admission a where a.id=:id", bhtParams);
+            if (persisted != null && !persisted.isEmpty()) {
+                oldBhtNo = persisted.get(0);
+            }
+        }
         addPatient();
         addGuardian();
         addPatientRoom();
         getFacade().edit(current);
+        if (oldBhtNo != null && !oldBhtNo.equals(current.getBhtNo())) {
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("bhtNo", oldBhtNo);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("bhtNo", current.getBhtNo());
+            auditService.logEncounterAudit(current, "BHT Number Changed",
+                    before, after, getSessionController().getLoggedUser());
+        }
         current = new Admission();
         patientRoom = new PatientRoom();
     }
@@ -2322,9 +2347,57 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             JsfUtil.addErrorMessage("No admission selected");
             return;
         }
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("registrationFlag", getCurrent().getEncounterRegistrationFlag());
         getCurrent().setEncounterRegistrationFlag(EncounterRegistrationFlag.STANDARD);
         getFacade().edit(getCurrent());
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("registrationFlag", getCurrent().getEncounterRegistrationFlag());
+        auditService.logEncounterAudit(getCurrent(), "Rapid Temp Admission Completed",
+                before, after, getSessionController().getLoggedUser());
         JsfUtil.addSuccessMessage("Registration marked as complete.");
+    }
+
+    /**
+     * Snapshot of the audit-relevant admission fields, used as before/after
+     * JSON for admission-lifecycle audit events (#22235).
+     */
+    private Map<String, Object> admissionSnapshotMap(Admission a) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        if (a == null) {
+            return m;
+        }
+        m.put("encounterID", a.getId());
+        m.put("bhtNo", a.getBhtNo());
+        m.put("encounterType", a.getEncounterType());
+        m.put("admissionType", a.getAdmissionType() != null ? a.getAdmissionType().getName() : null);
+        m.put("dateOfAdmission", a.getDateOfAdmission());
+        m.put("paymentMethod", a.getPaymentMethod());
+        m.put("creditCompany", a.getCreditCompany() != null ? a.getCreditCompany().getName() : null);
+        m.put("registrationFlag", a.getEncounterRegistrationFlag());
+        m.put("retired", a.isRetired());
+        if (a.getReferringConsultant() != null) {
+            m.put("consultant", a.getReferringConsultant().toString());
+        }
+        if (a.getOpdDoctor() != null) {
+            m.put("medicalOfficer", a.getOpdDoctor().toString());
+        }
+        if (a.getDepartment() != null) {
+            m.put("department", a.getDepartment().getName());
+        }
+        if (a.getPatient() != null) {
+            m.put("patient_ID", a.getPatient().getId());
+            if (a.getPatient().getPerson() != null) {
+                m.put("patient_name", a.getPatient().getPerson().getName());
+            }
+        }
+        if (a.getGuardian() != null) {
+            m.put("guardian_name", a.getGuardian().getName());
+        }
+        if (a.getParentEncounter() != null) {
+            m.put("parentEncounter_bhtNo", a.getParentEncounter().getBhtNo());
+        }
+        return m;
     }
 
     private void proceedWithAdmissionCheck() {
@@ -2367,6 +2440,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (isRapidTempAe()) {
             applyRapidTempPlaceholders();
         }
+        final boolean isNewAdmission = getCurrent().getId() == null || getCurrent().getId() <= 0;
         savePatient();
         savePatientAllergies();
         saveGuardian();
@@ -2526,6 +2600,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         saveEncounterCreditCompanies(current);
 
+        if (isNewAdmission) {
+            String auditTrigger = getCurrent().getParentEncounter() != null
+                    ? "Baby Admission Created" : "Admission Created";
+            auditService.logEncounterAudit(getCurrent(), auditTrigger,
+                    null, admissionSnapshotMap(getCurrent()),
+                    getSessionController().getLoggedUser());
+        }
+
         // Save EncounterCreditCompanies
         // Need to create EncounterCredit
         admittingProcessStarted = false;
@@ -2538,6 +2620,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (errorCheck()) {
             return;
         }
+        Map<String, Object> conversionBefore = admissionSnapshotMap(getCurrentNonBht());
         savePatient();
         savePatientAllergies();
         saveGuardian();
@@ -2615,6 +2698,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         getCurrentNonBht().setConvertedToAnotherEncounter(true);
         getFacade().edit(currentNonBht);
         currentNonBht = null;
+
+        auditService.logEncounterAudit(getCurrent(), "Admission Type Converted",
+                conversionBefore, admissionSnapshotMap(getCurrent()),
+                getSessionController().getLoggedUser());
 
         // Save EncounterCreditCompanies
         // Need to create EncounterCredit

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1706,9 +1706,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (getCurrent().getId() == null || getCurrent().getId() == 0) {
             JsfUtil.addSuccessMessage("No Patient Data Found");
         } else {
+            Map<String, Object> before = new LinkedHashMap<>();
+            Admission persisted = getEjbFacade().findWithoutCache(getCurrent().getId());
+            if (persisted != null) {
+                before.put("discharged", persisted.isDischarged());
+                before.put("dateOfDischarge", persisted.getDateOfDischarge());
+            }
             getCurrent().setDischarged(Boolean.TRUE);
             getCurrent().setDateOfDischarge(new Date());
             getEjbFacade().edit(current);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("discharged", getCurrent().isDischarged());
+            after.put("dateOfDischarge", getCurrent().getDateOfDischarge());
+            auditService.logEncounterAudit(getCurrent(), "Discharge",
+                    before, after, getSessionController().getLoggedUser());
         }
 
     }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -438,11 +438,26 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
 
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("creditCompany", patientEncounter.getCreditCompany() != null
+                ? patientEncounter.getCreditCompany().getName() : null);
+        before.put("creditLimit", patientEncounter.getCreditLimit());
+        before.put("creditPaidAmount", patientEncounter.getCreditPaidAmount());
+        before.put("creditUsedAmount", patientEncounter.getCreditUsedAmount());
+
         patientEncounter.setCreditCompany(null);
         patientEncounter.setCreditLimit(0);
         patientEncounter.setCreditPaidAmount(0);
         patientEncounter.setCreditUsedAmount(0);
         getPatientEncounterFacade().edit(patientEncounter);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("creditCompany", null);
+        after.put("creditLimit", 0);
+        after.put("creditPaidAmount", 0);
+        after.put("creditUsedAmount", 0);
+        auditService.logEncounterAudit(patientEncounter, "Credit Detail Reset",
+                before, after, getSessionController().getLoggedUser());
     }
 
     public String navigateToInpatientClinicalData() {
@@ -2727,6 +2742,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 ecc.setCreater(sessionController.getLoggedUser());
                 if (ecc.getInstitution() != null) {
                     getEncounterCreditCompanyFacade().create(ecc);
+                    Map<String, Object> eccState = new LinkedHashMap<>();
+                    eccState.put("creditCompany", ecc.getInstitution().getName());
+                    eccState.put("creditLimit", ecc.getCreditLimit());
+                    eccState.put("policyNo", ecc.getPolicyNo());
+                    eccState.put("referenceNo", ecc.getReferanceNo());
+                    auditService.logEncounterAudit(current, "Credit Company Added",
+                            null, eccState, getSessionController().getLoggedUser(),
+                            "EncounterCreditCompany", ecc.getId());
                     // Upsert back to patient-level insurance profile
                     patientInsuranceController.upsertFromEncounter(
                             current.getPatient(),

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -346,12 +346,17 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         }
 
         //Net to check if Any Payment Paid for this BHT
+        Map<String, Object> beforeCancel = new HashMap<>();
+        admissionToAuditMap(beforeCancel, current);
+        beforeCancel.put("retired", current.isRetired());
+        int retiredRoomCount = 0;
         for (PatientRoom pr : getPatientRoom()) {
             pr.setRetired(true);
             pr.setDischarged(true);
             pr.setRetiredAt(new Date());
             pr.setRetirer(getSessionController().getLoggedUser());
             getPatientRoomFacade().edit(pr);
+            retiredRoomCount++;
         }
         current.setRetired(true);
         current.setRetireComments("BHT Cancel");
@@ -359,6 +364,14 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         current.setRetirer(getSessionController().getLoggedUser());
         current.setComments(comment);
         getEjbFacade().edit(current);
+
+        Map<String, Object> afterCancel = new HashMap<>();
+        admissionToAuditMap(afterCancel, current);
+        afterCancel.put("retired", current.isRetired());
+        afterCancel.put("cancellationReason", comment);
+        afterCancel.put("retiredRoomCount", retiredRoomCount);
+        auditService.logEncounterAudit(current, "Admission Cancelled",
+                beforeCancel, afterCancel, sessionController.getLoggedUser());
 
         JsfUtil.addSuccessMessage("Bht Successfully Cancelled");
         prepereForNew();
@@ -451,10 +464,18 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     public void delete() {
 
         if (getCurrent() != null) {
+            Map<String, Object> before = new HashMap<>();
+            admissionToAuditMap(before, getCurrent());
+            before.put("retired", getCurrent().isRetired());
             getCurrent().setRetired(true);
             getCurrent().setRetiredAt(new Date());
             getCurrent().setRetirer(getSessionController().getLoggedUser());
             getFacade().edit(getCurrent());
+            Map<String, Object> after = new HashMap<>();
+            admissionToAuditMap(after, getCurrent());
+            after.put("retired", getCurrent().isRetired());
+            auditService.logEncounterAudit(getCurrent(), "Admission Deleted",
+                    before, after, sessionController.getLoggedUser());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
             JsfUtil.addErrorMessage("Nothing to Delete");

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -211,11 +211,31 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         current.setCreditCompany(ecc.getInstitution());
     }
 
+    /**
+     * Snapshot of an EncounterCreditCompany for credit-detail audit events (#22237).
+     */
+    private Map<String, Object> creditCompanyAuditMap(EncounterCreditCompany ecc) {
+        Map<String, Object> m = new HashMap<>();
+        if (ecc == null) {
+            return m;
+        }
+        m.put("creditCompany", ecc.getInstitution() != null ? ecc.getInstitution().getName() : null);
+        m.put("creditLimit", ecc.getCreditLimit());
+        m.put("policyNo", ecc.getPolicyNo());
+        m.put("referenceNo", ecc.getReferanceNo());
+        m.put("retired", ecc.isRetired());
+        return m;
+    }
+
     public void removeCreditCompany(EncounterCreditCompany ecc) {
         for (EncounterCreditCompany e : encounterCreditCompanys) {
             if (e == ecc) {
+                Map<String, Object> before = creditCompanyAuditMap(e);
                 e.setRetired(true);
                 encounterCreditCompanyFacade.edit(e);
+                auditService.logEncounterAudit(current, "Credit Company Removed",
+                        before, creditCompanyAuditMap(e), sessionController.getLoggedUser(),
+                        "EncounterCreditCompany", e.getId());
             }
         }
         current.setCreditCompany(null);
@@ -248,6 +268,10 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         newEncounterCreditCompany.setCreater(sessionController.getLoggedUser());
         newEncounterCreditCompany.setRetired(false);
         encounterCreditCompanyFacade.create(newEncounterCreditCompany);
+        auditService.logEncounterAudit(current, "Credit Company Added",
+                null, creditCompanyAuditMap(newEncounterCreditCompany),
+                sessionController.getLoggedUser(),
+                "EncounterCreditCompany", newEncounterCreditCompany.getId());
         encounterCreditCompanys.add(newEncounterCreditCompany);
         newEncounterCreditCompany = new EncounterCreditCompany();
         JsfUtil.addSuccessMessage("Credit company added");
@@ -257,7 +281,19 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         if (ecc == null) {
             return;
         }
+        // Session entity already carries the edited values; read the persisted
+        // row for the audit before-snapshot
+        Map<String, Object> before = null;
+        if (ecc.getId() != null) {
+            EncounterCreditCompany persisted = encounterCreditCompanyFacade.findWithoutCache(ecc.getId());
+            if (persisted != null) {
+                before = creditCompanyAuditMap(persisted);
+            }
+        }
         encounterCreditCompanyFacade.edit(ecc);
+        auditService.logEncounterAudit(current, "Credit Company Updated",
+                before, creditCompanyAuditMap(ecc), sessionController.getLoggedUser(),
+                "EncounterCreditCompany", ecc.getId());
         JsfUtil.addSuccessMessage("Saved");
     }
 
@@ -1149,7 +1185,13 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         m.put("bhtNo", o.getBhtNo());
         m.put("encounterType", o.getEncounterType());
         m.put("dateOfAdmission", o.getDateOfAdmission());
-        
+        m.put("paymentMethod", o.getPaymentMethod());
+        m.put("paymentScheme", o.getPaymentScheme() != null ? o.getPaymentScheme().getName() : null);
+        m.put("creditCompany", o.getCreditCompany() != null ? o.getCreditCompany().getName() : null);
+        m.put("creditLimit", o.getCreditLimit());
+        m.put("policyNo", o.getPolicyNo());
+        m.put("claimable", o.isClaimable());
+
         if (o.getReferringConsultant() != null) {
             m.put("consultant", o.getReferringConsultant().toString());
         }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -143,6 +143,8 @@ public class BhtSummeryController implements Serializable {
     @Inject
     PriceMatrixController priceMatrixController;
     //////////////////////////
+    @EJB
+    private com.divudi.service.AuditService auditService;
     @Inject
     private SessionController sessionController;
     @Inject
@@ -2217,9 +2219,20 @@ public class BhtSummeryController implements Serializable {
             }
         }
 
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("discharged", patientEncounter.isDischarged());
+        before.put("dateOfDischarge", patientEncounter.getDateOfDischarge());
+
         patientEncounter.setDischarged(false);
         patientEncounter.setDateOfDischarge(null);
         getPatientEncounterFacade().edit(patientEncounter);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("discharged", patientEncounter.isDischarged());
+        after.put("dateOfDischarge", patientEncounter.getDateOfDischarge());
+        auditService.logEncounterAudit(patientEncounter, "Discharge Cancelled",
+                before, after, sessionController.getLoggedUser());
+
         JsfUtil.addSuccessMessage("Discharge Cancelled Successfully");
 
     }

--- a/src/main/java/com/divudi/bean/inward/DischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/DischargeController.java
@@ -131,12 +131,26 @@ public class DischargeController implements Serializable {
         if (getCurrent().getId() == null || getCurrent().getId() == 0) {
             JsfUtil.addSuccessMessage("No Patient Data Found");
         } else {
+            // Read the persisted state for the audit before-snapshot; the
+            // session entity may already carry the new discharge date set by
+            // the calling flow (e.g. BhtSummeryController date change).
+            java.util.Map<String, Object> before = new java.util.LinkedHashMap<>();
+            Admission persisted = getEjbFacade().findWithoutCache(getCurrent().getId());
+            if (persisted != null) {
+                before.put("discharged", persisted.isDischarged());
+                before.put("dateOfDischarge", persisted.getDateOfDischarge());
+            }
             //  getCurrent().setLastPatientRoom(getPatientRoom().get(getPatientRoom().size() - 1));
             getCurrent().setDischarged(Boolean.TRUE);
             if (getCurrent().getDateOfDischarge() == null) {
                 getCurrent().setDateOfDischarge(new Date());
             }
             getEjbFacade().edit(getCurrent());
+            java.util.Map<String, Object> after = new java.util.LinkedHashMap<>();
+            after.put("discharged", getCurrent().isDischarged());
+            after.put("dateOfDischarge", getCurrent().getDateOfDischarge());
+            auditService.logEncounterAudit(getCurrent(), "Discharge",
+                    before, after, getSessionController().getLoggedUser());
             notificationController.createNotification(getCurrent(), "FinalDischarge");
             JsfUtil.addSuccessMessage("Discharged");
 

--- a/src/main/java/com/divudi/bean/inward/DischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/DischargeController.java
@@ -50,6 +50,8 @@ public class DischargeController implements Serializable {
     @Inject
     NotificationController notificationController;
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private AdmissionFacade ejbFacade;
     @EJB
     private PersonFacade personFacade;
@@ -81,10 +83,20 @@ public class DischargeController implements Serializable {
     public void delete() {
 
         if (getCurrent() != null) {
+            java.util.Map<String, Object> before = new java.util.LinkedHashMap<>();
+            before.put("bhtNo", getCurrent().getBhtNo());
+            before.put("retired", getCurrent().isRetired());
+            before.put("discharged", getCurrent().isDischarged());
             getCurrent().setRetired(true);
             getCurrent().setRetiredAt(new Date());
             getCurrent().setRetirer(getSessionController().getLoggedUser());
             getFacade().edit(getCurrent());
+            java.util.Map<String, Object> after = new java.util.LinkedHashMap<>();
+            after.put("bhtNo", getCurrent().getBhtNo());
+            after.put("retired", getCurrent().isRetired());
+            after.put("discharged", getCurrent().isDischarged());
+            auditService.logEncounterAudit(getCurrent(), "Admission Deleted",
+                    before, after, getSessionController().getLoggedUser());
             JsfUtil.addSuccessMessage("Deleted Successfully");
         } else {
             JsfUtil.addErrorMessage("Nothing to Delete");

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -122,6 +122,8 @@ public class InpatientClinicalDataController implements Serializable {
      * EJBs
      */
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private PatientEncounterFacade ejbFacade;
     @EJB
     ClinicalEntityFacade clinicalFindingItemFacade;
@@ -2957,12 +2959,30 @@ public class InpatientClinicalDataController implements Serializable {
             return;
         }
         saveClinicalDischarge();
+        java.util.Map<String, Object> before = clinicalDischargeStateMap();
         parentAdmission.setClinicallyDischarged(Boolean.TRUE);
         parentAdmission.setClinicalDischargeDateTime(new Date());
         parentAdmission.setClinicalDischargedBy(sessionController.getLoggedUser());
         getFacade().edit(parentAdmission);
+        auditService.logEncounterAudit(parentAdmission, "Clinical Discharge",
+                before, clinicalDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(parentAdmission, "ClinicalDischarge");
         JsfUtil.addSuccessMessage("Clinical discharge confirmed.");
+    }
+
+    /**
+     * Snapshot of the clinical discharge flags for audit events (#22236).
+     */
+    private java.util.Map<String, Object> clinicalDischargeStateMap() {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (parentAdmission == null) {
+            return m;
+        }
+        m.put("clinicallyDischarged", parentAdmission.isClinicallyDischarged());
+        m.put("clinicalDischargeDateTime", parentAdmission.getClinicalDischargeDateTime());
+        m.put("clinicalDischargedBy", parentAdmission.getClinicalDischargedBy() != null
+                ? parentAdmission.getClinicalDischargedBy().getName() : null);
+        return m;
     }
 
     public void cancelClinicalDischarge() {
@@ -2970,10 +2990,13 @@ public class InpatientClinicalDataController implements Serializable {
             JsfUtil.addErrorMessage("No admission found.");
             return;
         }
+        java.util.Map<String, Object> before = clinicalDischargeStateMap();
         parentAdmission.setClinicallyDischarged(Boolean.FALSE);
         parentAdmission.setClinicalDischargeDateTime(null);
         parentAdmission.setClinicalDischargedBy(null);
         getFacade().edit(parentAdmission);
+        auditService.logEncounterAudit(parentAdmission, "Clinical Discharge Cancelled",
+                before, clinicalDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Clinical discharge cancelled.");
     }
 

--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -33,6 +33,9 @@ import javax.persistence.TemporalType;
 public class NursingDischargeController implements Serializable {
 
     @EJB
+    private com.divudi.service.AuditService auditService;
+
+    @EJB
     private PatientEncounterFacade patientEncounterFacade;
 
     @EJB
@@ -195,12 +198,34 @@ public class NursingDischargeController implements Serializable {
                     + " pending pharmacy item(s) must be resolved first.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setNursingDischarged(Boolean.TRUE);
         currentEncounter.setNursingDischargeDateTime(new Date());
         currentEncounter.setNursingDischargedBy(sessionController.getLoggedUser());
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Nursing Discharge",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(currentEncounter, "NursingDischarge");
         JsfUtil.addSuccessMessage("Nursing discharge confirmed.");
+    }
+
+    /**
+     * Snapshot of the nursing/physical discharge flags for audit events (#22236).
+     */
+    private Map<String, Object> nursingDischargeStateMap() {
+        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (currentEncounter == null) {
+            return m;
+        }
+        m.put("nursingDischarged", currentEncounter.isNursingDischarged());
+        m.put("nursingDischargeDateTime", currentEncounter.getNursingDischargeDateTime());
+        m.put("nursingDischargedBy", currentEncounter.getNursingDischargedBy() != null
+                ? currentEncounter.getNursingDischargedBy().getName() : null);
+        m.put("physicalDischarged", currentEncounter.isPhysicalDischarged());
+        m.put("physicalDischargeDateTime", currentEncounter.getPhysicalDischargeDateTime());
+        m.put("physicalDischargedBy", currentEncounter.getPhysicalDischargedBy() != null
+                ? currentEncounter.getPhysicalDischargedBy().getName() : null);
+        return m;
     }
 
     public void cancelNursingDischarge() {
@@ -216,10 +241,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot cancel nursing discharge: physical discharge has already been confirmed. Cancel physical discharge first.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setNursingDischarged(Boolean.FALSE);
         currentEncounter.setNursingDischargeDateTime(null);
         currentEncounter.setNursingDischargedBy(null);
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Nursing Discharge Cancelled",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Nursing discharge cancelled.");
     }
 
@@ -244,10 +272,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm physical discharge: administrative discharge (final bill) has not been completed.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setPhysicalDischarged(Boolean.TRUE);
         currentEncounter.setPhysicalDischargeDateTime(new Date());
         currentEncounter.setPhysicalDischargedBy(sessionController.getLoggedUser());
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Physical Discharge",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(currentEncounter, "PhysicalDischarge");
         JsfUtil.addSuccessMessage("Physical discharge confirmed. Patient has left the hospital.");
     }
@@ -261,10 +292,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Physical discharge has not been confirmed.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setPhysicalDischarged(Boolean.FALSE);
         currentEncounter.setPhysicalDischargeDateTime(null);
         currentEncounter.setPhysicalDischargedBy(null);
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Physical Discharge Cancelled",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Physical discharge cancelled.");
     }
 


### PR DESCRIPTION
Closes #22235. Part of #22232. **Stacked on #22243** (base branch is `22234-audit-foundation-patient-encounter-id`) — after #22243 merges, I'll retarget this to `development`.

## What was implemented

All events go through `AuditService.logEncounterAudit` from #22243, so each carries `patientEncounterId` + JSON before/after snapshots and renders as a field-by-field diff on `/audit/all_audit_events.xhtml`. Audit failure never blocks the user action (helper swallows internally).

| Action | Trigger | Notes |
|---|---|---|
| `AdmissionController.saveSelected()` (new admissions incl. all `checkBeforeAdmit*` variants) | `Admission Created` / `Baby Admission Created` | `before=null`, after = new `admissionSnapshotMap` (bhtNo, encounterType, admissionType, dateOfAdmission, paymentMethod, creditCompany, registrationFlag, consultant, MO, department, patient, guardian, parent BHT). Baby trigger chosen when `parentEncounter` set. Satisfies the inward path of #17229. Not logged when the package-application failure path auto-retires the admission. |
| `AdmissionController.saveConvertSelected()` | `Admission Type Converted` | before = snapshot of the source (non-BHT) encounter, after = converted admission |
| `AdmissionController.updateBHTNo()` | `BHT Number Changed` | old BHT read from DB via JPQL **before** the edit (session entity already holds the new value); logged only when the number actually changed |
| `AdmissionController.markRapidTempAdmissionComplete()` | `Rapid Temp Admission Completed` | registrationFlag RAPID_TEMP_AE → STANDARD |
| `BhtEditController.cancelBht()` | `Admission Cancelled` | full before-snapshot + cancellationReason + retiredRoomCount |
| `AdmissionController.delete()`, `BhtEditController.delete()`, `DischargeController.delete()` | `Admission Deleted` | pre/post-retire snapshots |

**Deliberately not instrumented:** `navigateCancelBabyAdmission()` — it only abandons an *unsaved* baby-admission form (pure navigation, nothing persisted, so there is no state change to audit). Cancelling a *saved* baby admission goes through `cancelBht()`, which is audited.

## Verification

- `mvn compile` clean.
- Per the umbrella plan (#22232), instrumentation-only sub-issues get build + code-level verification; the audit plumbing itself was E2E-verified in #22243 (UpdateAdmission / Room Discharged / Room Discharge Cancelled all confirmed in DB with encounter linkage and rendered diffs), and the timeline page PR (#22240) will exercise these events end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)