### PR TITLE
feat(theater): add surgery validation with audit tracking

### DIFF
--- a/docs/superpowers/specs/2026-07-21-surgery-validation-audit-design.md
+++ b/docs/superpowers/specs/2026-07-21-surgery-validation-audit-design.md
@@ -86,18 +86,33 @@ Structure mirrors `inward_bill_intrim.xhtml`'s tabbed layout, but every query
 filters by `forwardReferenceBill = surgeryBill` instead of
 `patientEncounter = admission`. Tabs:
 
-- Room Details (theatre/surgery room charges)
 - Timed Service
 - Service Details
 - Medicine Issue
 - Store Issue
-- Medicines & Surgical Supplies
 - Professional Fees
 - Assisting Fees
-- Payments
 
 ("Out Side Charge Details" is intentionally omitted — it's an admission-level
-concept, not tied to a specific surgery.)
+concept, not tied to a specific surgery. "Medicines & Surgical Supplies" is
+a config-gated alternate split view of the same Medicine Issue bills, not a
+distinct bill type — not duplicated here.)
+
+**Room Details and Payments are intentionally omitted.** Investigation
+confirmed:
+- `TheatreRoom` charges (added in #22213) are linked to the admission's
+  theatre *visit* via `PatientTransferRequest.theatreRoom`, not to a specific
+  `SurgeryBill`.
+- Payment bills are recorded against the admission (`PatientEncounter`) via
+  `InwardBeanController.fetchPaymentBill(patientEncounter, ...)`, not linked
+  via `forwardReferenceBill` to any one surgery.
+
+Neither has a clean FK to a single surgery, so attributing them to one
+surgery here would risk misattribution when an admission has multiple
+surgeries or shared payments. Both remain checkable only from the existing
+per-admission interim bill. This also keeps the "all bills checked" gate for
+Validate unambiguous — it only needs to check bills reachable via
+`forwardReferenceBill = surgeryBill`.
 
 Each row shows `checkeAt` / `checkedBy` (read-only, same as interim bill) and
 a "View Bill" link using the same `f:setPropertyActionListener` /
@@ -132,10 +147,13 @@ is non-null and is itself a `SurgeryBill`. Action navigates to
   unchecked if the user tries anyway.
 - Action: `surgeryBill.setCompleted(true)`, `setCompletedBy(loggedUser)`,
   `setCompletedAt(now)`; `billFacade.edit(...)`.
-- Audit: `auditService.logEncounterAudit(surgeryBill.getPatientEncounter().getParentEncounter() /* admission-level PE */, "Validate Surgery", before, after, loggedUser, "Bill", surgeryBill.getId())` —
-  logged against the **admission-level** `PatientEncounter` (not the
-  surgery's own `procedure` sub-encounter) so it surfaces in the existing
-  Patient Story / Inpatient Event History timeline for free.
+- Audit: `auditService.logEncounterAudit(surgeryBill.getPatientEncounter(), "Validate Surgery", before, after, loggedUser, "Bill", surgeryBill.getId())` —
+  `surgeryBill.getPatientEncounter()` is already the admission-level
+  `PatientEncounter` (distinct from `surgeryBill.getProcedure()`, the
+  surgery's own sub-encounter); this is the exact pattern the existing
+  `SurgeryBillController.edit()` audit call already uses (line ~607-610), so
+  the event surfaces in the existing Patient Story / Inpatient Event History
+  timeline for free.
 
 ### 5. Revert action
 

--- a/docs/superpowers/specs/2026-07-21-surgery-validation-audit-design.md
+++ b/docs/superpowers/specs/2026-07-21-surgery-validation-audit-design.md
@@ -1,0 +1,229 @@
+# Surgery Validation with Audit Tracking — Design
+
+**Issue**: [hmislk/hmis#22287](https://github.com/hmislk/hmis/issues/22287)
+**Date**: 2026-07-21
+
+## Problem
+
+After Theatre completes a surgery, Billing needs to review every bill generated
+under that surgery (room, service, timed-service, pharmacy issue, professional
+fee, assisting fee, payment) against the paper Green Sheet, and mark each bill
+as checked — exactly like the existing interim-bill "Mark As Checked" flow,
+but scoped to one surgery instead of one admission.
+
+Once every bill under the surgery is checked, an authorized Billing user
+should be able to mark the surgery **Completed** ("validated"). After that:
+
+- Theatre/Billing can no longer add further room charges, services, timed
+  services, medicines, or professional fees against that surgery.
+- The Surgery Dashboard shows the surgery as Completed with those add actions
+  disabled.
+- An authorized user can **Revert** the Completed status (separate
+  privilege), re-enabling additions.
+- Every validate/revert action must be recorded for audit: who, when, and
+  (for revert) why.
+
+There is currently no page that shows "all bills for one surgery" — only the
+per-admission interim bill (`inward_bill_intrim.xhtml`), and no concept of a
+surgery-level completed/locked state.
+
+## Existing mechanisms this design reuses
+
+- **A surgery *is* a `Bill`** (`billType=BillType.SurgeryBill`), with its
+  clinical data in a child `PatientEncounter` (`Bill.procedure`). There is no
+  separate `Surgery` entity.
+- **Child bills link back via `Bill.forwardReferenceBill`** — every
+  room/service/timed-service/pharmacy/professional-fee bill generated under a
+  surgery sets `forwardReferenceBill` to the surgery bill. This is the
+  existing pattern `SurgeryBillController` already queries
+  (`findActiveBillsByForwardRef`, `createIssueTable`).
+- **"Checked" already exists** as `Bill.checkeAt` / `Bill.checkedBy`, set by
+  `InwardSearch.markAsChecked()` / `markAsUnChecked()`. (`Bill.checked` — the
+  boolean — is a *different*, unrelated flag used by GRN/purchase workflows;
+  not to be confused with the checked-bill mechanism.)
+- **`Bill.completed` / `completedBy` / `completedAt` already exist** and are
+  used by several pharmacy GRN/return/purchase workflows, but are **never
+  set or read for `SurgeryBill`-typed bills**. Confirmed via full-repo grep.
+  Since only the *current* completed/not-completed state matters (per user:
+  "complete or not is all that is required... completing and reverting any
+  number of times will have no issue"), these fields are reused directly for
+  surgery validation — no new persisted state field needed.
+- **Audit trail**: reuse the generic `AuditEvent` entity /
+  `AuditService.logEncounterAudit(...)`, the same mechanism built for the
+  Inpatient Event History work (#22232). Every validate/revert action is
+  logged as a full history row (user, timestamp, before/after JSON) — this
+  is where "who/when/why, every occurrence" lives, not on the `Bill` row
+  itself.
+- **Privilege pattern**: enum entries in `Privileges.java` (with a menu
+  category `switch` case) + registration in `UserPrivilageController.java`'s
+  privilege tree, checked via `webUserController.hasPrivilege(...)`.
+
+## Design
+
+### 1. Data model — no schema changes
+
+No new entity, no new columns. Surgery-validated state is:
+
+| Concept | Field | Notes |
+|---|---|---|
+| Is the surgery completed/validated? | `Bill.completed` (on the surgery bill) | reused, currently unused for SurgeryBill |
+| Who validated / last un-reverted it | `Bill.completedBy` | reused |
+| When | `Bill.completedAt` | reused |
+| Revert history (who/when/reason) | `AuditEvent` rows only | not persisted on `Bill` — see below |
+
+Revert does **not** get dedicated `Bill` columns. Validate/revert can happen
+any number of times; only the current state matters on the `Bill`, and full
+history is recoverable from `AuditEvent`.
+
+### 2. New page: per-surgery bill summary
+
+New XHTML page `src/main/webapp/theater/surgery_bill_summary.xhtml`, logic
+added directly to the existing `SurgeryBillController` (`@SessionScoped`,
+already holds the "current surgery" as `surgeryBill`, already `@EJB`-injects
+`AuditService`).
+
+Structure mirrors `inward_bill_intrim.xhtml`'s tabbed layout, but every query
+filters by `forwardReferenceBill = surgeryBill` instead of
+`patientEncounter = admission`. Tabs:
+
+- Room Details (theatre/surgery room charges)
+- Timed Service
+- Service Details
+- Medicine Issue
+- Store Issue
+- Medicines & Surgical Supplies
+- Professional Fees
+- Assisting Fees
+- Payments
+
+("Out Side Charge Details" is intentionally omitted — it's an admission-level
+concept, not tied to a specific surgery.)
+
+Each row shows `checkeAt` / `checkedBy` (read-only, same as interim bill) and
+a "View Bill" link using the same `f:setPropertyActionListener` /
+bill-type-specific reprint page pattern as the interim bill.
+
+Entry point: a new button on `patient_surgery.xhtml`'s surgery-selected panel
+("View Surgery Bill Summary" or similar), navigating via a new
+`SurgeryBillController` method that keeps `surgeryBill` set (it already is,
+being session-scoped) and returns the new page outcome.
+
+### 3. Back-link from bill view pages
+
+On the bill-view pages that already have "Back To Interim"
+(`inward_reprint_bill.xhtml`, `inward_reprint_bill_professional.xhtml`,
+`inward_reprint_bill_payment.xhtml`, and the pharmacy reprint equivalents
+reached from Medicine/Store Issue rows), add a second button — "Back to
+Surgery Summary" — rendered only when the viewed bill's `forwardReferenceBill`
+is non-null and is itself a `SurgeryBill`. Action navigates to
+`/theater/surgery_bill_summary` with an actionListener that re-seeds
+`surgeryBillController.surgeryBill` from the viewed bill's
+`forwardReferenceBill`, mirroring how "Back To Interim" reseeds
+`bhtSummeryController` via `createTables()`.
+
+### 4. Validate action
+
+- New privilege `InwardSurgeryValidate`.
+- Button on the surgery summary page (and/or dashboard), rendered when
+  `hasPrivilege('InwardSurgeryValidate')`.
+- **Enabled only when every bill under the surgery has `checkeAt != null`**
+  (query all bills with `forwardReferenceBill = surgeryBill`, reject if any
+  has a null `checkeAt`). Show a clear validation error listing what's still
+  unchecked if the user tries anyway.
+- Action: `surgeryBill.setCompleted(true)`, `setCompletedBy(loggedUser)`,
+  `setCompletedAt(now)`; `billFacade.edit(...)`.
+- Audit: `auditService.logEncounterAudit(surgeryBill.getPatientEncounter().getParentEncounter() /* admission-level PE */, "Validate Surgery", before, after, loggedUser, "Bill", surgeryBill.getId())` —
+  logged against the **admission-level** `PatientEncounter` (not the
+  surgery's own `procedure` sub-encounter) so it surfaces in the existing
+  Patient Story / Inpatient Event History timeline for free.
+
+### 5. Revert action
+
+- New privilege `InwardSurgeryValidationRevert` (separate from Validate, per
+  issue requirement that only "authorized Billing users" can revert).
+- Explicit "Revert Validation" button, rendered when
+  `hasPrivilege('InwardSurgeryValidationRevert')` **and** `surgeryBill.completed`.
+- Prompts for a reason (simple text input in a confirm dialog / small
+  `p:dialog`, not a new persisted field — the reason travels only into the
+  audit log's JSON payload).
+- Action: `surgeryBill.setCompleted(false)`, `setCompletedBy(null)`,
+  `setCompletedAt(null)`; `billFacade.edit(...)`.
+- Audit: `auditService.logEncounterAudit(..., "Revert Surgery Validation", before, after, loggedUser, "Bill", surgeryBill.getId())`
+  with the reason embedded in the after-JSON (or as part of `eventTrigger`
+  detail) — same target admission-level `PatientEncounter`.
+
+### 6. Lock enforcement
+
+**UI layer** — `patient_surgery.xhtml`, the surgery-selected panel's four
+add-action buttons:
+
+- "Add Services & Investigations"
+- "Direct Issue Medicines"
+- "Add Timed Services"
+- "Add Professional Fees"
+
+each get `disabled="#{surgeryBillController.surgeryBill.completed}"`
+(mirroring the existing `disabled="#{...patientEncounter.paymentFinalized}"`
+precedent already used on the "Edit Surgery" / "Add New Surgery" buttons on
+the same page). Dashboard also shows a "Completed" status badge when
+`surgeryBill.completed`.
+
+**Server layer** (defense in depth — blocks stale-page / direct-navigation
+bypass), each rejecting with a JSF error message when
+`surgeryBill.isCompleted()`:
+
+- `SurgeryBillController.generalChecking()` — the existing single choke
+  point already used for save/edit of the surgery bill itself (guards lines
+  ~132, 275, 331, 577, 959, 982, 1007, 1031). Add the completed-check here.
+- `BillBhtController`'s surgery-service save path (entered via
+  `navigateToSurgeryServices`).
+- `InwardTimedItemController.saveSurgeryTimedService()`.
+- `InwardProfessionalBillController.saveProfessionalFeeBill()` (entered via
+  `navigateToSurgeryProfessionalFees` → `addProfessionalFee()`).
+
+Each of these can load the target surgery bill fresh
+(`surgeryBillController.getSurgeryBill()` or the `Bill` reference already
+held by the controller) and check `.isCompleted()` before persisting.
+
+### 7. Privileges
+
+In `Privileges.java`:
+```java
+InwardSurgeryValidate("Inward Surgery Validate"),
+InwardSurgeryValidationRevert("Inward Surgery Validation Revert"),
+```
+plus corresponding `case` labels in the menu-category `switch` (grouped with
+the existing `InwardSurgeryAdd` / `InwardSurgeryManage` cases, category
+`"Inward"`).
+
+In `UserPrivilageController.java`, register both under the existing
+`inwardSurgeryNode`:
+```java
+new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidate, "Validate Surgery"), inwardSurgeryNode);
+new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidationRevert, "Revert Surgery Validation"), inwardSurgeryNode);
+```
+
+## Out of scope
+
+- Changing the meaning or usage of `Bill.completed` for any other bill type —
+  this reuse is additive and confirmed non-conflicting for `SurgeryBill`.
+- A dedicated UI for browsing surgery-validation audit history — the events
+  land in the existing Inpatient Event History timeline
+  (`admission_event_history.xhtml`) automatically; no new report page is
+  built as part of this issue.
+- Auto-revert on unchecking an individual bill — revert is always an
+  explicit, separately-privileged action.
+- Any changes to the baby-admission workflow that is being developed in
+  parallel; this issue only touches surgery/theatre bills
+  (`forwardReferenceBill` chains rooted at a `SurgeryBill`).
+
+## Testing plan
+
+Playwright pass against local Payara: select a surgery with a mix of
+service/pharmacy/professional-fee child bills, check each bill from the new
+summary page's "View Bill" links, confirm the Validate button stays disabled
+until all are checked, validate, confirm dashboard buttons disable and show
+Completed, revert with a reason, confirm buttons re-enable, and confirm both
+events appear in the admission's Inpatient Event History timeline. DB
+verification: `bill.completed`/`completedby`/`completedat` columns on the
+surgery bill row, and corresponding `AuditEvent` rows in the audit schema.

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -220,6 +220,8 @@ public class UserPrivilageController implements Serializable {
         TreeNode inwardSurgeryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Surgery"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryAdd, "Add Surgery"), inwardSurgeryNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryManage, "Manage Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidate, "Validate Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidationRevert, "Revert Surgery Validation"), inwardSurgeryNode);
 
         TreeNode clinicalDataViewNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical Data Access"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPatientHistoryView, "Patient History View"), clinicalDataViewNode);

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -148,6 +148,8 @@ public class BillBhtController implements Serializable {
     private BillNumberGenerator billNumberBean;
     @Inject
     BillController billController;
+    @Inject
+    private SurgeryBillController surgeryBillController;
     ///////////////////
 
     private double total;
@@ -690,6 +692,12 @@ public class BillBhtController implements Serializable {
         Date toDate = null;
 
         if (getBatchBill() == null) {
+            return;
+        }
+
+        if (batchBill.getBillType() == BillType.SurgeryBill
+                && surgeryBillController.isSurgeryLockedForAdditions(batchBill)) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
             return;
         }
 

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -442,6 +442,11 @@ public class InwardProfessionalBillController implements Serializable {
     }
 
     public void saveProfessionalFeeBill() {
+        if (getBatchBill() != null && surgeryBillController.isSurgeryLockedForAdditions(getBatchBill())) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
+
         if (generalChecking()) {
             return;
         }

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -414,6 +414,11 @@ public class InwardProfessionalBillController implements Serializable {
     }
 
     public void addProfessionalFee() {
+        if (getBatchBill() != null && surgeryBillController.isSurgeryLockedForAdditions(getBatchBill())) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
+
         if (generalChecking()) {
             return;
         }

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -82,6 +82,8 @@ public class InwardTimedItemController implements Serializable {
     private InwardBeanController inwardBean;
     @Inject
     BillBeanController billBean;
+    @Inject
+    private SurgeryBillController surgeryBillController;
     @EJB
     BillFeeFacade billFeeFacade;
     @EJB
@@ -522,6 +524,11 @@ public class InwardTimedItemController implements Serializable {
     }
 
     public void saveSurgeryTimedService() {
+        if (batchBill != null && surgeryBillController.isSurgeryLockedForAdditions(batchBill)) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
+
         if (generalChecking()) {
             return;
         }

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -13,6 +13,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.FeeType;
 import com.divudi.core.data.dataStructure.DepartmentBillItems;
 import com.divudi.core.data.inward.PatientEncounterComponentType;
 import com.divudi.core.data.inward.SurgeryBillType;
@@ -22,6 +23,7 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.PreBill;
@@ -167,6 +169,16 @@ public class SurgeryBillController implements Serializable {
         return "/theater/surgery_edit?faces-redirect=true";
     }
 
+    public String navigateToSurgeryBillSummary(Bill surgery) {
+        this.surgeryBill = surgery;
+        surgeryProfessionalFees = null;
+        surgeryAssistingFees = null;
+        surgeryServiceDepartmentItems = null;
+        surgeryMedicineIssues = null;
+        surgeryStoreIssues = null;
+        return "/theater/surgery_bill_summary?faces-redirect=true";
+    }
+
     // -------------------------------------------------------------------------
     // Surgery list & delete
     // -------------------------------------------------------------------------
@@ -174,6 +186,12 @@ public class SurgeryBillController implements Serializable {
     private List<Bill> surgeryList;
     private Bill selectedSurgeryToDelete;
     private List<Bill> blockingBillsForDelete;
+    private List<BillFee> surgeryProfessionalFees;
+    private List<BillFee> surgeryAssistingFees;
+    private List<DepartmentBillItems> surgeryServiceDepartmentItems;
+    private List<Bill> surgeryMedicineIssues;
+    private List<Bill> surgeryStoreIssues;
+    private String revertReason;
 
     public List<Bill> getSurgeryList() {
         if (surgeryList == null && getSurgeryBill().getPatientEncounter() != null) {
@@ -225,6 +243,83 @@ public class SurgeryBillController implements Serializable {
         HashMap<String, Object> params = new HashMap<>();
         params.put("surg", surgery);
         return getBillFacade().findByJpql(jpql, params);
+    }
+
+    public List<BillFee> getSurgeryProfessionalFees() {
+        if (surgeryProfessionalFees == null && getSurgeryBill().getId() != null) {
+            String jpql = "SELECT bt FROM BillFee bt WHERE bt.retired=false "
+                    + " and type(bt.staff)=:class "
+                    + " and bt.fee.feeType=:ftp "
+                    + " and bt.bill.billType=:btp "
+                    + " and bt.bill.forwardReferenceBill=:surg "
+                    + " order by bt.feeAdjusted desc";
+            HashMap<String, Object> hm = new HashMap<>();
+            hm.put("class", Consultant.class);
+            hm.put("ftp", FeeType.Staff);
+            hm.put("btp", BillType.InwardProfessional);
+            hm.put("surg", getSurgeryBill());
+            surgeryProfessionalFees = getBillFeeFacade().findByJpql(jpql, hm);
+        }
+        return surgeryProfessionalFees;
+    }
+
+    public List<BillFee> getSurgeryAssistingFees() {
+        if (surgeryAssistingFees == null && getSurgeryBill().getId() != null) {
+            String jpql = "SELECT bt FROM BillFee bt WHERE bt.retired=false "
+                    + " and type(bt.staff)!=:class "
+                    + " and bt.fee.feeType=:ftp "
+                    + " and bt.bill.billType=:btp "
+                    + " and bt.bill.forwardReferenceBill=:surg";
+            HashMap<String, Object> hm = new HashMap<>();
+            hm.put("class", Consultant.class);
+            hm.put("ftp", FeeType.Staff);
+            hm.put("btp", BillType.InwardProfessional);
+            hm.put("surg", getSurgeryBill());
+            surgeryAssistingFees = getBillFeeFacade().findByJpql(jpql, hm);
+        }
+        return surgeryAssistingFees;
+    }
+
+    public List<DepartmentBillItems> getSurgeryServiceDepartmentItems() {
+        if (surgeryServiceDepartmentItems == null && getSurgeryBill().getId() != null) {
+            surgeryServiceDepartmentItems = getInwardBean().createDepartmentBillItemsOptimized(
+                    getSurgeryBill().getPatientEncounter(), getSurgeryBill(), new ArrayList<>());
+        }
+        return surgeryServiceDepartmentItems;
+    }
+
+    public List<Bill> getSurgeryMedicineIssues() {
+        if (surgeryMedicineIssues == null && getSurgeryBill().getId() != null) {
+            surgeryMedicineIssues = findIssuesByForwardRef(BillType.PharmacyBhtPre);
+        }
+        return surgeryMedicineIssues;
+    }
+
+    public List<Bill> getSurgeryStoreIssues() {
+        if (surgeryStoreIssues == null && getSurgeryBill().getId() != null) {
+            surgeryStoreIssues = findIssuesByForwardRef(BillType.StoreBhtPre);
+        }
+        return surgeryStoreIssues;
+    }
+
+    private List<Bill> findIssuesByForwardRef(BillType billType) {
+        String jpql = "SELECT b FROM Bill b WHERE b.retired=false "
+                + " and b.billType=:btp "
+                + " and b.forwardReferenceBill=:surg "
+                + " and (type(b)=:preClass or type(b)=:refundClass)";
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("btp", billType);
+        hm.put("surg", getSurgeryBill());
+        hm.put("preClass", PreBill.class);
+        hm.put("refundClass", RefundBill.class);
+        return getBillFacade().findByJpql(jpql, hm);
+    }
+
+    public Bill getSurgeryTimedServiceBill() {
+        if (getSurgeryBill().getId() == null) {
+            return null;
+        }
+        return getBillBean().fetchByForwardBill(getSurgeryBill(), SurgeryBillType.TimedService);
     }
 
     private void retireSurgeryBill(Bill surgery) {
@@ -385,6 +480,11 @@ public class SurgeryBillController implements Serializable {
         clinicalEncounterComponent = null;
         clinicalEncounterComponents = null;
         clinicalSpeciality = null;
+        surgeryProfessionalFees = null;
+        surgeryAssistingFees = null;
+        surgeryServiceDepartmentItems = null;
+        surgeryMedicineIssues = null;
+        surgeryStoreIssues = null;
     }
 
     public void saveProcedure() {
@@ -909,6 +1009,102 @@ public class SurgeryBillController implements Serializable {
         this.proEncounterComponent = proEncounterComponent;
     }
 
+    public boolean isAllSurgeryBillsChecked() {
+        return getUncheckedSurgeryBillCount() == 0;
+    }
+
+    public long getUncheckedSurgeryBillCount() {
+        if (getSurgeryBill().getId() == null) {
+            return 0;
+        }
+        String jpql = "SELECT COUNT(b) FROM Bill b WHERE b.retired=false "
+                + " and b.cancelled=false "
+                + " and b.forwardReferenceBill=:surg "
+                + " and b.checkeAt IS NULL";
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("surg", getSurgeryBill());
+        return getBillFacade().findLongByJpql(jpql, hm);
+    }
+
+    public void validateSurgery() {
+        if (getSurgeryBill().getId() == null) {
+            JsfUtil.addErrorMessage("Select Surgery");
+            return;
+        }
+        if (!webUserController.hasPrivilege("InwardSurgeryValidate")) {
+            JsfUtil.addErrorMessage("You are not authorized to validate this surgery.");
+            return;
+        }
+        if (!isAllSurgeryBillsChecked()) {
+            JsfUtil.addErrorMessage("Cannot validate: " + getUncheckedSurgeryBillCount()
+                    + " bill(s) under this surgery are not yet checked.");
+            return;
+        }
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("completed", surgeryBill.isCompleted());
+
+        surgeryBill.setCompleted(true);
+        surgeryBill.setCompletedBy(sessionController.getLoggedUser());
+        surgeryBill.setCompletedAt(new Date());
+        getBillFacade().edit(surgeryBill);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("completed", true);
+        after.put("completedBy", sessionController.getLoggedUser().getWebUserPerson().getName());
+
+        auditService.logEncounterAudit(surgeryBill.getPatientEncounter(), "Validate Surgery",
+                before, after, sessionController.getLoggedUser(), "Bill", surgeryBill.getId());
+
+        JsfUtil.addSuccessMessage("Surgery validated.");
+    }
+
+    public String getRevertReason() {
+        return revertReason;
+    }
+
+    public void setRevertReason(String revertReason) {
+        this.revertReason = revertReason;
+    }
+
+    public void revertSurgeryValidation() {
+        if (getSurgeryBill().getId() == null) {
+            JsfUtil.addErrorMessage("Select Surgery");
+            return;
+        }
+        if (!webUserController.hasPrivilege("InwardSurgeryValidationRevert")) {
+            JsfUtil.addErrorMessage("You are not authorized to revert surgery validation.");
+            return;
+        }
+        if (!surgeryBill.isCompleted()) {
+            JsfUtil.addErrorMessage("Surgery is not currently validated.");
+            return;
+        }
+        Map<String, Object> before = new LinkedHashMap<>();
+        before.put("completed", true);
+        before.put("completedBy", surgeryBill.getCompletedBy() != null
+                ? surgeryBill.getCompletedBy().getWebUserPerson().getName() : null);
+
+        surgeryBill.setCompleted(false);
+        surgeryBill.setCompletedBy(null);
+        surgeryBill.setCompletedAt(null);
+        getBillFacade().edit(surgeryBill);
+
+        Map<String, Object> after = new LinkedHashMap<>();
+        after.put("completed", false);
+        after.put("revertedBy", sessionController.getLoggedUser().getWebUserPerson().getName());
+        after.put("reason", revertReason);
+
+        auditService.logEncounterAudit(surgeryBill.getPatientEncounter(), "Revert Surgery Validation",
+                before, after, sessionController.getLoggedUser(), "Bill", surgeryBill.getId());
+
+        revertReason = null;
+        JsfUtil.addSuccessMessage("Surgery validation reverted.");
+    }
+
+    public boolean isSurgeryLockedForAdditions(Bill surgery) {
+        return surgery != null && surgery.isCompleted();
+    }
+
     private boolean generalChecking() {
         if (getSurgeryBill().getPatientEncounter() == null) {
             JsfUtil.addErrorMessage("Admission ?");
@@ -927,6 +1123,11 @@ public class SurgeryBillController implements Serializable {
         if (getSurgeryBill().getPatientEncounter().isNursingDischarged()
                 && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
             JsfUtil.addErrorMessage("Cannot add charges: nursing discharge has been confirmed for this patient.");
+            return true;
+        }
+
+        if (getSurgeryBill().isCompleted()) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
             return true;
         }
 

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -28,6 +28,7 @@ import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.RefundBill;
+import com.divudi.core.entity.Item;
 import com.divudi.core.entity.inward.EncounterComponent;
 import com.divudi.core.entity.inward.TimedItem;
 import com.divudi.core.entity.inward.TimedItemFee;
@@ -170,12 +171,8 @@ public class SurgeryBillController implements Serializable {
     }
 
     public String navigateToSurgeryBillSummary(Bill surgery) {
+        resetSurgeryBillValues();
         this.surgeryBill = surgery;
-        surgeryProfessionalFees = null;
-        surgeryAssistingFees = null;
-        surgeryServiceDepartmentItems = null;
-        surgeryMedicineIssues = null;
-        surgeryStoreIssues = null;
         return "/theater/surgery_bill_summary?faces-redirect=true";
     }
 
@@ -251,6 +248,7 @@ public class SurgeryBillController implements Serializable {
                     + " and type(bt.staff)=:class "
                     + " and bt.fee.feeType=:ftp "
                     + " and bt.bill.billType=:btp "
+                    + " and bt.bill.cancelled=false "
                     + " and bt.bill.forwardReferenceBill=:surg "
                     + " order by bt.feeAdjusted desc";
             HashMap<String, Object> hm = new HashMap<>();
@@ -269,6 +267,7 @@ public class SurgeryBillController implements Serializable {
                     + " and type(bt.staff)!=:class "
                     + " and bt.fee.feeType=:ftp "
                     + " and bt.bill.billType=:btp "
+                    + " and bt.bill.cancelled=false "
                     + " and bt.bill.forwardReferenceBill=:surg";
             HashMap<String, Object> hm = new HashMap<>();
             hm.put("class", Consultant.class);
@@ -284,8 +283,45 @@ public class SurgeryBillController implements Serializable {
         if (surgeryServiceDepartmentItems == null && getSurgeryBill().getId() != null) {
             surgeryServiceDepartmentItems = getInwardBean().createDepartmentBillItemsOptimized(
                     getSurgeryBill().getPatientEncounter(), getSurgeryBill(), new ArrayList<>());
+            applySurgeryScopedCheckedCounts(surgeryServiceDepartmentItems);
         }
         return surgeryServiceDepartmentItems;
+    }
+
+    /**
+     * createDepartmentBillItemsOptimized's "Checked Count" is computed by
+     * InwardBeanController.getBulkCheckedBillItemCounts(items, patientEncounter),
+     * which is hard-scoped to admission-wide BillType.InwardBill and ignores
+     * forwardReferenceBill entirely — so it can show counts unrelated to this
+     * surgery. Override each item's transCheckedCount with a surgery-scoped
+     * count so the tab agrees with the forwardReferenceBill-based Validate gate.
+     */
+    private void applySurgeryScopedCheckedCounts(List<DepartmentBillItems> departmentBillItems) {
+        if (departmentBillItems == null || departmentBillItems.isEmpty()) {
+            return;
+        }
+        String jpql = "SELECT bi.item.id, COUNT(bi) FROM BillItem bi WHERE bi.retired=false "
+                + " and bi.bill.forwardReferenceBill=:surg "
+                + " and bi.bill.checkeAt IS NOT NULL "
+                + " GROUP BY bi.item.id";
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("surg", getSurgeryBill());
+        List<Object[]> rows = getBillItemFacade().findObjectsArrayByJpql(jpql, hm, null);
+        Map<Long, Long> checkedCountByItemId = new HashMap<>();
+        if (rows != null) {
+            for (Object[] row : rows) {
+                checkedCountByItemId.put((Long) row[0], (Long) row[1]);
+            }
+        }
+        for (DepartmentBillItems dep : departmentBillItems) {
+            if (dep.getItems() == null) {
+                continue;
+            }
+            for (Item item : dep.getItems()) {
+                Long checked = checkedCountByItemId.get(item.getId());
+                item.setTransCheckedCount(checked != null ? checked : 0);
+            }
+        }
     }
 
     public List<Bill> getSurgeryMedicineIssues() {
@@ -1077,6 +1113,10 @@ public class SurgeryBillController implements Serializable {
         }
         if (!surgeryBill.isCompleted()) {
             JsfUtil.addErrorMessage("Surgery is not currently validated.");
+            return;
+        }
+        if (revertReason == null || revertReason.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please provide a reason for reverting validation.");
             return;
         }
         Map<String, Object> before = new LinkedHashMap<>();

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -150,6 +150,8 @@ public enum Privileges {
     InwardDoctorPaymentAccess("Inward Doctor Payment Access"),
     InwardSurgeryAdd("Inward Surgery Add"),
     InwardSurgeryManage("Inward Surgery Manage"),
+    InwardSurgeryValidate("Inward Surgery Validate"),
+    InwardSurgeryValidationRevert("Inward Surgery Validation Revert"),
     InwardPatientHistoryView("Inward Patient History View"),
     InwardClinicalNotesView("Inward Clinical Notes View"),
     InwardWardMedicationsView("Inward Ward Medications View"),
@@ -1261,6 +1263,8 @@ public enum Privileges {
             case InwardDoctorPaymentAccess:
             case InwardSurgeryAdd:
             case InwardSurgeryManage:
+            case InwardSurgeryValidate:
+            case InwardSurgeryValidationRevert:
             case InwardPatientHistoryView:
             case InwardClinicalNotesView:
             case InwardWardMedicationsView:

--- a/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_professional.xhtml
@@ -41,13 +41,18 @@
                                         class="ui-button-warning mx-1" 
                                         icon="fa fa-square"
                                         rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  />
-                                    <p:commandButton 
+                                    <p:commandButton
                                         ajax="false" value="Back To Interim"
                                         action="/inward/inward_bill_intrim"
                                         class="mx-1 ui-button-info"
                                         icon="fa fa-backward"
                                         actionListener="#{bhtSummeryController.createTables()}"
                                         />
+                                    <p:commandButton ajax="false" value="Back to Surgery Summary"
+                                                      action="#{surgeryBillController.navigateToSurgeryBillSummary(inwardSearch.bill.forwardReferenceBill)}"
+                                                      rendered="#{inwardSearch.bill.forwardReferenceBill ne null and inwardSearch.bill.forwardReferenceBill.billType eq 'SurgeryBill'}"
+                                                      class="mx-1 ui-button-info"
+                                                      icon="fa fa-backward"/>
                                 </div>
                             </div>
                         </f:facet>       

--- a/src/main/webapp/inward/pharmacy_reprint_bill_sale_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_reprint_bill_sale_bht.xhtml
@@ -46,6 +46,11 @@
                                         icon="fa fa-backward"
                                         styleClass="ui-button-info ui-button-outlined"
                                         action="/inward/inward_bill_intrim" />
+                                    <p:commandButton ajax="false" value="Back to Surgery Summary"
+                                                      action="#{surgeryBillController.navigateToSurgeryBillSummary(pharmacyBillSearch.bill.forwardReferenceBill)}"
+                                                      rendered="#{pharmacyBillSearch.bill.forwardReferenceBill ne null and pharmacyBillSearch.bill.forwardReferenceBill.billType eq 'SurgeryBill'}"
+                                                      icon="fa fa-backward"
+                                                      styleClass="ui-button-info ui-button-outlined"/>
                                     <p:commandButton
                                         ajax="false"
                                         value="Inpatient Dashboard"

--- a/src/main/webapp/inward/store_reprint_bill_sale_bht.xhtml
+++ b/src/main/webapp/inward/store_reprint_bill_sale_bht.xhtml
@@ -54,6 +54,11 @@
                                              icon="fa fa-backward"
                                              class="m-2"
                                              action="/inward/inward_bill_intrim"  />
+                            <p:commandButton ajax="false" value="Back to Surgery Summary"
+                                             action="#{surgeryBillController.navigateToSurgeryBillSummary(storeBillSearch.bill.forwardReferenceBill)}"
+                                             rendered="#{storeBillSearch.bill.forwardReferenceBill ne null and storeBillSearch.bill.forwardReferenceBill.billType eq 'SurgeryBill'}"
+                                             icon="fa fa-backward"
+                                             class="m-2"/>
                         </div>
                     </div>
 

--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -190,6 +190,9 @@
                                     <h:outputLabel value="Surgery" class="mx-4"/>
                                 </f:facet>
                                 <in:surgeryDetail bill="#{surgeryBillController.surgeryBill}"/>
+                                <p:badge value="Surgery Validated / Completed" severity="success"
+                                          rendered="#{surgeryBillController.surgeryBill.completed}"
+                                          style="display:block; margin-top:0.5rem;"/>
                             </p:panel>
 
                             <!-- Navigate to Edit Surgery page -->
@@ -391,7 +394,8 @@
                                         ajax="false"
                                         action="#{billBhtController.navigateToSurgeryServices(surgeryBillController.surgeryBill)}"
                                         icon="fa fa-plus-square"
-                                        class="w-100"/>
+                                        class="w-100"
+                                        disabled="#{surgeryBillController.surgeryBill.completed}"/>
 
                                     <p:commandButton
                                         value="Direct Issue Medicines"
@@ -399,7 +403,8 @@
                                         action="/theater/inward_bill_surgery_issue?faces-redirect=true"
                                         actionListener="#{pharmacySaleBhtController.resetAll()}"
                                         icon="fa fa-pills"
-                                        class="w-100">
+                                        class="w-100"
+                                        disabled="#{surgeryBillController.surgeryBill.completed}">
                                         <f:setPropertyActionListener
                                             value="#{surgeryBillController.surgeryBill}"
                                             target="#{pharmacySaleBhtController.batchBill}"/>
@@ -410,7 +415,8 @@
                                         ajax="false"
                                         action="#{inwardTimedItemController.navigateToSurgeryTimedServices(surgeryBillController.surgeryBill)}"
                                         icon="fa fa-clock"
-                                        class="w-100">
+                                        class="w-100"
+                                        disabled="#{surgeryBillController.surgeryBill.completed}">
                                     </p:commandButton>
 
                                     <p:commandButton
@@ -418,7 +424,8 @@
                                         ajax="false"
                                         action="#{inwardProfessionalBillController.navigateToSurgeryProfessionalFees(surgeryBillController.surgeryBill)}"
                                         icon="fa fa-user-md"
-                                        class="w-100">
+                                        class="w-100"
+                                        disabled="#{surgeryBillController.surgeryBill.completed}">
                                     </p:commandButton>
 
                                     <p:commandButton

--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -436,6 +436,14 @@
                                         icon="fa fa-notes-medical"
                                         class="w-100">
                                     </p:commandButton>
+
+                                    <p:commandButton
+                                        value="Surgery Bill Summary / Validate"
+                                        ajax="false"
+                                        action="#{surgeryBillController.navigateToSurgeryBillSummary(surgeryBillController.surgeryBill)}"
+                                        icon="fa fa-clipboard-check"
+                                        class="w-100">
+                                    </p:commandButton>
                                 </div>
                             </p:panel>
 

--- a/src/main/webapp/theater/surgery_bill_summary.xhtml
+++ b/src/main/webapp/theater/surgery_bill_summary.xhtml
@@ -1,0 +1,249 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:panel class="m-1">
+                <f:facet name="header">
+                    <h:outputText styleClass="fas fa-clipboard-check"/>
+                    <h:outputLabel value="Surgery Bill Summary" class="mx-4"/>
+                </f:facet>
+
+                <div class="row">
+                    <div class="col-6">
+                        <h:outputLabel value="Patient: "/>
+                        <h:outputLabel value="#{surgeryBillController.surgeryBill.patientEncounter.patient.person.nameWithTitle}"/>
+                    </div>
+                    <div class="col-6">
+                        <h:outputLabel value="Surgery: "/>
+                        <h:outputLabel value="#{surgeryBillController.surgeryBill.procedure.item.name}"/>
+                    </div>
+                </div>
+
+                <div class="row mt-2">
+                    <div class="col-6">
+                        <p:badge value="Completed" severity="success"
+                                 rendered="#{surgeryBillController.surgeryBill.completed}"/>
+                        <p:badge value="Pending Validation" severity="warning"
+                                 rendered="#{not surgeryBillController.surgeryBill.completed}"/>
+                        <h:outputLabel value=" — #{surgeryBillController.uncheckedSurgeryBillCount} bill(s) not yet checked"
+                                       rendered="#{not surgeryBillController.surgeryBill.completed and surgeryBillController.uncheckedSurgeryBillCount gt 0}"
+                                       style="color:#b45309; margin-left:0.5rem;"/>
+                    </div>
+                    <div class="col-6 text-end">
+                        <p:commandButton
+                            value="Validate Surgery"
+                            ajax="false"
+                            icon="fa fa-check-circle"
+                            class="ui-button-success"
+                            action="#{surgeryBillController.validateSurgery()}"
+                            rendered="#{webUserController.hasPrivilege('InwardSurgeryValidate') and not surgeryBillController.surgeryBill.completed}"
+                            disabled="#{not surgeryBillController.allSurgeryBillsChecked}"
+                            onclick="if (!confirm('Validate this surgery? Further additions will be locked.')) return false;"/>
+
+                        <p:commandButton
+                            value="Revert Validation"
+                            ajax="false"
+                            icon="fa fa-rotate-left"
+                            class="ui-button-warning"
+                            action="#{surgeryBillController.revertSurgeryValidation()}"
+                            rendered="#{webUserController.hasPrivilege('InwardSurgeryValidationRevert') and surgeryBillController.surgeryBill.completed}"
+                            onclick="if (!confirm('Revert validation for this surgery? Additions will be re-enabled.')) return false;"/>
+                    </div>
+                </div>
+
+                <h:panelGroup layout="block" class="mt-2"
+                              rendered="#{webUserController.hasPrivilege('InwardSurgeryValidationRevert') and surgeryBillController.surgeryBill.completed}">
+                    <h:outputLabel value="Revert Reason: "/>
+                    <p:inputText value="#{surgeryBillController.revertReason}" style="width: 300px;"/>
+                </h:panelGroup>
+
+                <p:tabView class="mt-3">
+                    <p:tab title="Service Details">
+                        <p:dataTable value="#{surgeryBillController.surgeryServiceDepartmentItems}" var="dep"
+                                     emptyMessage="No services recorded.">
+                            <p:columnGroup type="header">
+                                <p:row>
+                                    <p:column headerText="Item Name"/>
+                                    <p:column headerText="Count"/>
+                                    <p:column headerText="Checked Count"/>
+                                    <p:column headerText="Pending Count"/>
+                                    <p:column headerText="View Bill Items"/>
+                                </p:row>
+                            </p:columnGroup>
+                            <p:subTable value="#{dep.items}" var="ser">
+                                <f:facet name="header">
+                                    <h:outputLabel value="#{dep.department.name}"/>
+                                </f:facet>
+                                <p:column>
+                                    <h:outputLabel value="#{ser.name}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                </p:column>
+                                <p:column class="text-end">
+                                    <h:outputLabel value="#{ser.transBillItemCount}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                </p:column>
+                                <p:column class="text-end">
+                                    <h:outputLabel value="#{ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                </p:column>
+                                <p:column class="text-end">
+                                    <h:outputLabel value="#{ser.transBillItemCount - ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                </p:column>
+                                <p:column>
+                                    <p:commandButton ajax="false" rendered="#{ser.transBillItemCount ne 0}"
+                                                      action="inward_edit_bill_item_view?faces-redirect=true"
+                                                      value="View Bill Items">
+                                        <f:setPropertyActionListener value="#{ser}" target="#{bhtSummeryController.item}"/>
+                                    </p:commandButton>
+                                </p:column>
+                            </p:subTable>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Timed Service">
+                        <h:panelGroup layout="block" rendered="#{surgeryBillController.surgeryTimedServiceBill eq null}">
+                            <h:outputLabel value="No timed services recorded."/>
+                        </h:panelGroup>
+                        <p:panelGrid columns="2" columnClasses="numberCol, textCol"
+                                     rendered="#{surgeryBillController.surgeryTimedServiceBill ne null}">
+                            <h:outputLabel value="Bill No"/>
+                            <h:outputLabel value="#{surgeryBillController.surgeryTimedServiceBill.deptId}"/>
+
+                            <h:outputLabel value="Bill Total"/>
+                            <h:outputLabel value="#{surgeryBillController.surgeryTimedServiceBill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+
+                            <h:outputLabel value="Checked By"/>
+                            <h:outputLabel value="#{surgeryBillController.surgeryTimedServiceBill.checkedBy.webUserPerson.name}"/>
+
+                            <h:outputLabel value="Checked At"/>
+                            <h:outputLabel value="#{surgeryBillController.surgeryTimedServiceBill.checkeAt}">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                            </h:outputLabel>
+                        </p:panelGrid>
+                        <p:commandButton ajax="false" value="View Bill"
+                                          rendered="#{surgeryBillController.surgeryTimedServiceBill ne null}"
+                                          action="inward_reprint_bill?faces-redirect=true">
+                            <f:setPropertyActionListener value="#{surgeryBillController.surgeryTimedServiceBill}" target="#{inwardSearch.bill}"/>
+                        </p:commandButton>
+                    </p:tab>
+
+                    <p:tab title="Medicine Issue">
+                        <p:dataTable value="#{surgeryBillController.surgeryMedicineIssues}" var="iss"
+                                     emptyMessage="No medicine issues recorded.">
+                            <p:column headerText="Bill No">#{iss.deptId}</p:column>
+                            <p:column headerText="Bill Total" class="text-end">
+                                <h:outputLabel value="#{iss.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Checked By">
+                                <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
+                            </p:column>
+                            <p:column headerText="Checked At">
+                                <h:outputLabel value="#{iss.checkeAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton ajax="false" action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
+                                                  rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}"
+                                                  value="View Issue">
+                                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                                </p:commandButton>
+                                <p:commandButton ajax="false" action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
+                                                  rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
+                                                  value="View Return">
+                                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Store Issue">
+                        <p:dataTable value="#{surgeryBillController.surgeryStoreIssues}" var="iss"
+                                     emptyMessage="No store issues recorded.">
+                            <p:column headerText="Bill No">#{iss.deptId}</p:column>
+                            <p:column headerText="Bill Total" class="text-end">
+                                <h:outputLabel value="#{iss.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Checked By">
+                                <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
+                            </p:column>
+                            <p:column headerText="Checked At">
+                                <h:outputLabel value="#{iss.checkeAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton ajax="false" action="store_reprint_bill_sale_bht?faces-redirect=true"
+                                                  rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}"
+                                                  value="View Issue">
+                                    <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
+                                </p:commandButton>
+                                <p:commandButton ajax="false" action="store_reprint_bill_return_bht?faces-redirect=true"
+                                                  rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
+                                                  value="View Return">
+                                    <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Professional Fees">
+                        <p:dataTable value="#{surgeryBillController.surgeryProfessionalFees}" var="pf"
+                                     emptyMessage="No professional fees recorded.">
+                            <p:column headerText="Name">#{pf.staff.person.nameWithTitle}</p:column>
+                            <p:column headerText="Fee Value">
+                                <h:outputLabel value="#{pf.feeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Checked By">
+                                <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.nameWithTitle}"/>
+                            </p:column>
+                            <p:column headerText="Checked At">
+                                <h:outputLabel value="#{pf.bill.checkeAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
+                                    <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </p:tab>
+
+                    <p:tab title="Assisting Fees">
+                        <p:dataTable value="#{surgeryBillController.surgeryAssistingFees}" var="pf"
+                                     emptyMessage="No assisting fees recorded.">
+                            <p:column headerText="Name">#{pf.staff.person.nameWithTitle}</p:column>
+                            <p:column headerText="Fee Value">
+                                <h:outputLabel value="#{pf.feeValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Checked By">
+                                <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.nameWithTitle}"/>
+                            </p:column>
+                            <p:column headerText="Checked At">
+                                <h:outputLabel value="#{pf.bill.checkeAt}">
+                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputLabel>
+                            </p:column>
+                            <p:column headerText="Action">
+                                <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
+                                    <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </p:tab>
+                </p:tabView>
+
+                <p:commandButton value="Back to Surgery Dashboard" ajax="false"
+                                  action="/theater/patient_surgery?faces-redirect=true"
+                                  icon="fa fa-arrow-left" class="mt-3"/>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Summary

Implements #22287 — a Surgery Validation process so Billing can review every bill under a surgery (checking each one, same mechanism as the existing per-admission interim bill) and then mark the surgery Completed/Validated once all bills are checked. Once validated, further charges are locked until an authorized user explicitly reverts.

- **New page** `theater/surgery_bill_summary.xhtml`: lists every bill under one surgery (`Bill.forwardReferenceBill`) across 6 tabs — Timed Service, Service Details, Medicine Issue, Store Issue, Professional Fees, Assisting Fees — each row showing checked status with a "View Bill" link, reached from a new button on the Surgery Dashboard.
- **Validate Surgery**: enabled only when every bill under the surgery has been checked; sets `Bill.completed`/`completedBy`/`completedAt` on the surgery's own bill (these fields already existed and were unused for `SurgeryBill`-typed bills — no schema change).
- **Revert Validation**: separate privilege (`InwardSurgeryValidationRevert`), explicit button with a reason field; clears the completed state. Validate/revert can happen any number of times — only current state is persisted on the Bill, full history lives in the audit log.
- **Lock enforcement**: once validated, the Surgery Dashboard shows a "Surgery Validated / Completed" badge and disables the 4 add-charge buttons (Add Services & Investigations, Direct Issue Medicines, Add Timed Services, Add Professional Fees). Enforced both at the UI layer and with server-side guards on all 3 underlying save paths (`BillBhtController.settleBillSurgery()`, `InwardTimedItemController.saveSurgeryTimedService()`, `InwardProfessionalBillController.saveProfessionalFeeBill()` + `addProfessionalFee()`).
- **Audit logging**: both actions logged via the existing `AuditService.logEncounterAudit(...)` (built for #22232), against the admission-level `PatientEncounter`, so events surface in the existing Inpatient Event History timeline.
- **New privileges**: `InwardSurgeryValidate`, `InwardSurgeryValidationRevert`.
- **Back-links**: "Back to Surgery Summary" added on the bill-view pages, alongside the existing "Back to Interim" links, so users checking bills from this new page can return to it directly.

Room Details and Payments are intentionally not shown on the new page — neither is linked to a specific surgery via `forwardReferenceBill` (theatre room charges are tied to the admission's theatre *visit*, not a surgery; payments are recorded against the admission). Full design rationale in `docs/superpowers/specs/2026-07-21-surgery-validation-audit-design.md`.

## Test plan

- [x] `mvn clean package` — BUILD SUCCESS, 151 existing unit tests pass
- [x] Local Payara deploy successful
- [x] Playwright E2E: Surgery Dashboard → Surgery Bill Summary page renders all 6 tabs
- [x] Validate Surgery button correctly privilege-gated (hidden without privilege, visible with it)
- [x] Validate action: DB `BILL.COMPLETED`/`COMPLETEDBY_ID`/`COMPLETEDAT` set correctly; `AUDITEVENT` row `Validate Surgery` logged with correct before/after JSON
- [x] Dashboard shows "Surgery Validated / Completed" badge; 4 add-charge buttons disabled after validation
- [x] Revert Validation (with reason) correctly clears DB state; `AUDITEVENT` row `Revert Surgery Validation` logged with reason in afterJson
- [x] Dashboard buttons re-enabled and badge cleared after revert
- [ ] Server-side guard rejection on the 3 non-primary save paths — code-reviewed (Task 2 review, one gap found and fixed: `saveProfessionalFeeBill()` was initially unguarded, now fixed) but not independently exercised live via UI this pass
- [ ] "N bills unchecked" Validate-gate rejection message — not exercised live (test surgery had 0 child bills, so the gate was trivially satisfied); logic verified by code review and DB query pattern inspection

Screenshots and full verification detail posted on the issue: https://github.com/hmislk/hmis/issues/22287#issuecomment-5028168112

Refs #22287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Surgery Bill Summary page with tabs for services, timed services, medicine/store issues, and professional fees.
  * Introduced surgery validation and validation-revert actions with privilege-based access, completion badge, unchecked-bills count, and mandatory revert reason on revert.
  * Added “Back to Surgery Summary” navigation from related reprint screens.
* **Bug Fixes**
  * Enforced that once a surgery is validated/completed, surgery-related additions and fee/timed-item changes are blocked until validation is reverted.
* **Documentation**
  * Added a design specification for surgery validation with audit tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->