### PR TITLE
feat(api): add force-password-reset and password-status endpoints

### DIFF
--- a/developer_docs/api/API_USER_MANAGEMENT.md
+++ b/developer_docs/api/API_USER_MANAGEMENT.md
@@ -74,6 +74,28 @@ Response:
 
 ---
 
+### POST `/api/users/{id}/force-password-reset` — Force reset without a new password
+
+Admin only. Flags `needToResetPassword=true` without requiring the caller to supply or
+know an actual new password. Distinct from `/reset-password`, which sets a real password.
+No request body.
+
+---
+
+### GET `/api/users/password-status` — Password reset status report
+
+Admin only. Returns `lastPasswordResetAt` and `needToResetPassword` for every active user.
+
+Optional query params: `from`, `to` (`yyyy-MM-dd`) — filters to users whose
+`lastPasswordResetAt` falls within the (inclusive) range. Omitted range returns all
+active users, including those who have never reset (`lastPasswordResetAt: null`).
+
+```
+GET /api/users/password-status?from=2026-06-01&to=2026-06-30
+```
+
+---
+
 ### GET `/api/users/{id}/privileges` — List user's privileges
 
 ---

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1229,6 +1229,7 @@ public class AnthropicApiService implements Serializable {
                 .add("description",
                         "Manage HMIS users, passwords, loggable departments, and department-scoped privileges.\n\n"
                         + "method: LIST | GET | POST | PUT | DELETE | RESET_PASSWORD | CHANGE_PASSWORD | "
+                        + "FORCE_PASSWORD_RESET | PASSWORD_STATUS | "
                         + "LIST_PRIVILEGES | ASSIGN_PRIVILEGES | REVOKE_PRIVILEGE | LIST_DEPARTMENTS | ASSIGN_DEPARTMENTS | "
                         + "LIST_AVAILABLE_PRIVILEGES | BULK_ASSIGN_PRIVILEGES | ASSIGN_PRIVILEGE_CATEGORIES | "
                         + "ASSIGN_ALL_PRIVILEGES_MULTI_DEPT\n\n"
@@ -1236,7 +1237,10 @@ public class AnthropicApiService implements Serializable {
                         + "ASSIGN_ALL_PRIVILEGES_MULTI_DEPT grants every privilege across supplied departmentIds (or all user's loggable depts if omitted). "
                         + "POST supports optional staffId to pre-link a Staff record at creation. "
                         + "Use LIST_AVAILABLE_PRIVILEGES before assigning explicit privilege names. "
-                        + "Always confirm with the user before POST, PUT, DELETE, RESET_PASSWORD, CHANGE_PASSWORD, "
+                        + "FORCE_PASSWORD_RESET flags the account for a mandatory reset on next login without setting an actual new "
+                        + "password (requires id only). PASSWORD_STATUS reports lastPasswordResetAt/needToResetPassword for every "
+                        + "active user, optionally filtered by from/to (yyyy-MM-dd) — read-only, no id required. "
+                        + "Always confirm with the user before POST, PUT, DELETE, RESET_PASSWORD, CHANGE_PASSWORD, FORCE_PASSWORD_RESET, "
                         + "ASSIGN_PRIVILEGES, REVOKE_PRIVILEGE, ASSIGN_DEPARTMENTS, BULK_ASSIGN_PRIVILEGES, "
                         + "ASSIGN_PRIVILEGE_CATEGORIES, or ASSIGN_ALL_PRIVILEGES_MULTI_DEPT.")
                 .add("input_schema", Json.createObjectBuilder()
@@ -1246,6 +1250,7 @@ public class AnthropicApiService implements Serializable {
                                         .add("enum", Json.createArrayBuilder()
                                                 .add("LIST").add("GET").add("POST").add("PUT").add("DELETE")
                                                 .add("RESET_PASSWORD").add("CHANGE_PASSWORD")
+                                                .add("FORCE_PASSWORD_RESET").add("PASSWORD_STATUS")
                                                 .add("LIST_PRIVILEGES").add("ASSIGN_PRIVILEGES").add("REVOKE_PRIVILEGE")
                                                 .add("LIST_DEPARTMENTS").add("ASSIGN_DEPARTMENTS")
                                                 .add("LIST_AVAILABLE_PRIVILEGES").add("BULK_ASSIGN_PRIVILEGES")
@@ -1276,7 +1281,9 @@ public class AnthropicApiService implements Serializable {
                                 .add("userIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated user IDs for BULK_ASSIGN_PRIVILEGES"))
                                 .add("departmentIds", Json.createObjectBuilder().add("type", "string").add("description", "Comma-separated department IDs for ASSIGN_DEPARTMENTS or ASSIGN_ALL_PRIVILEGES_MULTI_DEPT"))
                                 .add("staffId", Json.createObjectBuilder().add("type", "string").add("description", "Staff ID to link to the user on POST or via PUT /{id}/staff"))
-                                .add("retireComments", Json.createObjectBuilder().add("type", "string")))
+                                .add("retireComments", Json.createObjectBuilder().add("type", "string"))
+                                .add("from", Json.createObjectBuilder().add("type", "string").add("description", "PASSWORD_STATUS filter: lastPasswordResetAt on/after this date (yyyy-MM-dd)"))
+                                .add("to", Json.createObjectBuilder().add("type", "string").add("description", "PASSWORD_STATUS filter: lastPasswordResetAt on/before this date (yyyy-MM-dd)")))
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
@@ -4490,6 +4497,14 @@ public class AnthropicApiService implements Serializable {
                     addString(change, "currentPassword", jsonString(input, "currentPassword"));
                     body = change.build().toString();
                     break;
+                case "FORCE_PASSWORD_RESET":
+                    httpMethod = "POST";
+                    url = base + "/" + requireText(id, "id") + "/force-password-reset";
+                    break;
+                case "PASSWORD_STATUS":
+                    url = base + "/password-status?" + queryParam("from", jsonString(input, "from"))
+                            + "&" + queryParam("to", jsonString(input, "to"));
+                    break;
                 case "LIST_PRIVILEGES":
                     url = base + "/" + requireText(id, "id") + "/privileges";
                     break;
@@ -5586,7 +5601,12 @@ public class AnthropicApiService implements Serializable {
                 + "Bulk operations (POST /users/bulk/role-operations) target either explicit userIds or a {roleId?, departmentId?} filter "
                 + "(userIds wins) and use a two-step safety gate: call once with preview=true to see the resolved user count and per-aspect "
                 + "totals (capped at first 200 users), then repeat the identical call with confirm=true to actually apply — calling with "
-                + "neither preview nor confirm is rejected. GET /users/roles lists active roles with template summary counts.",
+                + "neither preview nor confirm is rejected. GET /users/roles lists active roles with template summary counts.\n\n"
+                + "POST /users/{id}/force-password-reset flags needToResetPassword=true without requiring a new password value — "
+                + "use this to force a specific account to reset on next login when you don't want to set (or don't know) an actual "
+                + "new password; distinct from /reset-password. GET /users/password-status (optional ?from=&to=, yyyy-MM-dd) reports "
+                + "lastPasswordResetAt and needToResetPassword for every active user, for auditing password-expiration policy coverage "
+                + "or answering 'who has reset within this period' questions.",
                 githubUrl(branch, "developer_docs/api/API_USER_MANAGEMENT.md"),
                 new String[][]{
                     {"GET",    "/users",                          "List users. Filters: query, departmentId, page, size"},
@@ -5615,7 +5635,9 @@ public class AnthropicApiService implements Serializable {
                     {"POST",   "/users/bulk/role-operations",     "Bulk RESET/EXPAND/NARROW for many users; preview=true then confirm=true"},
                     {"GET",    "/users/roles",                    "List active roles with template summary counts (privileges/icons/subscriptions, template login page)"},
                     {"PUT",    "/users/{id}/login-page",          "Upsert the user's default login page for a department (body: {departmentId, loginPage})"},
-                    {"DELETE", "/users/{id}/login-page/{departmentId}", "Retire the user's default login-page override for a department"}
+                    {"DELETE", "/users/{id}/login-page/{departmentId}", "Retire the user's default login-page override for a department"},
+                    {"POST",   "/users/{id}/force-password-reset", "Flag needToResetPassword=true without supplying a new password (distinct from reset-password)"},
+                    {"GET",    "/users/password-status",          "Report lastPasswordResetAt and needToResetPassword per active user. Filters: from, to (yyyy-MM-dd)"}
                 });
 
         appendModule(sb, "User Roles", "/user-roles",

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -362,7 +362,11 @@ public class CapabilityStatementResource {
                         + "for safety it requires preview=true first, then confirm=true to actually apply. "
                         + "GET /roles lists active roles with template summary counts (privileges/icons/subscriptions) and template login page. "
                         + "PUT /{id}/login-page (body: {departmentId, loginPage}) and DELETE /{id}/login-page/{departmentId} manage the "
-                        + "per-user-per-department default login page override.",
+                        + "per-user-per-department default login page override. "
+                        + "POST /{id}/force-password-reset flags needToResetPassword=true without requiring a new password value "
+                        + "(distinct from /reset-password, which sets an actual password). "
+                        + "GET /password-status (optional ?from=&to=, yyyy-MM-dd) reports lastPasswordResetAt and needToResetPassword "
+                        + "per active user; omitted range returns all users including those who have never reset.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("User Bulk Privileges", "/api/users/bulk-privileges",

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -325,7 +325,9 @@ public class UserManagementApi {
      * Optional query params: from, to (yyyy-MM-dd) — filters the list to users whose
      * lastPasswordResetAt falls within the (inclusive) range. Omitting both returns
      * every active user, including those who have never reset their password
-     * (lastPasswordResetAt: null).
+     * (lastPasswordResetAt: null). A 'from' bound always excludes never-reset users
+     * (they haven't reset since anything). A 'to'-only bound (no 'from') includes
+     * never-reset users - they are, by definition, at least as overdue as any date.
      */
     @GET
     @Path("/password-status")
@@ -354,7 +356,7 @@ public class UserManagementApi {
         for (WebUser u : users) {
             Date lastReset = u.getLastPasswordResetAtRaw();
             if (from != null && (lastReset == null || lastReset.before(from))) continue;
-            if (to != null && (lastReset == null || lastReset.after(to))) continue;
+            if (to != null && lastReset != null && lastReset.after(to)) continue;
             Map<String, Object> m = new LinkedHashMap<>();
             m.put("userId", u.getId());
             m.put("name", u.getName());

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -298,6 +298,74 @@ public class UserManagementApi {
         }
     }
 
+    /**
+     * POST /api/users/{id}/force-password-reset
+     * Flags the user for a mandatory password reset on next login (respected by the
+     * "Allow admin to force password change" config option), without requiring the
+     * caller to supply or know a new password value. Distinct from /reset-password,
+     * which sets an actual new password. Audit-logged via ApiKey attribution, unlike
+     * a direct database update.
+     */
+    @POST
+    @Path("/{id}/force-password-reset")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response forcePasswordReset(@PathParam("id") Long id) {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+        WebUser u = webUserFacade.find(id);
+        if (u == null || u.isRetired()) return errorResponse("User not found", 404);
+        u.setNeedToResetPassword(true);
+        webUserFacade.edit(u);
+        return successResponse(toUserMap(u));
+    }
+
+    /**
+     * GET /api/users/password-status
+     * Optional query params: from, to (yyyy-MM-dd) — filters the list to users whose
+     * lastPasswordResetAt falls within the (inclusive) range. Omitting both returns
+     * every active user, including those who have never reset their password
+     * (lastPasswordResetAt: null).
+     */
+    @GET
+    @Path("/password-status")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listPasswordStatus() {
+        WebUser apiUser = validateApiUser();
+        if (apiUser == null) return errorResponse("Not a valid key", 401);
+        if (!isAdmin(apiUser)) return errorResponse("Insufficient privileges", 403);
+
+        String fromStr = value("from");
+        String toStr = value("to");
+        Date from = parseDateParam(fromStr);
+        if (fromStr != null && !fromStr.trim().isEmpty() && from == null) {
+            return errorResponse("Invalid 'from' date, expected yyyy-MM-dd", 400);
+        }
+        Date to = parseDateParam(toStr);
+        if (toStr != null && !toStr.trim().isEmpty() && to == null) {
+            return errorResponse("Invalid 'to' date, expected yyyy-MM-dd", 400);
+        }
+        if (to != null) {
+            to = new Date(to.getTime() + 24L * 60 * 60 * 1000 - 1); // make 'to' inclusive of the whole day
+        }
+
+        List<WebUser> users = webUserFacade.findByJpql("select w from WebUser w where w.retired=false order by w.name");
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (WebUser u : users) {
+            Date lastReset = u.getLastPasswordResetAtRaw();
+            if (from != null && (lastReset == null || lastReset.before(from))) continue;
+            if (to != null && (lastReset == null || lastReset.after(to))) continue;
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("userId", u.getId());
+            m.put("name", u.getName());
+            m.put("personName", u.getWebUserPerson() != null ? u.getWebUserPerson().getName() : null);
+            m.put("lastPasswordResetAt", lastReset);
+            m.put("needToResetPassword", u.isNeedToResetPassword());
+            out.add(m);
+        }
+        return successResponse(out);
+    }
+
     @GET
     @Path("/{id}/privileges")
     @Produces(MediaType.APPLICATION_JSON)
@@ -1526,6 +1594,15 @@ public class UserManagementApi {
     private int parseInt(String v, int d) { try { return v == null ? d : Integer.parseInt(v); } catch (Exception e) { return d; } }
 
     private Long parseLong(String v, Long d) { try { return v == null ? d : Long.parseLong(v); } catch (Exception e) { return d; } }
+
+    private Date parseDateParam(String v) {
+        if (v == null || v.trim().isEmpty()) return null;
+        try {
+            return new java.text.SimpleDateFormat("yyyy-MM-dd").parse(v.trim());
+        } catch (java.text.ParseException e) {
+            return null;
+        }
+    }
 
     private WebUser validateApiUser() {
         String key = requestContext.getHeader("Finance");

--- a/src/main/java/com/divudi/ws/common/UserManagementApi.java
+++ b/src/main/java/com/divudi/ws/common/UserManagementApi.java
@@ -1586,6 +1586,7 @@ public class UserManagementApi {
         m.put("siteId", u.getSite() != null ? u.getSite().getId() : null);
         m.put("roleId", u.getRole() != null ? u.getRole().getId() : null);
         m.put("personName", u.getWebUserPerson() != null ? u.getWebUserPerson().getName() : null);
+        m.put("needToResetPassword", u.isNeedToResetPassword());
         return m;
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #22298 (password expiration null-check fix, already merged). That work flagged an API gap: the only way to mark an account for a mandatory password reset was `/reset-password`, which requires supplying a brand-new password. There was no way to just flag an account for forced reset via API, or to report password-reset status across users, without a direct database write.

- `POST /api/users/{id}/force-password-reset` — flags `needToResetPassword=true` without requiring a new password value. Distinct from `/reset-password`, which sets an actual password. Audit-logged via API key attribution rather than a direct DB update.
- `GET /api/users/password-status` (optional `?from=&to=`, `yyyy-MM-dd`) — reports `lastPasswordResetAt` and `needToResetPassword` per active user. Answers the "who has reset within a period" / "last reset date per user" report a client explicitly asked for that previously had no API answer.

Also updated per the API development checklist:
- `CapabilityStatementResource` — documents both endpoints under the Users resource.
- `AnthropicApiService` — system prompt module description + `manage_users` tool schema (new `FORCE_PASSWORD_RESET`, `PASSWORD_STATUS` methods) + tool execution wiring, so the AI assistant can call them too.
- `developer_docs/api/API_USER_MANAGEMENT.md` — endpoint documentation.

Closes #22301

## Test plan
- [x] Compiles cleanly (verified locally with JDK 11)
- [ ] `POST /api/users/{id}/force-password-reset` on a test user → response shows the user, and their next login is forced to the change-password screen
- [ ] `GET /api/users/password-status` with no params → returns all active users, `lastPasswordResetAt: null` for users who've never reset
- [ ] `GET /api/users/password-status?from=2026-01-01&to=2026-07-01` → only returns users whose `lastPasswordResetAt` falls in that range
- [ ] `GET /api/capabilities` → confirm the Users resource description mentions both new endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only endpoint to force a user password reset on next login.
  * Added admin-only password status reporting for active users, including whether a reset is needed.
  * Password status can be filtered by an inclusive `from`/`to` reset-date range (`yyyy-MM-dd`), and includes users who have never reset their password.
  * Extended the user-management assistant tools to support these actions.
* **Documentation**
  * Updated API and capability documentation to describe the new endpoints, request details, and query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->