### PR TITLE
feat(audit): encounter-level discharge audit events (#22232 sub-issue 3)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1706,9 +1706,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (getCurrent().getId() == null || getCurrent().getId() == 0) {
             JsfUtil.addSuccessMessage("No Patient Data Found");
         } else {
+            Map<String, Object> before = new LinkedHashMap<>();
+            Admission persisted = getEjbFacade().findWithoutCache(getCurrent().getId());
+            if (persisted != null) {
+                before.put("discharged", persisted.isDischarged());
+                before.put("dateOfDischarge", persisted.getDateOfDischarge());
+            }
             getCurrent().setDischarged(Boolean.TRUE);
             getCurrent().setDateOfDischarge(new Date());
             getEjbFacade().edit(current);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("discharged", getCurrent().isDischarged());
+            after.put("dateOfDischarge", getCurrent().getDateOfDischarge());
+            auditService.logEncounterAudit(getCurrent(), "Discharge",
+                    before, after, getSessionController().getLoggedUser());
         }
 
     }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -143,6 +143,8 @@ public class BhtSummeryController implements Serializable {
     @Inject
     PriceMatrixController priceMatrixController;
     //////////////////////////
+    @EJB
+    private com.divudi.service.AuditService auditService;
     @Inject
     private SessionController sessionController;
     @Inject
@@ -2217,9 +2219,20 @@ public class BhtSummeryController implements Serializable {
             }
         }
 
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("discharged", patientEncounter.isDischarged());
+        before.put("dateOfDischarge", patientEncounter.getDateOfDischarge());
+
         patientEncounter.setDischarged(false);
         patientEncounter.setDateOfDischarge(null);
         getPatientEncounterFacade().edit(patientEncounter);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("discharged", patientEncounter.isDischarged());
+        after.put("dateOfDischarge", patientEncounter.getDateOfDischarge());
+        auditService.logEncounterAudit(patientEncounter, "Discharge Cancelled",
+                before, after, sessionController.getLoggedUser());
+
         JsfUtil.addSuccessMessage("Discharge Cancelled Successfully");
 
     }

