### PR TITLE
fix(inward): separate actions from reports on Nursing Dashboard panels

### DIFF
--- a/developer_docs/inward/2026-07-20-nursing-dashboard-action-report-split-design.md
+++ b/developer_docs/inward/2026-07-20-nursing-dashboard-action-report-split-design.md
@@ -1,0 +1,95 @@
+# Nursing Dashboard — Action/Report Panel Split Design Spec
+
+Date: 2026-07-20
+Status: Approved by user, pending implementation
+
+## Problem Statement
+
+The Inpatient Dashboard (`/inward/admission_profile.xhtml`) was already redesigned (#21852) to separate stateful **Actions** from read-only **Reports & History** within each panel, using colored sub-panel strips (green-tinted Actions, grey-tinted Reports). It also consolidated 6 stale multi-patient pharmacy search links into 4 encounter-scoped report buttons backed by `InwardPharmacyEncounterReportController`, since a single admission is already selected on that page — no date-range/department filter is needed.
+
+The Nursing Dashboard (`/nurse/index.xhtml`, `NursingWorkBenchController`) serves a similar per-selected-admission view (the nurse picks one room/BHT from the sidebar, then acts on it — see `selectAdmission()`), but never received the same treatment:
+
+- **Pharmaceuticals & Consumables panel** (`col-6`, lines ~526-665): 12 buttons flat, no grouping. Includes the 6 actions (BHT Request, Direct Issue, Discharge Issue, Theatre Issue, Receive, Return) mixed with 6 report/search buttons that are stale duplicates of pages meant for the general multi-patient Nursing Workbench queue — not for the one patient already selected here. One of the six, "Search IP Direct Issue Returns by Item" (`/inward/pharmacy_search_return_bill_item_bht`), is a **dead link** — no such page exists in the codebase.
+- **Clinical Data panel** (`col-3`, lines ~159-292): mixes discharge-workflow actions (Clinical/Nursing/Physical Discharge, Hold Professional Payments) with read-only history/report links (Patient History, Clinical Notes, Ward Medications, Medicine Timeline, Discharge Medications, Investigations, Images, Diagnosis Card).
+- **Room Management panel** (`col-2`, lines ~293-359): mixes the Room Details report link with 4 room-change actions (Add New Room, Add Guardian Room, Initiate Transfer, Accept Patients).
+
+This is the same defect class already fixed once on the Inpatient Dashboard side (#21852) and again for BHT Issue Receive (#22154: "separate nurse-workbench (filtered) vs admission-scoped (unfiltered) lists"). This spec applies the identical fix to the 3 remaining mixed panels on the Nursing Dashboard.
+
+## Scope
+
+In scope — `src/main/webapp/nurse/index.xhtml` only, three panels:
+1. Pharmaceuticals & Consumables
+2. Clinical Data
+3. Room Management
+
+No new controller logic. `InwardPharmacyEncounterReportController`'s 4 navigate methods (`navigateToInpatientPharmacyRequestsList`, `navigateToInpatientPharmacyRequestDraftsList`, `navigateToInpatientPharmacyDirectIssuesList`, `navigateToInpatientPharmacyReturnsList`) already work against any `patientEncounter` set via `f:setPropertyActionListener`; the Nursing Dashboard already holds the selected admission in `admissionController.current` (set by `NursingWorkBenchController.selectAdmission()`), so the same buttons wire up directly.
+
+Out of scope: Service panel, Operation Theatre panel, Laboratory panel, Edit panel — these are already single-purpose (all-actions or already narrow) and don't mix concerns. The Inpatient Dashboard itself is unchanged (already correct). No new privileges.
+
+## Design
+
+### 1. Pharmaceuticals & Consumables → split into two sub-panels
+
+Reuse the exact visual pattern from `admission_profile.xhtml` (colored strip, uppercase small muted label, `row g-2` / `col-6` button grid):
+
+**Pharmacy Actions** (green-tinted strip `#e8f5ee`):
+- Pharmacy BHT Request (`admissionController.navigateToPharmacyBhtRequest`)
+- Direct Issue to BHTs
+- Issue Discharge Medicines
+- Direct Issue to Theatre Cases
+- Receive Medicines from Pharmacy
+- Return Medicines to Pharmacy
+
+(All 6 keep their existing action methods/listeners unchanged — this is a pure markup regroup, no logic change.)
+
+**Pharmacy Reports & History** (grey-tinted strip `#eef1f4`) — replaces the 6 stale buttons with the 4 already-built encounter-scoped report buttons, copied verbatim from `admission_profile.xhtml` lines 1047-1102, retargeted at `admissionController.current`:
+- Pharmacy Requests → `inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()`
+- Draft Pharmacy Requests → `navigateToInpatientPharmacyRequestDraftsList()`
+- Direct Issues → `navigateToInpatientPharmacyDirectIssuesList()`
+- Issue Returns → `navigateToInpatientPharmacyReturnsList()`
+
+Each carries `<f:setPropertyActionListener value="#{admissionController.current}" target="#{inwardPharmacyEncounterReportController.patientEncounter}" />`.
+
+Removed entirely (stale, multi-patient-scoped, superseded by the above): "BHT Issue Requests", "View Pharmacy Requests", "Draft BHT Issue Requests" (old `SearchController`-backed variant), "Search IP Direct Issues by Bill", "Search IP Direct Issues by Item", "Search IP Direct Issue Returns by Bill", "Search IP Direct Issue Returns by Item" (the dead link). These pages remain unchanged/untouched — they're still reachable from the general Pharmacy menu (`InwardPharmacyMenu`) for actual multi-patient search use; only the dashboard shortcuts are removed, per the same precedent as #21852's Part A scope note.
+
+### 2. Clinical Data → split into two sub-panels
+
+**Clinical Actions** (green-tinted strip):
+- Clinical Discharge, Nursing Discharge, Physical Discharge (existing color-coded complete/incomplete `styleClass` logic unchanged)
+- Hold Professional Payments
+
+**Clinical Reports & Records** (grey-tinted strip):
+- Patient History, Clinical Notes, Ward Medications, Medicine Timeline, Discharge Medications, Investigations, Images, Diagnosis Card
+
+All existing `action`/`rendered`/`f:setPropertyActionListener` attributes carry over unchanged — markup regroup only.
+
+### 3. Room Management → split into two sub-panels
+
+**Room Actions** (green-tinted strip):
+- Add New Room, Add Guardian Room, Initiate Transfer, Accept Patients
+
+**Room Status** (grey-tinted strip):
+- Room Details
+
+Existing attributes unchanged.
+
+### Column widths
+
+Splitting each panel into two vertically-stacked sub-panels doesn't need wider columns — the existing `col-2`/`col-3`/`col-6` panel widths are kept, matching the Inpatient Dashboard's own `col-3` pharmacy panel which fits both sub-panels comfortably. Only the internal button grid changes (flat list → two grouped `row g-2` grids with a header label and background tint each).
+
+## No functional regressions
+
+Pure rendering/grouping change plus removal of 7 stale/redundant navigation shortcuts (6 replaced by existing encounter-scoped equivalents, all pointing at controller methods/pages that remain fully intact for their original general-search use elsewhere in the app). No new privileges, no changed business logic, no changed target pages except the dashboard's own button wiring.
+
+## Testing Plan
+
+- Playwright E2E: log in, open Nursing Workbench, select a room/BHT, verify Pharmacy/Clinical Data/Room Management panels render with distinct Actions vs Reports sections, verify the 4 pharmacy report buttons land directly on the encounter-scoped list pages (same as Inpatient Dashboard equivalents) with data pre-loaded for the selected admission, verify no dead links remain.
+- Manual/code check: confirm none of the 7 removed buttons' target pages/controllers are now orphaned (they're still reachable via the general Pharmacy menu — `InwardPharmacyMenu` items in `developer_docs/navigation/inward_navigation.md`).
+
+## Documentation
+
+- Update `developer_docs/navigation/inward_navigation.md` if the Nursing Dashboard section needs it (currently the doc doesn't enumerate nurse/index.xhtml's internal panel buttons in detail — check during implementation whether an update is warranted).
+
+## GitHub Issue
+
+No existing open issue covers this exact scope (checked `hmislk/hmis` issues — #22154 and #21852 are the precedent/related closed issues, not duplicates). A new issue will be created before implementation, following `/start-issue`.

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -159,133 +159,143 @@
                                         <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelClinicalData')}">
                                             <div class="col-3">
                                                 <p:panel header="Clinical Data">
-                                                    <div class="d-grid gap-3">
-                                                        <p:commandButton
-                                                            id="btnPatientHistoryNurse"
-                                                            value="Patient History"
-                                                            action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPatientHistoryView')}"
-                                                            icon="fa fa-history"
-                                                            class="w-100">
-                                                            <f:setPropertyActionListener
-                                                                value="#{admissionController.current.patient}"
-                                                                target="#{patientController.current}" />
-                                                        </p:commandButton>
+                                                    <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Clinical Actions</div>
+                                                        <div class="d-grid gap-3">
+                                                            <p:commandButton
+                                                                id="btnClinicalDischargeNurse"
+                                                                value="Clinical Discharge"
+                                                                ajax="false"
+                                                                action="#{inpatientClinicalDataController.navigateToClinicalDischargeFromAdmission(admissionController.current)}"
+                                                                icon="fa fa-sign-out-alt"
+                                                                title="Navigate to Clinical Discharge"
+                                                                rendered="#{webUserController.hasPrivilege('InpatientClinicalDischarge')}"
+                                                                styleClass="w-100 #{admissionController.current.clinicallyDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnClinicalNotesNurse"
-                                                            value="Clinical Notes"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardClinicalNotesView')}"
-                                                            action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
-                                                            icon="fa fa-file-medical-alt"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnNursingDischarge"
+                                                                value="Nursing Discharge"
+                                                                ajax="false"
+                                                                action="#{nursingDischargeController.navigateToNursingDischarge(admissionController.current)}"
+                                                                icon="fa fa-user-nurse"
+                                                                title="Navigate to Nursing Discharge"
+                                                                rendered="#{webUserController.hasPrivilege('InwardNursingDischarge')}"
+                                                                styleClass="w-100 #{admissionController.current.nursingDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnWardMedicationsNurse"
-                                                            value="Ward Medications"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardWardMedicationsView')}"
-                                                            action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
-                                                            icon="fa fa-pills"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnPhysicalDischarge"
+                                                                value="Physical Discharge"
+                                                                ajax="false"
+                                                                action="#{nursingDischargeController.navigateToPhysicalDischarge(admissionController.current)}"
+                                                                icon="fa fa-walking"
+                                                                title="Navigate to Physical Discharge"
+                                                                rendered="#{webUserController.hasPrivilege('InwardPhysicalDischarge')}"
+                                                                styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnMedicineTimelineNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InpatientClinicalAssessment')}"
-                                                            value="Medicine Timeline"
-                                                            ajax="false"
-                                                            action="#{inpatientClinicalDataController.navigateToWardMedicinesTimeline(admissionController.current)}"
-                                                            icon="fa fa-project-diagram"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnHoldProfessionalPayments"
+                                                                value="Hold Professional Payments"
+                                                                ajax="false"
+                                                                action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
+                                                                icon="fa fa-hand-paper"
+                                                                title="Navigate to Hold Professional Payments"
+                                                                rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                                                styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
 
-                                                        <p:commandButton
-                                                            id="btnDischargeMedicationsNurse"
-                                                            value="Discharge Medications"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardDischargeMedicationsView')}"
-                                                            action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
-                                                            icon="fa fa-prescription-bottle-alt"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                    <hr class="my-2"/>
 
-                                                        <p:commandButton
-                                                            id="btnInvestigationsNurse"
-                                                            value="Investigations"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardInvestigationsView')}"
-                                                            action="#{admissionController.navigateToInpatientInvestigations()}"
-                                                            icon="fa fa-search"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                    <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Clinical Reports &amp; Records</div>
+                                                        <div class="d-grid gap-3">
+                                                            <p:commandButton
+                                                                id="btnPatientHistoryNurse"
+                                                                value="Patient History"
+                                                                action="#{patientController.navigateToPatientProfileFromAdmissionProfile()}"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardPatientHistoryView')}"
+                                                                icon="fa fa-history"
+                                                                class="w-100">
+                                                                <f:setPropertyActionListener
+                                                                    value="#{admissionController.current.patient}"
+                                                                    target="#{patientController.current}" />
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnImagesNurse"
-                                                            value="Images"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardImagesView')}"
-                                                            action="#{admissionController.navigateToInpatientImages}"
-                                                            icon="fa fa-images"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnClinicalNotesNurse"
+                                                                value="Clinical Notes"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardClinicalNotesView')}"
+                                                                action="#{admissionController.navigateToInpatientClinicalAssessmentList()}"
+                                                                icon="fa fa-file-medical-alt"
+                                                                class="w-100">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnDiagnosisCardNurse"
-                                                            value="Diagnosis Card"
-                                                            ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardDiagnosisCardView')}"
-                                                            action="#{admissionController.navigateToInpatientDiagnosisCard()}"
-                                                            icon="fa fa-diagnoses"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnWardMedicationsNurse"
+                                                                value="Ward Medications"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardWardMedicationsView')}"
+                                                                action="#{inpatientClinicalDataController.navigateToInwardMedicinesFromAdmission(admissionController.current)}"
+                                                                icon="fa fa-pills"
+                                                                class="w-100">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnClinicalDischargeNurse"
-                                                            value="Clinical Discharge"
-                                                            ajax="false"
-                                                            action="#{inpatientClinicalDataController.navigateToClinicalDischargeFromAdmission(admissionController.current)}"
-                                                            icon="fa fa-sign-out-alt"
-                                                            title="Navigate to Clinical Discharge"
-                                                            rendered="#{webUserController.hasPrivilege('InpatientClinicalDischarge')}"
-                                                            styleClass="w-100 #{admissionController.current.clinicallyDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnMedicineTimelineNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InpatientClinicalAssessment')}"
+                                                                value="Medicine Timeline"
+                                                                ajax="false"
+                                                                action="#{inpatientClinicalDataController.navigateToWardMedicinesTimeline(admissionController.current)}"
+                                                                icon="fa fa-project-diagram"
+                                                                class="w-100">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnNursingDischarge"
-                                                            value="Nursing Discharge"
-                                                            ajax="false"
-                                                            action="#{nursingDischargeController.navigateToNursingDischarge(admissionController.current)}"
-                                                            icon="fa fa-user-nurse"
-                                                            title="Navigate to Nursing Discharge"
-                                                            rendered="#{webUserController.hasPrivilege('InwardNursingDischarge')}"
-                                                            styleClass="w-100 #{admissionController.current.nursingDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnDischargeMedicationsNurse"
+                                                                value="Discharge Medications"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardDischargeMedicationsView')}"
+                                                                action="#{inpatientClinicalDataController.navigateToDischargeMedicinesFromAdmission(admissionController.current)}"
+                                                                icon="fa fa-prescription-bottle-alt"
+                                                                class="w-100">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnPhysicalDischarge"
-                                                            value="Physical Discharge"
-                                                            ajax="false"
-                                                            action="#{nursingDischargeController.navigateToPhysicalDischarge(admissionController.current)}"
-                                                            icon="fa fa-walking"
-                                                            title="Navigate to Physical Discharge"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPhysicalDischarge')}"
-                                                            styleClass="w-100 #{admissionController.current.physicalDischarged ? 'ui-button-success' : 'ui-button-warning'}">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnInvestigationsNurse"
+                                                                value="Investigations"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardInvestigationsView')}"
+                                                                action="#{admissionController.navigateToInpatientInvestigations()}"
+                                                                icon="fa fa-search"
+                                                                class="w-100">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnHoldProfessionalPayments"
-                                                            value="Hold Professional Payments"
-                                                            ajax="false"
-                                                            action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(admissionController.current)}"
-                                                            icon="fa fa-hand-paper"
-                                                            title="Navigate to Hold Professional Payments"
-                                                            rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
-                                                            styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnImagesNurse"
+                                                                value="Images"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardImagesView')}"
+                                                                action="#{admissionController.navigateToInpatientImages}"
+                                                                icon="fa fa-images"
+                                                                class="w-100">
+                                                            </p:commandButton>
+
+                                                            <p:commandButton
+                                                                id="btnDiagnosisCardNurse"
+                                                                value="Diagnosis Card"
+                                                                ajax="false"
+                                                                rendered="#{webUserController.hasPrivilege('InwardDiagnosisCardView')}"
+                                                                action="#{admissionController.navigateToInpatientDiagnosisCard()}"
+                                                                icon="fa fa-diagnoses"
+                                                                class="w-100">
+                                                            </p:commandButton>
+                                                        </div>
                                                     </div>
                                                 </p:panel>
                                             </div>
@@ -293,66 +303,76 @@
                                         <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelRoomManagement')}">
                                             <div class="col-2">
                                                 <p:panel header="Room Management">
-                                                    <div class="d-grid gap-3">
-                                                        <p:commandButton
-                                                            id="btnRoomDetailsNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomOccupency')}"
-                                                            value="Room Details"
-                                                            ajax="false"
-                                                            action="#{admissionController.navigateToPatientRoomDetails()}"
-                                                            icon="fa-solid fa-bed"
-                                                            class="w-100 ui-button-info">
-                                                        </p:commandButton>
+                                                    <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Room Actions</div>
+                                                        <div class="d-grid gap-3">
+                                                            <p:commandButton
+                                                                id="btnAddNewRoomNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
+                                                                disabled="#{admissionController.current.discharged eq true}"
+                                                                value="Add New Room"
+                                                                ajax="false"
+                                                                action="#{admissionController.navigateToAddRoom}"
+                                                                icon="fa fa-plus-circle"
+                                                                class="w-100 ui-button-success">
+                                                                <f:setPropertyActionListener
+                                                                    value="#{admissionController.current}"
+                                                                    target="#{roomChangeController.current}" />
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnAddNewRoomNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
-                                                            disabled="#{admissionController.current.discharged eq true}"
-                                                            value="Add New Room"
-                                                            ajax="false"
-                                                            action="#{admissionController.navigateToAddRoom}"
-                                                            icon="fa fa-plus-circle"
-                                                            class="w-100 ui-button-success">
-                                                            <f:setPropertyActionListener
-                                                                value="#{admissionController.current}"
-                                                                target="#{roomChangeController.current}" />
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnAddGuardianRoomNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
+                                                                value="Add Guardian Room"
+                                                                ajax="false"
+                                                                disabled="#{admissionController.current.discharged eq true}"
+                                                                action="#{admissionController.navigateToAddGuardianRoom}"
+                                                                icon="fa fa-user-plus"
+                                                                class="w-100 ui-button-success">
+                                                                <f:setPropertyActionListener
+                                                                    value="#{admissionController.current}"
+                                                                    target="#{roomChangeController.current}" />
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnAddGuardianRoomNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
-                                                            value="Add Guardian Room"
-                                                            ajax="false"
-                                                            disabled="#{admissionController.current.discharged eq true}"
-                                                            action="#{admissionController.navigateToAddGuardianRoom}"
-                                                            icon="fa fa-user-plus"
-                                                            class="w-100 ui-button-success">
-                                                            <f:setPropertyActionListener
-                                                                value="#{admissionController.current}"
-                                                                target="#{roomChangeController.current}" />
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnInitiateTransferNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InwardRoomTransferInitiate')}"
+                                                                value="Initiate Transfer"
+                                                                ajax="false"
+                                                                disabled="#{admissionController.current.discharged eq true}"
+                                                                action="#{patientTransferController.navigateToInitiateTransferForAdmission(admissionController.current)}"
+                                                                icon="fa fa-arrow-right"
+                                                                class="w-100 ui-button-info">
+                                                            </p:commandButton>
 
-                                                        <p:commandButton
-                                                            id="btnInitiateTransferNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InwardRoomTransferInitiate')}"
-                                                            value="Initiate Transfer"
-                                                            ajax="false"
-                                                            disabled="#{admissionController.current.discharged eq true}"
-                                                            action="#{patientTransferController.navigateToInitiateTransferForAdmission(admissionController.current)}"
-                                                            icon="fa fa-arrow-right"
-                                                            class="w-100 ui-button-info">
-                                                        </p:commandButton>
+                                                            <p:commandButton
+                                                                id="btnAcceptPatientsNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InwardRoomPatientAccept')}"
+                                                                value="Accept Patients"
+                                                                ajax="false"
+                                                                disabled="#{not patientTransferController.hasPendingRequestsForDepartment}"
+                                                                action="#{patientTransferController.navigateToPatientAccept()}"
+                                                                icon="fa fa-check-circle"
+                                                                class="w-100 ui-button-success">
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
 
-                                                        <p:commandButton
-                                                            id="btnAcceptPatientsNurse"
-                                                            rendered="#{webUserController.hasPrivilege('InwardRoomPatientAccept')}"
-                                                            value="Accept Patients"
-                                                            ajax="false"
-                                                            disabled="#{not patientTransferController.hasPendingRequestsForDepartment}"
-                                                            action="#{patientTransferController.navigateToPatientAccept()}"
-                                                            icon="fa fa-check-circle"
-                                                            class="w-100 ui-button-success">
-                                                        </p:commandButton>
+                                                    <hr class="my-2"/>
+
+                                                    <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Room Status</div>
+                                                        <div class="d-grid gap-3">
+                                                            <p:commandButton
+                                                                id="btnRoomDetailsNurse"
+                                                                rendered="#{webUserController.hasPrivilege('InwardRoomRoomOccupency')}"
+                                                                value="Room Details"
+                                                                ajax="false"
+                                                                action="#{admissionController.navigateToPatientRoomDetails()}"
+                                                                icon="fa-solid fa-bed"
+                                                                class="w-100 ui-button-info">
+                                                            </p:commandButton>
+                                                        </div>
                                                     </div>
                                                 </p:panel>
                                             </div>
@@ -526,139 +546,145 @@
                                         <h:panelGroup  rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelPharmaceuticals')}">
                                             <div class="col-6">
                                                 <p:panel header="Pharmaceuticals &amp; Consumables">
-                                                    <div class="d-grid gap-3">
-                                                        <p:commandButton
-                                                            value="Pharmacy BHT Request"
-                                                            ajax="false"
-                                                            action="#{admissionController.navigateToPharmacyBhtRequest}"
-                                                            icon="fa fa-prescription-bottle-alt"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest')}"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                    <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Pharmacy Actions</div>
+                                                        <div class="row g-2">
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    value="Pharmacy BHT Request"
+                                                                    ajax="false"
+                                                                    action="#{admissionController.navigateToPharmacyBhtRequest}"
+                                                                    icon="fa fa-prescription-bottle-alt"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest')}"
+                                                                    class="w-100">
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    value="Direct Issue to BHTs"
+                                                                    action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"
+                                                                    actionListener="#{pharmacySaleBhtController.resetAll()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                                                    icon="pi pi-check"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="issueDischargeMedicinesBtnNurse"
+                                                                    value="Issue Discharge Medicines"
+                                                                    action="/inward/pharmacy_discharge_medicine_issue?faces-redirect=true"
+                                                                    actionListener="#{pharmacySaleBhtController.resetAllForDischargeIssue()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
+                                                                    icon="fa fa-prescription-bottle-alt"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{pharmacySaleBhtController.patientEncounter}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    value="Direct Issue to Theatre Cases"
+                                                                    action="/theater/inward_bill_surgery_issue?faces-redirect=true"
+                                                                    actionListener="#{pharmacySaleBhtController.resetAll()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                                                    icon="pi pi-check"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnReceiveMedicinesFromPharmacy"
+                                                                    value="Receive Medicines from Pharmacy"
+                                                                    title="Receive Medicines from Pharmacy"
+                                                                    ajax="false"
+                                                                    action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
+                                                                    icon="fa fa-truck-medical"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
+                                                                    class="w-100">
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnReturnMedicinesToPharmacy"
+                                                                    value="Return Medicines to Pharmacy"
+                                                                    ajax="false"
+                                                                    action="#{wardPharmacyReturnToPharmacyController.navigateToReturn(admissionController.current)}"
+                                                                    disabled="#{admissionController.current eq null}"
+                                                                    icon="fa fa-truck-ramp-box"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardPharmacyReturnSubmit')}"
+                                                                    class="w-100">
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </div>
 
-                                                        <p:commandButton
-                                                            id="btnReceiveMedicinesFromPharmacy"
-                                                            value="Receive Medicines from Pharmacy"
-                                                            title="Receive Medicines from Pharmacy"
-                                                            ajax="false"
-                                                            action="#{wardPharmacyBhtIssueReceiveController.navigateToPendingList}"
-                                                            icon="fa fa-truck-medical"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyBhtReceive')}"
-                                                            class="w-100">
-                                                        </p:commandButton>
+                                                    <hr class="my-2"/>
 
-                                                        <p:commandButton
-                                                            id="btnReturnMedicinesToPharmacy"
-                                                            value="Return Medicines to Pharmacy"
-                                                            ajax="false"
-                                                            action="#{wardPharmacyReturnToPharmacyController.navigateToReturn(admissionController.current)}"
-                                                            disabled="#{admissionController.current eq null}"
-                                                            icon="fa fa-truck-ramp-box"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyReturnSubmit')}"
-                                                            class="w-100">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton
-                                                            id="issueDischargeMedicinesBtnNurse"
-                                                            value="Issue Discharge Medicines"
-                                                            action="/inward/pharmacy_discharge_medicine_issue?faces-redirect=true"
-                                                            actionListener="#{pharmacySaleBhtController.resetAllForDischargeIssue()}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacyDischargeMedicineIssue')}"
-                                                            icon="fa fa-prescription-bottle-alt"
-                                                            class="w-100"
-                                                            ajax="false">
-                                                            <f:setPropertyActionListener
-                                                                value="#{admissionController.current}"
-                                                                target="#{pharmacySaleBhtController.patientEncounter}" />
-                                                        </p:commandButton>
-
-                                                        <p:commandButton
-                                                            value="Direct Issue to BHTs"
-                                                            action="/inward/pharmacy_bill_issue_bht?faces-redirect=true"  
-                                                            actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="Direct Issue to Theatre Cases"
-                                                            action="/theater/inward_bill_surgery_issue?faces-redirect=true" 
-                                                            actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="BHT Issue Requests"
-                                                            action="/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true" 
-                                                            actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton
-                                                            value="View Pharmacy Requests"
-                                                            action="#{admissionController.navigateToSearchInwardBills}"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
-                                                            icon="pi pi-check"
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton
-                                                            value="Draft BHT Issue Requests"
-                                                            action="/ward/ward_pharmacy_bht_issue_request_drafts_search?faces-redirect=true"
-                                                            rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
-                                                            icon="pi pi-file-edit"
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="Search IP Direct Issues by Bill"
-                                                            action="/inward/pharmacy_search_sale_bill_bht"
-                                                            actionListener="#{searchController.makeListNull}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="Search IP Direct Issues by Item"
-                                                            action="/inward/pharmacy_search_sale_bill_item_bht?faces-redirect=true"
-                                                            actionListener="#{searchController.makeListNull}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="Search IP Direct Issue Returns by Bill"
-                                                            action="/inward/pharmacy_search_return_bill_bht?faces-redirect=true"
-                                                            actionListener="#{searchController.makeListNull}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
-
-                                                        <p:commandButton 
-                                                            value="Search IP Direct Issue Returns by Item"
-                                                            action="/inward/pharmacy_search_return_bill_item_bht?faces-redirect=true"
-                                                            actionListener="#{searchController.makeListNull}"
-                                                            rendered="#{webUserController.hasPrivilege('PharmacySale')}"
-                                                            icon="pi pi-check" 
-                                                            class="w-100"
-                                                            ajax="false">
-                                                        </p:commandButton>
+                                                    <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Pharmacy Reports &amp; History</div>
+                                                        <div class="row g-2">
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnPharmacyRequestsHistoryNurse"
+                                                                    value="Pharmacy Requests"
+                                                                    action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
+                                                                    icon="fa fa-clipboard-list"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnPharmacyRequestDraftsNurse"
+                                                                    value="Draft Pharmacy Requests"
+                                                                    action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestDraftsList()}"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardPharmacyIssueRequest') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
+                                                                    icon="fa fa-file-pen"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnDirectIssuesHistoryNurse"
+                                                                    value="Direct Issues"
+                                                                    action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyDirectIssuesList()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                                                    icon="fa fa-file-invoice"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnIssueReturnsHistoryNurse"
+                                                                    value="Issue Returns"
+                                                                    action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyReturnsList()}"
+                                                                    rendered="#{webUserController.hasPrivilege('PharmacySale')}"
+                                                                    icon="fa fa-rotate-left"
+                                                                    class="w-100"
+                                                                    ajax="false">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </p:panel>
                                             </div>


