### PR TITLE
feat(audit): remaining inpatient action audit events (#22232 sub-issue 6)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -378,8 +378,17 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
         try {
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+            before.put("retired", pa.isRetired());
             pa.setRetired(true);
             clinicalFindingValueFacade.edit(pa);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+            after.put("retired", pa.isRetired());
+            auditService.logEncounterAudit(current, "Patient Allergy Removed",
+                    before, after, getSessionController().getLoggedUser(),
+                    "ClinicalFindingValue", pa.getId());
             getPatientAllergies().remove(pa);
             JsfUtil.addSuccessMessage("Allergy removed successfully");
         } catch (Exception e) {

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -165,16 +165,37 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             currentPatientAllergy.setClinicalFindingValueType(ClinicalFindingValueType.PatientAllergy);
         }
         clinicalFindingValueFacade.create(currentPatientAllergy);
+        auditService.logEncounterAudit(current, "Patient Allergy Added",
+                null, allergyAuditMap(currentPatientAllergy), sessionController.getLoggedUser(),
+                "ClinicalFindingValue", currentPatientAllergy.getId());
         patientAllergies.add(currentPatientAllergy);
         currentPatientAllergy = null;
+    }
+
+    /**
+     * Snapshot of a patient allergy for audit events (#22239).
+     */
+    private Map<String, Object> allergyAuditMap(ClinicalFindingValue pa) {
+        Map<String, Object> m = new HashMap<>();
+        if (pa == null) {
+            return m;
+        }
+        m.put("allergy", pa.getItemValue() != null ? pa.getItemValue().getName() : null);
+        m.put("value", pa.getStringValue());
+        m.put("retired", pa.isRetired());
+        return m;
     }
 
     public void removePatientAllergy(ClinicalFindingValue pa) {
         if (pa == null) {
             return;
         }
+        Map<String, Object> before = allergyAuditMap(pa);
         pa.setRetired(true);
         clinicalFindingValueFacade.edit(pa);
+        auditService.logEncounterAudit(current, "Patient Allergy Removed",
+                before, allergyAuditMap(pa), sessionController.getLoggedUser(),
+                "ClinicalFindingValue", pa.getId());
         patientAllergies.remove(pa);
     }
 
@@ -1191,6 +1212,15 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         m.put("creditLimit", o.getCreditLimit());
         m.put("policyNo", o.getPolicyNo());
         m.put("claimable", o.isClaimable());
+        if (o.getGuardian() != null) {
+            m.put("guardian_nic", o.getGuardian().getNic());
+            m.put("guardian_phone", o.getGuardian().getPhone());
+            m.put("guardian_mobile", o.getGuardian().getMobile());
+            m.put("guardian_address", o.getGuardian().getAddress());
+        }
+        if (o.getGuardianRelationshipToPatient() != null) {
+            m.put("guardian_relationship", o.getGuardianRelationshipToPatient().getName());
+        }
 
         if (o.getReferringConsultant() != null) {
             m.put("consultant", o.getReferringConsultant().toString());

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -41,7 +41,25 @@ public class InwardDocumentUploadController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
     private SessionController sessionController;
+    @javax.ejb.EJB
+    private com.divudi.service.AuditService auditService;
     // </editor-fold>
+
+    /**
+     * Snapshot of an uploaded document for audit events (#22239).
+     */
+    private Map<String, Object> documentAuditMap(Upload u) {
+        Map<String, Object> m = new HashMap<>();
+        if (u == null) {
+            return m;
+        }
+        m.put("fileName", u.getFileName());
+        m.put("fileType", u.getFileType());
+        m.put("uploadType", u.getUploadType());
+        m.put("comments", u.getComments());
+        m.put("retired", u.isRetired());
+        return m;
+    }
 
     // <editor-fold defaultstate="collapsed" desc="Variables">
     private PatientEncounter currentEncounter;
@@ -126,6 +144,9 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
             uploadFacade.create(upload);
+            auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
+                    null, documentAuditMap(upload), sessionController.getLoggedUser(),
+                    "Upload", upload.getId());
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
             file = null;
             selectedUploadType = null;
@@ -180,6 +201,9 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
             uploadFacade.create(upload);
+            auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
+                    null, documentAuditMap(upload), sessionController.getLoggedUser(),
+                    "Upload", upload.getId());
             JsfUtil.addSuccessMessage("Document uploaded successfully.");
             selectedUploadType = null;
             comments = null;
