### PR TITLE
feat(audit): financial adjustment audit events at settlement (#22232 sub-issue 5)

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -229,6 +229,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardInvestigationsView, "Investigations View"), clinicalDataViewNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardImagesView, "Images View"), clinicalDataViewNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDiagnosisCardView, "Diagnosis Card View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEventHistoryView, "Event History View"), clinicalDataViewNode);
 
         TreeNode inwardPharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyMenu, "Pharmacy Menu"), inwardPharmacyNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -378,8 +378,17 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
         try {
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+            before.put("retired", pa.isRetired());
             pa.setRetired(true);
             clinicalFindingValueFacade.edit(pa);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+            after.put("retired", pa.isRetired());
+            auditService.logEncounterAudit(current, "Patient Allergy Removed",
+                    before, after, getSessionController().getLoggedUser(),
+                    "ClinicalFindingValue", pa.getId());
             getPatientAllergies().remove(pa);
             JsfUtil.addSuccessMessage("Allergy removed successfully");
         } catch (Exception e) {

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -165,16 +165,37 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             currentPatientAllergy.setClinicalFindingValueType(ClinicalFindingValueType.PatientAllergy);
         }
         clinicalFindingValueFacade.create(currentPatientAllergy);
+        auditService.logEncounterAudit(current, "Patient Allergy Added",
+                null, allergyAuditMap(currentPatientAllergy), sessionController.getLoggedUser(),
+                "ClinicalFindingValue", currentPatientAllergy.getId());
         patientAllergies.add(currentPatientAllergy);
         currentPatientAllergy = null;
+    }
+
+    /**
+     * Snapshot of a patient allergy for audit events (#22239).
+     */
+    private Map<String, Object> allergyAuditMap(ClinicalFindingValue pa) {
+        Map<String, Object> m = new HashMap<>();
+        if (pa == null) {
+            return m;
+        }
+        m.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+        m.put("value", pa.getStringValue());
+        m.put("retired", pa.isRetired());
+        return m;
     }
 
     public void removePatientAllergy(ClinicalFindingValue pa) {
         if (pa == null) {
             return;
         }
+        Map<String, Object> before = allergyAuditMap(pa);
         pa.setRetired(true);
         clinicalFindingValueFacade.edit(pa);
+        auditService.logEncounterAudit(current, "Patient Allergy Removed",
+                before, allergyAuditMap(pa), sessionController.getLoggedUser(),
+                "ClinicalFindingValue", pa.getId());
         patientAllergies.remove(pa);
     }
 
@@ -1191,6 +1212,15 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         m.put("creditLimit", o.getCreditLimit());
         m.put("policyNo", o.getPolicyNo());
         m.put("claimable", o.isClaimable());
