### PR TITLE
fix(inward): route discharge notification clicks through AdmissionController

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -976,8 +976,11 @@ test-fixture data, not a bug.
   → **Add Subscription**.
 - The **Application-wide** checkbox's visible box intercepts Playwright's
   normal click on the underlying `p:selectBooleanCheckbox` input — click via
-  `document.querySelector('.ui-chkbox-box')` (or the right index if there
-  are several checkboxes on the page) instead of the accessibility-tree ref.
+  a selector scoped to its own JSF id (`chkApplicationWide` in
+  `admin/users/user_subscription.xhtml`), not a bare `.ui-chkbox-box` index,
+  which picks whichever checkbox happens to be first/nth on the page and can
+  silently toggle the wrong control if the page has more than one:
+  `document.querySelector('[id$="chkApplicationWide"] .ui-chkbox-box')`.
 
 Found while verifying issue #21538 (discharge notifications routing to the
 wrong patient) — the fix couldn't be end-to-end tested at all until this was

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -953,6 +953,61 @@ AND (a.VMP_ID IS NULL OR a.VMP_ID NOT IN (
 ```
 Verified while testing issue #22312.
 
+## 41. A local dev DB with an empty `TRIGGERSUBSCRIPTION` table means notification-generating actions silently produce zero `UserNotification` rows
+
+Discharging a patient, changing a room, etc. always creates a `Notification`
+row, but the actual per-user `UserNotification` rows (what the bell icon and
+`/Notification/user_notifications.xhtml` show) only get created for webusers
+who hold a matching `TriggerSubscription`
+(`NotificationController.createNotification(...)` →
+`userNotificationController.createUserNotifications(nn)` →
+`TriggerSubscriptionController.fillSubscribedUsersByDepartment(...)`). A
+freshly-restored or never-fully-seeded local DB can have **zero rows in
+`TRIGGERSUBSCRIPTION`**, in which case discharging any number of patients
+produces `Notification` rows but no `UserNotification` rows for anyone —
+this looks identical to "the feature doesn't work" but is actually missing
+test-fixture data, not a bug.
+
+- Diagnose with `SELECT COUNT(*) FROM TRIGGERSUBSCRIPTION;` — 0 confirms this.
+- Fix through the UI, not SQL (per this doc's "use the admin UI" pattern,
+  §26): Admin → Manage Users → select the target user → **Manage User
+  Subscriptions** → tick **Application-wide** → pick the relevant
+  `TriggerType` (e.g. "Inward Patient Room Discharge - System Notification")
+  → **Add Subscription**.
+- The **Application-wide** checkbox's visible box intercepts Playwright's
+  normal click on the underlying `p:selectBooleanCheckbox` input — click via
+  `document.querySelector('.ui-chkbox-box')` (or the right index if there
+  are several checkboxes on the page) instead of the accessibility-tree ref.
+
+Found while verifying issue #21538 (discharge notifications routing to the
+wrong patient) — the fix couldn't be end-to-end tested at all until this was
+discovered and worked around.
+
+## 42. PrimeFaces bare `update="someId"` can 500 from inside a `p:dataTable`/`ui:repeat` row even though the id exists on the page
+
+A `p:commandButton update="someId"` where `someId` is a **sibling id
+declared outside** the enclosing `p:dataTable`/`ui:repeat`/`p:column` throws
+a hard 500 (`javax.faces.component.search.ComponentNotFoundException:
+Cannot find component for expressions "someId"`) as soon as that button is
+rendered for any row — not just on click, since PrimeFaces builds the ajax
+request descriptor (including resolving `update`) during **encode**, not
+decode. It can appear to work for row 0 by coincidence and break only from
+row 1 onward, or break for every row once a row's content changes (e.g. a
+row toggling into "retired" state and rendering a previously-`rendered=false`
+button for the first time) — so it can look like a row-index-specific bug
+rather than a general one.
+
+Fix: don't rely on plain-id resolution reaching outside the table/repeat.
+Use `update="@form"` (safe/simple when refreshing the whole form is
+acceptable) or an absolute id path — this project's `jsf-ajax` skill already
+documents `@this`/`@form`/`:#{p:resolveFirstComponentWithId(...)}` as the
+required patterns for exactly this reason.
+
+Found while fixing issue #21538: `Notification/user_notifications.xhtml`'s
+"Restore" button (`update="reNot"`, `reNot` being the `h:panelGroup`
+wrapping the whole list) crashed the page load itself once a retired
+notification was shown in a row other than the first.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -20,7 +20,8 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.UserNotification;
 import com.divudi.core.entity.Notification;
-import com.divudi.bean.inward.BhtSummeryController;
+import com.divudi.bean.inward.AdmissionController;
+import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Sms;
@@ -84,7 +85,7 @@ public class UserNotificationController implements Serializable {
     @Inject
     NotificationPushService notificationPushService;
     @Inject
-    BhtSummeryController bhtSummeryController;
+    AdmissionController admissionController;
     private Date date;
     // Notification list filters
     private boolean todayNotification;
@@ -398,16 +399,14 @@ public class UserNotificationController implements Serializable {
         if (un.getNotification().getPatientRoom() != null) {
             PatientRoom pr = un.getNotification().getPatientRoom();
             if (pr.getPatientEncounter() != null) {
-                bhtSummeryController.setPatientEncounter(pr.getPatientEncounter());
-                return bhtSummeryController.navigateToInpatientProfile();
+                return navigateToAdmissionProfileFor(pr.getPatientEncounter());
             }
             return "";
         }
 
         // Handle PatientEncounter-based notifications
         if (un.getNotification().getPatientEncounter() != null) {
-            bhtSummeryController.setPatientEncounter(un.getNotification().getPatientEncounter());
-            return bhtSummeryController.navigateToInpatientProfile();
+            return navigateToAdmissionProfileFor(un.getNotification().getPatientEncounter());
         }
 
         if (un.getNotification().getBill() == null) {
@@ -464,6 +463,23 @@ public class UserNotificationController implements Serializable {
                 return "";
         }
 
+    }
+
+    /**
+     * admission_profile.xhtml reads admissionController.current (an
+     * Admission), not bhtSummeryController.patientEncounter. The normal
+     * "Inpatient Dashboard" button sets both together via
+     * AdmissionController.navigateToAdmissionProfilePage(); this mirrors
+     * that so a notification click doesn't leave admissionController.current
+     * pointing at whichever admission was last viewed through the normal
+     * flow (issue #21538).
+     */
+    private String navigateToAdmissionProfileFor(PatientEncounter patientEncounter) {
+        if (!(patientEncounter instanceof Admission)) {
+            return "";
+        }
+        admissionController.setCurrent((Admission) patientEncounter);
+        return admissionController.navigateToAdmissionProfilePage();
     }
 
     public void createUserNotifications(Notification notification) {

--- a/src/main/webapp/Notification/user_notifications.xhtml
+++ b/src/main/webapp/Notification/user_notifications.xhtml
@@ -23,6 +23,20 @@
                             refreshNotificationList();
                         }
                     </script>
+                    <style>
+                        /* Card list, not a grid: strip PrimeFaces' default table chrome. */
+                        .ui-notification-list.ui-datatable table,
+                        .ui-notification-list .ui-datatable-header,
+                        .ui-notification-list .ui-datatable-footer {
+                            border: none;
+                            background: transparent;
+                        }
+                        .ui-notification-list .ui-datatable-data > tr > td {
+                            border: none;
+                            padding: 0;
+                            background: transparent;
+                        }
+                    </style>
 
                     <!-- Single remove-confirmation dialog shared across all rows -->
                     <p:dialog header="Remove Notification" widgetVar="dlgRemove" modal="true" width="350">
@@ -95,7 +109,12 @@
 
                         <!-- Notification list -->
                         <h:panelGroup id="reNot">
-                            <ui:repeat value="#{userNotificationController.items}" var="un">
+                            <!-- p:dataTable (not ui:repeat): ui:repeat isn't a NamingContainer, so
+                                 row-scoped ids for the same action get conflated across rows
+                                 (issue #21538). -->
+                            <p:dataTable value="#{userNotificationController.items}" var="un" rowKey="#{un.id}"
+                                         styleClass="ui-notification-list">
+                            <p:column>
                                 <div class="row mt-2 shadow-lg"
                                      style="#{un.notification.bill != null and un.notification.bill.cancelled ? 'background-color: #e35656;' : ''}">
 
@@ -203,7 +222,7 @@
                                                     <!-- Shown when listing cleared notifications -->
                                                     <p:commandButton id="btnRestore" class="ui-button-success mx-2"
                                                                      icon="fas fa-rotate-left" value="Restore"
-                                                                     process="@this" update="reNot"
+                                                                     process="@this" update="@form"
                                                                      rendered="#{un.retired}"
                                                                      action="#{userNotificationController.restoreUserNotification(un)}" />
                                                 </div>
@@ -212,7 +231,8 @@
                                     </div>
 
                                 </div>
-                            </ui:repeat>
+                            </p:column>
+                            </p:dataTable>
                         </h:panelGroup>
 
                     </h:panelGroup>


### PR DESCRIPTION
## Summary

Closes #21538. Clicking a discharge notification always opened the **most recently discharged patient's** admission profile instead of the patient the notification was actually for.

The four earlier investigation comments on the issue theorized a `ui:repeat` duplicate-component-id problem. Live reproduction (fresh login, two real patients discharged in sequence, DB verification of exactly which `UserNotification` row got marked `seen`/`retired`) disproved that: the server always correctly resolved the clicked notification. The actual bug was that `UserNotificationController.navigateToCurrentNotificationRequest()` only updated `bhtSummeryController.patientEncounter`, but `admission_profile.xhtml` reads `admissionController.current` — a separate `@SessionScoped` bean that only the *normal* "Inpatient Dashboard" button flow (`AdmissionController.navigateToAdmissionProfilePage()`) kept in sync. So a notification click always displayed whichever admission was last viewed through the normal flow — which, in a discharge → check-notifications workflow, is reliably the most recently discharged patient.

**Fix**: `UserNotificationController` now routes both PatientRoom-based and PatientEncounter-based notification clicks through `AdmissionController.setCurrent()` + `navigateToAdmissionProfilePage()`, the same path the normal button uses.

**Also fixed** a related crash found while reproducing this: the notification list's "Restore" button threw a hard 500 (`ComponentNotFoundException`) for any row after the first, because its `update="reNot"` bare-id reference couldn't resolve from inside a `ui:repeat` row. Converted the list from `ui:repeat` to `p:dataTable` (proper per-row `NamingContainer` scoping) and pointed the Restore button's `update` at `@form` instead.

## Test plan

- [x] Rebuilt and redeployed locally; verified end-to-end against real discharge data (not code-only)
- [x] Fresh login, discharged two real inpatients (BHT/56749, BHT/56746) back-to-back
- [x] Clicked the **older** notification — confirmed it now opens that patient's own profile, not the more recently discharged one (screenshots + DB verification in the [issue comment](https://github.com/hmislk/hmis/issues/21538#issuecomment-5035766848))
- [x] Confirmed via DB that exactly the clicked `UserNotification` row is marked `seen=1, retired=1`, not any other row
- [x] Verified the Restore-button crash: reproduced the 500 on `development`-equivalent code, then confirmed it's gone after the `p:dataTable` + `update="@form"` fix
- [x] Repeated the whole flow with a second, independent fresh pair of patients to rule out session-state artifacts from testing
- [x] Documented two new gotchas discovered during E2E testing in `developer_docs/testing/playwright-e2e-workflow.md` (§39, §40): an empty local `TRIGGERSUBSCRIPTION` table silently means no `UserNotification` rows ever get created, and PrimeFaces bare `update="id"` references can 500 from inside a table/repeat row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notification clicks for patient encounter and discharge events now take you directly to the related admission profile.

- **Bug Fixes**
  - Updated the notification list UI to use a PrimeFaces data table for more consistent rendering and row behavior.
  - Improved notification row styling (reduced table chrome) for cleaner presentation.
  - “Restore” now refreshes the entire notification form to avoid inconsistent Ajax updates.

- **Documentation**
  - Expanded Playwright E2E workflow docs with troubleshooting “gotchas” for local notification data and PrimeFaces Ajax update/render issues (including a UI workaround).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->