### PR DESCRIPTION
## Summary

- Splits the Nursing Dashboard's (`/nurse/index.xhtml`) three mixed panels — **Pharmaceuticals & Consumables**, **Clinical Data**, **Room Management** — into visually distinct **Actions** vs **Reports & History** sub-panels, matching the pattern already established on the Inpatient Dashboard by #21852.
- Replaces 6 stale multi-patient pharmacy search/report shortcuts (BHT Issue Requests, View Pharmacy Requests, Draft BHT Issue Requests, Search IP Direct Issues by Bill/Item, Search IP Direct Issue Returns by Bill/Item) with the 4 encounter-scoped report buttons already built for the Inpatient Dashboard (Pharmacy Requests, Draft Pharmacy Requests, Direct Issues, Issue Returns — via `InwardPharmacyEncounterReportController`), wired to the admission already selected on this dashboard instead of requiring a separate date/department-filtered search.
- Removes a dead link: "Search IP Direct Issue Returns by Item" pointed at `/inward/pharmacy_search_return_bill_item_bht`, a page that does not exist anywhere in the codebase.
- Pure XHTML/markup change — no Java, no new controller logic, no changed privileges. All existing `action`/`rendered` attributes for retained buttons are untouched; only the surrounding panel structure was regrouped.

Closes #22292

