### PR TITLE
Add PDF export to Inward & OPD reports, fix stubbed PDF button

### DIFF
--- a/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
+++ b/src/main/java/com/divudi/bean/inward/CreditCompanyDebtorGroupedReportController.java
@@ -14,6 +14,17 @@ import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -548,6 +559,229 @@ public class CreditCompanyDebtorGroupedReportController implements Serializable 
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public void downloadPdf() {
+        if (groups == null || groups.isEmpty()) {
+            return;
+        }
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpServletResponse response =
+                (HttpServletResponse) facesContext.getExternalContext().getResponse();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy");
+        SimpleDateFormat dtf = new SimpleDateFormat("dd MMM yyyy HH:mm");
+
+        final int COL_COUNT = 11;
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate(), 18, 18, 24, 18);
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+            Font subtitleFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
+            Font labelFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 9);
+            Font valueFont = FontFactory.getFont(FontFactory.HELVETICA, 9);
+            Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8, Color.WHITE);
+            Font cellFont = FontFactory.getFont(FontFactory.HELVETICA, 8);
+            Font groupFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+            Font subtotalFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+            Font grandTotalFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8, Color.WHITE);
+
+            Color headerBg = new Color(89, 89, 89);
+            Color groupBg = new Color(217, 217, 217);
+            Color subtotalBg = new Color(255, 242, 204);
+            Color grandTotalBg = new Color(0, 77, 64);
+
+            // --- Title / subtitle / printed-by ---
+            String institutionName = sessionController.getInstitution() != null
+                    ? sessionController.getInstitution().getName() : "Institution";
+
+            Paragraph p1 = new Paragraph(institutionName, titleFont);
+            p1.setAlignment(Element.ALIGN_CENTER);
+            document.add(p1);
+
+            Paragraph p2 = new Paragraph("Inpatient Credit Company Debtor Report (Grouped)",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
+            p2.setAlignment(Element.ALIGN_CENTER);
+            document.add(p2);
+
+            Paragraph p3 = new Paragraph(
+                    "Printed By: "
+                    + (sessionController.getLoggedUser() != null
+                       && sessionController.getLoggedUser().getWebUserPerson() != null
+                            ? sessionController.getLoggedUser().getWebUserPerson().getName() : "-")
+                    + "   at " + dtf.format(new Date()),
+                    subtitleFont);
+            p3.setAlignment(Element.ALIGN_CENTER);
+            document.add(p3);
+
+            document.add(new Paragraph(" "));
+
+            // --- Filter details ---
+            String dateBasisLabel;
+            switch (dateBasis) {
+                case "dischargeDate": dateBasisLabel = "Discharge Date"; break;
+                case "admissionDate": dateBasisLabel = "Admission Date"; break;
+                default:              dateBasisLabel = "Payment / Bill Date"; break;
+            }
+
+            PdfPTable filterTable = new PdfPTable(2);
+            filterTable.setWidthPercentage(65);
+            filterTable.setHorizontalAlignment(Element.ALIGN_LEFT);
+            filterTable.setSpacingBefore(4);
+            filterTable.setSpacingAfter(10);
+            filterTable.setWidths(new float[]{1f, 2f});
+
+            addPdfInfoRow(filterTable, "Date Basis", dateBasisLabel, labelFont, valueFont);
+            addPdfInfoRow(filterTable, "From", fromDate != null ? dtf.format(fromDate) : "-", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "To", toDate != null ? dtf.format(toDate) : "-", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Credit Company",
+                    institution != null ? institution.getName() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Institution",
+                    admittingInstitution != null ? admittingInstitution.getName() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Site",
+                    site != null ? site.getName() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Department",
+                    department != null ? department.getName() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Admission Type",
+                    admissionType != null ? admissionType.getName() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Payment Method",
+                    paymentMethod != null ? paymentMethod.toString() : "All", labelFont, valueFont);
+            addPdfInfoRow(filterTable, "Outstanding Only",
+                    outstandingOnly ? "Yes" : "No", labelFont, valueFont);
+
+            document.add(filterTable);
+
+            // --- Main data table ---
+            PdfPTable table = new PdfPTable(COL_COUNT);
+            table.setWidthPercentage(100);
+            table.setSpacingBefore(6);
+            table.setWidths(new float[]{1.1f, 0.9f, 1.6f, 1f, 1f, 1f, 1f, 1.1f, 1.1f, 1f, 1.1f});
+
+            String[] headers = {
+                "Bill No", "BHT No", "Patient Name", "Bill Date",
+                "Admitted", "Discharged",
+                "Bill Total", "Settled by Company", "Settled by Patient",
+                "Total Paid", "Outstanding"
+            };
+            for (String h : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(h, headerFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+                cell.setBackgroundColor(headerBg);
+                cell.setPadding(4f);
+                table.addCell(cell);
+            }
+
+            // --- Data rows ---
+            for (CreditCompanyDebtorGroupDTO group : groups) {
+                // Company group header (spans all columns)
+                PdfPCell groupCell = new PdfPCell(new Phrase(group.getCreditCompanyName(), groupFont));
+                groupCell.setColspan(COL_COUNT);
+                groupCell.setBackgroundColor(groupBg);
+                groupCell.setPadding(4f);
+                table.addCell(groupCell);
+
+                // Bill rows
+                for (Bill b : group.getBills()) {
+                    addPdfCell(table, b.getDeptId(), cellFont, Element.ALIGN_LEFT, null);
+                    addPdfCell(table,
+                            b.getPatientEncounter() != null ? b.getPatientEncounter().getBhtNo() : "",
+                            cellFont, Element.ALIGN_LEFT, null);
+                    addPdfCell(table,
+                            b.getPatient() != null && b.getPatient().getPerson() != null
+                                    ? b.getPatient().getPerson().getName() : "",
+                            cellFont, Element.ALIGN_LEFT, null);
+                    addPdfCell(table,
+                            b.getBillDate() != null ? sdf.format(b.getBillDate()) : "",
+                            cellFont, Element.ALIGN_CENTER, null);
+                    addPdfCell(table,
+                            b.getPatientEncounter() != null && b.getPatientEncounter().getDateOfAdmission() != null
+                                    ? sdf.format(b.getPatientEncounter().getDateOfAdmission()) : "",
+                            cellFont, Element.ALIGN_CENTER, null);
+                    addPdfCell(table,
+                            b.getPatientEncounter() != null && b.getPatientEncounter().getDateOfDischarge() != null
+                                    ? sdf.format(b.getPatientEncounter().getDateOfDischarge()) : "",
+                            cellFont, Element.ALIGN_CENTER, null);
+                    addPdfCell(table, String.format("%,.2f", b.getNetTotal()), cellFont, Element.ALIGN_RIGHT, null);
+                    addPdfCell(table, String.format("%,.2f", b.getSettledAmountBySponsor()), cellFont, Element.ALIGN_RIGHT, null);
+                    addPdfCell(table, String.format("%,.2f", b.getSettledAmountByPatient()), cellFont, Element.ALIGN_RIGHT, null);
+                    addPdfCell(table, String.format("%,.2f", b.getPaidAmount()), cellFont, Element.ALIGN_RIGHT, null);
+                    addPdfCell(table, String.format("%,.2f", b.getNetTotal() - b.getPaidAmount()), cellFont, Element.ALIGN_RIGHT, null);
+                }
+
+                // Subtotal row (label spans first 6 columns, matching the Excel layout)
+                PdfPCell subLabelCell = new PdfPCell(
+                        new Phrase(group.getCreditCompanyName() + " Subtotal", subtotalFont));
+                subLabelCell.setColspan(6);
+                subLabelCell.setBackgroundColor(subtotalBg);
+                subLabelCell.setPadding(4f);
+                table.addCell(subLabelCell);
+                addPdfCell(table, String.format("%,.2f", group.getSubBillTotal()), subtotalFont, Element.ALIGN_RIGHT, subtotalBg);
+                addPdfCell(table, String.format("%,.2f", group.getSubSettledByCompany()), subtotalFont, Element.ALIGN_RIGHT, subtotalBg);
+                addPdfCell(table, String.format("%,.2f", group.getSubSettledByPatient()), subtotalFont, Element.ALIGN_RIGHT, subtotalBg);
+                addPdfCell(table, String.format("%,.2f", group.getSubTotalPaid()), subtotalFont, Element.ALIGN_RIGHT, subtotalBg);
+                addPdfCell(table, String.format("%,.2f", group.getSubOutstandingTotal()), subtotalFont, Element.ALIGN_RIGHT, subtotalBg);
+            }
+
+            // --- Grand total row ---
+            PdfPCell grandLabelCell = new PdfPCell(new Phrase("Grand Total", grandTotalFont));
+            grandLabelCell.setColspan(6);
+            grandLabelCell.setBackgroundColor(grandTotalBg);
+            grandLabelCell.setPadding(4f);
+            table.addCell(grandLabelCell);
+            addPdfCell(table, String.format("%,.2f", grandBillTotal), grandTotalFont, Element.ALIGN_RIGHT, grandTotalBg);
+            addPdfCell(table, String.format("%,.2f", grandSettledByCompany), grandTotalFont, Element.ALIGN_RIGHT, grandTotalBg);
+            addPdfCell(table, String.format("%,.2f", grandSettledByPatient), grandTotalFont, Element.ALIGN_RIGHT, grandTotalBg);
+            addPdfCell(table, String.format("%,.2f", grandPaidTotal), grandTotalFont, Element.ALIGN_RIGHT, grandTotalBg);
+            addPdfCell(table, String.format("%,.2f", grandOutstandingTotal), grandTotalFont, Element.ALIGN_RIGHT, grandTotalBg);
+
+            document.add(table);
+            document.close();
+
+            byte[] fileBytes = baos.toByteArray();
+
+            // --- Write response atomically ---
+            String filename = "CC_Debtor_Grouped_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".pdf";
+            response.reset();
+            response.setContentType("application/pdf");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+            response.setContentLength(fileBytes.length);
+            try (OutputStream out = response.getOutputStream()) {
+                out.write(fileBytes);
+                out.flush();
+            }
+            facesContext.responseComplete();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void addPdfCell(PdfPTable table, String text, Font font, int alignment, Color backgroundColor) {
+        PdfPCell cell = new PdfPCell(new Phrase(text != null ? text : "", font));
+        cell.setHorizontalAlignment(alignment);
+        cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+        cell.setPadding(4f);
+        if (backgroundColor != null) {
+            cell.setBackgroundColor(backgroundColor);
+        }
+        table.addCell(cell);
+    }
+
+    private void addPdfInfoRow(PdfPTable table, String label, String value, Font labelFont, Font valueFont) {
+        PdfPCell labelCell = new PdfPCell(new Phrase(label, labelFont));
+        labelCell.setBorder(PdfPCell.NO_BORDER);
+        labelCell.setPadding(3f);
+        PdfPCell valueCell = new PdfPCell(new Phrase(value != null ? value : "", valueFont));
+        valueCell.setBorder(PdfPCell.NO_BORDER);
+        valueCell.setPadding(3f);
+        table.addCell(labelCell);
+        table.addCell(valueCell);
     }
 
     private int createFilterRow(XSSFSheet sheet, int rowIdx, String label, String value,

--- a/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
@@ -191,6 +191,10 @@
                                                      class="ui-button-success mr-2"
                                                      actionListener="#{creditCompanyDebtorGroupedReportController.downloadExcel}"
                                                      ajax="false" />
+                                    <p:commandButton value="PDF" icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1"
+                                                     actionListener="#{creditCompanyDebtorGroupedReportController.downloadPdf}"
+                                                     ajax="false" />
                                     <p:commandButton value="Print" icon="fas fa-print"
                                                      class="ui-button-info ml-1" ajax="false">
                                         <p:printer target="debtorGroupedTable" />

--- a/src/main/webapp/credit/inward_credit_company_debtor_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_debtor_report.xhtml
@@ -236,6 +236,14 @@
                                                         target="tblReport"
                                                         fileName="inward_credit_company_debtors" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF"
+                                                     icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1"
+                                                     ajax="false">
+                                        <p:dataExporter type="pdf"
+                                                        target="tblReport"
+                                                        fileName="inward_credit_company_debtors" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_report_bht_deposit_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_deposit_detail.xhtml
@@ -175,6 +175,11 @@
                                         <p:dataExporter type="xlsx" target="tblReport"
                                                         fileName="BHT_Deposit_Detail" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF" icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1" ajax="false">
+                                        <p:dataExporter type="pdf" target="tblReport"
+                                                        fileName="BHT_Deposit_Detail" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_report_bht_deposit_summary.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_deposit_summary.xhtml
@@ -175,6 +175,11 @@
                                         <p:dataExporter type="xlsx" target="tblReport"
                                                         fileName="BHT_Deposit_Summary" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF" icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1" ajax="false">
+                                        <p:dataExporter type="pdf" target="tblReport"
+                                                        fileName="BHT_Deposit_Summary" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -218,6 +218,14 @@
                                                         target="tblReport"
                                                         fileName="BHT_Payment_Detail" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF"
+                                                     icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1"
+                                                     ajax="false">
+                                        <p:dataExporter type="pdf"
+                                                        target="tblReport"
+                                                        fileName="BHT_Payment_Detail" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
@@ -218,6 +218,14 @@
                                                         target="tblReport"
                                                         fileName="BHT_Payment_Summary" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF"
+                                                     icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1"
+                                                     ajax="false">
+                                        <p:dataExporter type="pdf"
+                                                        target="tblReport"
+                                                        fileName="BHT_Payment_Summary" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_report_invoice_journal.xhtml
+++ b/src/main/webapp/inward/inward_report_invoice_journal.xhtml
@@ -216,6 +216,14 @@
                                                         target="tblReport"
                                                         fileName="Inpatient_Invoice_Journal" />
                                     </p:commandButton>
+                                    <p:commandButton value="PDF"
+                                                     icon="fas fa-file-pdf"
+                                                     class="ui-button-danger mx-1"
+                                                     ajax="false">
+                                        <p:dataExporter type="pdf"
+                                                        target="tblReport"
+                                                        fileName="Inpatient_Invoice_Journal" />
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/reportInstitution/report_cash_category_with_pro_day.xhtml
+++ b/src/main/webapp/reportInstitution/report_cash_category_with_pro_day.xhtml
@@ -69,6 +69,34 @@
 
                                             />
                         </p:commandButton>
+                        <p:commandButton value="PDF" ajax="false" class="ui-button-danger mx-1" icon="fas fa-file-pdf" >
+                            <p:dataExporter type="pdf" target="opd_new:opd_new,
+                                            colCash,
+                                            colCredit,
+                                            outside:outside,
+                                            pharmacy:pharmacy,
+                                            pharmacyc:pharmacyc,
+                                            pharmacyws:pharmacyws,
+                                            pharmacywsc:pharmacywsc,
+                                            inward_collection:inward_collection,
+                                            agent_collection:agent_collection,
+                                            credit_collection:credit_collection,
+                                            credit_collection_inward:credit_collection_inward,
+                                            credit_collection_pharmacy:credit_collection_pharmacy,
+                                            credit_collection_pharmacy_old:credit_collection_pharmacy_old,
+                                            col,
+                                            opd_professional:opd_professional,
+                                            opd_professional_credit:opd_professional_credit,
+                                            inward_professional:inward_professional,
+                                            credit_card:credit_card,
+                                            cheque:cheque,
+                                            finalSum,
+                                            slip:slip,
+                                            opd_new_credit:opd_new_credit"
+                                            fileName="Book_Keeping_Summery_with_pro_day"
+
+                                            />
+                        </p:commandButton>
                     </h:panelGrid>
                 <!--            <p:spacer height="30" />-->
                 <p:panel id="panelPrint" styleClass="noBorder summeryBorder">

--- a/src/main/webapp/reportInstitution/report_cash_category_with_pro_month.xhtml
+++ b/src/main/webapp/reportInstitution/report_cash_category_with_pro_month.xhtml
@@ -52,14 +52,34 @@
                                         outside:outside,
                                         pharmacy:pharmacy,
                                         pharmacyws:pharmacyws,
-                                        inward:inward,                                     
+                                        inward:inward,
                                         col,
                                         opd_professional:opd_professional,
                                         opd_professional_credit:opd_professional_credit,
-                                        inward_professional:inward_professional,                                     
+                                        inward_professional:inward_professional,
                                         finalSum,
                                         pharmacywsc:pharmacywsc,
-                                        pharmacyc:pharmacyc" 
+                                        pharmacyc:pharmacyc"
+                                        fileName="Book_Keeping_Summery_with_pro_day"
+
+                                        />
+                    </p:commandButton>
+                    <p:commandButton value="PDF" ajax="false" class="ui-button-danger mx-1" icon="fas fa-file-pdf" >
+                        <p:dataExporter type="pdf" target="opd_new:opd_new,
+                                        colCash,
+                                        opd_new_credit:opd_new_credit,
+                                        colCredit,
+                                        outside:outside,
+                                        pharmacy:pharmacy,
+                                        pharmacyws:pharmacyws,
+                                        inward:inward,
+                                        col,
+                                        opd_professional:opd_professional,
+                                        opd_professional_credit:opd_professional_credit,
+                                        inward_professional:inward_professional,
+                                        finalSum,
+                                        pharmacywsc:pharmacywsc,
+                                        pharmacyc:pharmacyc"
                                         fileName="Book_Keeping_Summery_with_pro_day"
 
                                         />

--- a/src/main/webapp/reportInstitution/report_cash_category_without_pro_day.xhtml
+++ b/src/main/webapp/reportInstitution/report_cash_category_without_pro_day.xhtml
@@ -69,6 +69,34 @@
 
                                         />
                     </p:commandButton>
+                    <p:commandButton value="PDF" ajax="false" class="ui-button-danger mx-1" icon="fas fa-file-pdf" >
+                        <p:dataExporter type="pdf" target="opd_new:opd_new,
+                                        colCash,
+                                        colCredit,
+                                        outside:outside,
+                                        pharmacy:pharmacy,
+                                        pharmacyc:pharmacyc,
+                                        pharmacyws:pharmacyws,
+                                        pharmacywsc:pharmacywsc,
+                                        inward_collection1:inward_collection1,
+                                        agent_collection:agent_collection,
+                                        collecting_centre_collection:collecting_centre_collection,
+                                        credit_collection:credit_collection,
+                                        credit_collection_inward:credit_collection_inward,
+                                        credit_collection_pharmacy:credit_collection_pharmacy,
+                                        col,
+                                        opd_professional_credit:opd_professional_credit,
+                                        inward_professional:inward_professional,
+                                        credit_card:credit_card,
+                                        online_settlement:online_settlement,
+                                        slip:slip,
+                                        cheque:cheque,
+                                        finalSum,
+                                        opd_new_credit:opd_new_credit"
+                                        fileName="Book_Keeping_Summery_without_pro_day_by_category_dat_end"
+
+                                        />
+                    </p:commandButton>
                 </h:panelGrid>
 
 <!--            <p:dataTable id="Val" value="#{billBeanController.billFees}" var="bf" >

--- a/src/main/webapp/reportInstitution/report_cash_category_without_pro_month.xhtml
+++ b/src/main/webapp/reportInstitution/report_cash_category_without_pro_month.xhtml
@@ -40,22 +40,41 @@
                             <p:printer target="panelPrint" />
                         </p:commandButton>
                         <p:commandButton value="Excel" ajax="false" class="ui-button-success" icon="fas fa-file-excel" >
-                            <p:dataExporter type="xlsx" target="opd_new:opd_new, 
+                            <p:dataExporter type="xlsx" target="opd_new:opd_new,
                                          colCash,
                                          colCredit,
                                          outside:outside,
                                          pharmacywsc:pharmacywsc,
-                                         inward:inward,                                     
+                                         inward:inward,
                                          col,
                                          opd_professional_credit:opd_professional_credit,
-                                         inward_professional:inward_professional,                                     
+                                         inward_professional:inward_professional,
                                          finalSum,
                                          opd_new_credit:opd_new_credit,
                                          pharmacy:pharmacy,
                                          pharmacyc:pharmacyc,
-                                         pharmacyws:pharmacyws" 
+                                         pharmacyws:pharmacyws"
                                          fileName="Book_Keeping_Summery_without_pro_month_by_category_month_end"
-                                              
+
+                                           />
+                        </p:commandButton>
+                        <p:commandButton value="PDF" ajax="false" class="ui-button-danger mx-1" icon="fas fa-file-pdf" >
+                            <p:dataExporter type="pdf" target="opd_new:opd_new,
+                                         colCash,
+                                         colCredit,
+                                         outside:outside,
+                                         pharmacywsc:pharmacywsc,
+                                         inward:inward,
+                                         col,
+                                         opd_professional_credit:opd_professional_credit,
+                                         inward_professional:inward_professional,
+                                         finalSum,
+                                         opd_new_credit:opd_new_credit,
+                                         pharmacy:pharmacy,
+                                         pharmacyc:pharmacyc,
+                                         pharmacyws:pharmacyws"
+                                         fileName="Book_Keeping_Summery_without_pro_month_by_category_month_end"
+
                                            />
                         </p:commandButton>
                     </h:panelGrid>

--- a/src/main/webapp/reportInstitution/report_credit_category.xhtml
+++ b/src/main/webapp/reportInstitution/report_credit_category.xhtml
@@ -63,7 +63,14 @@
                         <p:commandButton value="Excel" ajax="false" class="ui-button-success mx-2" icon="fas fa-file-excel">
                             <p:dataExporter type="xlsx" target="opd_new:opd_new"
                                          fileName="Book_Keeping_Summery_with_pro_day"
-                                              
+
+                                           />
+                        </p:commandButton>
+
+                        <p:commandButton value="PDF" ajax="false" class="ui-button-danger mx-2" icon="fas fa-file-pdf">
+                            <p:dataExporter type="pdf" target="opd_new:opd_new"
+                                         fileName="Book_Keeping_Summery_with_pro_day"
+
                                            />
                         </p:commandButton>
                     </h:panelGrid>

--- a/src/main/webapp/reportInstitution/report_online_payments.xhtml
+++ b/src/main/webapp/reportInstitution/report_online_payments.xhtml
@@ -43,7 +43,11 @@
 
                             <p:commandButton ajax="false" value="Excel" styleClass="noPrintButton" style="float: right;" >
                                 <p:dataExporter type="xlsx" target="tbl" fileName="on_line_settle_bills"  />
-                            </p:commandButton>  
+                            </p:commandButton>
+
+                            <p:commandButton ajax="false" value="PDF" class="ui-button-danger mx-1" icon="fas fa-file-pdf" styleClass="noPrintButton" style="float: right;" >
+                                <p:dataExporter type="pdf" target="tbl" fileName="on_line_settle_bills"  />
+                            </p:commandButton>
                         </h:panelGrid>
 
 

--- a/src/main/webapp/reportInstitution/report_opd_investigation_summery_by_category.xhtml
+++ b/src/main/webapp/reportInstitution/report_opd_investigation_summery_by_category.xhtml
@@ -49,6 +49,10 @@
                     <p:commandButton class="ui-button-success" icon="fas fa-file-excel" actionListener="#{serviceSummery.createInvestigationCategorySummery()}" value="Excel" ajax="false">
                         <p:dataExporter type="xlsx" target="opd" fileName="Investigation_Summery_By_Category"  />
                     </p:commandButton>
+
+                    <p:commandButton class="ui-button-danger mx-2" icon="fas fa-file-pdf" actionListener="#{serviceSummery.createInvestigationCategorySummery()}" value="PDF" ajax="false">
+                        <p:dataExporter type="pdf" target="opd" fileName="Investigation_Summery_By_Category"  />
+                    </p:commandButton>
                 </h:panelGrid>
 
 

--- a/src/main/webapp/reports/cashier_reports/total_cashier_summary.xhtml
+++ b/src/main/webapp/reports/cashier_reports/total_cashier_summary.xhtml
@@ -82,12 +82,20 @@
                                 class="ui-button-warning" icon="fas fa-cogs">
                             </p:commandButton>
 
-                            <p:commandButton 
-                                value="Download Excel" 
-                                ajax="false" 
-                                class="mx-2 ui-button-success" 
+                            <p:commandButton
+                                value="Download Excel"
+                                ajax="false"
+                                class="mx-2 ui-button-success"
                                 icon="fa fa-file-excel">
                                 <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="xlsx" ></p:dataExporter>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                value="PDF"
+                                ajax="false"
+                                class="mx-2 ui-button-danger"
+                                icon="fas fa-file-pdf">
+                                <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="pdf" ></p:dataExporter>
                             </p:commandButton>
 
                         </h:panelGrid>

--- a/src/main/webapp/reports/cashier_reports/total_cashier_summary.xhtml
+++ b/src/main/webapp/reports/cashier_reports/total_cashier_summary.xhtml
@@ -86,8 +86,8 @@
                                 value="Download Excel"
                                 ajax="false"
                                 class="mx-2 ui-button-success"
-                                icon="fa fa-file-excel">
-                                <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="xlsx" ></p:dataExporter>
+                                icon="fas fa-file-excel">
+                                <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="xlsx" />
                             </p:commandButton>
 
                             <p:commandButton
@@ -95,7 +95,7 @@
                                 ajax="false"
                                 class="mx-2 ui-button-danger"
                                 icon="fas fa-file-pdf">
-                                <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="pdf" ></p:dataExporter>
+                                <p:dataExporter target="tblCashier" fileName="All_Cashier_Summary" type="pdf" />
                             </p:commandButton>
 
                         </h:panelGrid>

--- a/src/main/webapp/reports/financialReports/service_category_wise_bill_detail_OPD.xhtml
+++ b/src/main/webapp/reports/financialReports/service_category_wise_bill_detail_OPD.xhtml
@@ -174,6 +174,7 @@
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Service Category Wise Bill Detail Report for OPD" />
                             </p:commandButton>
                             <p:commandButton class="ui-button-danger mx-1" icon= "fas fa-file-pdf" ajax="false" value="PDF">
+                                <p:dataExporter type="pdf" target="tbl" fileName="Service Category Wise Bill Detail Report for OPD" />
                             </p:commandButton>
                         </div>
 


### PR DESCRIPTION
## Summary
- Adds a **PDF** export button (PrimeFaces `p:dataExporter type="pdf"`) next to the existing Excel button on 14 report pages: BHT payment/deposit summary & detail, inpatient credit company debtor report, invoice journal, the four "Book Keeping Summary" composite reports (with/without professional, day/month), OPD investigation summary by category, online payments, and total cashier summary.
- Adds a new custom `downloadPdf()` method to `CreditCompanyDebtorGroupedReportController` (OpenPDF, mirroring the existing `downloadExcel()` group/subtotal/grand-total structure) for the grouped debtor report, since it renders as a plain HTML table (not `p:dataTable`) and can't use `p:dataExporter`.
- Fixes the genuinely stubbed PDF button on `service_category_wise_bill_detail_OPD.xhtml` (was an empty `<p:commandButton>` with no export logic).
- Re-verified the PDF button on `ip_income_category_wise_report.xhtml`, reported broken in the issue — it already works correctly (fixed in a prior commit); no code change was needed there.

### Note: separate pre-existing bug found (not fixed here, out of scope)
While testing `service_category_wise_bill_detail_OPD.xhtml`, its **Process** button throws `MethodNotFoundException` — it calls `searchController.createItemizedSalesReportOpd()`, which doesn't exist (the real method is `createItemizedSalesReport()`). This bug predates this change (commit `1448ffebb5`, 2024-10-12) and means the whole report has never generated data, not just its PDF export. Flagging for a separate fix since it's unrelated to PDF export.

## Test plan
Verified end-to-end via Playwright against local Payara (`coop` DB), department **Inward**, using BHT/55351 (bill `Inward/INWFINAL/82`, credit company AIA Insurance Lanka PLC) and related June 2026 records:

- [x] `inward_report_bht_payment_summary.xhtml` — PDF downloaded, row data matches on-screen table
- [x] `inward_credit_company_debtor_report.xhtml` — PDF downloaded, matches on-screen data + grand total (44,345.36)
- [x] `inward_credit_company_debtor_grouped_report.xhtml` (new custom `downloadPdf()`) — PDF shows both credit-company groups (AIA Insurance, HNB Assurance) with correct subtotals and grand total, matching the Excel export
- [x] `report_cash_category_with_pro_day.xhtml` (multi-target composite export, highest-risk case) — PDF renders all ~15 sections (Cash/Credit VAT Collection, Pharmacy/Inward/Agent/Credit Company Collections, Professional Payment, Credit Card/Cheque Transactions, etc.) across 3 pages, matching the on-screen composite report
- [x] `service_category_wise_bill_detail_OPD.xhtml` — stub button fixed (dataExporter now wired); blocked from full data verification by the separate pre-existing Process-button bug noted above
- [x] `ip_income_category_wise_report.xhtml` — re-tested existing PDF button with real June 2026 data; PDF matches on-screen report (Net Amount 38,290.74)
- [x] Local build (`mvn clean package`) and Payara redeploy succeeded with no errors in `server.log`

Closes #21775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PDF download support for the Inpatient Credit Company Debtor (Grouped) report, including applied filters, grouped details, subtotals, and grand totals.
  * Added PDF export buttons across multiple reports (BHT Deposit/Payment, Inpatient Invoice Journal, Total Cashier Summary, Online Payments, Cash Category reports, Report Credit Category, Investigation Summary by Category, Service Category Wise Bill Detail for OPD).
  * Existing report tables can now be downloaded as PDF alongside current Excel and print options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->