@@ -197,10 +221,14 @@ public class InwardDocumentUploadController implements Serializable {
         if (u == null) {
             return;
         }
+        Map<String, Object> before = documentAuditMap(u);
         u.setRetired(true);
         u.setRetirer(sessionController.getLoggedUser());
         u.setRetiredAt(new Date());
         uploadFacade.edit(u);
+        auditService.logEncounterAudit(currentEncounter, "Document Removed",
+                before, documentAuditMap(u), sessionController.getLoggedUser(),
+                "Upload", u.getId());
         loadDocuments();
         JsfUtil.addSuccessMessage("Document removed.");
     }

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -48,6 +48,8 @@ public class PatientTransferController implements Serializable {
     private AdmissionController admissionController;
 
     @EJB
+    private com.divudi.service.AuditService auditService;
+    @EJB
     private AdmissionFacade admissionFacade;
     @EJB
     private PatientTransferRequestFacade patientTransferRequestFacade;
@@ -217,6 +219,30 @@ public class PatientTransferController implements Serializable {
         return true;
     }
 
+    /**
+     * Snapshot of a transfer request for audit events (#22239).
+     */
+    private java.util.Map<String, Object> transferAuditMap(PatientTransferRequest req) {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (req == null) {
+            return m;
+        }
+        m.put("status", req.getStatus());
+        m.put("theatreTransferType", req.getTheatreTransferType());
+        m.put("theatreOccupancyStatus", req.getTheatreOccupancyStatus());
+        m.put("fromRoom", req.getFromPatientRoom() != null && req.getFromPatientRoom().getRoomFacilityCharge() != null
+                ? req.getFromPatientRoom().getRoomFacilityCharge().getName() : null);
+        m.put("toRoom", req.getToRoomFacilityCharge() != null ? req.getToRoomFacilityCharge().getName() : null);
+        m.put("notes", req.getNotes());
+        return m;
+    }
+
+    private void auditTransfer(PatientTransferRequest req, String trigger, java.util.Map<String, Object> before) {
+        auditService.logEncounterAudit(req != null ? req.getAdmission() : null, trigger,
+                before, transferAuditMap(req), sessionController.getLoggedUser(),
+                "PatientTransferRequest", req != null ? req.getId() : null);
+    }
+
     public void initiateTransfer() {
         if (current == null) {
             JsfUtil.addErrorMessage("Please select a patient first.");
@@ -255,6 +281,7 @@ public class PatientTransferController implements Serializable {
         req.setNotes(notes);
         patientTransferRequestFacade.create(req);
         lastInitiatedRequest = req;
+        auditTransfer(req, "Transfer Initiated", null);
 
         JsfUtil.addSuccessMessage("Transfer initiated successfully.");
         targetRoomFacilityCharge = null;
@@ -278,10 +305,12 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("This transfer request is no longer pending and cannot be cancelled.");
             return;
         }
+        java.util.Map<String, Object> beforeCancel = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.CANCELLED);
         persisted.setCancelledAt(new Date());
         persisted.setCancelledBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Transfer Cancelled", beforeCancel);
         lastInitiatedRequest = null;
         loadCurrentAdmissionRequests();
         JsfUtil.addSuccessMessage("Transfer request cancelled. You may now initiate a new one.");
@@ -303,6 +332,7 @@ public class PatientTransferController implements Serializable {
             return;
         }
 
+        java.util.Map<String, Object> beforeAccept = transferAuditMap(req);
         Date effectiveAt = req.getAcceptedAt() != null ? req.getAcceptedAt() : new Date();
         req.setAcceptedAt(effectiveAt);
 
@@ -337,6 +367,7 @@ public class PatientTransferController implements Serializable {
         req.setStatus(TransferRequestStatus.ACCEPTED);
         req.setAcceptedBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(req);
+        auditTransfer(req, "Transfer Accepted", beforeAccept);
 
         loadPendingForDepartment();
         JsfUtil.addSuccessMessage("Patient accepted successfully.");
@@ -346,10 +377,12 @@ public class PatientTransferController implements Serializable {
         if (req == null) {
             return;
         }
+        java.util.Map<String, Object> beforeCancel = transferAuditMap(req);
         req.setStatus(TransferRequestStatus.CANCELLED);
         req.setCancelledAt(new Date());
         req.setCancelledBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(req);
+        auditTransfer(req, "Transfer Cancelled", beforeCancel);
         loadPendingForDepartment();
         JsfUtil.addSuccessMessage("Transfer request cancelled.");
     }
@@ -537,6 +570,7 @@ public class PatientTransferController implements Serializable {
         req.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(req);
         lastInitiatedRequest = req;
+        auditTransfer(req, "Sent To Theatre", null);
         JsfUtil.addSuccessMessage("Patient sent to theatre successfully.");
         targetRoomFacilityCharge = null;
         selectedSurgeryBill = null;
@@ -553,6 +587,7 @@ public class PatientTransferController implements Serializable {
             loadPendingForTheatre();
             return;
         }
+        java.util.Map<String, Object> beforeTheatreAccept = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.ACCEPTED);
         persisted.setAcceptedAt(new Date());
         persisted.setAcceptedBy(sessionController.getLoggedUser());
@@ -571,6 +606,7 @@ public class PatientTransferController implements Serializable {
         }
 
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Theatre Patient Accepted", beforeTheatreAccept);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Patient accepted in theatre.");
@@ -588,11 +624,13 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Patient must be in RECEIVED_IN_THEATRE status to mark as In Theatre.");
             return;
         }
+        java.util.Map<String, Object> beforeInTheatre = transferAuditMap(persisted);
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.IN_THEATRE);
         if (persisted.getProcedureStartAt() == null) {
             persisted.setProcedureStartAt(new Date());
         }
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Marked In Theatre", beforeInTheatre);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Patient marked as In Theatre.");
@@ -610,11 +648,13 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Patient must be IN_THEATRE status to mark procedure as completed.");
             return;
         }
