### PR TITLE
fix(auth): treat missing lastPasswordResetAt as expired password

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1804,7 +1804,11 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         // Check password expiration
         if (enablePasswordExpiration) {
-            if (loggedUser.getLastPasswordResetAt() == null) {
+            // Use the raw (non-self-initializing) accessor - getLastPasswordResetAt()
+            // silently sets the field to "now" when null, which would make a null
+            // check here always false and defeat the expiration check entirely.
+            Date lastPasswordResetAt = loggedUser.getLastPasswordResetAtRaw();
+            if (lastPasswordResetAt == null) {
                 // No recorded password change (e.g. account predates this feature) -
                 // treat as an unknown-age, expired password rather than silently exempting it.
                 passwordRequirementMessage = "Password has expired. Please reset your password.";
@@ -1812,7 +1816,7 @@ public class SessionController implements Serializable, HttpSessionListener {
                 return false;
             }
             long expirationMillis = passwordExpirationPeriod * 24L * 60 * 60 * 1000; // Convert days to milliseconds
-            long timeSinceLastReset = System.currentTimeMillis() - loggedUser.getLastPasswordResetAt().getTime();
+            long timeSinceLastReset = System.currentTimeMillis() - lastPasswordResetAt.getTime();
             if (timeSinceLastReset > expirationMillis) {
                 passwordRequirementMessage = "Password has expired. Please reset your password.";
                 JsfUtil.addErrorMessage("Password has expired. Please reset your password.");

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1804,14 +1804,19 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         // Check password expiration
         if (enablePasswordExpiration) {
+            if (loggedUser.getLastPasswordResetAt() == null) {
+                // No recorded password change (e.g. account predates this feature) -
+                // treat as an unknown-age, expired password rather than silently exempting it.
+                passwordRequirementMessage = "Password has expired. Please reset your password.";
+                JsfUtil.addErrorMessage("Password has expired. Please reset your password.");
+                return false;
+            }
             long expirationMillis = passwordExpirationPeriod * 24L * 60 * 60 * 1000; // Convert days to milliseconds
-            if (loggedUser.getLastPasswordResetAt() != null) {
-                long timeSinceLastReset = System.currentTimeMillis() - loggedUser.getLastPasswordResetAt().getTime();
-                if (timeSinceLastReset > expirationMillis) {
-                    passwordRequirementMessage = "Password has expired. Please reset your password.";
-                    JsfUtil.addErrorMessage("Password has expired. Please reset your password.");
-                    return false;
-                }
+            long timeSinceLastReset = System.currentTimeMillis() - loggedUser.getLastPasswordResetAt().getTime();
+            if (timeSinceLastReset > expirationMillis) {
+                passwordRequirementMessage = "Password has expired. Please reset your password.";
+                JsfUtil.addErrorMessage("Password has expired. Please reset your password.");
+                return false;
             }
         }
 

--- a/src/main/java/com/divudi/core/entity/WebUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUser.java
@@ -380,6 +380,15 @@ public class WebUser implements Serializable {
         return lastPasswordResetAt;
     }
 
+    /**
+     * Returns the raw persisted value without the self-initializing side effect
+     * of {@link #getLastPasswordResetAt()}. Use this when null needs to be
+     * distinguished from "never reset" (e.g. password expiration checks).
+     */
+    public Date getLastPasswordResetAtRaw() {
+        return lastPasswordResetAt;
+    }
+
     public void setLastPasswordResetAt(Date lastPasswordResetAt) {
         this.lastPasswordResetAt = lastPasswordResetAt;
     }


### PR DESCRIPTION
## Summary
- `SessionController.arePasswordRequirementsFulfilled()` skipped the password-expiration check entirely whenever `WebUser.lastPasswordResetAt` was `null`, silently exempting any account that has never gone through a password-change flow (self-service, admin reset, or API) from the "Enable password expiration" policy — regardless of actual password age.
- Confirmed on Ruhunu production (read-only query): 157/182 accounts (86%) had `lastPasswordResetAt = NULL` and were therefore never prompted, no matter how old their password was.
- Fix: when expiration is enabled and `lastPasswordResetAt` is `null`, treat the password as expired (unknown-age password = worst case) instead of skipping the check.

Closes #22298

## Test plan
- [ ] Compiles cleanly (verified locally with JDK 11)
- [ ] QA: with "Enable password expiration" on, log in as a user whose `lastPasswordResetAt` is null → should be forced to reset password
- [ ] QA: log in as a user with a recent `lastPasswordResetAt` (within the expiration window) → should log in normally, no forced reset
- [ ] QA: log in as a user with an old `lastPasswordResetAt` (past the expiration window) → should be forced to reset password (unchanged existing behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password-expiration validation to correctly handle accounts with no recorded password reset date.
  * Users with a missing reset timestamp are now prompted to reset their password instead of being evaluated using an unintended default value.
  * Existing expiration checks remain in place when a reset timestamp is available, enforcing the configured password lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->