### PR TITLE
fix(inward): stop hiding investigation/service name behind ShowServiceCharges

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1011,6 +1011,34 @@ Found while fixing issue #21538: `Notification/user_notifications.xhtml`'s
 wrapping the whole list) crashed the page load itself once a retired
 notification was shown in a row other than the first.
 
+## 43. A freshly-created test user needs a `WebUserDepartment` row, not just a `Department` field, to log in at all
+
+Creating a disposable test user via Admin > Manage Users > Add New User
+(`admin/users/user_add_new.xhtml`) and setting its `Department` field is not
+enough to let it log in. Login checks `listLoggableDepts(user)`
+(`SessionController.java`), which queries the `WebUserDepartment` join table
+— not the `WebUser.department` column. With no matching `WebUserDepartment`
+row, login fails with "This user has no privilage to login to any
+Department. Please conact system administrator." even though the user
+record itself looks fully configured.
+
+The Add New User form has no field for this; department-login grants are
+managed separately via **Manage Users > (select user) > Manage User
+Departments**. For a quick disposable test account it's simplest to insert
+the row directly:
+```sql
+INSERT INTO webuserdepartment (CREATEDAT, RETIRED, DEPARTMENT_ID, WEBUSER_ID)
+VALUES (NOW(), 0, <department_id>, <webuser_id>);
+```
+Also useful: no `WebUserRole` in this DB grants `ShowServiceCharges` (verified
+via `webuserroleprivilege`) — it's only assigned to individual users
+directly in `webuserprivilege`. So any freshly-created user with no role
+already lacks it, no extra step needed to test privilege-gated hiding.
+
+Found while verifying issue #22310 (fee row hidden along with its item name
+when `ShowServiceCharges` is absent) — needed a throwaway non-privileged
+login to confirm the fix without touching any real staff account.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -675,11 +675,7 @@
                                                         value="#{billBhtController.lstBillFees}"
                                                         var="bif"
                                                         rowKey="#{bif.id}"
-                                                        rowExpandMode="single"
-                                                        rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
-                                                                         or (webUserController.hasPrivilege('ShowInwardFee'))
-                                                                         or (webUserController.hasPrivilege('ShowServiceCharges'))
-                                                                         ? '':'noDisplayRow'}">
+                                                        rowExpandMode="single">
                                                         <p:column width="2em">
                                                             <f:facet name="header"> </f:facet>
                                                             <p:rowToggler />

--- a/src/main/webapp/theater/inward_bill_surgery_service.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_service.xhtml
@@ -290,11 +290,7 @@
                                             </p:dataTable>
                                         </p:tab>
                                         <p:tab id="tabBillFee" title="Fees" >
-                                            <p:dataTable rowIndexVar="rowIndex" value="#{billBhtController.lstBillFees}" var="bif"
-                                                         rowStyleClass="#{(bif.billItem.item.chargesVisibleForInward)
-                                                                          or (webUserController.hasPrivilege('ShowInwardFee'))
-                                                                          or (webUserController.hasPrivilege('ShowServiceCharges'))
-                                                                          ? '':'noDisplayRow'}">
+                                            <p:dataTable rowIndexVar="rowIndex" value="#{billBhtController.lstBillFees}" var="bif">
                                                 <p:column>
                                                     <f:facet name="header">No</f:facet>
                                                     <h:outputLabel value="#{rowIndex+1}"/>


### PR DESCRIPTION
## Summary
- The Fees tab on `inward_bill_service.xhtml` hid the **entire fee row** (via a `rowStyleClass`/`noDisplayRow` CSS hide) whenever the item wasn't flagged "Rates visible during Inward Billing" and the user lacked `ShowInwardFee`/`ShowServiceCharges` — this included the Item Name column, which has no `rendered` guard of its own. Since that item flag defaults to `false`, a normal user lacking only `ShowServiceCharges` lost the item name too, not just the fee amount, reproducing #22310 exactly.
- Removed the row-level hide so the row (Item Name, Qty, Speciality, Payee) always renders; every money column (Unit Rate, Total Gross, Discount, Service Charge, Net Total, VAT) already has its own correct `ShowServiceCharges` `rendered` guard and is unchanged.
- Applied the identical fix to `theater/inward_bill_surgery_service.xhtml`'s Fees tab, which had the exact same construct and root cause (found while investigating #22310; not separately reported).
- Documented a related Playwright testing gotcha in `developer_docs/testing/playwright-e2e-workflow.md`: a freshly-created test user needs a `WebUserDepartment` row (not just the `Department` field) to log in at all.

No Java or schema changes — pure XHTML `rendered`/`rowStyleClass` edit.

## Test plan
- [x] Rebuilt and redeployed locally (`mvn clean package -DskipTests` + `asadmin redeploy`), confirmed no errors in `server.log`.
- [x] Added "DOCTOR CHARGES" to a real local BHT admission (BHT/55354) and viewed the Fees tab as `buddhika` (has `ShowServiceCharges`): all columns show as before — no regression.
- [x] Created a disposable test user with no privileges and viewed the same Fees tab: Item Name/Qty/Speciality/Payee visible, all money columns and the row-expansion breakdown correctly absent. Test user retired after verification.
- [x] Verified via code inspection that `theater/inward_bill_surgery_service.xhtml`'s money columns already have their own `ShowServiceCharges` guards, matching the pattern in the primary fix.
- Screenshots posted on the issue: https://github.com/hmislk/hmis/issues/22310#issuecomment-5041538916

Fixes #22310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fee rows in inward service and surgery billing screens are now displayed consistently instead of being conditionally hidden.

- **Documentation**
  - Added end-to-end testing guidance for creating disposable test users, including required department associations, login troubleshooting, and applicable privilege setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->