--- a/src/main/java/com/divudi/bean/inward/DischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/DischargeController.java
@@ -131,12 +131,26 @@ public class DischargeController implements Serializable {
         if (getCurrent().getId() == null || getCurrent().getId() == 0) {
             JsfUtil.addSuccessMessage("No Patient Data Found");
         } else {
+            // Read the persisted state for the audit before-snapshot; the
+            // session entity may already carry the new discharge date set by
+            // the calling flow (e.g. BhtSummeryController date change).
+            java.util.Map<String, Object> before = new java.util.LinkedHashMap<>();
+            Admission persisted = getEjbFacade().findWithoutCache(getCurrent().getId());
+            if (persisted != null) {
+                before.put("discharged", persisted.isDischarged());
+                before.put("dateOfDischarge", persisted.getDateOfDischarge());
+            }
             //  getCurrent().setLastPatientRoom(getPatientRoom().get(getPatientRoom().size() - 1));
             getCurrent().setDischarged(Boolean.TRUE);
             if (getCurrent().getDateOfDischarge() == null) {
                 getCurrent().setDateOfDischarge(new Date());
             }
             getEjbFacade().edit(getCurrent());
+            java.util.Map<String, Object> after = new java.util.LinkedHashMap<>();
+            after.put("discharged", getCurrent().isDischarged());
+            after.put("dateOfDischarge", getCurrent().getDateOfDischarge());
+            auditService.logEncounterAudit(getCurrent(), "Discharge",
+                    before, after, getSessionController().getLoggedUser());
             notificationController.createNotification(getCurrent(), "FinalDischarge");
             JsfUtil.addSuccessMessage("Discharged");
 

--- a/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientClinicalDataController.java
@@ -122,6 +122,8 @@ public class InpatientClinicalDataController implements Serializable {
      * EJBs
      */
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private PatientEncounterFacade ejbFacade;
     @EJB
     ClinicalEntityFacade clinicalFindingItemFacade;
@@ -2957,12 +2959,30 @@ public class InpatientClinicalDataController implements Serializable {
             return;
         }
         saveClinicalDischarge();
+        java.util.Map<String, Object> before = clinicalDischargeStateMap();
         parentAdmission.setClinicallyDischarged(Boolean.TRUE);
         parentAdmission.setClinicalDischargeDateTime(new Date());
         parentAdmission.setClinicalDischargedBy(sessionController.getLoggedUser());
         getFacade().edit(parentAdmission);
+        auditService.logEncounterAudit(parentAdmission, "Clinical Discharge",
+                before, clinicalDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(parentAdmission, "ClinicalDischarge");
         JsfUtil.addSuccessMessage("Clinical discharge confirmed.");
+    }
+
+    /**
+     * Snapshot of the clinical discharge flags for audit events (#22236).
+     */
+    private java.util.Map<String, Object> clinicalDischargeStateMap() {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (parentAdmission == null) {
+            return m;
+        }
+        m.put("clinicallyDischarged", parentAdmission.isClinicallyDischarged());
+        m.put("clinicalDischargeDateTime", parentAdmission.getClinicalDischargeDateTime());
+        m.put("clinicalDischargedBy", parentAdmission.getClinicalDischargedBy() != null
+                ? parentAdmission.getClinicalDischargedBy().getName() : null);
+        return m;
     }
 
     public void cancelClinicalDischarge() {
@@ -2970,10 +2990,13 @@ public class InpatientClinicalDataController implements Serializable {
             JsfUtil.addErrorMessage("No admission found.");
             return;
         }
+        java.util.Map<String, Object> before = clinicalDischargeStateMap();
         parentAdmission.setClinicallyDischarged(Boolean.FALSE);
         parentAdmission.setClinicalDischargeDateTime(null);
         parentAdmission.setClinicalDischargedBy(null);
         getFacade().edit(parentAdmission);
+        auditService.logEncounterAudit(parentAdmission, "Clinical Discharge Cancelled",
+                before, clinicalDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Clinical discharge cancelled.");
     }
 

--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -33,6 +33,9 @@ import javax.persistence.TemporalType;
 public class NursingDischargeController implements Serializable {
 
     @EJB
+    private com.divudi.service.AuditService auditService;
+
+    @EJB
     private PatientEncounterFacade patientEncounterFacade;
 
     @EJB
@@ -195,12 +198,34 @@ public class NursingDischargeController implements Serializable {
                     + " pending pharmacy item(s) must be resolved first.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setNursingDischarged(Boolean.TRUE);
         currentEncounter.setNursingDischargeDateTime(new Date());
         currentEncounter.setNursingDischargedBy(sessionController.getLoggedUser());
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Nursing Discharge",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(currentEncounter, "NursingDischarge");
         JsfUtil.addSuccessMessage("Nursing discharge confirmed.");
+    }
+
+    /**
+     * Snapshot of the nursing/physical discharge flags for audit events (#22236).
+     */
+    private Map<String, Object> nursingDischargeStateMap() {
+        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (currentEncounter == null) {
+            return m;
+        }
+        m.put("nursingDischarged", currentEncounter.isNursingDischarged());
+        m.put("nursingDischargeDateTime", currentEncounter.getNursingDischargeDateTime());
+        m.put("nursingDischargedBy", currentEncounter.getNursingDischargedBy() != null
+                ? currentEncounter.getNursingDischargedBy().getName() : null);
+        m.put("physicalDischarged", currentEncounter.isPhysicalDischarged());
+        m.put("physicalDischargeDateTime", currentEncounter.getPhysicalDischargeDateTime());
+        m.put("physicalDischargedBy", currentEncounter.getPhysicalDischargedBy() != null
+                ? currentEncounter.getPhysicalDischargedBy().getName() : null);
+        return m;
     }
 
     public void cancelNursingDischarge() {
@@ -216,10 +241,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot cancel nursing discharge: physical discharge has already been confirmed. Cancel physical discharge first.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setNursingDischarged(Boolean.FALSE);
         currentEncounter.setNursingDischargeDateTime(null);
         currentEncounter.setNursingDischargedBy(null);
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Nursing Discharge Cancelled",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Nursing discharge cancelled.");
     }
 
@@ -244,10 +272,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm physical discharge: administrative discharge (final bill) has not been completed.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setPhysicalDischarged(Boolean.TRUE);
         currentEncounter.setPhysicalDischargeDateTime(new Date());
         currentEncounter.setPhysicalDischargedBy(sessionController.getLoggedUser());
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Physical Discharge",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         notificationController.createNotification(currentEncounter, "PhysicalDischarge");
         JsfUtil.addSuccessMessage("Physical discharge confirmed. Patient has left the hospital.");
     }
@@ -261,10 +292,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Physical discharge has not been confirmed.");
             return;
         }
+        Map<String, Object> before = nursingDischargeStateMap();
         currentEncounter.setPhysicalDischarged(Boolean.FALSE);
         currentEncounter.setPhysicalDischargeDateTime(null);
         currentEncounter.setPhysicalDischargedBy(null);
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Physical Discharge Cancelled",
+                before, nursingDischargeStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Physical discharge cancelled.");
     }
 


### PR DESCRIPTION
Closes #22236. Part of #22232. **Stacked on #22244** (base `22235-audit-admission-lifecycle`) — will be retargeted to `development` as the stack merges.

## What was implemented

All via `AuditService.logEncounterAudit` (from #22243): `patientEncounterId` linkage, JSON before/after, never throws.

| Action | Trigger | Notes |
|---|---|---|
| `DischargeController.discharge()` / `AdmissionController.discharge()` | `Discharge` | Before-state is read **from the DB** (`findWithoutCache`) because calling flows (e.g. `BhtSummeryController` settlement date change) stage the new discharge date on the session entity before calling discharge — a session-side snapshot would show no diff |
| `BhtSummeryController.dischargeCancel()` | `Discharge Cancelled` | beforeJson preserves the original discharge date — the encounter-level fix for #21623: after cancellation, history still shows the original discharge and its cancellation |
| `NursingDischargeController.confirmNursingDischarge()` / `cancelNursingDischarge()` | `Nursing Discharge` / `Nursing Discharge Cancelled` | shared nursing+physical flag snapshot (flags, timestamps, by-user) |
| `NursingDischargeController.confirmPhysicalDischarge()` / `cancelPhysicalDischarge()` | `Physical Discharge` / `Physical Discharge Cancelled` | same snapshot |
| `InpatientClinicalDataController.confirmClinicalDischarge()` / `cancelClinicalDischarge()` | `Clinical Discharge` / `Clinical Discharge Cancelled` | clinical flag snapshot; included because it is the third leg of the encounter-level discharge workflow alongside nursing/physical |

**Discharge date/time edits:** the settlement-page date change goes through `DischargeController.discharge()`; its DB-read before-snapshot means a re-discharge at a new date renders as a `dateOfDischarge` before/after diff — no separate instrumentation needed.

## Verification

- `mvn compile` clean; getter names verified against `PatientEncounter` (`isClinicallyDischarged`, `isNursingDischarged`, `isPhysicalDischarged` all exist).
- Per the umbrella plan, instrumentation-only sub-issues get build + code-level verification; the shared audit plumbing was E2E-verified in #22243 and the timeline page PR (#22240) will exercise these events end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)