### PR TITLE
fix(pharmacy): include Direct Purchase Return in movement out report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -977,7 +977,8 @@ public class PharmacySummaryReportController implements Serializable {
                 BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED,
                 BillTypeAtomic.PHARMACY_ISSUE,
                 BillTypeAtomic.PHARMACY_ISSUE_CANCELLED,
-                BillTypeAtomic.PHARMACY_ISSUE_RETURN
+                BillTypeAtomic.PHARMACY_ISSUE_RETURN,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND
         );
     }
 

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2766,12 +2766,21 @@ public class BillService {
         // positive = stock came back on a return). For a "movement OUT" report we want the
         // quantity that went out, so we negate the summed pbi.qty: a sale yields a positive
         // out-quantity and a return reduces it, matching the signed value columns below.
+        // Direct Purchase Return is an exception: DirectPurchaseReturnController always
+        // persists pbi.qty as a positive magnitude (see its calculateBillItemDetails()), not
+        // the negative-for-out convention above, even though it is itself an OUT movement
+        // (goods leaving stock back to the supplier). This is a known writer bug tracked
+        // under #21032/#21053 (pbi.qty should be negative for this bill type but the writer
+        // is not yet fixed there); negating it here like a normal sale would flip its sign
+        // and net it against genuine sales, so it's added un-negated to match the current
+        // (buggy) persisted convention. If #21053 is ever fixed to store negative qty for
+        // this bill type, this special case must be removed at the same time.
         jpql = "select new com.divudi.core.data.dto.PharmacyMovementOutByItemDTO( "
                 + " it.id, "
                 + " coalesce(it.name, 'N/A'), "
                 + " it.code, "
                 + " coalesce(cat.name, 'N/A'), "
-                + " (coalesce(sum(pbi.qty), 0.0) * -1.0), "
+                + " coalesce(sum(case when b.billTypeAtomic = :directPurchaseReturnBta then pbi.qty else (pbi.qty * -1.0) end), 0.0), "
                 + " coalesce(sum(bi.grossValue), 0.0), "
                 + " coalesce(sum(bi.discount), 0.0), "
                 + " coalesce(sum(bi.marginValue), 0.0), "
@@ -2787,6 +2796,7 @@ public class BillService {
                 + " and b.createdAt between :fromDate and :toDate ";
 
         params.put("billTypesAtomics", billTypeAtomics);
+        params.put("directPurchaseReturnBta", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
         params.put("fromDate", fromDate);
         params.put("toDate", toDate);
 


### PR DESCRIPTION
## Summary
- The Pharmacy Movement Out with Stock Report (`pharmacy/reports/movement_reports/movement_out_by_sale_issue_and_consumption_with_current_stock_report.xhtml`) was missing Direct Purchase Return transactions, understating stock movement and valuation.
- Added `BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND` to `PharmacySummaryReportController.getPharmacyMovementOutBillTypes()`, the single list all three report views (By Bill, By Bill Type, By Item) filter on. Plain `PHARMACY_DIRECT_PURCHASE` (the purchase itself, a stock-IN transaction) is intentionally left out — it already belongs to the procurement/IN reports.
- Fixed a sign bug surfaced during verification: `BillService.fetchPharmacyMovementOutByItemDTOs()` (the "By Item" view) aggregates quantity via `sum(pbi.qty) * -1`, assuming every included bill type stores a negative `PharmaceuticalBillItem.qty` for an OUT movement (true for sales). Direct Purchase Return instead persists qty as a **positive** magnitude — a known, already-tracked writer bug (#21032/#21053). Added a bill-type-aware `CASE WHEN` so the query reads today's actual persisted sign for this bill type instead of blindly negating it, with a code comment flagging that this must be revisited if #21053 is ever fixed at the writer level.

## Test plan
Verified locally against Main Pharmacy department on a local Payara + MySQL (`coop` DB) instance:
- [x] Created a real Direct Purchase Return (100 units of Amoxil 250mg capsule) against an existing Direct Purchase bill (`MP/DP/26/037910`), finalized it, creating bill `MP/DPR/26/037940` (`PHARMACY_DIRECT_PURCHASE_REFUND`).
- [x] Ran the Movement Out report **By Item** view — item now shows the correct positive out-quantity (100) and correct net value (400.00), instead of not appearing at all (pre-fix) or the wrong sign (-100, caught mid-verification before the sign fix).
- [x] Ran the Movement Out report **By Bill** view — the return bill appears in the listing with correct totals.
- [x] Confirmed a plain Direct Purchase (non-return) bill does **not** appear in this OUT report.
- [x] Spot-checked the DB (`BILL.BILLTYPEATOMIC='PHARMACY_DIRECT_PURCHASE_REFUND'`, `BILLITEM.NETVALUE=400`, `PHARMACEUTICALBILLITEM.QTY=100`) matches the report output.
- [x] Confirmed via the XHTML's "Included Pharmacy Bill Types" panel that "Pharmacy Direct Purchase Refund" is now listed.

Screenshots and full verification notes posted on hmislk/hmis#21833.

Closes #21833

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pharmacy movement-out reports now include direct purchase refunds.
  * Quantities for direct purchase refunds are calculated with the correct sign, improving inventory movement totals and report accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->