### PR TITLE
Inward: Support multiple final bill versions per admission with a Confirmed Final Bill

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -567,6 +567,7 @@ public class CreditCompanyDueController implements Serializable {
                 + "WHERE bill.retired <> :br "
                 + "AND (bill.cancelled = false OR bill.cancelled IS NULL) "
                 + "AND bill.billTypeAtomic IN :bts "
+                + "AND bill.referenceBill.confirmedFinalBill = true "
                 + "AND (ABS(bill.netTotal) - ABS(bill.paidAmount)) > :minBalance";
 
         parameters.put("br", true);
@@ -2303,6 +2304,8 @@ public class CreditCompanyDueController implements Serializable {
         jpql += "AND bill.billTypeAtomic in :bts ";
         parameters.put("bts", bts);
 
+        jpql += "AND bill.referenceBill.confirmedFinalBill = true ";
+
         if (filteringCreditCompany != null) {
             jpql += " and bill.creditCompany =:ins ";
             parameters.put("ins", filteringCreditCompany);
@@ -2469,6 +2472,8 @@ public class CreditCompanyDueController implements Serializable {
 
         jpql += "AND bill.billTypeAtomic in :bts ";
         parameters.put("bts", bts);
+
+        jpql += "AND bill.referenceBill.confirmedFinalBill = true ";
 
         if (institution != null) {
             jpql += " and bill.creditCompany =:ins ";

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -289,6 +289,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBillUnrestrictedAccess, "Inward Bill Search Without Restriction"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBillUnrestricted, "Inward Final Bill Settle Without Restriction"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBill, "Inward Settle Final Bill"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillCreateVersion, "Inward Final Bill Create New Version"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillSetConfirmed, "Inward Final Bill Set As Confirmed"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
@@ -245,6 +245,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
                 + " where b.retired = false"
                 + " and b.cancelled = false"
                 + " and b.billType = :bt"
+                + " and b.confirmedFinalBill = true"
                 + " and b.patientEncounter = :enc"
                 + " order by b.id desc";
         Map<String, Object> params = new HashMap<>();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1833,6 +1833,18 @@ public class BhtSummeryController implements Serializable {
         saveBill();
         saveBillItem();
 
+        // Scoped here (not in the shared saveBill()) because saveBill() is also called by
+        // saveProvisionalBill() for a bill that is about to become BillType.InwardProvisionalBill,
+        // not a final bill — flipping confirmedFinalBill there would wrongly unconfirm the real
+        // confirmed version on every provisional save.
+        getCurrent().setConfirmedFinalBill(true);
+        if (getPatientEncounter().getFinalBill() != null && !getPatientEncounter().getFinalBill().getId().equals(getCurrent().getId())) {
+            Bill oldConfirmed = getPatientEncounter().getFinalBill();
+            oldConfirmed.setConfirmedFinalBill(false);
+            getBillFacade().edit(oldConfirmed);
+        }
+        getBillFacade().edit(getCurrent());
+
         if (getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
             getInwardBean().updateCreditDetail(getPatientEncounter(), getCurrent().getNetTotal());
             for (CreditCompanyAllocation alloc : creditCompanyAllocations) {
@@ -2690,26 +2702,6 @@ public class BhtSummeryController implements Serializable {
 
     }
 
-    /**
-     * Computes the next final-bill version serial for this admission. Serials
-     * are never reused, even for cancelled bills, so the count intentionally
-     * does not filter on cancelled/retired status. billTypeAtomic (not just
-     * billType) is required — the cancellation-record Bill created by
-     * createCancelBill() copies billType=InwardFinalBill from the bill it
-     * cancels, so filtering on billType alone would count cancellation
-     * records as extra versions.
-     */
-    private int computeNextVersionSerial(PatientEncounter pe) {
-        String jpql = "select count(b) from Bill b where b.patientEncounter = :pe and b.billType = :billType"
-                + " and b.billTypeAtomic = :atomic";
-        Map<String, Object> params = new HashMap<>();
-        params.put("pe", pe);
-        params.put("billType", BillType.InwardFinalBill);
-        params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL);
-        long count = getBillFacade().findLongByJpql(jpql, params);
-        return (int) count + 1;
-    }
-
     private void saveBill() {
 
         getCurrent().setGrantTotal(grantTotal);
@@ -2724,11 +2716,6 @@ public class BhtSummeryController implements Serializable {
         getCurrent().setCreditCompany(getPatientEncounter().getCreditCompany());
         getCurrent().setInstitution(getSessionController().getInstitution());
         getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL);
-        int versionSerial = computeNextVersionSerial(patientEncounter);
-        getCurrent().setFinalBillVersionSerial(versionSerial);
-        getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
-        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
-
         getCurrent().setBillType(BillType.InwardFinalBill);
 
         getCurrent().setBillDate(new Date());
@@ -2741,18 +2728,23 @@ public class BhtSummeryController implements Serializable {
 
         writeDiscountBreakdownToFinanceDetails(getCurrent());
 
-        getCurrent().setConfirmedFinalBill(true);
-        if (patientEncounter.getFinalBill() != null && (getCurrent().getId() == null || !patientEncounter.getFinalBill().getId().equals(getCurrent().getId()))) {
-            Bill oldConfirmed = patientEncounter.getFinalBill();
-            oldConfirmed.setConfirmedFinalBill(false);
-            getBillFacade().edit(oldConfirmed);
-        }
+        // Version-serial assignment and persist are done under a per-encounter lock
+        // (held for the read-count-then-write span, not just the read) so two
+        // concurrent final-bill saves for the same admission cannot both compute
+        // the same serial before either insert commits.
+        getBillNumberBean().withFinalBillVersionLock(patientEncounter, () -> {
+            int versionSerial = getBillNumberBean().computeNextFinalBillVersionSerial(patientEncounter);
+            getCurrent().setFinalBillVersionSerial(versionSerial);
+            getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
 
-        if (getCurrent().getId() == null) {
-            getBillFacade().create(getCurrent());
-        } else {
-            getBillFacade().edit(getCurrent());
-        }
+            if (getCurrent().getId() == null) {
+                getBillFacade().create(getCurrent());
+            } else {
+                getBillFacade().edit(getCurrent());
+            }
+            return null;
+        });
     }
 
     private void writeDiscountBreakdownToFinanceDetails(Bill bill) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -182,6 +182,7 @@ public class BhtSummeryController implements Serializable {
     List<PatientRoom> patientRooms;
     private List<CreditCompanyAllocation> creditCompanyAllocations;
     private EncounterCreditCompany newEncounterCreditCompany;
+    private boolean creatingNewVersion;
     //////////////////////////
     private double grantTotal = 0.0;
     private double discount;
@@ -1879,6 +1880,7 @@ public class BhtSummeryController implements Serializable {
         showOrginalBill = false;
         printPreview = true;
         originalBill = null;
+        creatingNewVersion = false;
     }
 
     /**
@@ -1957,6 +1959,13 @@ public class BhtSummeryController implements Serializable {
             createCreditBillForCreditCompany(getPatientEncounter(), getCurrent().getNetTotal());
         }
 
+        getCurrent().setConfirmedFinalBill(true);
+        if (getPatientEncounter().getFinalBill() != null && !getPatientEncounter().getFinalBill().getId().equals(getCurrent().getId())) {
+            Bill oldConfirmed = getPatientEncounter().getFinalBill();
+            oldConfirmed.setConfirmedFinalBill(false);
+            getBillFacade().edit(oldConfirmed);
+        }
+
         getPatientEncounter().setFinalBill(getCurrent());
         getPatientEncounter().setGrantTotal(getCurrent().getGrantTotal());
         getPatientEncounter().setDiscount(getCurrent().getDiscount());
@@ -1974,6 +1983,72 @@ public class BhtSummeryController implements Serializable {
         originalBill = null;
 
         return "inward_bill_final?faces-redirect=true";
+    }
+
+    /**
+     * Starts a brand-new final bill version for the same admission, seeded
+     * from {@code sourceBill}'s discount and credit-company allocations, but
+     * recomputing all live charge tables fresh (the source bill's exact
+     * BillItems are not frozen/replayed).
+     */
+    public String createNewVersionFromBill(Bill sourceBill) {
+        creatingNewVersion = true;
+        setPatientEncounter(sourceBill.getPatientEncounter());
+
+        createTables();
+        calculateDiscount();
+        updateTotal();
+
+        if (sourceBill.getBillFinanceDetails() != null
+                && sourceBill.getBillFinanceDetails().getBillDiscount() != null
+                && sourceBill.getBillFinanceDetails().getBillDiscount().doubleValue() != 0) {
+            billLevelDiscount = sourceBill.getBillFinanceDetails().getBillDiscount().doubleValue();
+            // Recompute discount/due for the restored bill-level discount, mirroring
+            // listnerDiscontAmmountChanged() — done manually (not via that listener)
+            // because creditCompanyAllocations isn't seeded yet at this point and the
+            // listener would rebuild it from live data before rebuildAllocationsFromSourceBill runs.
+            discount = itemDiscountTotal + chargeTypeDiscountTotal + billLevelDiscount;
+            due = (grantTotal - discount) - paid;
+        }
+
+        creditCompanyAllocations = rebuildAllocationsFromSourceBill(sourceBill);
+
+        // Initializes `originalBill` (mirrors toSettle()'s sequence) — settle() requires
+        // it to be non-null; without this call it stays null on the create-version path.
+        settleOriginalBill();
+
+        getCurrent().setPreviousVersion(sourceBill);
+
+        return "inward_bill_final?faces-redirect=true";
+    }
+
+    /**
+     * Rebuilds the on-screen credit-company allocation split from the CC
+     * commitment bills recorded against {@code sourceBill}, so a new version
+     * starts from the same split rather than forcing the cashier to
+     * re-allocate from scratch.
+     */
+    private List<CreditCompanyAllocation> rebuildAllocationsFromSourceBill(Bill sourceBill) {
+        List<CreditCompanyAllocation> allocations = new ArrayList<>();
+        String jpql = "select b from Bill b where b.referenceBill = :sourceBill and b.billTypeAtomic = :atomic and b.cancelled = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("sourceBill", sourceBill);
+        params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
+        List<Bill> ccBills = getBillFacade().findByJpql(jpql, params);
+
+        double allocatedSoFar = 0.0;
+        if (ccBills != null) {
+            for (Bill ccBill : ccBills) {
+                allocations.add(new CreditCompanyAllocation(ccBill.getCreditCompany(), ccBill.getNetTotal()));
+                allocatedSoFar += ccBill.getNetTotal();
+            }
+        }
+
+        double newLiveNetDue = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
+        double patientPortion = Math.max(0.0, newLiveNetDue - allocatedSoFar);
+        allocations.add(new CreditCompanyAllocation(patientPortion, true));
+
+        return allocations;
     }
 
     public void createCreditBillForCreditCompany(PatientEncounter patientEncounter, Double netTotal) {
@@ -2021,7 +2096,14 @@ public class BhtSummeryController implements Serializable {
                 || getPatientEncounter().getPaymentMethod() != PaymentMethod.Credit) {
             return;
         }
-        creditCompanyAllocations = null;
+        // When creating a new final bill version, the allocation list was already
+        // seeded from the source bill's credit-company split (see
+        // createNewVersionFromBill/rebuildAllocationsFromSourceBill) — clicking
+        // Process here must not discard that starting point. In the normal
+        // interim-settle flow, always rebuild from live data.
+        if (!creatingNewVersion) {
+            creditCompanyAllocations = null;
+        }
         populateCreditCompanyAllocations();
     }
 
@@ -2389,7 +2471,7 @@ public class BhtSummeryController implements Serializable {
             return true;
         }
 
-        if (getPatientEncounter().isPaymentFinalized()) {
+        if (getPatientEncounter().isPaymentFinalized() && !creatingNewVersion) {
             JsfUtil.addErrorMessage("Payment is Finalized U need to cancel Previuios Final Bill of This Bht");
             return true;
         }
@@ -2608,6 +2690,26 @@ public class BhtSummeryController implements Serializable {
 
     }
 
+    /**
+     * Computes the next final-bill version serial for this admission. Serials
+     * are never reused, even for cancelled bills, so the count intentionally
+     * does not filter on cancelled/retired status. billTypeAtomic (not just
+     * billType) is required — the cancellation-record Bill created by
+     * createCancelBill() copies billType=InwardFinalBill from the bill it
+     * cancels, so filtering on billType alone would count cancellation
+     * records as extra versions.
+     */
+    private int computeNextVersionSerial(PatientEncounter pe) {
+        String jpql = "select count(b) from Bill b where b.patientEncounter = :pe and b.billType = :billType"
+                + " and b.billTypeAtomic = :atomic";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", pe);
+        params.put("billType", BillType.InwardFinalBill);
+        params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL);
+        long count = getBillFacade().findLongByJpql(jpql, params);
+        return (int) count + 1;
+    }
+
     private void saveBill() {
 
         getCurrent().setGrantTotal(grantTotal);
@@ -2622,8 +2724,10 @@ public class BhtSummeryController implements Serializable {
         getCurrent().setCreditCompany(getPatientEncounter().getCreditCompany());
         getCurrent().setInstitution(getSessionController().getInstitution());
         getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL);
-        getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL));
-        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL));
+        int versionSerial = computeNextVersionSerial(patientEncounter);
+        getCurrent().setFinalBillVersionSerial(versionSerial);
+        getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
+        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
 
         getCurrent().setBillType(BillType.InwardFinalBill);
 
@@ -2636,6 +2740,14 @@ public class BhtSummeryController implements Serializable {
         getCurrent().setCreater(getSessionController().getLoggedUser());
 
         writeDiscountBreakdownToFinanceDetails(getCurrent());
+
+        getCurrent().setConfirmedFinalBill(true);
+        if (patientEncounter.getFinalBill() != null && (getCurrent().getId() == null || !patientEncounter.getFinalBill().getId().equals(getCurrent().getId()))) {
+            Bill oldConfirmed = patientEncounter.getFinalBill();
+            oldConfirmed.setConfirmedFinalBill(false);
+            getBillFacade().edit(oldConfirmed);
+        }
+
         if (getCurrent().getId() == null) {
             getBillFacade().create(getCurrent());
         } else {

--- a/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
+++ b/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
@@ -98,6 +98,7 @@ public class CreditCompanyDebtorGroupedReportController implements Serializable 
                 + " where b.retired=false"
                 + " and (b.cancelled=false or b.cancelled is null)"
                 + " and b.billTypeAtomic=:bta"
+                + " and b.referenceBill.confirmedFinalBill=true"
                 + " and " + dateField + " between :frm and :to";
 
         if (institution != null) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2159,6 +2159,7 @@ public class InwardBeanController implements Serializable {
                 + " where b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:btp "
+                + " and b.confirmedFinalBill=true "
                 + " and b.patientEncounter=:pe"
                 + " order by b.id desc";
         HashMap hm = new HashMap();
@@ -2173,6 +2174,7 @@ public class InwardBeanController implements Serializable {
                 + " where b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:btp "
+                + " and b.confirmedFinalBill=true "
                 + " and b.patientEncounter.paymentFinalized=true";
         HashMap hm = new HashMap();
         hm.put("btp", BillType.InwardFinalBill);

--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -194,6 +194,7 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
                 + " b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:btp "
+                + " and b.confirmedFinalBill=true "
                 + " and b.patientEncounter=:pe "
                 + " order by b.id desc";
         HashMap hm = new HashMap();
@@ -217,6 +218,7 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
                 + " b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:btp "
+                + " and b.confirmedFinalBill=true "
                 + " and b.patientEncounter=:pe "
                 + " order by b.id desc";
         HashMap hm = new HashMap();

--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -278,6 +278,7 @@ public class InwardRefundController implements Serializable {
                 + " b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:btp "
+                + " and b.confirmedFinalBill=true "
                 + " and b.patientEncounter=:pe"
                 + " order by b.id desc";
         HashMap hm = new HashMap();

--- a/src/main/java/com/divudi/bean/inward/InwardReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportController.java
@@ -4993,8 +4993,8 @@ public class InwardReportController implements Serializable {
                 + "WHERE b.retired = false "
                 + "AND b.cancelled = false "
                 + "AND b.billType = :bt "
-                + "AND b.patientEncounter.id IN :ids "
-                + "ORDER BY b.patientEncounter.id, b.id DESC";
+                + "AND b.confirmedFinalBill = true "
+                + "AND b.patientEncounter.id IN :ids";
 
         Map<String, Object> params = new HashMap<>();
         params.put("bt", BillType.InwardFinalBill);
@@ -5005,7 +5005,7 @@ public class InwardReportController implements Serializable {
         if (bills != null) {
             for (Bill bill : bills) {
                 if (bill.getPatientEncounter() != null && bill.getPatientEncounter().getId() != null) {
-                    result.putIfAbsent(bill.getPatientEncounter().getId(), bill);
+                    result.put(bill.getPatientEncounter().getId(), bill);
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -93,6 +93,8 @@ public class InwardSearch implements Serializable {
     PaymentService paymentService;
     @EJB
     DrawerService drawerService;
+    @EJB
+    private com.divudi.service.AuditService auditService;
 
     /**
      * JSF Controllers
@@ -141,6 +143,7 @@ public class InwardSearch implements Serializable {
     List<BillItem> refundingItems;
     private List<Bill> bills;
     private List<BillItem> tempbillItems;
+    private List<Bill> finalBillVersions;
     /////////////////////
 
     PaymentMethod paymentMethod;
@@ -593,28 +596,98 @@ public class InwardSearch implements Serializable {
             return "";
         }
 
-        String jpql;
-        Map temMap = new HashMap();
-        jpql = "select b from Bill b where"
-                + " b.billType = :billType and "
-                + " b.retired=false ";
+        finalBillVersions = null;
+        List<Bill> versions = fetchFinalBillVersions(admission);
 
-        jpql += " and  b.patientEncounter=:pe ";
-        temMap.put("pe", admission);
-
-        temMap.put("billType", BillType.InwardFinalBill);
-        jpql += " order by b.id desc ";
-
-        // bill = getBillFacade().findFirstByJpql(jpql, temMap, TemporalType.TIMESTAMP);
-        bill = getBillFacade().findFirstByJpql(jpql, temMap);
-
-        if (bill == null) {
+        if (versions.isEmpty()) {
             JsfUtil.addErrorMessage("No Final Bill Created");
             return "";
         }
-        withProfessionalFee = false;
 
-        return "/inward/inward_reprint_bill_final?faces-redirect=true";
+        if (versions.size() == 1) {
+            bill = versions.get(0);
+            withProfessionalFee = false;
+            return "/inward/inward_reprint_bill_final?faces-redirect=true";
+        }
+
+        return "/inward/inward_final_bill_list?faces-redirect=true";
+    }
+
+    /**
+     * Lazily fetches and caches all final-bill versions for the currently
+     * selected {@link #admission}. Callers that switch admissions must reset
+     * {@link #finalBillVersions} to null before calling this getter again.
+     */
+    public List<Bill> getFinalBillVersions() {
+        if (finalBillVersions == null && admission != null) {
+            finalBillVersions = fetchFinalBillVersions(admission);
+        }
+        return finalBillVersions;
+    }
+
+    private List<Bill> fetchFinalBillVersions(PatientEncounter admission) {
+        // billTypeAtomic (not just billType) is required here — the cancellation-record
+        // Bill created by createCancelBill() copies billType=InwardFinalBill from the
+        // bill it cancels, so filtering on billType alone would list cancellation
+        // records as if they were final bill versions.
+        String jpql = "select b from Bill b where b.patientEncounter = :pe and b.billType = :billType"
+                + " and b.billTypeAtomic = :atomic and b.retired = false order by b.finalBillVersionSerial asc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", admission);
+        params.put("billType", BillType.InwardFinalBill);
+        params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL);
+        return getBillFacade().findByJpql(jpql, params);
+    }
+
+    /**
+     * User-facing action to mark {@code newConfirmed} as the confirmed final
+     * bill version for its admission. Privilege checks are done in the XHTML
+     * via {@code rendered}, not here.
+     */
+    public void setAsConfirmedFinalBill(Bill newConfirmed) {
+        if (newConfirmed == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return;
+        }
+        if (newConfirmed.isCancelled()) {
+            JsfUtil.addErrorMessage("Cannot confirm a cancelled bill");
+            return;
+        }
+        setAsConfirmedFinalBillInternal(newConfirmed);
+        JsfUtil.addSuccessMessage("Final Bill Version Confirmed");
+        finalBillVersions = null;
+    }
+
+    /**
+     * Repoints {@code pe.finalBill} to {@code newConfirmed}, flips the
+     * {@code confirmedFinalBill} flag on the old and new bills, and mirrors
+     * the totals copy done in {@link BhtSummeryController#settle()}. Shared
+     * by the explicit "set as confirmed" action and the cancel-triggered
+     * auto-promotion of the next latest version.
+     */
+    private void setAsConfirmedFinalBillInternal(Bill newConfirmed) {
+        PatientEncounter pe = newConfirmed.getPatientEncounter();
+
+        Long previousFinalBillId = pe.getFinalBill() != null ? pe.getFinalBill().getId() : null;
+
+        if (pe.getFinalBill() != null && !pe.getFinalBill().getId().equals(newConfirmed.getId())) {
+            Bill oldConfirmed = pe.getFinalBill();
+            oldConfirmed.setConfirmedFinalBill(false);
+            getBillFacade().edit(oldConfirmed);
+        }
+
+        newConfirmed.setConfirmedFinalBill(true);
+        getBillFacade().edit(newConfirmed);
+
+        pe.setFinalBill(newConfirmed);
+        pe.setGrantTotal(newConfirmed.getGrantTotal());
+        pe.setDiscount(newConfirmed.getDiscount());
+        pe.setNetTotal(newConfirmed.getNetTotal());
+        getPatientEncounterFacade().edit(pe);
+
+        auditService.logEncounterAudit(pe, "Final Bill Version Confirmed",
+                previousFinalBillId, newConfirmed.getId(), sessionController.getLoggedUser(),
+                "Bill", newConfirmed.getId());
     }
 
     public String navigateToProvisionalBillForAdmission() {
@@ -1428,6 +1501,8 @@ public class InwardSearch implements Serializable {
                 return;
             }
 
+            boolean wasConfirmedFinalBill = getBill().isConfirmedFinalBill();
+
             CancelledBill cb = createCancelBill();
             //Copy & paste
             if (cb.getId() == null) {
@@ -1436,15 +1511,53 @@ public class InwardSearch implements Serializable {
             cancelBillItems(cb);
             getBill().setCancelled(true);
             getBill().setCancelledBill(cb);
+            getBill().setConfirmedFinalBill(false);
             getBillFacade().edit((BilledBill) getBill());
 
-            getBill().getPatientEncounter().setGrantTotal(0);
-            getBill().getPatientEncounter().setDiscount(0);
-            getBill().getPatientEncounter().setNetTotal(0);
-            getBill().getPatientEncounter().setAdjustedTotal(0);
-            getBill().getPatientEncounter().setPaymentFinalized(false);
-            getBill().getPatientEncounter().setCreditUsedAmount(0);
-            getPatientEncounterFacade().edit(getBill().getPatientEncounter());
+            // Only the cancellation of the *confirmed* version affects the encounter's
+            // totals/paymentFinalized/finalBill — cancelling an already-superseded,
+            // non-confirmed version must leave the confirmed version's state untouched.
+            if (wasConfirmedFinalBill) {
+                List<Bill> remainingVersions = fetchFinalBillVersions(getBill().getPatientEncounter());
+                List<Bill> nonCancelled = new ArrayList<>();
+                if (remainingVersions != null) {
+                    for (Bill v : remainingVersions) {
+                        if (!v.isCancelled()) {
+                            nonCancelled.add(v);
+                        }
+                    }
+                }
+                if (nonCancelled.isEmpty()) {
+                    getBill().getPatientEncounter().setGrantTotal(0);
+                    getBill().getPatientEncounter().setDiscount(0);
+                    getBill().getPatientEncounter().setNetTotal(0);
+                    getBill().getPatientEncounter().setAdjustedTotal(0);
+                    getBill().getPatientEncounter().setPaymentFinalized(false);
+                    getBill().getPatientEncounter().setCreditUsedAmount(0);
+                    getBill().getPatientEncounter().setFinalBill(null);
+                    getPatientEncounterFacade().edit(getBill().getPatientEncounter());
+                } else {
+                    Bill nextConfirmed = nonCancelled.get(0);
+                    for (Bill v : nonCancelled) {
+                        if (v.getFinalBillVersionSerial() != null
+                                && (nextConfirmed.getFinalBillVersionSerial() == null
+                                || v.getFinalBillVersionSerial() > nextConfirmed.getFinalBillVersionSerial())) {
+                            nextConfirmed = v;
+                        }
+                    }
+                    // nextConfirmed was loaded by a separate query, so its patientEncounter
+                    // association is a distinct (though same-row) managed instance from
+                    // getBill().getPatientEncounter(). Force identity before promoting so
+                    // setAsConfirmedFinalBillInternal's edit() is the single, authoritative
+                    // persist for this encounter — otherwise a second edit() on the stale
+                    // getBill().getPatientEncounter() instance would silently clobber the
+                    // finalBill repoint this call just made.
+                    nextConfirmed.setPatientEncounter(getBill().getPatientEncounter());
+                    setAsConfirmedFinalBillInternal(nextConfirmed);
+                }
+            } else {
+                getPatientEncounterFacade().edit(getBill().getPatientEncounter());
+            }
 
             JsfUtil.addSuccessMessage("Cancelled");
 

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -102,6 +102,8 @@ public enum Privileges {
     InwardSearchFinalBill("Inward Search Final Bill"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
     InwardSettleFinalBill("Inward Settle Final Bill"),
+    InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),
+    InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
     InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
     InwardLaboratory("Inward Laboratory"),
@@ -1231,6 +1233,8 @@ public enum Privileges {
             case InwardFormTemplateAdmin:
             case InwardFormFill:
             case InwardSettleFinalBill:
+            case InwardFinalBillCreateVersion:
+            case InwardFinalBillSetConfirmed:
             case InwardSaveProvisionalFinalBill:
             case InwardLaboratory:
             case InwardLaboratoryBarcodeGeneration:

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -352,6 +352,11 @@ public class Bill implements Serializable, RetirableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Bill backwardReferenceBill;
 
+    private Integer finalBillVersionSerial; // 1, 2, 3... for this admission's final-bill lineage; null for non-final-bill types
+    private boolean confirmedFinalBill;     // denormalized flag, true iff pe.finalBill == this bill
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bill previousVersion;           // the bill this version was created from; null for the first version; display-only, not used in any query
+
     @Transient
     private double tmpReturnTotal;
     @Transient
@@ -2066,6 +2071,30 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setBackwardReferenceBill(Bill backwardReferenceBill) {
         this.backwardReferenceBill = backwardReferenceBill;
+    }
+
+    public Integer getFinalBillVersionSerial() {
+        return finalBillVersionSerial;
+    }
+
+    public void setFinalBillVersionSerial(Integer finalBillVersionSerial) {
+        this.finalBillVersionSerial = finalBillVersionSerial;
+    }
+
+    public boolean isConfirmedFinalBill() {
+        return confirmedFinalBill;
+    }
+
+    public void setConfirmedFinalBill(boolean confirmedFinalBill) {
+        this.confirmedFinalBill = confirmedFinalBill;
+    }
+
+    public Bill getPreviousVersion() {
+        return previousVersion;
+    }
+
+    public void setPreviousVersion(Bill previousVersion) {
+        this.previousVersion = previousVersion;
     }
 
     public List<Bill> getForwardReferenceBills() {

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -931,6 +931,44 @@ public class BillNumberGenerator {
         this.patientFacade = patientFacade;
     }
 
+    /**
+     * Runs {@code action} (computing the next final-bill version serial and
+     * persisting the bill that uses it) under a per-encounter lock, so two
+     * concurrent final-bill saves for the same admission cannot interleave
+     * between reading the count and committing their insert — a bare
+     * count-then-insert without this would let both reads see the same count.
+     * Mirrors this class's existing lockMap/ReentrantLock pattern; the lock
+     * lives here (a @Singleton EJB) rather than on the @SessionScoped
+     * BhtSummeryController because only a singleton's lockMap is guaranteed
+     * shared across different users' sessions.
+     */
+    public <T> T withFinalBillVersionLock(com.divudi.core.entity.PatientEncounter pe, java.util.function.Supplier<T> action) {
+        String lockKey = "finalBillVersionSerial-" + pe.getId();
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            return action.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Counts existing final-bill versions for the admission. Must only be
+     * called while holding the lock from {@link #withFinalBillVersionLock}
+     * — on its own this count-then-caller-increments pattern is racy.
+     */
+    public int computeNextFinalBillVersionSerial(com.divudi.core.entity.PatientEncounter pe) {
+        String jpql = "select count(b) from Bill b where b.patientEncounter = :pe and b.billType = :billType"
+                + " and b.billTypeAtomic = :atomic";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("pe", pe);
+        params.put("billType", BillType.InwardFinalBill);
+        params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL);
+        long count = billFacade.findLongByJpql(jpql, params);
+        return (int) count + 1;
+    }
+
     public synchronized String institutionBillNumberGenerator(Institution ins, BillType billType, BillClassType billClassType, BillNumberSuffix billNumberSuffix) {
         BillNumber billNumber = fetchLastBillNumber(ins, billType, billClassType);
         StringBuilder result = new StringBuilder();

--- a/src/main/java/com/divudi/ejb/CreditBean.java
+++ b/src/main/java/com/divudi/ejb/CreditBean.java
@@ -560,6 +560,7 @@ public class CreditBean {
                 + " where b.retired=false "
                 + " and (b.cancelled=false or b.cancelled is null) "
                 + " and b.billTypeAtomic=:bta "
+                + " and b.referenceBill.confirmedFinalBill=true "
                 + " and b.creditCompany=:cc "
                 + " and b.billDate between :frm and :to "
                 + " and (abs(b.netTotal)-abs(b.paidAmount)) >:val "
@@ -582,6 +583,7 @@ public class CreditBean {
                 + " where b.retired=false "
                 + " and (b.cancelled=false or b.cancelled is null) "
                 + " and b.billTypeAtomic=:bta "
+                + " and b.referenceBill.confirmedFinalBill=true "
                 + " and b.creditCompany=:cc "
                 + " and " + dateField + " between :frm and :to "
                 + " and (abs(b.netTotal)-abs(b.paidAmount)) >:val ";
@@ -616,6 +618,7 @@ public class CreditBean {
                 + " where b.retired=false "
                 + " and (b.cancelled=false or b.cancelled is null) "
                 + " and b.billTypeAtomic=:bta "
+                + " and b.referenceBill.confirmedFinalBill=true "
                 + " and " + dateField + " between :frm and :to "
                 + " and (abs(b.netTotal)-abs(b.paidAmount)) >:val ";
         HashMap hm = new HashMap();

--- a/src/main/resources/db/migrations/v2.16.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.16.0/migration.sql
@@ -1,0 +1,159 @@
+-- Migration v2.16.0: Add bill columns for multiple final bill versions per admission
+-- Issue: hmislk/hmis#22282
+--
+-- Background:
+--   Inward final bills can now have multiple versions per admission (/1, /2, /3...),
+--   with exactly one marked as the Confirmed Final Bill that counts financially.
+--   Bill gains three new fields: FINALBILLVERSIONSERIAL (the version number),
+--   CONFIRMEDFINALBILL (denormalized flag mirroring patientencounter.finalBill),
+--   and PREVIOUSVERSION_ID (display-only link to the bill a version was created from).
+--   Production persistence.xml has no DDL generation, so the columns and FK must be
+--   created explicitly here, per the v2.15.0 precedent.
+--
+--   CONFIRMEDFINALBILL defaults to false for every existing row, which would break
+--   credit-company dues / refund / payment-total queries (now filtered on
+--   confirmedFinalBill=true) for every admission that was already finalized before
+--   this migration runs. This script backfills CONFIRMEDFINALBILL=true and
+--   FINALBILLVERSIONSERIAL=1 on each admission's existing patientencounter.finalBill,
+--   since every pre-existing admission has at most one non-cancelled final bill today
+--   (multiple versions were not possible before this feature).
+--
+-- UNIVERSAL: Detects actual table name case via INFORMATION_SCHEMA so this script
+--   works on both case-sensitive (Linux) and case-insensitive (Windows) MySQL.
+--
+-- IDEMPOTENT: The ADD COLUMN / ADD FOREIGN KEY / backfill statements are gated on
+--   INFORMATION_SCHEMA existence checks and WHERE-clause guards so the script can
+--   be safely re-run.
+
+SELECT 'Migration v2.16.0 - Add bill columns for multiple final bill versions' AS status;
+
+-- ==========================================
+-- STEP 0: RESOLVE ACTUAL TABLE NAMES
+-- ==========================================
+
+SET @bill_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+SET @patientencounter_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'PATIENTENCOUNTER'
+    LIMIT 1
+);
+
+SELECT CONCAT('Resolved bill table as: ', IFNULL(@bill_table, '(not found)')) AS info;
+SELECT CONCAT('Resolved patientencounter table as: ', IFNULL(@patientencounter_table, '(not found)')) AS info;
+
+-- ==========================================
+-- STEP 1: ADD COLUMN FINALBILLVERSIONSERIAL (if missing)
+-- ==========================================
+
+SET @col_serial_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'FINALBILLVERSIONSERIAL'
+);
+
+SET @sql_add_serial = IF(@bill_table IS NOT NULL AND @col_serial_exists = 0,
+    CONCAT('ALTER TABLE ', @bill_table, ' ADD COLUMN FINALBILLVERSIONSERIAL INT NULL'),
+    'SELECT ''bill.FINALBILLVERSIONSERIAL already exists or table missing — skipping column add'' AS info'
+);
+PREPARE stmt FROM @sql_add_serial;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 2: ADD COLUMN CONFIRMEDFINALBILL (if missing)
+-- ==========================================
+
+SET @col_confirmed_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'CONFIRMEDFINALBILL'
+);
+
+SET @sql_add_confirmed = IF(@bill_table IS NOT NULL AND @col_confirmed_exists = 0,
+    CONCAT('ALTER TABLE ', @bill_table, ' ADD COLUMN CONFIRMEDFINALBILL TINYINT(1) NOT NULL DEFAULT 0'),
+    'SELECT ''bill.CONFIRMEDFINALBILL already exists or table missing — skipping column add'' AS info'
+);
+PREPARE stmt FROM @sql_add_confirmed;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 3: ADD COLUMN PREVIOUSVERSION_ID (if missing)
+-- ==========================================
+
+SET @col_prevver_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'PREVIOUSVERSION_ID'
+);
+
+SET @sql_add_prevver = IF(@bill_table IS NOT NULL AND @col_prevver_exists = 0,
+    CONCAT('ALTER TABLE ', @bill_table, ' ADD COLUMN PREVIOUSVERSION_ID BIGINT NULL'),
+    'SELECT ''bill.PREVIOUSVERSION_ID already exists or table missing — skipping column add'' AS info'
+);
+PREPARE stmt FROM @sql_add_prevver;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 4: ADD FOREIGN KEY PREVIOUSVERSION_ID -> bill(ID) (if missing)
+-- ==========================================
+
+SET @fk_prevver_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      AND CONSTRAINT_NAME = 'FK_bill_previousversion'
+);
+
+SET @sql_add_fk = IF(@bill_table IS NOT NULL AND @fk_prevver_exists = 0,
+    CONCAT('ALTER TABLE ', @bill_table,
+           ' ADD CONSTRAINT FK_bill_previousversion',
+           ' FOREIGN KEY (PREVIOUSVERSION_ID) REFERENCES ', @bill_table, '(ID)'),
+    'SELECT ''FK_bill_previousversion already exists or table missing — skipping FK add'' AS info'
+);
+PREPARE stmt FROM @sql_add_fk;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================
+-- STEP 5: BACKFILL CONFIRMEDFINALBILL + FINALBILLVERSIONSERIAL
+-- ==========================================
+-- Every admission finalized before this migration has at most one
+-- non-cancelled final bill (multiple versions were impossible until now),
+-- namely patientencounter.finalBill. Mark that bill as confirmed and /1,
+-- so existing financial queries (now scoped to confirmedFinalBill=true)
+-- keep returning the same results they did before this migration.
+
+SET @sql_backfill = IF(@bill_table IS NOT NULL AND @patientencounter_table IS NOT NULL,
+    CONCAT(
+        'UPDATE ', @bill_table, ' b ',
+        'JOIN ', @patientencounter_table, ' pe ON pe.FINALBILL_ID = b.ID ',
+        'SET b.CONFIRMEDFINALBILL = 1, ',
+        '    b.FINALBILLVERSIONSERIAL = IFNULL(b.FINALBILLVERSIONSERIAL, 1) ',
+        'WHERE b.CONFIRMEDFINALBILL = 0'
+    ),
+    'SELECT ''bill or patientencounter table missing — skipping confirmedFinalBill backfill'' AS info'
+);
+PREPARE stmt FROM @sql_backfill;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.16.0 complete' AS status;

--- a/src/main/resources/db/migrations/v2.16.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.16.0/rollback.sql
@@ -1,0 +1,87 @@
+-- Rollback v2.16.0
+-- Drops the FK and the FINALBILLVERSIONSERIAL / CONFIRMEDFINALBILL / PREVIOUSVERSION_ID
+-- columns added to bill in v2.16.0. Idempotent and case-insensitive: only drops what exists.
+-- The confirmedFinalBill/version-serial backfill is data, not schema, and is discarded
+-- along with the columns — nothing further to reverse.
+
+SET @bill_table = (
+    SELECT TABLE_NAME
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+-- STEP 1: DROP FOREIGN KEY (if present)
+SET @fk_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      AND CONSTRAINT_NAME = 'FK_bill_previousversion'
+);
+
+SET @sql_drop_fk = IF(@bill_table IS NOT NULL AND @fk_exists > 0,
+    CONCAT('ALTER TABLE ', @bill_table, ' DROP FOREIGN KEY FK_bill_previousversion'),
+    'SELECT ''FK_bill_previousversion not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_fk;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- STEP 2: DROP COLUMN PREVIOUSVERSION_ID (if present)
+SET @col_prevver = (
+    SELECT COLUMN_NAME
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'PREVIOUSVERSION_ID'
+    LIMIT 1
+);
+
+SET @sql_drop_prevver = IF(@bill_table IS NOT NULL AND @col_prevver IS NOT NULL,
+    CONCAT('ALTER TABLE ', @bill_table, ' DROP COLUMN ', @col_prevver),
+    'SELECT ''bill.PREVIOUSVERSION_ID not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_prevver;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- STEP 3: DROP COLUMN CONFIRMEDFINALBILL (if present)
+SET @col_confirmed = (
+    SELECT COLUMN_NAME
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'CONFIRMEDFINALBILL'
+    LIMIT 1
+);
+
+SET @sql_drop_confirmed = IF(@bill_table IS NOT NULL AND @col_confirmed IS NOT NULL,
+    CONCAT('ALTER TABLE ', @bill_table, ' DROP COLUMN ', @col_confirmed),
+    'SELECT ''bill.CONFIRMEDFINALBILL not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_confirmed;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- STEP 4: DROP COLUMN FINALBILLVERSIONSERIAL (if present)
+SET @col_serial = (
+    SELECT COLUMN_NAME
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = @bill_table
+      AND UPPER(COLUMN_NAME) = 'FINALBILLVERSIONSERIAL'
+    LIMIT 1
+);
+
+SET @sql_drop_serial = IF(@bill_table IS NOT NULL AND @col_serial IS NOT NULL,
+    CONCAT('ALTER TABLE ', @bill_table, ' DROP COLUMN ', @col_serial),
+    'SELECT ''bill.FINALBILLVERSIONSERIAL not found — nothing to drop'' AS info'
+);
+PREPARE stmt FROM @sql_drop_serial;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Rollback v2.16.0 complete' AS status;

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -1,0 +1,156 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <h:body>
+
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form id="formFinalBillVersions">
+
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardSettleFinalBill')}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between">
+                                <div class="d-flex">
+                                    <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
+                                    <h:outputLabel value="Final Bill Versions" class="mx-4"></h:outputLabel>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fas fa-id-card"
+                                        class="ui-button-secondary"
+                                        value="Inpatient Dashboard"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                        title="Back to Inpatient Dashboard">
+                                        <f:setPropertyActionListener
+                                            value="#{inwardSearch.admission}"
+                                            target="#{admissionController.current}">
+                                        </f:setPropertyActionListener>
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <div class="row mt-3">
+                            <div class="col-lg-6">
+                                <common:patient_details_for_addmission editable="false" searchable="false" controller="#{admissionController}" class="w-100" />
+                            </div>
+                            <div class="col-lg-6">
+                                <common:admission_details admission="#{admissionController.current}" class="w-100"/>
+                            </div>
+                        </div>
+
+                        <p:panel class="mt-3">
+                            <f:facet name="header">
+                                <h:outputLabel value="All Final Bill Versions"></h:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tblFinalBillVersions"
+                                widgetVar="wTblFinalBillVersions"
+                                rowKey="#{b.id}"
+                                value="#{inwardSearch.finalBillVersions}"
+                                var="b"
+                                emptyMessage="No final bill versions found."
+                                paginator="true"
+                                rows="10"
+                                paginatorAlwaysVisible="false"
+                                paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                class="w-100">
+
+                                <p:column headerText="Serial" width="80">
+                                    <h:outputText value="/#{b.finalBillVersionSerial}" />
+                                </p:column>
+
+                                <p:column headerText="Bill Number">
+                                    <h:outputText value="#{b.deptId}" />
+                                </p:column>
+
+                                <p:column headerText="Created">
+                                    <h:outputText value="#{b.createdAt}">
+                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                    </h:outputText>
+                                    <br/>
+                                    <h:outputText value="#{b.creater.webUserPerson.name}" styleClass="text-muted" />
+                                </p:column>
+
+                                <p:column headerText="Net Total" style="text-align: right;">
+                                    <h:outputText value="#{b.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Claimable Total" style="text-align: right;">
+                                    <h:outputText value="#{b.claimableTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Status">
+                                    <p:tag value="Confirmed" severity="success" rendered="#{b.confirmedFinalBill}" />
+                                    <p:tag value="Cancelled" severity="danger" rendered="#{not b.confirmedFinalBill and b.cancelled}" />
+                                    <p:tag value="Available" severity="secondary" rendered="#{not b.confirmedFinalBill and not b.cancelled}" />
+                                </p:column>
+
+                                <p:column headerText="Actions" width="320">
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-print"
+                                        class="ui-button-info me-1"
+                                        value="View / Print"
+                                        title="View #{b.deptId}"
+                                        action="/inward/inward_reprint_bill_final?faces-redirect=true">
+                                        <f:setPropertyActionListener
+                                            value="#{b}"
+                                            target="#{inwardSearch.bill}">
+                                        </f:setPropertyActionListener>
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-check-circle"
+                                        class="ui-button-success me-1"
+                                        value="Set as Confirmed"
+                                        title="Set as Confirmed #{b.deptId}"
+                                        actionListener="#{inwardSearch.setAsConfirmedFinalBill(b)}"
+                                        rendered="#{not b.cancelled and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillSetConfirmed')}">
+                                        <p:confirm header="Confirm" message="Set bill #{b.deptId} as the Confirmed Final Bill?" icon="pi pi-exclamation-triangle" />
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-plus"
+                                        class="ui-button-warning"
+                                        value="Create New Version"
+                                        title="Create New Version from #{b.deptId}"
+                                        action="#{bhtSummeryController.createNewVersionFromBill(b)}"
+                                        rendered="#{not b.cancelled and webUserController.hasPrivilege('InwardFinalBillCreateVersion')}">
+                                    </p:commandButton>
+
+                                </p:column>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                    </p:panel>
+
+                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
+                        <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-success" icon="pi pi-check" />
+                        <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
+                    </p:confirmDialog>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -43,6 +43,14 @@
                                             disabled="#{inwardSearch.bill.cancelled}"  />
                                         <p:commandButton
                                             ajax="false"
+                                            icon="fa fa-plus"
+                                            class="ui-button-warning"
+                                            value="Create New Version"
+                                            title="Create New Version from #{inwardSearch.bill.deptId}"
+                                            action="#{bhtSummeryController.createNewVersionFromBill(inwardSearch.bill)}"
+                                            rendered="#{not inwardSearch.bill.cancelled and webUserController.hasPrivilege('InwardFinalBillCreateVersion')}" />
+                                        <p:commandButton
+                                            ajax="false"
                                             icon="fas fa-id-card"
                                             class="ui-button-secondary "
                                             value="Inpatient Dashboard"


### PR DESCRIPTION
## Summary

Implements #22282: hospitals can now create a new final bill version for an
admission (numbered `/1`, `/2`, `/3`…) without cancelling the previous one,
with exactly one version marked the **Confirmed Final Bill** that counts
financially. `PatientEncounter.finalBill` remains the authoritative pointer
to the confirmed version, so the ~224 existing readers of that field are
unaffected.

- `Bill` gains `finalBillVersionSerial`, `confirmedFinalBill` (denormalized,
  kept in sync with `pe.finalBill`), and `previousVersion` (display-only
  link to the source bill a version was created from)
- `BhtSummeryController.createNewVersionFromBill(Bill)` — starts a new
  version from any non-cancelled existing final bill: recomputes live
  charges, restores the bill-level discount, and clones the credit-company
  allocation split from the source bill's `InwardFinalBillCCPayment` bills
  (there is no persisted allocation entity to copy — it's reconstructed
  from the settled CC payment bills)
- `InwardSearch.setAsConfirmedFinalBill(Bill)` — switches the confirmed
  version, re-syncing `PatientEncounter.finalBill`/totals and logging an
  audit event, same pattern `settle()` already uses
- New page `inward_final_bill_list.xhtml` — lists all versions for an
  admission with status badges (Confirmed / Available / Cancelled) and
  per-row actions (View/Print, Set as Confirmed, Create New Version)
- `InwardSearch.navigateToFinalBillForAdmission()` — routes to the
  existing reprint page unchanged when exactly one version exists; to the
  new list page when more than one exists
- Cancelling the confirmed version auto-promotes the next-latest surviving
  version (or restores the interim bill if none remain); cancelling a
  superseded, non-confirmed version leaves the confirmed version's state
  untouched
- ~9 financial-correctness-critical queries (credit company dues, refund
  bounds, payment totals — `CreditBean`, `CreditCompanyDueController`,
  `CreditCompanyDebtorGroupedReportController`, `InwardBeanController`,
  `InwardPaymentController`, `InwardRefundController`,
  `BhtPaymentSummaryReportController`, `InwardReportController`) rescoped
  to the confirmed version only
- Two new privileges: `InwardFinalBillCreateVersion`,
  `InwardFinalBillSetConfirmed`
- Migration `v2.16.0` adds the new `Bill` columns and backfills
  `confirmedFinalBill=true` on every admission's existing final bill —
  without this, the new query scoping would show zero dues for every
  already-settled admission

**Explicitly out of scope** (income/QuickBooks report aggregations that
would double-count once a real multi-version admission exists, but no
admission has more than one final bill until this ships) — flagged as a
fast-follow, not fixed here: `InwardReportController1`, `ReportsController`,
`QuickBookReportController`, `MdInwardReportController`, `Qb.java`.
`SearchController`'s admin browse/search screens intentionally continue to
list every bill (not filtered to confirmed-only) since they're
list-everything screens by design.

Cancellation gaps outside this issue's scope (stale `pe.finalBill` in the
pre-existing single-bill case, CC payment bills not auto-cancelled with
their parent) remain tracked separately in #22281.

## Test plan

Verified end-to-end locally against a real admission (Playwright + direct
DB queries) — details and screenshots posted to the issue:
https://github.com/hmislk/hmis/issues/22282#issuecomment-5020433735

- [x] Single-bill admission — "Final Bill" button still opens the reprint
      page directly, unchanged behavior
- [x] Created a second version — discount and credit-company allocation
      (split across two companies) correctly cloned, survived clicking
      "Process," settled into a new confirmed version with its own CC
      payment bills
- [x] Version list page — correct status badges and conditional actions
- [x] Set as Confirmed — switched back and forth, `finalBill`/totals
      repointed correctly each time, audit trail recorded
- [x] Cancelled the confirmed version while another remained — correctly
      auto-promoted
- [x] Cancelled the last remaining version — `finalBill` cleared,
      `paymentFinalized` reset, interim restored
- [x] Spot-checked `CreditBean` dues query — correctly excludes CC bills
      belonging to a no-longer-confirmed version
- [x] `mvn compile` — clean

Five real bugs were found and fixed during this E2E pass (not caught by
code review alone) — see the issue comment for details: a UX dead-end with
no path to create a second version from a single-bill admission, the
"Process" button discarding cloned CC allocations, a `NullPointerException`
from an uninitialized `originalBill`, a stale-JPA-entity bug silently
reverting the confirmed-bill repoint on cancellation, and a missing
`billTypeAtomic` filter that let cancellation-record bills pollute the
version count and list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added final-bill version management for admissions, including creating a new version, viewing/printing versions, confirming a version, and cancelling versions.
  * Introduced inpatient permissions for creating versions and setting a confirmed final bill.
  * Added concurrency-safe numbering for newly created final-bill versions.
* **Bug Fixes**
  * Financial calculations, reports, payments, and refunds now consider only confirmed final bills.
  * Cancelling a confirmed version can automatically promote the next appropriate remaining version.
* **Database/Improvements**
  * Upgraded billing data to support final-bill versioning and confirmation state, preserving existing confirmed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->