### PR TITLE
feat(inward): relocate Manage Allergies and Hold Professional Payments buttons

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -876,6 +876,45 @@ button you're about to click — required-field validation on a JSF
 `ajax="false"` postback applies to the whole `<h:form>`, not just the
 fields near the button.
 
+## 38. A local dev DB missing columns for an already-shipped entity field surfaces as a hung page, and `ALTER TABLE` alone doesn't fix it — the pool needs a flush
+
+Entity fields that were added to the codebase a while ago (e.g.
+`PatientEncounter.professionalPaymentsOnHold` / `...HoldDateTime` /
+`...HoldBy` / `...HoldNotes`) can be **missing from a local dev database**
+that was never migrated, even though nothing about the current change
+touches those fields. Symptoms are confusing because EclipseLink issues a
+`SELECT *`-style query for the whole entity on any page that touches it, so
+the failure isn't localized to the field you'd expect:
+
+- Direct-navigating to a page via URL (bypassing the app's normal
+  click-through flow) can appear to **hang indefinitely** in Playwright
+  (`browserBackend.callTool` timeouts on `navigate`/`snapshot`/even
+  `tabs list`) rather than showing an error — the request never actually
+  hangs server-side, but an error response mid-navigation can leave the
+  MCP browser bridge stuck. If a normal in-app link/button navigation to
+  the same destination works cleanly and shows the real `SQLSyntaxErrorException:
+  Unknown column '...' in 'field list'` page, that confirms it's this
+  gotcha, not a broken browser.
+- The fix is a plain `ALTER TABLE ... ADD COLUMN ...` matching the
+  entity's field type (check the `@Column`/type in the entity class), but
+  **the running Payara connection pool caches connections/statement
+  metadata from before the ALTER** — re-hitting the page immediately after
+  the ALTER still throws the identical "Unknown column" error. Flush the
+  pool before retrying:
+  `asadmin flush-connection-pool <poolName>` (find the pool name via
+  `grep -B2 'jndi-name="jdbc/coop"' domain.xml` → look for the
+  `<jdbc-resource pool-name="...">` line, e.g. `poolCoopLocal` for
+  `jdbc/coop`).
+- Combining this with §20's privilege-row gotcha: if panels are still
+  missing after the schema+pool fix, check privileges next — they're
+  independent causes of the same "content silently doesn't render" symptom.
+
+Verified while testing the Inward Dashboard "Manage Allergies" /
+"Hold Professional Payments" button relocation (issue #22248), where the
+local `coop.patientencounter` table was missing all four
+`professionalpayments*` columns and `patienttransferrequest` was missing
+`theatreroom_id`.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -244,19 +244,6 @@
                                 </div>
                                 <div class="col-6">
                                     <p:commandButton
-                                        value="Manage Allergies"
-                                        ajax="false"
-                                        rendered="#{webUserController.hasPrivilege('InwardManageAllergies')}"
-                                        action="#{bhtEditController.navigateToManageAllergies()}"
-                                        icon="fa-solid fa-allergies"
-                                        class="w-100">
-                                        <f:setPropertyActionListener
-                                            value="#{admissionController.current}"
-                                            target="#{bhtEditController.current}"/>
-                                    </p:commandButton>
-                                </div>
-                                <div class="col-6">
-                                    <p:commandButton
                                         value="Cancel Admission"
                                         ajax="false"
                                         rendered="#{webUserController.hasPrivilege('InwardAdmissionCancel')}"
@@ -469,6 +456,18 @@
                                         <f:setPropertyActionListener
                                             value="#{admissionController.current}"
                                             target="#{bhtSummeryController.patientEncounter}"/>
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        id="btnHoldProfessionalPayments"
+                                        value="Hold Professional Payments"
+                                        ajax="false"
+                                        action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
+                                        icon="fa fa-hand-paper"
+                                        title="Navigate to Hold Professional Payments"
+                                        rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                        styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
                                     </p:commandButton>
                                 </div>
                             </div>
@@ -837,14 +836,15 @@
                                     </div>
                                     <div class="col-6">
                                         <p:commandButton
-                                            id="btnHoldProfessionalPayments"
-                                            value="Hold Professional Payments"
+                                            value="Manage Allergies"
                                             ajax="false"
-                                            action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
-                                            icon="fa fa-hand-paper"
-                                            title="Navigate to Hold Professional Payments"
-                                            rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
-                                            styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
+                                            rendered="#{webUserController.hasPrivilege('InwardManageAllergies')}"
+                                            action="#{bhtEditController.navigateToManageAllergies()}"
+                                            icon="fa-solid fa-allergies"
+                                            class="w-100">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{bhtEditController.current}"/>
                                         </p:commandButton>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- Moves **Manage Allergies** from the Admission panel into the **Clinical Data** panel on the Inpatient Dashboard (`admission_profile.xhtml`), per issue #22248.
- Bundled in an unrelated small fix at the requester's ask (no separate issue): moves **Hold Professional Payments** from Clinical Data into the **Billing** panel, since it's a billing-related action.
- Both buttons keep their exact original privilege gates (`InwardManageAllergies` / `InwardHoldProfessionalPayments`) and navigation targets — only their panel location changed. Pure XHTML relocation, no Java changes.
- **Known behavior change** (confirmed with requester): the Billing panel only renders when `parentEncounter == null`, so Hold Professional Payments is no longer visible on baby/child encounters (it had no such restriction under Clinical Data). Professional payment holds are billing-level and apply to the primary encounter.
- Documents a local-dev testing gotcha found while verifying this (`developer_docs/testing/playwright-e2e-workflow.md` §38): a local DB missing entity columns for an already-shipped feature can look like a hung page, and needs a Payara connection-pool flush after the schema fix, not just the `ALTER TABLE`.

## Test plan
Verified end-to-end via Playwright against a local Payara deployment (admission BHT/55354):
- [x] Admission panel no longer shows Manage Allergies.
- [x] Clinical Data → Actions now shows Manage Allergies; clicking navigates to `inward_manage_allergies.xhtml` with the correct patient context.
- [x] Billing panel now shows Hold Professional Payments alongside Payments/Estimated Bill; clicking navigates to `inward_professional_payment_hold.xhtml` correctly.
- [x] `git diff` reviewed — only the two button blocks moved, no other markup touched.
- Screenshots and details posted to https://github.com/hmislk/hmis/issues/22248#issuecomment-5015557452

Closes #22248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Hold Professional Payments** action in the Billing section for authorized users.
  - Restored **Manage Allergies** under Clinical Data for easier access to allergy management.

- **Documentation**
  - Added troubleshooting guidance for local Playwright failures caused by missing database fields and cached connection metadata.
  - Documented connection-pool flushing and verification steps, including separate privilege-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->