### PR TITLE
feat(inward): Inpatient Event History timeline page (#22232 sub-issue 7)

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -229,6 +229,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardInvestigationsView, "Investigations View"), clinicalDataViewNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardImagesView, "Images View"), clinicalDataViewNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDiagnosisCardView, "Diagnosis Card View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEventHistoryView, "Event History View"), clinicalDataViewNode);
 
         TreeNode inwardPharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyMenu, "Pharmacy Menu"), inwardPharmacyNode);

--- a/src/main/java/com/divudi/bean/inward/InpatientEventHistoryController.java
+++ b/src/main/java/com/divudi/bean/inward/InpatientEventHistoryController.java
@@ -1,0 +1,204 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.data.inward.InpatientTimelineRow;
+import com.divudi.core.entity.AuditEvent;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.AuditEventFacade;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.WebUserFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Inpatient Event History ("Patient Story", #22240) — merges the encounter's
+ * bills and its encounter-linked audit events into one chronological timeline
+ * shown from the Inpatient Dashboard.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Named
+@SessionScoped
+public class InpatientEventHistoryController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private WebUserController webUserController;
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private AuditEventFacade auditEventFacade;
+    @EJB
+    private WebUserFacade webUserFacade;
+
+    private PatientEncounter patientEncounter;
+    private List<InpatientTimelineRow> timelineRows;
+
+    public String navigateToEventHistory(PatientEncounter pe) {
+        if (pe == null) {
+            JsfUtil.addErrorMessage("No admission selected");
+            return "";
+        }
+        if (!webUserController.hasPrivilege("InwardEventHistoryView")) {
+            JsfUtil.addErrorMessage("You are not authorized to view the event history");
+            return "";
+        }
+        patientEncounter = pe;
+        loadTimeline();
+        return "/inward/admission_event_history?faces-redirect=true";
+    }
+
+    public void loadTimeline() {
+        timelineRows = new ArrayList<>();
+        if (patientEncounter == null || patientEncounter.getId() == null) {
+            return;
+        }
+
+        String billJpql = "select b from Bill b "
+                + " where b.retired=false "
+                + " and b.patientEncounter=:pe "
+                + " order by b.createdAt";
+        Map<String, Object> billParams = new HashMap<>();
+        billParams.put("pe", patientEncounter);
+        List<Bill> bills = billFacade.findByJpql(billJpql, billParams);
+        if (bills != null) {
+            for (Bill b : bills) {
+                StringBuilder description = new StringBuilder();
+                if (b.getBillTypeAtomic() != null) {
+                    description.append(b.getBillTypeAtomic().getLabel());
+                } else if (b.getBillType() != null) {
+                    description.append(b.getBillType().getLabel());
+                } else {
+                    description.append("Bill");
+                }
+                if (b.getDeptId() != null && !b.getDeptId().trim().isEmpty()) {
+                    description.append(" — ").append(b.getDeptId());
+                }
+                if (b.isCancelled()) {
+                    description.append(" (Cancelled)");
+                }
+                timelineRows.add(new InpatientTimelineRow(
+                        b.getCreatedAt(),
+                        "Billing",
+                        description.toString(),
+                        b.getCreater() != null ? b.getCreater().getName() : null,
+                        b.getId(),
+                        b.getNetTotal(),
+                        null));
+            }
+        }
+
+        String auditJpql = "select a from AuditEvent a "
+                + " where a.patientEncounterId=:peid "
+                + " order by a.eventDataTime";
+        Map<String, Object> auditParams = new HashMap<>();
+        auditParams.put("peid", patientEncounter.getId());
+        List<AuditEvent> auditEvents = auditEventFacade.findByJpql(auditJpql, auditParams);
+        if (auditEvents != null) {
+            Map<Long, String> userNames = resolveUserNames(auditEvents);
+            for (AuditEvent ae : auditEvents) {
+                timelineRows.add(new InpatientTimelineRow(
+                        ae.getEventDataTime(),
+                        categorize(ae.getEventTrigger()),
+                        ae.getEventTrigger(),
+                        ae.getWebUserId() != null ? userNames.get(ae.getWebUserId()) : null,
+                        null,
+                        null,
+                        ae));
+            }
+        }
+
+        Collections.sort(timelineRows);
+    }
+
+    /**
+     * AuditEvent stores only the webUserId (it lives in the audit persistence
+     * unit); resolve display names from the main unit in one query.
+     */
+    private Map<Long, String> resolveUserNames(List<AuditEvent> auditEvents) {
+        Map<Long, String> names = new HashMap<>();
+        Set<Long> ids = new HashSet<>();
+        for (AuditEvent ae : auditEvents) {
+            if (ae.getWebUserId() != null) {
+                ids.add(ae.getWebUserId());
+            }
+        }
+        if (ids.isEmpty()) {
+            return names;
+        }
+        String jpql = "select w from WebUser w where w.id in :ids";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ids", new ArrayList<>(ids));
+        List<WebUser> users = webUserFacade.findByJpql(jpql, params);
+        if (users != null) {
+            for (WebUser u : users) {
+                names.put(u.getId(), u.getName());
+            }
+        }
+        return names;
+    }
+
+    private String categorize(String trigger) {
+        if (trigger == null) {
+            return "Other";
+        }
+        String t = trigger.toLowerCase();
+        if (t.contains("room") || t.contains("transfer") || t.contains("theatre")) {
+            return "Room / Transfer";
+        }
+        if (t.contains("discharge")) {
+            return "Discharge";
+        }
+        if (t.contains("credit") || t.contains("payment")) {
+            return "Payment / Credit";
+        }
+        if (t.contains("discount") || t.contains("fee") || t.contains("settle")
+                || t.contains("price")) {
+            return "Financial";
+        }
+        if (t.contains("admission") || t.contains("bht") || t.contains("patient changed")) {
+            return "Admission";
+        }
+        return "Other";
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public List<InpatientTimelineRow> getTimelineRows() {
+        if (timelineRows == null) {
+            timelineRows = new ArrayList<>();
+        }
+        return timelineRows;
+    }
+
+    public void setTimelineRows(List<InpatientTimelineRow> timelineRows) {
+        this.timelineRows = timelineRows;
+    }
+
+}

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -155,6 +155,7 @@ public enum Privileges {
     InwardInvestigationsView("Inward Investigations View"),
     InwardImagesView("Inward Images View"),
     InwardDiagnosisCardView("Inward Diagnosis Card View"),
+    InwardEventHistoryView("Inward Event History View"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Inpatient Dashboard Panels">
@@ -1263,6 +1264,7 @@ public enum Privileges {
             case InwardInvestigationsView:
             case InwardImagesView:
             case InwardDiagnosisCardView:
+            case InwardEventHistoryView:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/java/com/divudi/core/data/inward/InpatientTimelineRow.java
+++ b/src/main/java/com/divudi/core/data/inward/InpatientTimelineRow.java
@@ -1,0 +1,105 @@
+/*
+ * Open Hospital Management Information System
+ *
+ * Dr M H B Ariyaratne
+ */
+package com.divudi.core.data.inward;
+
+import com.divudi.core.entity.AuditEvent;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * One row of the Inpatient Event History timeline (#22240) — either a bill
+ * (billing-traceable event) or an AuditEvent (non-billing action), merged
+ * chronologically to tell the full story of an admission.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+public class InpatientTimelineRow implements Serializable, Comparable<InpatientTimelineRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Date when;
+    private final String category;
+    private final String description;
+    private final String user;
+    private final Long billId;
+    private final Double amount;
+    private final AuditEvent auditEvent;
+
+    public InpatientTimelineRow(Date when, String category, String description,
+            String user, Long billId, Double amount, AuditEvent auditEvent) {
+        this.when = when;
+        this.category = category;
+        this.description = description;
+        this.user = user;
+        this.billId = billId;
+        this.amount = amount;
+        this.auditEvent = auditEvent;
+    }
+
+    @Override
+    public int compareTo(InpatientTimelineRow other) {
+        if (when == null && (other == null || other.when == null)) {
+            return 0;
+        }
+        if (when == null) {
+            return -1;
+        }
+        if (other == null || other.when == null) {
+            return 1;
+        }
+        return when.compareTo(other.when);
+    }
+
+    /**
+     * Unique row key for the PrimeFaces dataTable (required by rowExpansion).
+     */
+    public String getKey() {
+        if (billId != null) {
+            return "B" + billId;
+        }
+        if (auditEvent != null && auditEvent.getId() != null) {
+            return "A" + auditEvent.getId();
+        }
+        return "R" + System.identityHashCode(this);
+    }
+
+    public boolean isBillRow() {
+        return billId != null;
+    }
+
+    public boolean isAuditRow() {
+        return auditEvent != null;
+    }
+
+    public Date getWhen() {
+        return when;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public AuditEvent getAuditEvent() {
+        return auditEvent;
+    }
+
+}

--- a/src/main/webapp/inward/admission_event_history.xhtml
+++ b/src/main/webapp/inward/admission_event_history.xhtml
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formEventHistory">
+
+                    <p:panel class="m-1">
+                        <f:facet name="header">
+                            <h:outputText value="Inpatient Event History" />
+                            <h:outputText
+                                value=" — #{inpatientEventHistoryController.patientEncounter.patient.person.nameWithTitle} | BHT: #{inpatientEventHistoryController.patientEncounter.bhtNo}"
+                                rendered="#{inpatientEventHistoryController.patientEncounter ne null}" />
+                        </f:facet>
+                        <f:facet name="actions">
+                            <p:commandButton
+                                value="Refresh"
+                                action="#{inpatientEventHistoryController.loadTimeline()}"
+                                icon="fa fa-sync"
+                                update="formEventHistory"
+                                class="ui-button-secondary ui-button-outlined me-1" />
+                            <p:commandButton
+                                value="Inpatient Dashboard"
+                                ajax="false"
+                                action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-info ui-button-outlined" />
+                        </f:facet>
+
+                        <p:dataTable
+                            id="tblTimeline"
+                            value="#{inpatientEventHistoryController.timelineRows}"
+                            var="row"
+                            rowKey="#{row.key}"
+                            rowIndexVar="rowIndex"
+                            paginator="true"
+                            rows="50"
+                            paginatorPosition="bottom"
+                            emptyMessage="No events recorded for this admission yet."
+                            class="w-100">
+
+                            <p:column style="width:2rem;">
+                                <p:rowToggler rendered="#{row.auditRow}" />
+                            </p:column>
+
+                            <p:column headerText="Date &amp; Time" style="width:11rem;">
+                                <h:outputText value="#{row.when}">
+                                    <f:convertDateTime pattern="dd MMM yyyy HH:mm:ss" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Category" style="width:10rem;">
+                                <p:tag value="#{row.category}"
+                                       severity="#{row.billRow ? 'info' : 'success'}" />
+                            </p:column>
+
+                            <p:column headerText="Event">
+                                <h:outputText value="#{row.description}" />
+                            </p:column>
+
+                            <p:column headerText="User" style="width:10rem;">
+                                <h:outputText value="#{row.user}" />
+                            </p:column>
+
+                            <p:column headerText="Amount" style="width:8rem; text-align:right;">
+                                <h:outputText value="#{row.amount}" rendered="#{row.billRow}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:rowExpansion>
+                                <h:panelGroup rendered="#{row.auditRow}">
+                                    <h:outputText value="Changes" styleClass="fw-bold d-block mb-1" />
+                                    <h:outputText value="#{row.auditEvent.difference}"
+                                                  style="white-space:pre-wrap; font-family:monospace;" />
+                                </h:panelGroup>
+                            </p:rowExpansion>
+
+                        </p:dataTable>
+                    </p:panel>
+
+                </h:form>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -938,6 +938,17 @@
                                             class="w-100">
                                         </p:commandButton>
                                     </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            value="Event History"
+                                            ajax="false"
+                                            rendered="#{webUserController.hasPrivilege('InwardEventHistoryView')}"
+                                            action="#{inpatientEventHistoryController.navigateToEventHistory(admissionController.current)}"
+                                            icon="fa fa-stream"
+                                            title="Full chronological story of this admission — bills and audited actions"
+                                            class="w-100">
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>


### PR DESCRIPTION
Closes #22240. Part of #22232 — the final sub-issue. **Stacked on #22257** (base `22239-audit-remaining-actions`) — GitHub will auto-retarget to `development` as the stack merges.

## What was implemented

- **`/inward/admission_event_history.xhtml`** + **`InpatientEventHistoryController`** (session-scoped, loads in the navigation method — no `f:viewAction`) + **`InpatientTimelineRow`** view model.
- **Timeline**: bills (`Bill where patientEncounter=:pe and retired=false`) merged chronologically with audit events (`AuditEvent where patientEncounterId=:peid`). Audit `webUserId`s are resolved to display names from the main persistence unit in one `in :ids` query (AuditEvent lives in the audit PU).
- **Rows**: timestamp, category tag (Billing / Admission / Room-Transfer / Discharge / Payment-Credit / Financial / Other), description (bill type label + bill number, or audit trigger), user, amount for bill rows; cancelled bills flagged `(Cancelled)` and cancellation bills appear as their own rows. Audit rows expand to the before/after field diff (`AuditEvent.getDifference()`).
- **Dashboard link**: "Event History" button in the Inpatient Dashboard Reports & Records section.
- **Privilege**: new `InwardEventHistoryView` (enum + user-privilege tree under Inward → Clinical Data Access), enforced both on the button `rendered` and inside the navigation method.

## Verified locally (Playwright E2E + DB), BHT/53362

- Button hidden without the privilege; visible and functional with it.
- Page shows 5 bill rows (pharmacy BHT request → issue Rs 1,846.34 → accept → return, with bill numbers) + 3 audit rows (UpdateAdmission, Room Discharged, Room Discharge Cancelled) in chronological order with user attribution.
- Row expansion renders the diff, e.g. `discharged: true→false, dischargedAt→null, dischargedBy: buddhika→null`.
- Fix found during testing: `p:rowExpansion` requires `rowKey` → synthetic key `B<billId>` / `A<auditEventId>` on the row model.

![Inpatient Event History timeline](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22240-inpatient-event-history-timeline.png)

Full E2E details in the [issue comment](https://github.com/hmislk/hmis/issues/22240#issuecomment-5015308494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