## Design

Full design spec: `developer_docs/inward/2026-07-20-nursing-dashboard-action-report-split-design.md` (included in this PR).

## Test plan

- [x] Static verification: file is well-formed XML (parsed with `xml.etree.ElementTree`), all opening/closing tags balance (`div`, `p:panel`, `h:panelGroup`, `p:commandButton` all matched counts), no duplicate component `id`s in the file (33 unique IDs).
- [x] Confirmed all 4 new pharmacy report buttons call real, existing no-arg methods on `InwardPharmacyEncounterReportController` (`navigateToInpatientPharmacyRequestsList`, `navigateToInpatientPharmacyRequestDraftsList`, `navigateToInpatientPharmacyDirectIssuesList`, `navigateToInpatientPharmacyReturnsList`) and that the bean exposes a `patientEncounter` getter/setter compatible with `f:setPropertyActionListener`.
- [x] Diffed every retained button's `action`/`rendered`/`f:setPropertyActionListener` against the pre-change version to confirm only surrounding markup (colored Actions/Reports wrapper divs) changed — no method names, privilege strings, or bean references were altered for retained buttons.
- [x] Confirmed the 4 new buttons' EL expressions match character-for-character against the already-working equivalents in `admission_profile.xhtml` (Inpatient Dashboard).
- [ ] Local Payara wasn't running for this pass; per CLAUDE.md's testing rule, JSF-only changes (no Java) don't require compilation/redeploy — this was skipped by explicit agreement with the repo owner. A reviewer with a running local instance can visually confirm the Nursing Dashboard panel layout as a final sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized the Nursing Dashboard into clearly separated action and report/history sections.
  * Added distinct Clinical Actions and Clinical Reports & Records groupings.
  * Streamlined Pharmacy Actions and consolidated pharmacy history and reporting options.

* **Documentation**
  * Added a design specification describing the dashboard layout, control updates, and verification checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->