### PR TITLE
fix(inward): address CodeRabbit review comments from PR #22249 (audit events)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -164,7 +164,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         if (currentPatientAllergy.getClinicalFindingValueType() == null) {
             currentPatientAllergy.setClinicalFindingValueType(ClinicalFindingValueType.PatientAllergy);
         }
-        clinicalFindingValueFacade.create(currentPatientAllergy);
+        clinicalFindingValueFacade.createAndFlush(currentPatientAllergy);
         auditService.logEncounterAudit(current, "Patient Allergy Added",
                 null, allergyAuditMap(currentPatientAllergy), sessionController.getLoggedUser(),
                 "ClinicalFindingValue", currentPatientAllergy.getId());

--- a/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDocumentUploadController.java
@@ -143,7 +143,7 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreatedAt(new Date());
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
-            uploadFacade.create(upload);
+            uploadFacade.createAndFlush(upload);
             auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
                     null, documentAuditMap(upload), sessionController.getLoggedUser(),
                     "Upload", upload.getId());
@@ -200,7 +200,7 @@ public class InwardDocumentUploadController implements Serializable {
             upload.setCreatedAt(new Date());
             upload.setCreater(sessionController.getLoggedUser());
             upload.setRetired(false);
-            uploadFacade.create(upload);
+            uploadFacade.createAndFlush(upload);
             auditService.logEncounterAudit(currentEncounter, "Document Uploaded",
                     null, documentAuditMap(upload), sessionController.getLoggedUser(),
                     "Upload", upload.getId());

--- a/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPriceAdjustmntController.java
@@ -194,7 +194,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setCreatedAt(new Date());
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
-            getFacade().create(a);
+            getFacade().createAndFlush(a);
             auditPriceAdjustmentAdded(a);
         }
         JsfUtil.addSuccessMessage("Saved Successfully");
@@ -236,7 +236,7 @@ public class InwardPriceAdjustmntController implements Serializable {
         a.setCreatedAt(new Date());
         a.setCreater(getSessionController().getLoggedUser());
         if (a.getId() == null) {
-            getFacade().create(a);
+            getFacade().createAndFlush(a);
             auditPriceAdjustmentAdded(a);
         }
         JsfUtil.addSuccessMessage("Saved Successfully");
@@ -282,7 +282,7 @@ public class InwardPriceAdjustmntController implements Serializable {
             a.setCreatedAt(new Date());
             a.setCreater(getSessionController().getLoggedUser());
             if (a.getId() == null) {
-                getFacade().create(a);
+                getFacade().createAndFlush(a);
                 auditPriceAdjustmentAdded(a);
             }
         }

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -279,7 +279,7 @@ public class PatientTransferController implements Serializable {
         req.setCreatedAt(new Date());
         req.setCreater(sessionController.getLoggedUser());
         req.setNotes(notes);
-        patientTransferRequestFacade.create(req);
+        patientTransferRequestFacade.createAndFlush(req);
         lastInitiatedRequest = req;
         auditTransfer(req, "Transfer Initiated", null);
 
@@ -568,7 +568,7 @@ public class PatientTransferController implements Serializable {
         req.setInitiatedBy(sessionController.getLoggedUser());
         req.setCreatedAt(new Date());
         req.setCreater(sessionController.getLoggedUser());
-        patientTransferRequestFacade.create(req);
+        patientTransferRequestFacade.createAndFlush(req);
         lastInitiatedRequest = req;
         auditTransfer(req, "Sent To Theatre", null);
         JsfUtil.addSuccessMessage("Patient sent to theatre successfully.");
@@ -690,7 +690,7 @@ public class PatientTransferController implements Serializable {
         returnReq.setInitiatedBy(sessionController.getLoggedUser());
         returnReq.setCreatedAt(new Date());
         returnReq.setCreater(sessionController.getLoggedUser());
-        patientTransferRequestFacade.create(returnReq);
+        patientTransferRequestFacade.createAndFlush(returnReq);
         auditTransfer(returnReq, "Return To Ward Initiated", null);
 
         Date returnedAt = persisted.getReturnedToWardAt() != null ? persisted.getReturnedToWardAt() : new Date();

--- a/src/main/webapp/inward/admission_event_history.xhtml
+++ b/src/main/webapp/inward/admission_event_history.xhtml
@@ -11,7 +11,7 @@
 
                 <h:form id="formEventHistory">
 
-                    <p:panel class="m-1">
+                    <p:panel class="m-1" rendered="#{webUserController.hasPrivilege('InwardEventHistoryView')}">
                         <f:facet name="header">
                             <h:outputText value="Inpatient Event History" />
                             <h:outputText


### PR DESCRIPTION
Follow-up to #22249, which was merged while these review fixes were being prepared. Addresses both CodeRabbit findings:

- **Null object IDs in audit logs (Major):** switched `create()` to `createAndFlush()` at the 9 flagged sites where a newly-persisted entity's generated ID is immediately passed to `AuditService` as `objectId` (`InwardPriceAdjustmntController` ×3, `InwardDocumentUploadController` ×2, `PatientTransferController` ×3, `BhtEditController` ×1).
- **Defense-in-depth authorization (Minor):** guarded the `admission_event_history.xhtml` main panel with `rendered="#{webUserController.hasPrivilege('InwardEventHistoryView')}"`, matching the privilege already checked in the navigation method.

Refs #22238

🤖 Generated with [Claude Code](https://claude.com/claude-code)