### PR TITLE
feat(pharmacy): validate stock availability when issuing BHT medicines

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -915,6 +915,44 @@ local `coop.patientencounter` table was missing all four
 `professionalpayments*` columns and `patienttransferrequest` was missing
 `theatreroom_id`.
 
+## 39. Local dev DB has no `FrequencyUnit`/`DurationUnit`/`DoseUnit` seed rows — the prescription "Calculate & Add" path is untestable locally
+
+`ward_pharmacy_bht_issue_request_bill.xhtml`'s Prescription section (Dose/Dose
+Unit/Frequency/Duration/Duration Unit → "Calculate & Add") requires selecting
+a `FrequencyUnit` and `DurationUnit` — both are `Category` subclasses stored
+in the single-table `category` (via `@Inheritance` with no strategy = default
+`SINGLE_TABLE`, discriminated by `DTYPE`). The local `coop` DB has **zero**
+rows with `DTYPE` in (`FrequencyUnit`, `DurationUnit`, `DoseUnit`) — confirmed
+via `SELECT DISTINCT DTYPE FROM category`. Both dropdowns render as
+`combobox "Select"` with no other options, and submitting anyway fails with
+`"Calculation Error: Incomplete prescription: dose, frequency, duration and
+duration unit are required"`. **Workaround**: use the "Dispense Request" →
+"+ Add Dispense Only" path instead (item autocomplete + plain qty field, no
+prescription fields) — but that path has the toDepartment bug from §31, so
+still fix `TODEPARTMENT_ID` via SQL afterward. Verified while testing issue
+#22312.
+
+## 40. Auto-substitution can silently turn a "zero stock" test case into "issued in full"
+
+When testing a BHT/pharmacy-request stock-shortfall feature, don't assume an
+item with 0 stock at the issuing department will exercise the "no stock"
+code path — `PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest`
+(and similar issuing flows) auto-substitutes to a same-VMP sibling AMP with
+stock before falling back to "no stock". An item whose exact AMP has 0 stock
+but has an in-stock sibling under the same VMP (e.g. `Levo 500mg Tablet` →
+`EVITRA 500MG`) will be silently issued in full via the substitute, hiding the
+zero-stock code path entirely. To reliably hit "no stock at all", pick an item
+with **no in-stock siblings under its VMP either** — verify first:
+```sql
+SELECT a.ID, a.NAME, a.VMP_ID FROM item a WHERE a.DTYPE='Amp'
+AND a.ID NOT IN (SELECT ib.ITEM_ID FROM stock s JOIN itembatch ib ON s.ITEMBATCH_ID=ib.ID
+                 WHERE s.DEPARTMENT_ID=<dept> AND s.STOCK>0)
+AND (a.VMP_ID IS NULL OR a.VMP_ID NOT IN (
+  SELECT a2.VMP_ID FROM item a2 JOIN itembatch ib2 ON ib2.ITEM_ID=a2.ID
+  JOIN stock s2 ON s2.ITEMBATCH_ID=ib2.ID WHERE s2.DEPARTMENT_ID=<dept> AND s2.STOCK>0 AND a2.DTYPE='Amp');
+```
+Verified while testing issue #22312.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1801,7 +1801,11 @@ public class PharmacySaleBhtController implements Serializable {
                 return true;
             }
             if (bi.getPharmaceuticalBillItem().getStock() == null) {
-                JsfUtil.addErrorMessage("Requested item not found" + bi.getItem().getName());
+                double requestedQtyForCheck = Math.abs(bi.getPharmaceuticalBillItem().getQty());
+                JsfUtil.addErrorMessage("No stock available for " + bi.getItem().getName()
+                        + ". Available: 0, Requested: " + requestedQtyForCheck
+                        + ", Remaining not issued: " + requestedQtyForCheck
+                        + ". Please select a substitute or check pharmacy stock.");
                 return true;
             }
             if (bi.getPharmaceuticalBillItem().getStock().getItemBatch() == null) {
@@ -2135,13 +2139,6 @@ public class PharmacySaleBhtController implements Serializable {
             }
             Stock tbiStock = tbi.getPharmaceuticalBillItem().getStock();
             double requestedQtyForSettle = Math.abs(tbi.getPharmaceuticalBillItem().getQty());
-            if (tbiStock == null) {
-                JsfUtil.addErrorMessage("No stock available for " + tbi.getItem().getName()
-                        + ". Available: 0, Requested: " + requestedQtyForSettle
-                        + ", Remaining not issued: " + requestedQtyForSettle
-                        + ". Please select a substitute or check pharmacy stock.");
-                return false;
-            }
             if (requestedQtyForSettle > tbiStock.getStock()) {
                 double availableQty = tbiStock.getStock();
                 JsfUtil.addErrorMessage("Not Enough Stock for " + tbi.getItem().getName()

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -295,6 +295,12 @@ public class PharmacySaleBhtController implements Serializable {
     // pharmacist sees the original prescription against what was actually resolved
     // (and any low/no-stock shortfall) — prevents silent omissions. Issue #21334.
     private List<DischargeConversionRow> dischargeConversionReport = new ArrayList<>();
+    // Per-requested-line stock availability report shown on the BHT issue-request
+    // page so the pharmacist sees Available/Requested/Remaining BEFORE clicking
+    // "Issue to BHT", instead of only a late error on settle. Kept separate from
+    // dischargeConversionReport (different flow) so this change cannot regress
+    // the stable discharge-issue path. Issue #22312.
+    private List<BhtIssueStockReportRow> bhtIssueStockReport = new ArrayList<>();
     Department department;
     String errorMessage = "";
     /////////////////
@@ -772,6 +778,7 @@ public class PharmacySaleBhtController implements Serializable {
         cachedMatrixByAdmissionDepartment = null;
         dischargeIssueMode = false;
         dischargeConversionReport = new ArrayList<>();
+        bhtIssueStockReport = new ArrayList<>();
     }
 
     /**
@@ -1126,6 +1133,23 @@ public class PharmacySaleBhtController implements Serializable {
     /** True when any converted line was not issued in full (needs pharmacist attention). */
     public boolean isDischargeConversionHasAttentionItems() {
         for (DischargeConversionRow r : getDischargeConversionReport()) {
+            if (r.isNeedsAttention()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<BhtIssueStockReportRow> getBhtIssueStockReport() {
+        if (bhtIssueStockReport == null) {
+            bhtIssueStockReport = new ArrayList<>();
+        }
+        return bhtIssueStockReport;
+    }
+
+    /** True when any BHT issue-request line was not issued in full (needs pharmacist attention). */
+    public boolean isBhtIssueStockReportHasAttentionItems() {
+        for (BhtIssueStockReportRow r : getBhtIssueStockReport()) {
             if (r.isNeedsAttention()) {
                 return true;
             }
@@ -2110,12 +2134,19 @@ public class PharmacySaleBhtController implements Serializable {
                 return false;
             }
             Stock tbiStock = tbi.getPharmaceuticalBillItem().getStock();
+            double requestedQtyForSettle = Math.abs(tbi.getPharmaceuticalBillItem().getQty());
             if (tbiStock == null) {
-                JsfUtil.addErrorMessage("No stock available for " + tbi.getItem().getName() + ". Please check pharmacy stock.");
+                JsfUtil.addErrorMessage("No stock available for " + tbi.getItem().getName()
+                        + ". Available: 0, Requested: " + requestedQtyForSettle
+                        + ", Remaining not issued: " + requestedQtyForSettle
+                        + ". Please select a substitute or check pharmacy stock.");
                 return false;
             }
-            if (Math.abs(tbi.getPharmaceuticalBillItem().getQty()) > tbiStock.getStock()) {
-                JsfUtil.addErrorMessage("Not Enough Stock " + tbi.getItem().getName());
+            if (requestedQtyForSettle > tbiStock.getStock()) {
+                double availableQty = tbiStock.getStock();
+                JsfUtil.addErrorMessage("Not Enough Stock for " + tbi.getItem().getName()
+                        + ". Available: " + availableQty + ", Requested: " + requestedQtyForSettle
+                        + ", Remaining not issued: " + (requestedQtyForSettle - availableQty) + ".");
                 return false;
             }
         }
@@ -2860,6 +2891,9 @@ public class PharmacySaleBhtController implements Serializable {
         // same @SessionScoped controller so items are priced with the inward
         // price matrix, not at bare retail. (PR #21330 review)
         dischargeIssueMode = false;
+        // Reset the stock-availability report on every (re)generation so a stale
+        // report from a previous request/navigation is never shown. Issue #22312.
+        bhtIssueStockReport = new ArrayList<>();
         if (b == null) {
             JsfUtil.addErrorMessage("No bill");
             return;
@@ -2951,14 +2985,17 @@ public class PharmacySaleBhtController implements Serializable {
 
             Amp exactAmp = null;
             List<StockQty> exactStockQtys = null;
+            double exactCandidateQty = 0;
 
             Amp sameStrengthAmp = null;
             List<StockQty> sameStrengthStockQtys = null;
             Date sameStrengthEarliestExpiry = null;
+            double sameStrengthCandidateQty = 0;
 
             Amp fallbackAmp = null;
             List<StockQty> fallbackStockQtys = null;
             Date fallbackEarliestExpiry = null;
+            double fallbackCandidateQty = 0;
 
             for (Amp candidate : candidateAmps) {
                 Double ampStrength = candidate.getStrengthOfAnIssueUnit();
@@ -2992,6 +3029,7 @@ public class PharmacySaleBhtController implements Serializable {
                 if (isExact) {
                     exactAmp = candidate;
                     exactStockQtys = stockQtys;
+                    exactCandidateQty = candidateQty;
                     break; // exact match is optimal
                 } else if (isSameStrength
                         && (sameStrengthAmp == null
@@ -3000,6 +3038,7 @@ public class PharmacySaleBhtController implements Serializable {
                     sameStrengthAmp = candidate;
                     sameStrengthStockQtys = stockQtys;
                     sameStrengthEarliestExpiry = candidateEarliestExpiry;
+                    sameStrengthCandidateQty = candidateQty;
                 } else if (!isSameStrength
                         && (fallbackAmp == null
                         || (candidateEarliestExpiry != null && (fallbackEarliestExpiry == null
@@ -3007,28 +3046,35 @@ public class PharmacySaleBhtController implements Serializable {
                     fallbackAmp = candidate;
                     fallbackStockQtys = stockQtys;
                     fallbackEarliestExpiry = candidateEarliestExpiry;
+                    fallbackCandidateQty = candidateQty;
                 }
             }
 
             // Pick best available candidate
             final List<StockQty> selectedStockQtys;
             final boolean isSubstitute;
+            final double selectedCandidateQty;
 
             if (exactAmp != null) {
                 selectedStockQtys = exactStockQtys;
                 isSubstitute = false;
+                selectedCandidateQty = exactCandidateQty;
             } else if (sameStrengthAmp != null) {
                 selectedStockQtys = sameStrengthStockQtys;
                 isSubstitute = true;
+                selectedCandidateQty = sameStrengthCandidateQty;
             } else if (fallbackAmp != null) {
                 selectedStockQtys = fallbackStockQtys;
                 isSubstitute = true;
+                selectedCandidateQty = fallbackCandidateQty;
             } else {
                 selectedStockQtys = null;
                 isSubstitute = false;
+                selectedCandidateQty = issuableQty;
             }
 
             if (selectedStockQtys != null && !selectedStockQtys.isEmpty()) {
+                double issuedQtyForLine = 0.0;
                 for (StockQty sq : selectedStockQtys) {
                     if (sq.getQty() == 0) {
                         continue;
@@ -3066,7 +3112,26 @@ public class PharmacySaleBhtController implements Serializable {
                     }
                     calculateRates(billItem);
                     billItems.add(billItem);
+                    issuedQtyForLine += sq.getQty();
                 }
+
+                // Stock-availability report row for this requested line. Issue #22312.
+                BhtIssueStockReportRow reportRow = new BhtIssueStockReportRow();
+                reportRow.setRequestedItemName(requestedItem.getName());
+                reportRow.setRequestedQty(selectedCandidateQty);
+                reportRow.setIssuedQty(issuedQtyForLine);
+                if (issuedQtyForLine >= selectedCandidateQty) {
+                    reportRow.setStatus(BhtIssueStockReportRow.Status.ISSUED_FULL);
+                    reportRow.setMessage("");
+                } else {
+                    double remaining = selectedCandidateQty - issuedQtyForLine;
+                    reportRow.setStatus(BhtIssueStockReportRow.Status.PARTIAL_LOW_STOCK);
+                    reportRow.setMessage("Available: " + issuedQtyForLine + ", Requested: " + selectedCandidateQty
+                            + ", Remaining not issued: " + remaining + " of " + requestedItem.getName()
+                            + " at " + dept.getName()
+                            + ". Issued the available quantity — use \"Select a Substitute\" or split the rest manually.");
+                }
+                bhtIssueStockReport.add(reportRow);
             } else {
                 // No stock found for any AMP — add placeholder for manual resolution
                 billItem = new BillItem();
@@ -3089,6 +3154,18 @@ public class PharmacySaleBhtController implements Serializable {
                 billItem.getPharmaceuticalBillItem().setBillItem(billItem);
                 calculateRates(billItem);
                 billItems.add(billItem);
+
+                // Stock-availability report row for this requested line. Issue #22312.
+                BhtIssueStockReportRow reportRow = new BhtIssueStockReportRow();
+                reportRow.setRequestedItemName(requestedItem.getName());
+                reportRow.setRequestedQty(issuableQty);
+                reportRow.setIssuedQty(0.0);
+                reportRow.setStatus(BhtIssueStockReportRow.Status.NOT_AVAILABLE);
+                reportRow.setMessage("Available: 0, Requested: " + issuableQty
+                        + ", Remaining not issued: " + issuableQty + " of " + requestedItem.getName()
+                        + " at " + dept.getName()
+                        + ". No stock found — use \"Select a Substitute\" to resolve before settling.");
+                bhtIssueStockReport.add(reportRow);
             }
         }
 
@@ -3886,6 +3963,110 @@ public class PharmacySaleBhtController implements Serializable {
                     return "Issued in full";
                 case QTY_DEFAULTED:
                     return "Qty defaulted — verify";
+                case PARTIAL_LOW_STOCK:
+                    return "Partial — low stock";
+                case NOT_AVAILABLE:
+                    return "Not available";
+                default:
+                    return "";
+            }
+        }
+    }
+
+    /**
+     * One row of the per-requested-line stock availability report shown on the
+     * BHT issue-request page. Captures the requested quantity against what was
+     * actually issuable from stock so the pharmacist sees Available/Requested/
+     * Remaining BEFORE clicking "Issue to BHT". Issue #22312.
+     */
+    public static class BhtIssueStockReportRow implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public enum Status {
+            ISSUED_FULL,
+            PARTIAL_LOW_STOCK,
+            NOT_AVAILABLE
+        }
+
+        private String requestedItemName;
+        private Double requestedQty;
+        private Double issuedQty;
+        private Status status;
+        private String message;
+
+        public BhtIssueStockReportRow() {
+        }
+
+        public String getRequestedItemName() {
+            return requestedItemName;
+        }
+
+        public void setRequestedItemName(String requestedItemName) {
+            this.requestedItemName = requestedItemName;
+        }
+
+        public Double getRequestedQty() {
+            return requestedQty;
+        }
+
+        public void setRequestedQty(Double requestedQty) {
+            this.requestedQty = requestedQty;
+        }
+
+        public Double getIssuedQty() {
+            return issuedQty;
+        }
+
+        public void setIssuedQty(Double issuedQty) {
+            this.issuedQty = issuedQty;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        /** True when this row needs the pharmacist's attention (not fully issued). */
+        public boolean isNeedsAttention() {
+            return status != Status.ISSUED_FULL;
+        }
+
+        /** Bootstrap/PrimeFaces severity keyword for styling the row. */
+        public String getSeverity() {
+            if (status == null) {
+                return "info";
+            }
+            switch (status) {
+                case ISSUED_FULL:
+                    return "success";
+                case PARTIAL_LOW_STOCK:
+                    return "warning";
+                case NOT_AVAILABLE:
+                    return "danger";
+                default:
+                    return "info";
+            }
+        }
+
+        public String getStatusLabel() {
+            if (status == null) {
+                return "";
+            }
+            switch (status) {
+                case ISSUED_FULL:
+                    return "Issued in full";
                 case PARTIAL_LOW_STOCK:
                     return "Partial — low stock";
                 case NOT_AVAILABLE:

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -263,6 +263,61 @@
                     </h:panelGroup>
                 </h:panelGroup>
 
+                <h:panelGroup layout="block" styleClass="row mb-3"
+                              rendered="#{not empty pharmacySaleBhtController.bhtIssueStockReport}">
+                    <div class="col-12">
+                        <p:panel id="panelBhtIssueStockReport" class="w-100"
+                                 toggleable="true"
+                                 collapsed="#{not pharmacySaleBhtController.bhtIssueStockReportHasAttentionItems}">
+                            <f:facet name="header">
+                                <div class="d-flex align-items-center w-100">
+                                    <h:outputText styleClass="fas fa-boxes me-2" />
+                                    <p:outputLabel value="Stock Availability Report" styleClass="fw-bold" />
+                                    <p:tag styleClass="ms-3"
+                                           value="Review — insufficient stock"
+                                           severity="warning"
+                                           rendered="#{pharmacySaleBhtController.bhtIssueStockReportHasAttentionItems}" />
+                                    <p:tag styleClass="ms-3"
+                                           value="All issued in full"
+                                           severity="success"
+                                           rendered="#{not pharmacySaleBhtController.bhtIssueStockReportHasAttentionItems}" />
+                                </div>
+                            </f:facet>
+                            <p:dataTable id="tblBhtIssueStockReport"
+                                         value="#{pharmacySaleBhtController.bhtIssueStockReport}"
+                                         var="sr"
+                                         styleClass="w-100"
+                                         stripedRows="true"
+                                         size="small">
+                                <p:column headerText="Requested Item">
+                                    <h:outputText value="#{sr.requestedItemName}" />
+                                </p:column>
+                                <p:column headerText="Requested" style="width:7em;" styleClass="text-end">
+                                    <h:outputText value="#{sr.requestedQty}">
+                                        <f:convertNumber pattern="#,##0.##" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Issued" style="width:7em;" styleClass="text-end">
+                                    <h:outputText value="#{sr.issuedQty}">
+                                        <f:convertNumber pattern="#,##0.##" />
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status" style="width:12em;">
+                                    <p:tag value="#{sr.statusLabel}" severity="#{sr.severity}" />
+                                </p:column>
+                                <p:column headerText="Note">
+                                    <h:outputText value="#{sr.message}" styleClass="text-muted" />
+                                </p:column>
+                            </p:dataTable>
+                            <h:panelGroup layout="block" styleClass="alert alert-warning m-2"
+                                          rendered="#{pharmacySaleBhtController.bhtIssueStockReportHasAttentionItems}">
+                                <i class="fa fa-exclamation-triangle me-2"></i>
+                                <h:outputText value="One or more requested medicines have insufficient or no stock. Use &quot;Select a Substitute&quot; on the flagged row(s) or arrange stock before settling — settling will be blocked until resolved." />
+                            </h:panelGroup>
+                        </p:panel>
+                    </div>
+                </h:panelGroup>
+
                 <p:panel header="Available Items" class="mt-2">
                     <style>
                         .auto-substituted-row { background-color: #FFF3CD !important; }


### PR DESCRIPTION
## Summary
- Fixes #22312: when issuing medicines for a Pharmacy Request to BHT, the pharmacist previously had no visibility into stock shortfalls until a late, generic error after clicking "Issue to BHT" (or worse, a partial quantity was silently issued with no notice at all).
- Adds a **Stock Availability Report** panel to `ward_pharmacy_bht_issue.xhtml`, built in `PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest()`, showing per requested line: Requested / Issued / Status / Note — auto-expanded with a warning banner whenever any line needs attention.
- Three states:
  - **Issued in full** — requested quantity fully covered.
  - **Partial — low stock** — less available than requested; note shows `Available / Requested / Remaining not issued`; the available quantity is still issued in one click (confirmed business rule), but now with a clear upfront warning instead of a silent shortfall.
  - **Not available** — zero stock (after auto-substitution is attempted); the existing placeholder bill line stays so "Select a Substitute" still works, but settling is now blocked with an **enriched** error message (`Available / Requested / Remaining`) until resolved.
- New `BhtIssueStockReportRow` static inner class is intentionally kept **separate** from the existing `DischargeConversionRow` (used by the unrelated, stable discharge-medicine-issue flow) to keep this change's blast radius to zero on that path.

## Test plan
Verified end-to-end with Playwright against a local deployment + direct MySQL checks (local `coop` model-hospital dataset):
- [x] **Full stock**: requested 6 of an item with 40 in stock → "Issued in full", settled successfully, stock deducted 40→34.
- [x] **Partial stock**: requested 5 of an item with 1 in stock → "Partial — low stock" with note "Available: 1.0, Requested: 5.0, Remaining not issued: 4.0 ...", panel auto-expanded with warning banner, settle still succeeded and issued 1 unit (stock deducted 1→0).
- [x] **Zero stock, no substitutable sibling**: requested 2 of an item with 0 stock anywhere under its VMP → "Not available" with the enriched note, "Issue to BHT" blocked (confirmed via DB — no settle bill created for the request).
- [x] **Regression check**: an item with 0 stock on its exact AMP but an in-stock VMP sibling still auto-substitutes and reports "Issued in full" — pre-existing substitution behavior unaffected.
- [x] `mvn clean package` — full test suite (151 tests) passes.
- [x] Local Payara redeploy — no errors in `server.log`.

Screenshots and full verification narrative posted on the issue: https://github.com/hmislk/hmis/issues/22312#issuecomment-5035597743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a stock availability report to BHT issue requests, showing requested quantities, issued quantities, and item status.
  - Highlighted partial or unavailable stock and provided guidance for resolving issues.
  - Prevented settlement when stock requirements are not met.
  - Added clearer messages for unavailable or insufficient stock.

- **Documentation**
  - Expanded Playwright testing guidance for missing seed data and zero-stock scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->