### PR TITLE
feat(audit): payment method & credit detail audit events (#22232 sub-issue 4)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -438,11 +438,26 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
 
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("creditCompany", patientEncounter.getCreditCompany() != null
+                ? patientEncounter.getCreditCompany().getName() : null);
+        before.put("creditLimit", patientEncounter.getCreditLimit());
+        before.put("creditPaidAmount", patientEncounter.getCreditPaidAmount());
+        before.put("creditUsedAmount", patientEncounter.getCreditUsedAmount());
+
         patientEncounter.setCreditCompany(null);
         patientEncounter.setCreditLimit(0);
         patientEncounter.setCreditPaidAmount(0);
         patientEncounter.setCreditUsedAmount(0);
         getPatientEncounterFacade().edit(patientEncounter);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("creditCompany", null);
+        after.put("creditLimit", 0);
+        after.put("creditPaidAmount", 0);
+        after.put("creditUsedAmount", 0);
+        auditService.logEncounterAudit(patientEncounter, "Credit Detail Reset",
+                before, after, getSessionController().getLoggedUser());
     }
 
     public String navigateToInpatientClinicalData() {
@@ -2727,6 +2742,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 ecc.setCreater(sessionController.getLoggedUser());
                 if (ecc.getInstitution() != null) {
                     getEncounterCreditCompanyFacade().create(ecc);
+                    Map<String, Object> eccState = new LinkedHashMap<>();
+                    eccState.put("creditCompany", ecc.getInstitution().getName());
+                    eccState.put("creditLimit", ecc.getCreditLimit());
+                    eccState.put("policyNo", ecc.getPolicyNo());
+                    eccState.put("referenceNo", ecc.getReferanceNo());
+                    auditService.logEncounterAudit(current, "Credit Company Added",
+                            null, eccState, getSessionController().getLoggedUser(),
+                            "EncounterCreditCompany", ecc.getId());
                     // Upsert back to patient-level insurance profile
                     patientInsuranceController.upsertFromEncounter(
                             current.getPatient(),

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -211,11 +211,31 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         current.setCreditCompany(ecc.getInstitution());
     }
 
+    /**
+     * Snapshot of an EncounterCreditCompany for credit-detail audit events (#22237).
+     */
+    private Map<String, Object> creditCompanyAuditMap(EncounterCreditCompany ecc) {
+        Map<String, Object> m = new HashMap<>();
+        if (ecc == null) {
+            return m;
+        }
+        m.put("creditCompany", ecc.getInstitution() != null ? ecc.getInstitution().getName() : null);
+        m.put("creditLimit", ecc.getCreditLimit());
+        m.put("policyNo", ecc.getPolicyNo());
+        m.put("referenceNo", ecc.getReferanceNo());
+        m.put("retired", ecc.isRetired());
+        return m;
+    }
+
     public void removeCreditCompany(EncounterCreditCompany ecc) {
         for (EncounterCreditCompany e : encounterCreditCompanys) {
             if (e == ecc) {
+                Map<String, Object> before = creditCompanyAuditMap(e);
                 e.setRetired(true);
                 encounterCreditCompanyFacade.edit(e);
+                auditService.logEncounterAudit(current, "Credit Company Removed",
+                        before, creditCompanyAuditMap(e), sessionController.getLoggedUser(),
+                        "EncounterCreditCompany", e.getId());
             }
         }
         current.setCreditCompany(null);
@@ -248,6 +268,10 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         newEncounterCreditCompany.setCreater(sessionController.getLoggedUser());
         newEncounterCreditCompany.setRetired(false);
         encounterCreditCompanyFacade.create(newEncounterCreditCompany);
+        auditService.logEncounterAudit(current, "Credit Company Added",
+                null, creditCompanyAuditMap(newEncounterCreditCompany),
+                sessionController.getLoggedUser(),
+                "EncounterCreditCompany", newEncounterCreditCompany.getId());
         encounterCreditCompanys.add(newEncounterCreditCompany);
         newEncounterCreditCompany = new EncounterCreditCompany();
         JsfUtil.addSuccessMessage("Credit company added");
@@ -257,7 +281,19 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         if (ecc == null) {
             return;
         }
+        // Session entity already carries the edited values; read the persisted
+        // row for the audit before-snapshot
+        Map<String, Object> before = null;
+        if (ecc.getId() != null) {
+            EncounterCreditCompany persisted = encounterCreditCompanyFacade.findWithoutCache(ecc.getId());
+            if (persisted != null) {
+                before = creditCompanyAuditMap(persisted);
+            }
+        }
         encounterCreditCompanyFacade.edit(ecc);
+        auditService.logEncounterAudit(current, "Credit Company Updated",
+                before, creditCompanyAuditMap(ecc), sessionController.getLoggedUser(),
+                "EncounterCreditCompany", ecc.getId());
         JsfUtil.addSuccessMessage("Saved");
     }
 
@@ -1149,7 +1185,13 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         m.put("bhtNo", o.getBhtNo());
         m.put("encounterType", o.getEncounterType());
         m.put("dateOfAdmission", o.getDateOfAdmission());
-        
+        m.put("paymentMethod", o.getPaymentMethod());
+        m.put("paymentScheme", o.getPaymentScheme() != null ? o.getPaymentScheme().getName() : null);
+        m.put("creditCompany", o.getCreditCompany() != null ? o.getCreditCompany().getName() : null);
+        m.put("creditLimit", o.getCreditLimit());
+        m.put("policyNo", o.getPolicyNo());
+        m.put("claimable", o.isClaimable());
+
         if (o.getReferringConsultant() != null) {
             m.put("consultant", o.getReferringConsultant().toString());
         }


### PR DESCRIPTION
Closes #22237. Part of #22232. **Stacked on #22245** (base `22236-audit-discharge-actions`) — will be retargeted to `development` as the stack merges.

## What was implemented

| Change | Effect |
|---|---|
| `admissionToAuditMap` extended (paymentMethod, paymentScheme, creditCompany, creditLimit, policyNo, claimable) | The existing `UpdateAdmission` audit — fired by both the Edit Admission and **Edit Payment Details** save flows — now shows payment/credit changes as field-by-field diffs (acceptance criterion 2) |
| `BhtEditController.addNewCreditCompany()` | `Credit Company Added` (company, limit, policyNo, referenceNo) |
| `BhtEditController.removeCreditCompany()` | `Credit Company Removed` with before-snapshot |
| `BhtEditController.saveEncounterCreditCompany()` | `Credit Company Updated` — before-state read from DB via `findWithoutCache` (session entity already edited by JSF) |
| `AdmissionController.saveEncounterCreditCompanies()` | `Credit Company Added` when companies staged during admission creation/conversion are actually persisted |
| `AdmissionController.resetCreditDetail()` | `Credit Detail Reset` with cleared fields (company, limit, paid, used) |

**Deliberately not instrumented:** `admissionPaymentMethodChange()` — it is an AJAX value-change listener that persists nothing (it only pre-fills the last-used credit company); the persisted payment-method change goes through `saveCurrent()`/`saveSelected()`, which the extended audit map / Admission Created snapshot now covers. Likewise the in-memory `addCreditCompnay()`/`removeCreditCompany()` on the admission form mutate an unsaved list — the persisted outcome is audited at `saveEncounterCreditCompanies()`.

All events carry `patientEncounterId`; ECC events also set `entityType=EncounterCreditCompany` + `objectId`. Audit failure never blocks the action.

## Verification

`mvn compile` clean. Per the umbrella plan, instrumentation-only sub-issues get build + code-level verification; plumbing E2E-verified in #22243, and #22240 will exercise the timeline end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)