+        if (o.getGuardian() != null) {
+            m.put("guardian_nic", o.getGuardian().getNic());
+            m.put("guardian_phone", o.getGuardian().getPhone());
+            m.put("guardian_mobile", o.getGuardian().getMobile());
+            m.put("guardian_address", o.getGuardian().getAddress());
+        }
+        if (o.getGuardianRelationshipToPatient() != null) {
+            m.put("guardian_relationship", o.getGuardianRelationshipToPatient().getName());
+        }
 
         if (o.getReferringConsultant() != null) {
             m.put("consultant", o.getReferringConsultant().toString());

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -492,7 +492,36 @@ public class BhtSummeryController implements Serializable {
         this.toDate = toDate;
     }
 
+    /**
+     * Snapshot of a room's per-charge discount values for audit events (#22238).
+     */
+    private Map<String, Object> roomDiscountAuditMap(PatientRoom pr) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        if (pr == null) {
+            return m;
+        }
+        m.put("room", pr.getRoomFacilityCharge() != null ? pr.getRoomFacilityCharge().getName() : null);
+        m.put("discountRoomCharge", pr.getDiscountRoomCharge());
+        m.put("discountMaintainCharge", pr.getDiscountMaintainCharge());
+        m.put("discountLinenCharge", pr.getDiscountLinenCharge());
+        m.put("discountMedicalCareCharge", pr.getDiscountMedicalCareCharge());
+        m.put("discountAdministrationCharge", pr.getDiscountAdministrationCharge());
+        m.put("discountNursingCharge", pr.getDiscountNursingCharge());
+        m.put("discountMoCharge", pr.getDiscountMoCharge());
+        return m;
+    }
+
+    private void auditRoomDiscountChange(Map<String, Object> before, PatientRoom pr) {
+        auditService.logEncounterAudit(getPatientEncounter(), "Room Discount Changed",
+                before, roomDiscountAuditMap(pr), sessionController.getLoggedUser(),
+                "PatientRoom", pr.getId());
+    }
+
     public void changeDiscountListener(ChargeItemTotal cit) {
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("chargeType", cit.getInwardChargeType());
+        before.put("total", cit.getTotal());
+        before.put("requestedDiscount", cit.getDiscount());
         double discountPercent = (cit.getDiscount() * 100) / cit.getTotal();
         double disValue = 0;
         switch (cit.getInwardChargeType()) {
@@ -524,9 +553,18 @@ public class BhtSummeryController implements Serializable {
 //        cit.setAdjustedTotal(cit.getTotal());
 
         updateTotal();
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("chargeType", cit.getInwardChargeType());
+        after.put("total", cit.getTotal());
+        after.put("appliedDiscount", cit.getDiscount());
+        after.put("adjustedTotal", cit.getAdjustedTotal());
+        auditService.logEncounterAudit(getPatientEncounter(), "Settlement Discount Changed",
+                before, after, sessionController.getLoggedUser());
     }
 
     public void changeDiscountListenerPatientRoomRoomCharge(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -537,11 +575,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomMaintain(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -552,11 +592,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomLinen(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -567,11 +609,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomMedicalCare(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -582,11 +626,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomAdministration(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
         //Administration Charge
@@ -596,11 +642,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomNursing(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -611,11 +659,13 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
 
     public void changeDiscountListenerPatientRoomMo(PatientRoom pR) {
+        Map<String, Object> before = roomDiscountAuditMap(getPatientRoomFacade().findWithoutCache(pR.getId()));
         getPatientRoomFacade().edit(pR);
         double disCountPercent = 0;
 
@@ -626,6 +676,7 @@ public class BhtSummeryController implements Serializable {
         }
 
         updateRoomChargeTypeTotal();
+        auditRoomDiscountChange(before, pR);
 
         patientRooms = getInwardBean().fetchPatientRoomAll(getPatientEncounter(), childPatientEncouters);
     }
@@ -1813,6 +1864,23 @@ public class BhtSummeryController implements Serializable {
         getBillFacade().edit(getCurrent());
 
         updatePaymentBillList();
+
+        Map<String, Object> settlementState = new LinkedHashMap<>();
+        settlementState.put("finalBillId", getCurrent().getId());
+        settlementState.put("grantTotal", getCurrent().getGrantTotal());
+        settlementState.put("discount", getCurrent().getDiscount());
+        settlementState.put("netTotal", getCurrent().getNetTotal());
+        if (chargeItemTotals != null) {
+            for (ChargeItemTotal cit : chargeItemTotals) {
+                if (cit.getDiscount() != 0) {
+                    settlementState.put("discount_" + cit.getInwardChargeType(), cit.getDiscount());
+                }
+            }
+        }
+        auditService.logEncounterAudit(getPatientEncounter(), "Final Bill Settled",
+                null, settlementState, sessionController.getLoggedUser(),
+                "Bill", getCurrent().getId());
+
         JsfUtil.addSuccessMessage("Bill Saved");
 
         showOrginalBill = false;

--- a/src/main/java/com/divudi/bean/inward/InpatientEventHistoryController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientEventHistoryController.java
@@ -1,0 +1,204 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.data.inward.InpatientTimelineRow;
+import com.divudi.core.entity.AuditEvent;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.AuditEventFacade;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.WebUserFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Inpatient Event History ("Patient Story", #22240) — merges the encounter's
+ * bills and its encounter-linked audit events into one chronological timeline
+ * shown from the Inpatient Dashboard.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Named
+@SessionScoped
+public class InpatientEventHistoryController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private WebUserController webUserController;
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private AuditEventFacade auditEventFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    private PatientEncounter patientEncounter;
+    private List<InpatientTimelineRow> timelineRows;
+
+    public String navigateToEventHistory(PatientEncounter pe) {
+        if (pe == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return "";
+        }
+        if (!webUserController.hasPrivilege("InwardEventHistoryView")) {
+            JsfUtil.addErrorMessage("You are not authorized to view the event history");
+            return "";
+        }
+        patientEncounter = pe;
+        loadTimeline();
+        return "/inward/admission_event_history?faces-redirect=true";
+    }
+
+    public void loadTimeline() {
+        timelineRows = new ArrayList<>();
+        if (patientEncounter == null || patientEncounter.getId() == null) {
+            return;
+        }
+
+        String billJpql = "select b from Bill b "
+                + " where b.retired=false "
+                + " and b.patientEncounter=:pe "
+                + " order by b.createdAt";
+        Map<String, Object> billParams = new HashMap<>();
+        billParams.put("pe", patientEncounter);
+        List<Bill> bills = billFacade.findByJpql(billJpql, billParams);
+        if (bills != null) {
+            for (Bill b : bills) {
+                StringBuilder description = new StringBuilder();
+                if (b.getBillTypeAtomic() != null) {
+                    description.append(b.getBillTypeAtomic().getLabel());
+                } else if (b.getBillType() != null) {
+                    description.append(b.getBillType().getLabel());
+                } else {
+                    description.append("Bill");
+                }
+                if (b.getDeptId() != null && !b.getDeptId().trim().isEmpty()) {
+                    description.append(" — ").append(b.getDeptId());
+                }
+                if (b.isCancelled()) {
+                    description.append(" (Cancelled)");
+                }
+                timelineRows.add(new InpatientTimelineRow(
+                        b.getCreatedAt(),
+                        "Billing",
+                        description.toString(),
+                        b.getCreater() != null ? b.getCreater().getName() : null,
+                        b.getId(),
+                        b.getNetTotal(),
+                        null));
+            }
+        }
+
+        String auditJpql = "select a from AuditEvent a "
+                + " where a.patientEncounterId=:peid "
+                + " order by a.eventDataTime";
+        Map<String, Object> auditParams = new HashMap<>();
+        auditParams.put("peid", patientEncounter.getId());
+        List<AuditEvent> auditEvents = auditEventFacade.findByJpql(auditJpql, auditParams);
+        if (auditEvents != null) {
+            Map<Long, String> userNames = resolveUserNames(auditEvents);
+            for (AuditEvent ae : auditEvents) {
+                timelineRows.add(new InpatientTimelineRow(
+                        ae.getEventDataTime(),
+                        categorize(ae.getEventTrigger()),
+                        ae.getEventTrigger(),
+                        ae.getWebUserId() != null ? userNames.get(ae.getWebUserId()) : null,
+                        null,
+                        null,
+                        ae));
+            }
+        }
+
+        Collections.sort(timelineRows);
+    }
+
+    /**
+     * AuditEvent stores only the webUserId (it lives in the audit persistence
+     * unit); resolve display names from the main unit in one query.
+     */
+    private Map<Long, String> resolveUserNames(List<AuditEvent> auditEvents) {
+        Map<Long, String> names = new HashMap<>();
+        Set<Long> ids = new HashSet<>();
+        for (AuditEvent ae : auditEvents) {
+            if (ae.getWebUserId() != null) {
+                ids.add(ae.getWebUserId());
+            }
+        }
+        if (ids.isEmpty()) {
+            return names;
+        }
+        String jpql = "select w from WebUser w where w.id in :ids";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ids", new ArrayList<>(ids));
+        List<WebUser> users = webUserFacade.findByJpql(jpql, params);
+        if (users != null) {
+            for (WebUser u : users) {
+                names.put(u.getId(), u.getName());
+            }
+        }
+        return names;
+    }
+
+    private String categorize(String trigger) {
+        if (trigger == null) {
+            return "Other";
+        }
+        String t = trigger.toLowerCase();
+        if (t.contains("room") || t.contains("transfer") || t.contains("theatre")) {
+            return "Room / Transfer";
+        }
+        if (t.contains("discharge")) {
+            return "Discharge";
+        }
+        if (t.contains("credit") || t.contains("payment")) {
+            return "Payment / Credit";
+        }
+        if (t.contains("discount") || t.contains("fee") || t.contains("settle")
+                || t.contains("price")) {
+            return "Financial";
+        }
+        if (t.contains("admission") || t.contains("bht") || t.contains("patient changed")) {
+            return "Admission";
+        }
+        return "Other";
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public List<InpatientTimelineRow> getTimelineRows() {
+        if (timelineRows == null) {
+            timelineRows = new ArrayList<>();
+        }
+        return timelineRows;
+    }
+
+    public void setTimelineRows(List<InpatientTimelineRow> timelineRows) {
+        this.timelineRows = timelineRows;
+    }
+
+}

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -41,7 +41,25 @@ public class InwardDocumentUploadController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
     private SessionController sessionController;
+    @javax.ejb.EJB
+    private com.divudi.service.AuditService auditService;
     // </editor-fold>
+
+    /**
+     * Snapshot of an uploaded document for audit events (#22239).
+     */
+    private Map<String, Object> documentAuditMap(Upload u) {
+        Map<String, Object> m = new HashMap<>();
+        if (u == null) {
+            return m;
+        }
+        m.put("fileName", u.getFileName());
+        m.put("fileType", u.getFileType());
+        m.put("uploadType", u.getUploadType());
+        m.put("comments", u.getComments());
+        m.put("retired", u.isRetired());
+        return m;
+    }
 
     // <editor-fold defaultstate="collapsed" desc="Variables">
     private PatientEncounter currentEncounter;
@@ -126,6 +144,9 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
             uploadFacade.create(upload);
+            auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
+                    null, documentAuditMap(upload), sessionController.getLoggedUser(),
+                    "Upload", upload.getId());
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
             file = null;
             selectedUploadType = null;
@@ -180,6 +201,9 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
             uploadFacade.create(upload);
+            auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
+                    null, documentAuditMap(upload), sessionController.getLoggedUser(),
+                    "Upload", upload.getId());
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
             selectedUploadType = null;
             comments = null;
@@ -197,10 +221,14 @@ public class InwardDocumentUploadController implements Serializable {
         if (u == null) {
             return;
         }
+        Map<String, Object> before = documentAuditMap(u);
         u.setRetired(true);
         u.setRetirer(sessionController.getLoggedUser());
         u.setRetiredAt(new Date());
         uploadFacade.edit(u);
+        auditService.logEncounterAudit(currentEncounter, "Document Removed",
+                before, documentAuditMap(u), sessionController.getLoggedUser(),
+                "Upload", u.getId());
         loadDocuments();
         JsfUtil.addSuccessMessage("Document removed.");
     }

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -56,6 +56,8 @@ public class InwardPriceAdjustmntController implements Serializable {
     @Inject
     PharmaceuticalItemCategoryController pharmaceuticalItemCategoryController;
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private PriceMatrixFacade ejbFacade;
     @Enumerated(EnumType.STRING)
     PaymentMethod paymentMethod;
@@ -83,6 +85,34 @@ public class InwardPriceAdjustmntController implements Serializable {
         admissionType = null;
         roomCategory = null;
         items = null;
+    }
+
+    /**
+     * Snapshot of an inward price adjustment (PriceMatrix) for audit events
+     * (#22238). Price adjustments are institution-level master data, so the
+     * event is not linked to a patient encounter.
+     */
+    private java.util.Map<String, Object> priceAdjustmentAuditMap(PriceMatrix a) {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (a == null) {
+            return m;
+        }
+        m.put("department", a.getDepartment() != null ? a.getDepartment().getName() : null);
+        m.put("category", a.getCategory() != null ? a.getCategory().getName() : null);
+        m.put("roomCategory", a.getRoomCategory() != null ? a.getRoomCategory().getName() : null);
+        m.put("paymentMethod", a.getPaymentMethod());
+        m.put("admissionType", a.getAdmissionType() != null ? a.getAdmissionType().getName() : null);
+        m.put("creditCompany", a.getCreditCompany() != null ? a.getCreditCompany().getName() : null);
+        m.put("fromPrice", a.getFromPrice());
+        m.put("toPrice", a.getToPrice());
+        m.put("margin", a.getMargin());
+        return m;
+    }
+
+    private void auditPriceAdjustmentAdded(PriceMatrix a) {
+        auditService.logEncounterAudit(null, "Inward Price Adjustment Added",
+                null, priceAdjustmentAuditMap(a), getSessionController().getLoggedUser(),
+                "PriceMatrix", a.getId());
     }
 
     public void preparedAdd() {
@@ -165,6 +195,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
             getFacade().create(a);
+            auditPriceAdjustmentAdded(a);
         }
         JsfUtil.addSuccessMessage("Saved Successfully");
         recreateModel();
@@ -206,6 +237,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
             getFacade().create(a);
+            auditPriceAdjustmentAdded(a);
         }
         JsfUtil.addSuccessMessage("Saved Successfully");
         recreateModel();
@@ -251,6 +283,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             a.setCreater(getSessionController().getLoggedUser());
             if (a.getId() == null) {
                 getFacade().create(a);
+                auditPriceAdjustmentAdded(a);
             }
         }
 

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillControllerEstimate.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillControllerEstimate.java
@@ -65,6 +65,8 @@ public class InwardProfessionalBillControllerEstimate implements Serializable {
     AdmissionController admissionController;
     ////////////////////
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private BillFacade ejbFacade;
     @EJB
     private BillItemFacade billItemFacade;
@@ -184,7 +186,36 @@ public class InwardProfessionalBillControllerEstimate implements Serializable {
     }
 
     public void updateProFee(BillFee bf) {
+        // Persisted value for the audit before-snapshot; the session entity
+        // already carries the newly entered fee
+        java.util.Map<String, Object> before = null;
+        if (bf != null && bf.getId() != null) {
+            BillFee persisted = getBillFeeFacade().findWithoutCache(bf.getId());
+            if (persisted != null) {
+                before = professionalFeeAuditMap(persisted);
+            }
+        }
         updateBillFee(bf);
+        auditService.logEncounterAudit(
+                getBatchBill() != null ? getBatchBill().getPatientEncounter() : null,
+                "Professional Fee Estimate Changed",
+                before, professionalFeeAuditMap(bf), getSessionController().getLoggedUser(),
+                "BillFee", bf != null ? bf.getId() : null);
+    }
+
+    /**
+     * Snapshot of a professional-fee estimate for audit events (#22238).
+     */
+    private java.util.Map<String, Object> professionalFeeAuditMap(BillFee bf) {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (bf == null) {
+            return m;
+        }
+        m.put("staff", bf.getStaff() != null && bf.getStaff().getPerson() != null
+                ? bf.getStaff().getPerson().getName() : null);
+        m.put("feeValue", bf.getFeeValue());
+        m.put("retired", bf.isRetired());
+        return m;
     }
 
     private void updateBillItem(BillItem billItem) {
@@ -224,6 +255,8 @@ public class InwardProfessionalBillControllerEstimate implements Serializable {
             return;
         }
 
+        java.util.Map<String, Object> before = professionalFeeAuditMap(encounterComponent.getBillFee());
+
         retiredEncounterComponent(encounterComponent);
         retiredBillFee(encounterComponent.getBillFee());
 
@@ -231,6 +264,13 @@ public class InwardProfessionalBillControllerEstimate implements Serializable {
         updateBill(encounterComponent.getBillItem().getBill());
         getBillBean().updateBatchBill(getBatchBill());
 
+        auditService.logEncounterAudit(
+                getBatchBill() != null ? getBatchBill().getPatientEncounter() : null,
+                "Professional Fee Estimate Removed",
+                before, professionalFeeAuditMap(encounterComponent.getBillFee()),
+                getSessionController().getLoggedUser(),
+                "BillFee",
+                encounterComponent.getBillFee() != null ? encounterComponent.getBillFee().getId() : null);
     }
 
     private void retiredEncounterComponent(EncounterComponent encounterComponent) {
@@ -389,6 +429,13 @@ public class InwardProfessionalBillControllerEstimate implements Serializable {
         getProEncounterComponents().add(proEncounterComponent);
 
         saveSurgeryProfessional();
+
+        auditService.logEncounterAudit(getBatchBill().getPatientEncounter(),
+                "Professional Fee Estimate Added",
+                null, professionalFeeAuditMap(proEncounterComponent.getBillFee()),
+                getSessionController().getLoggedUser(),
+                "BillFee",
+                proEncounterComponent.getBillFee() != null ? proEncounterComponent.getBillFee().getId() : null);
 
         proEncounterComponent = null;
     }

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -48,6 +48,8 @@ public class PatientTransferController implements Serializable {
     private AdmissionController admissionController;
 
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private AdmissionFacade admissionFacade;
     @EJB
     private PatientTransferRequestFacade patientTransferRequestFacade;
@@ -217,6 +219,30 @@ public class PatientTransferController implements Serializable {
         return true;
     }
 
+    /**
+     * Snapshot of a transfer request for audit events (#22239).
+     */
+    private java.util.Map<String, Object> transferAuditMap(PatientTransferRequest req) {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (req == null) {
+            return m;
+        }
+        m.put("status", req.getStatus());
+        m.put("theatreTransferType", req.getTheatreTransferType());
+        m.put("theatreOccupancyStatus", req.getTheatreOccupancyStatus());
+        m.put("fromRoom", req.getFromPatientRoom() != null && req.getFromPatientRoom().getRoomFacilityCharge() != null
+                ? req.getFromPatientRoom().getRoomFacilityCharge().getName() : null);
+        m.put("toRoom", req.getToRoomFacilityCharge() != null ? req.getToRoomFacilityCharge().getName() : null);
+        m.put("notes", req.getNotes());
+        return m;
+    }
+
+    private void auditTransfer(PatientTransferRequest req, String trigger, java.util.Map<String, Object> before) {
+        auditService.logEncounterAudit(req != null ? req.getAdmission() : null, trigger,
+                before, transferAuditMap(req), sessionController.getLoggedUser(),
+                "PatientTransferRequest", req != null ? req.getId() : null);
+    }
+
     public void initiateTransfer() {
         if (current == null) {
             JsfUtil.addErrorMessage("Please select a patient first.");
@@ -255,6 +281,7 @@ public class PatientTransferController implements Serializable {
         req.setNotes(notes);
         patientTransferRequestFacade.create(req);
         lastInitiatedRequest = req;
+        auditTransfer(req, "Transfer Initiated", null);
 
         JsfUtil.addSuccessMessage("Transfer initiated successfully.");
         targetRoomFacilityCharge = null;
@@ -278,10 +305,12 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("This transfer request is no longer pending and cannot be cancelled.");
             return;
         }
+        java.util.Map<String, Object> beforeCancel = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.CANCELLED);
         persisted.setCancelledAt(new Date());
         persisted.setCancelledBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Transfer Cancelled", beforeCancel);
         lastInitiatedRequest = null;
         loadCurrentAdmissionRequests();
         JsfUtil.addSuccessMessage("Transfer request cancelled. You may now initiate a new one.");
@@ -303,6 +332,7 @@ public class PatientTransferController implements Serializable {
             return;
         }
 
+        java.util.Map<String, Object> beforeAccept = transferAuditMap(req);
         Date effectiveAt = req.getAcceptedAt() != null ? req.getAcceptedAt() : new Date();
         req.setAcceptedAt(effectiveAt);
 
@@ -337,6 +367,7 @@ public class PatientTransferController implements Serializable {
         req.setStatus(TransferRequestStatus.ACCEPTED);
         req.setAcceptedBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(req);
+        auditTransfer(req, "Transfer Accepted", beforeAccept);
 
         loadPendingForDepartment();
         JsfUtil.addSuccessMessage("Patient accepted successfully.");
@@ -346,10 +377,12 @@ public class PatientTransferController implements Serializable {
         if (req == null) {
             return;
         }
+        java.util.Map<String, Object> beforeCancel = transferAuditMap(req);
         req.setStatus(TransferRequestStatus.CANCELLED);
         req.setCancelledAt(new Date());
         req.setCancelledBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(req);
+        auditTransfer(req, "Transfer Cancelled", beforeCancel);
         loadPendingForDepartment();
         JsfUtil.addSuccessMessage("Transfer request cancelled.");
     }
@@ -537,6 +570,7 @@ public class PatientTransferController implements Serializable {
         req.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(req);
         lastInitiatedRequest = req;
+        auditTransfer(req, "Sent To Theatre", null);
         JsfUtil.addSuccessMessage("Patient sent to theatre successfully.");
         targetRoomFacilityCharge = null;
         selectedSurgeryBill = null;
@@ -553,6 +587,7 @@ public class PatientTransferController implements Serializable {
             loadPendingForTheatre();
             return;
         }
+        java.util.Map<String, Object> beforeTheatreAccept = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.ACCEPTED);
         persisted.setAcceptedAt(new Date());
         persisted.setAcceptedBy(sessionController.getLoggedUser());
@@ -571,6 +606,7 @@ public class PatientTransferController implements Serializable {
         }
 
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Theatre Patient Accepted", beforeTheatreAccept);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Patient accepted in theatre.");
@@ -588,11 +624,13 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Patient must be in RECEIVED_IN_THEATRE status to mark as In Theatre.");
             return;
         }
+        java.util.Map<String, Object> beforeInTheatre = transferAuditMap(persisted);
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.IN_THEATRE);
         if (persisted.getProcedureStartAt() == null) {
             persisted.setProcedureStartAt(new Date());
         }
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Marked In Theatre", beforeInTheatre);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Patient marked as In Theatre.");
@@ -610,11 +648,13 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Patient must be IN_THEATRE status to mark procedure as completed.");
             return;
         }
+        java.util.Map<String, Object> beforeCompleted = transferAuditMap(persisted);
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.PROCEDURE_COMPLETED);
         if (persisted.getProcedureEndAt() == null) {
             persisted.setProcedureEndAt(new Date());
         }
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Procedure Completed", beforeCompleted);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Procedure marked as completed.");
@@ -651,6 +691,7 @@ public class PatientTransferController implements Serializable {
         returnReq.setCreatedAt(new Date());
         returnReq.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(returnReq);
+        auditTransfer(returnReq, "Return To Ward Initiated", null);
 
         Date returnedAt = persisted.getReturnedToWardAt() != null ? persisted.getReturnedToWardAt() : new Date();
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
@@ -682,10 +723,12 @@ public class PatientTransferController implements Serializable {
             loadPendingReturnsForWard();
             return;
         }
+        java.util.Map<String, Object> beforeReturnAccept = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.ACCEPTED);
         persisted.setAcceptedAt(new Date());
         persisted.setAcceptedBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Return To Ward Accepted", beforeReturnAccept);
 
         // Update the master SEND_TO_THEATRE record's returnedToWardAt if not already set
         PatientTransferRequest theatreReq = findActiveSendToTheatreRequestForReturn(persisted);

--- a/src/main/java/com/divudi/bean/inward/ServiceFeeEdit.java
+++ b/src/main/java/com/divudi/bean/inward/ServiceFeeEdit.java
@@ -41,6 +41,8 @@ public class ServiceFeeEdit implements Serializable {
     private BillItem billItem;
     private List<BillFee> billFees;
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private BillFeeFacade billFeeFacade;
     @Inject
     private InwardBeanController inwardBean;
@@ -144,6 +146,16 @@ public class ServiceFeeEdit implements Serializable {
             return;
         }
 
+        // Persisted values for the audit before-snapshot; the row-edit event has
+        // already applied the new values to the session entity
+        java.util.Map<String, Object> before = null;
+        if (billFee.getId() != null) {
+            BillFee persisted = getBillFeeFacade().findWithoutCache(billFee.getId());
+            if (persisted != null) {
+                before = serviceFeeAuditMap(persisted);
+            }
+        }
+
         billFee.setEditor(getSessionController().getLoggedUser());
         billFee.setEditedAt(new Date());
 
@@ -179,6 +191,28 @@ public class ServiceFeeEdit implements Serializable {
 
         billItemNetTotal = billItem.getNetValue();
         billNetTotal = billItem.getBill().getNetTotal();
+
+        auditService.logEncounterAudit(encounter, "Service Fee Edited",
+                before, serviceFeeAuditMap(billFee), getSessionController().getLoggedUser(),
+                "BillFee", billFee.getId());
+    }
+
+    /**
+     * Snapshot of a service bill fee for audit events (#22238).
+     */
+    private java.util.Map<String, Object> serviceFeeAuditMap(BillFee bf) {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (bf == null) {
+            return m;
+        }
+        m.put("item", bf.getBillItem() != null && bf.getBillItem().getItem() != null
+                ? bf.getBillItem().getItem().getName() : null);
+        m.put("fee", bf.getFee() != null ? bf.getFee().getName() : null);
+        m.put("feeValue", bf.getFeeValue());
+        m.put("feeGrossValue", bf.getFeeGrossValue());
+        m.put("staff", bf.getStaff() != null && bf.getStaff().getPerson() != null
+                ? bf.getStaff().getPerson().getName() : null);
+        return m;
     }
 
     public List<BillFee> getBillFees() {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -155,6 +155,7 @@ public enum Privileges {
     InwardInvestigationsView("Inward Investigations View"),
     InwardImagesView("Inward Images View"),
     InwardDiagnosisCardView("Inward Diagnosis Card View"),
+    InwardEventHistoryView("Inward Event History View"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Inpatient Dashboard Panels">
@@ -1263,6 +1264,7 @@ public enum Privileges {
             case InwardInvestigationsView:
             case InwardImagesView:
             case InwardDiagnosisCardView:
+            case InwardEventHistoryView:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/java/com/divudi/core/data/inward/InpatientTimelineRow.java
+++ b/src/main/java/com/divudi/core/data/inward/InpatientTimelineRow.java
@@ -1,0 +1,105 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ */
+package com.divudi.core.data.inward;
+
+import com.divudi.core.entity.AuditEvent;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * One row of the Inpatient Event History timeline (#22240) — either a bill
+ * (billing-traceable event) or an AuditEvent (non-billing action), merged
+ * chronologically to tell the full story of an admission.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public class InpatientTimelineRow implements Serializable, Comparable<InpatientTimelineRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Date when;
+    private final String category;
+    private final String description;
+    private final String user;
+    private final Long billId;
+    private final Double amount;
+    private final AuditEvent auditEvent;
+
+    public InpatientTimelineRow(Date when, String category, String description,
+            String user, Long billId, Double amount, AuditEvent auditEvent) {
+        this.when = when;
+        this.category = category;
+        this.description = description;
+        this.user = user;
+        this.billId = billId;
+        this.amount = amount;
+        this.auditEvent = auditEvent;
+    }
+
+    @Override
+    public int compareTo(InpatientTimelineRow other) {
+        if (when == null && (other == null || other.when == null)) {
+            return 0;
+        }
+        if (when == null) {
+            return -1;
+        }
+        if (other == null || other.when == null) {
+            return 1;
+        }
+        return when.compareTo(other.when);
+    }
+
+    /**
+     * Unique row key for the PrimeFaces dataTable (required by rowExpansion).
+     */
+    public String getKey() {
+        if (billId != null) {
+            return "B" + billId;
+        }
+        if (auditEvent != null && auditEvent.getId() != null) {
+            return "A" + auditEvent.getId();
+        }
+        return "R" + System.identityHashCode(this);
+    }
+
+    public boolean isBillRow() {
+        return billId != null;
+    }
+
+    public boolean isAuditRow() {
+        return auditEvent != null;
+    }
+
+    public Date getWhen() {
+        return when;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public AuditEvent getAuditEvent() {
+        return auditEvent;
+    }
+
+}

--- a/src/main/webapp/inward/admission_event_history.xhtml
+++ b/src/main/webapp/inward/admission_event_history.xhtml
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formEventHistory">
+
+                    <p:panel class="m-1">
+                        <f:facet name="header">
+                            <h:outputText value="Inpatient Event History" />
+                            <h:outputText
+                                value=" — #{inpatientEventHistoryController.patientEncounter.patient.person.nameWithTitle} | BHT: #{inpatientEventHistoryController.patientEncounter.bhtNo}"
+                                rendered="#{inpatientEventHistoryController.patientEncounter ne null}" />
+                        </f:facet>
+                        <f:facet name="actions">
+                            <p:commandButton
+                                value="Refresh"
+                                action="#{inpatientEventHistoryController.loadTimeline()}"
+                                icon="fa fa-sync"
+                                update="formEventHistory"
+                                class="ui-button-secondary ui-button-outlined me-1" />
+                            <p:commandButton
+                                value="Inpatient Dashboard"
+                                ajax="false"
+                                action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-info ui-button-outlined" />
+                        </f:facet>
+
+                        <p:dataTable
+                            id="tblTimeline"
+                            value="#{inpatientEventHistoryController.timelineRows}"
+                            var="row"
+                            rowKey="#{row.key}"
+                            rowIndexVar="rowIndex"
+                            paginator="true"
+                            rows="50"
+                            paginatorPosition="bottom"
+                            emptyMessage="No events recorded for this admission yet."
+                            class="w-100">
+
+                            <p:column style="width:2rem;">
+                                <p:rowToggler rendered="#{row.auditRow}" />
+                            </p:column>
+
+                            <p:column headerText="Date &amp; Time" style="width:11rem;">
+                                <h:outputText value="#{row.when}">
+                                    <f:convertDateTime pattern="dd MMM yyyy HH:mm:ss" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Category" style="width:10rem;">
+                                <p:tag value="#{row.category}"
+                                       severity="#{row.billRow ? 'info' : 'success'}" />
+                            </p:column>
+
+                            <p:column headerText="Event">
+                                <h:outputText value="#{row.description}" />
+                            </p:column>
+
+                            <p:column headerText="User" style="width:10rem;">
+                                <h:outputText value="#{row.user}" />
+                            </p:column>
+
+                            <p:column headerText="Amount" style="width:8rem; text-align:right;">
+                                <h:outputText value="#{row.amount}" rendered="#{row.billRow}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:rowExpansion>
+                                <h:panelGroup rendered="#{row.auditRow}">
+                                    <h:outputText value="Changes" styleClass="fw-bold d-block mb-1" />
+                                    <h:outputText value="#{row.auditEvent.difference}"
+                                                  style="white-space:pre-wrap; font-family:monospace;" />
+                                </h:panelGroup>
+                            </p:rowExpansion>
+
+                        </p:dataTable>
+                    </p:panel>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -938,6 +938,17 @@
                                             class="w-100">
                                         </p:commandButton>
                                     </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Event History"
+                                            ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardEventHistoryView')}"
+                                            action="#{inpatientEventHistoryController.navigateToEventHistory(admissionController.current)}"
+                                            icon="fa fa-stream"
+                                            title="Full chronological story of this admission — bills and audited actions"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>


### PR DESCRIPTION
Closes #22238. Part of #22232. **Stacked on #22244** (base `22235-audit-admission-lifecycle`, which now carries #22235+#22236+#22237 after #22245/#22246 were merged into it).

## What was implemented

All via `AuditService.logEncounterAudit` (patientEncounterId + JSON snapshots, never blocks the action).

| Action | Trigger | Notes |
|---|---|---|
| `BhtSummeryController.changeDiscountListener()` | `Settlement Discount Changed` | before = requested discount + total per charge type; after = applied discount + adjusted total (the applied value can differ from what the user typed — price-matrix rules) |
| All 7 `changeDiscountListenerPatientRoom*()` | `Room Discount Changed` | before-state read **from the DB** (`findWithoutCache`) because each listener persists the JSF-applied value on entry; shared `roomDiscountAuditMap` covers all room/maintain/linen/medical-care/admin/nursing/MO discounts, `entityType=PatientRoom` |
| `BhtSummeryController.settle()` | `Final Bill Settled` | summary snapshot: final bill id, grantTotal, discount, netTotal + every non-zero per-charge-type discount → a settled bill's discount history is reconstructable (acceptance criterion 2) together with the change events |
| `ServiceFeeEdit.updateFee()` | `Service Fee Edited` | DB-read before snapshot: item, fee name, feeValue, feeGrossValue, staff; `entityType=BillFee` |
| `InwardProfessionalBillControllerEstimate` add/update/remove | `Professional Fee Estimate Added/Changed/Removed` | staff + feeValue snapshots; update uses DB-read before |
| `InwardPriceAdjustmntController` (all 3 create paths incl. per-category bulk add) | `Inward Price Adjustment Added` | **Institution-level master data** — no encounter to link, so `patientEncounterId` stays null; `entityType=PriceMatrix` with full matrix snapshot |

**Settlement date changes:** the settlement-page discharge-date flow goes through `DischargeController.discharge()`, already audited with DB-read before-state in #22245 — date edits appear as `dateOfDischarge` diffs there.

## Verification

`mvn compile` clean. Per the umbrella plan, instrumentation-only sub-issues get build + code-level verification; plumbing E2E-verified in #22243; #22240 will exercise the timeline end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inpatient Event History view combining billing activity and audit events in a chronological timeline.
  * Added an Event History option to the inpatient dashboard, subject to access privileges.
  * Added timeline details including event categories, descriptions, users, amounts, and recorded changes.

* **Auditability**
  * Expanded activity tracking for allergies, documents, price adjustments, professional and service fees, patient transfers, room discounts, guardian details, and final bill settlement.
  * Audit records now capture relevant before-and-after changes for supported actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->