+        java.util.Map<String, Object> beforeCompleted = transferAuditMap(persisted);
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.PROCEDURE_COMPLETED);
         if (persisted.getProcedureEndAt() == null) {
             persisted.setProcedureEndAt(new Date());
         }
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Procedure Completed", beforeCompleted);
         loadPendingForTheatre();
         loadInTheatreRequests();
         JsfUtil.addSuccessMessage("Procedure marked as completed.");
@@ -651,6 +691,7 @@ public class PatientTransferController implements Serializable {
         returnReq.setCreatedAt(new Date());
         returnReq.setCreater(sessionController.getLoggedUser());
         patientTransferRequestFacade.create(returnReq);
+        auditTransfer(returnReq, "Return To Ward Initiated", null);
 
         Date returnedAt = persisted.getReturnedToWardAt() != null ? persisted.getReturnedToWardAt() : new Date();
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RETURNED_TO_WARD);
@@ -682,10 +723,12 @@ public class PatientTransferController implements Serializable {
             loadPendingReturnsForWard();
             return;
         }
+        java.util.Map<String, Object> beforeReturnAccept = transferAuditMap(persisted);
         persisted.setStatus(TransferRequestStatus.ACCEPTED);
         persisted.setAcceptedAt(new Date());
         persisted.setAcceptedBy(sessionController.getLoggedUser());
         patientTransferRequestFacade.edit(persisted);
+        auditTransfer(persisted, "Return To Ward Accepted", beforeReturnAccept);
 
         // Update the master SEND_TO_THEATRE record's returnedToWardAt if not already set
         PatientTransferRequest theatreReq = findActiveSendToTheatreRequestForReturn(persisted);


### PR DESCRIPTION
Closes #22239. Part of #22232. **Stacked on #22249** (base `22238-audit-financial-adjustments`) — GitHub will auto-retarget to `development` when #22249 merges.

## What was implemented

All via `AuditService.logEncounterAudit` (patientEncounterId + JSON snapshots, never blocks the action).

| Area | Triggers | Notes |
|---|---|---|
| `PatientTransferController` (ward + theatre workflow) | `Transfer Initiated`, `Transfer Accepted`, `Transfer Cancelled` (both cancel paths), `Sent To Theatre`, `Theatre Patient Accepted`, `Marked In Theatre`, `Procedure Completed`, `Return To Ward Initiated`, `Return To Ward Accepted` | shared `transferAuditMap` (status, theatreTransferType, theatreOccupancyStatus, from/to rooms, notes); `entityType=PatientTransferRequest`; before-snapshots captured pre-mutation |
| `InwardDocumentUploadController` | `Document Uploaded` (both upload paths), `Document Removed` | file name, detected type, upload type, comments; `entityType=Upload` |
| `BhtEditController` allergies | `Patient Allergy Added`, `Patient Allergy Removed` | persisting paths (create/retire on `ClinicalFindingValue`) |
| `AdmissionController.removePatientAllergy()` | `Patient Allergy Removed` | dashboard Manage Allergies flow |
| Guardian details | via existing `UpdateAdmission` diff | `admissionToAuditMap` extended with guardian NIC/phone/mobile/address/relationship — guardian edits on the Edit Admission flow now render as field diffs |

## Deliberately not instrumented (with reasons)

- **Guardian room add/change** — the underlying saves run through `RoomChangeController`, already audited since #22243 (`Guardian Room Added/Changed/Removed`).
- **`InwardReservationController`** — read-only calendar (`onEventMove`/`onEventResize` only show a FacesMessage; nothing persists). Reservation lifecycle lives in `AppointmentController` (outside inward scope); the reservation→admission link is captured by the `Admission Created` event.
- **`BedBoardController`** — pure view/navigation (drill-down, `openBed` navigates into the admission flow); no state-changing action exists.
- **In-memory allergy list mutations** on the admission form and `AdmissionPatientChangeController` — they persist nothing; the saved set lands with the audited admission save.

## Verification

`mvn compile` clean. Per the umbrella plan, instrumentation-only sub-issues get build + code-level verification; #22240 will exercise the timeline end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
