### PR TITLE
fix(pharmacy): block sale bill cancellation after item return or refund

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1803,7 +1803,7 @@ public class PharmacyBillSearch implements Serializable {
         }
 
         if (getBill().getBillType() == BillType.PharmacySale) {
-            if (checkSaleReturn(getBill().getReferenceBill())) {
+            if (checkSaleReturn(getBill())) {
                 JsfUtil.addErrorMessage("Sale had been Returned u can't cancell bill ");
                 return true;
             }
@@ -1891,6 +1891,49 @@ public class PharmacyBillSearch implements Serializable {
 
         Long count = getBillFacade().findLongByJpql(jpql, params);
         return count != null && count > 0;
+    }
+
+    /**
+     * Public method to check if the current Sale-for-Cashier bill already has
+     * an active (non-cancelled) item return against it.
+     * Used in XHTML to disable the Cancel button once a return has been processed.
+     * @return true if this Sale bill has been returned
+     */
+    public boolean hasActiveSaleReturn() {
+        if (getBill() == null || getBill().getBillType() != BillType.PharmacySale) {
+            return false;
+        }
+        return checkSaleReturn(getBill());
+    }
+
+    /**
+     * Public method to check if the current item-return bill already has an
+     * active (non-cancelled) refund payment processed against it. Queries
+     * fresh instead of navigating Bill.returnCashBills, whose lazy collection
+     * can be stale in the shared L2 cache when the refund bill was created in
+     * a separate request. Used both to gate the Cancel button in XHTML and to
+     * guard the server-side cancel action.
+     *
+     * Queries the base {@code Bill} type, not {@code RefundBill}: the refund
+     * payment bill created by PharmacyRefundForItemReturnsController is
+     * persisted as a plain {@code Bill} (DTYPE='Bill'), so a "From RefundBill"
+     * query would silently miss it.
+     * @return true if a refund payment has been processed for this bill
+     */
+    public boolean hasActiveReturnCashBill() {
+        if (getBill() == null) {
+            return false;
+        }
+        String sql = "Select b From Bill b where b.retired=false "
+                + " and b.cancelled=false "
+                + " and b.billType=:bt "
+                + " and b.referenceBill=:ref "
+                + " and b.billedBill is null";
+        HashMap hm = new HashMap();
+        hm.put("ref", getBill());
+        hm.put("bt", BillType.PharmacySale);
+        List<Bill> tmp = getBillFacade().findByJpql(sql, hm);
+        return !tmp.isEmpty();
     }
 
     private boolean checkSaleReturn(Bill b) {
@@ -3330,7 +3373,7 @@ public class PharmacyBillSearch implements Serializable {
                 return;
             }
 
-            if (getBill().checkActiveReturnCashBill()) {
+            if (hasActiveReturnCashBill()) {
                 JsfUtil.addErrorMessage("Payment for this bill Already Paid");
                 return;
             }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1924,7 +1924,7 @@ public class PharmacyBillSearch implements Serializable {
         if (getBill() == null) {
             return false;
         }
-        String sql = "Select b From Bill b where b.retired=false "
+        String sql = "Select count(b) From Bill b where b.retired=false "
                 + " and b.cancelled=false "
                 + " and b.billType=:bt "
                 + " and b.referenceBill=:ref "
@@ -1932,8 +1932,8 @@ public class PharmacyBillSearch implements Serializable {
         HashMap hm = new HashMap();
         hm.put("ref", getBill());
         hm.put("bt", BillType.PharmacySale);
-        List<Bill> tmp = getBillFacade().findByJpql(sql, hm);
-        return !tmp.isEmpty();
+        Long count = getBillFacade().findLongByJpql(sql, hm);
+        return count != null && count > 0;
     }
 
     private boolean checkSaleReturn(Bill b) {

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_return_pre.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_return_pre.xhtml
@@ -38,8 +38,8 @@
                                         value="Cancel"
                                         icon="fas fa-ban"
                                         class="ui-button-danger mx-2"
-                                        action="pharmacy_cancel_bill_return_pre?faces-redirect=true" 
-                                        disabled="#{pharmacyBillSearch.bill.cancelled}">                           
+                                        action="pharmacy_cancel_bill_return_pre?faces-redirect=true"
+                                        disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.hasActiveReturnCashBill()}">
                                     </p:commandButton>
                                 </h:panelGroup>
                             </div>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
@@ -107,8 +107,8 @@
                                             value="To Cancel"
                                             icon="fa fa-cancel"
                                             class="ui-button-danger m-1"
-                                            action="pharmacy_cancel_bill_retail?faces-redirect=true" 
-                                            disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded}"
+                                            action="pharmacy_cancel_bill_retail?faces-redirect=true"
+                                            disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded or pharmacyBillSearch.hasActiveSaleReturn()}"
                                             rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
                                         </p:commandButton>
                                     </h:panelGroup>


### PR DESCRIPTION
## Summary

Closes #22126.

- Fixes `PharmacyBillSearch.pharmacyErrorCheck()`: the cancel guard for `BillType.PharmacySale` bills checked the bill's *order pre-bill* (`getBill().getReferenceBill()`) for an active item return instead of the sale bill itself (`getBill()`). The actual "Return Items Only" bill's `billedBill` points at the sale bill, so the guard's query never matched and cancellation of a Sale-for-Cashier bill was never blocked, regardless of whether items had been returned or payment refunded.
- Adds `PharmacyBillSearch.hasActiveSaleReturn()` and wires it into the "To Cancel" button's `disabled` state on `pharmacy_reprint_bill_sale_cashier.xhtml`, so the button is greyed out proactively (not just blocked after a click).
- Found and fixed a second, related bug while verifying: the item-return bill's own cancel guard (`pharmacyReturnPreCancel()`) already checked `Bill.checkActiveReturnCashBill()`, but that check silently failed for two reasons — (1) it navigates a lazily-loaded bidirectional `@OneToMany` collection that can be stale across requests in EclipseLink's shared L2 cache, and (2) even queried fresh, the retail-sale refund/payment bill is persisted as plain `Bill` (DTYPE='Bill'), not `RefundBill`, so a `From RefundBill b` query silently excludes it. Replaced with `PharmacyBillSearch.hasActiveReturnCashBill()`, a fresh `From Bill b` query, used both server-side and to gate the Cancel button on `pharmacy_reprint_bill_return_pre.xhtml`.

## Test plan

Verified end-to-end against local Main Pharmacy data, two full cycles:

- [x] Create Sale-for-Cashier bill, settle payment
- [x] Return items only → original Sale bill's "To Cancel" disabled immediately (before refund); forced server-side cancel rejected with "Sale had been Returned u can't cancel bill"
- [x] Process return payment (refund) → return-items bill's own "Cancel" disabled; forced server-side cancel rejected with "Payment for this bill Already Paid"
- [x] Confirmed via DB that no bill in the chain was left cancelled after the blocked attempts
- [x] `mvn compile` clean after each change

Screenshots and full repro notes posted on the issue: https://github.com/hmislk/hmis/issues/22126#issuecomment-5030060278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation safeguards for pharmacy bills by considering active sale returns and related return cash bills.
  * Updated “reprint” views so the Cancel action is disabled when a return is active (including return cash scenarios) and when bills are already cancelled/refunded.
  * Ensured cancellation is blocked appropriately during return workflows to prevent invalid state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->