### PR TITLE
Add dedicated config option for Mark Foreigner/Local buttons (#22311)

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -43,6 +43,7 @@ This document lists the configuration options used in the application and their 
 | Key                                                              | Type      | Default | Description                                                                                             |
 | ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `OPD Billing - Clear Referring Doctor on New Bill`              | Boolean   | `true`  | When true, clears the referring doctor and referring institution when starting a new OPD bill. When false, the values are preserved across consecutive bills. |
+| `Show Mark Foreigner and Mark Local Buttons in Billing`         | Boolean   | `true`  | Controls visibility of the Mark Foreigner / Mark Local buttons across OPD Billing, Channel Booking, Clinic Sessions, and Inward Service Bill screens. Independent of `Save the Patient with Patient Status` (which only controls the read-only status badge/toggle shown during patient registration). See issue #22311. |
 
 ## Pharmacy Procurement
 

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -357,6 +357,13 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         ));
 
         metadata.addConfigOption(new ConfigOptionInfo(
+                "Show Mark Foreigner and Mark Local Buttons in Billing",
+                "Controls visibility of the Mark Foreigner / Mark Local buttons during OPD billing, channel booking, clinic sessions, and inward service billing",
+                "opd_bill_ac.xhtml line 1412 (gpLocalForeign panelGroup) and equivalent panels in opd_bill.xhtml, opd_order.xhtml, opd_pre_bill.xhtml, channel booking pages, clinic sessions, inward service bill pages",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
                 "Allow Local Number For Opd Billing",
                 "Shows local number panel for entering local reference numbers",
                 "opd_bill_ac.xhtml line 461: Local number panel",

--- a/src/main/webapp/channel/channel_booking_by_date.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_date.xhtml
@@ -528,7 +528,7 @@
                                                     </p:commandButton>
                                                 </p:panel>
                                                 <p:panel>
-                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                         <p:commandButton 
                                                             value="Mark Foreigner" 
                                                             class="mx-2 my-2"

--- a/src/main/webapp/channel/channel_booking_by_month.xhtml
+++ b/src/main/webapp/channel/channel_booking_by_month.xhtml
@@ -773,7 +773,7 @@
                                                 </h:panelGroup>
 
                                                 <h:outputLabel value="Foriegner"/>
-                                                <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                     <p:commandButton 
                                                         value="Mark Foreigner" 
                                                         action="#{bookingControllerViewScopeMonth.markAsForeigner}" 

--- a/src/main/webapp/channel/manage_booking_by_date.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_date.xhtml
@@ -520,7 +520,7 @@
 
                                                 <p:outputLabel value="Citizenship" ></p:outputLabel>
                                                 <p:panel>
-                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                         <p:commandButton
                                                             value="Mark Foreigner"
                                                             class="mx-2 my-2"

--- a/src/main/webapp/channel/manage_booking_by_month.xhtml
+++ b/src/main/webapp/channel/manage_booking_by_month.xhtml
@@ -704,7 +704,7 @@
                                                         <h:outputLabel value="Foriegner"/>
                                                     </div>
                                                     <div class="col-8">
-                                                        <h:panelGroup id="gpLocalForeign" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                        <h:panelGroup id="gpLocalForeign" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                             <p:commandButton
                                                                 value="Mark Foreigner"
                                                                 style="width: 65%; margin-bottom: 10px;"

--- a/src/main/webapp/clinic/sessions.xhtml
+++ b/src/main/webapp/clinic/sessions.xhtml
@@ -474,7 +474,7 @@
                                                         action="#{clinicController.addNormalSubsequentVisit()}" >
                                                     </p:commandButton>
                                                     <p:spacer height="1" width="10" ></p:spacer>
-                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                    <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                         <p:commandButton 
                                                             value="Mark Foreigner" 
                                                             class="mx-2"

--- a/src/main/webapp/inward/inward_service_bill.xhtml
+++ b/src/main/webapp/inward/inward_service_bill.xhtml
@@ -843,7 +843,7 @@
                                         </div>
 
                                         <div class="col-md-4" >
-                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                 <p:commandButton 
                                                     value="Mark Foreigner" 
                                                     class="mx-2"

--- a/src/main/webapp/inward/inward_service_bill_ac.xhtml
+++ b/src/main/webapp/inward/inward_service_bill_ac.xhtml
@@ -917,7 +917,7 @@
                                         </div>
 
                                         <div class="col-md-4" >
-                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                 <p:commandButton 
                                                     value="Mark Foreigner" 
                                                     class="mx-2"

--- a/src/main/webapp/opd/opd_bill.xhtml
+++ b/src/main/webapp/opd/opd_bill.xhtml
@@ -1467,7 +1467,7 @@
                                         </div>
 
                                         <div class="col-md-4" >
-                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                 <p:commandButton 
                                                     value="Mark Foreigner" 
                                                     class="mx-2"

--- a/src/main/webapp/opd/opd_bill_ac.xhtml
+++ b/src/main/webapp/opd/opd_bill_ac.xhtml
@@ -1409,7 +1409,7 @@
                                         </div>
 
                                         <div class="col-md-4" >
-                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                 <p:commandButton 
                                                     value="Mark Foreigner" 
                                                     class="mx-2"

--- a/src/main/webapp/opd/opd_order.xhtml
+++ b/src/main/webapp/opd/opd_order.xhtml
@@ -1263,7 +1263,7 @@
                                         </div>
 
                                         <div class="col-md-4" >
-                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                            <h:panelGroup id="gpLocalForeign"  class="col-md-6" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                 <p:commandButton 
                                                     value="Mark Foreigner" 
                                                     class="mx-2"

--- a/src/main/webapp/opd/opd_pre_bill.xhtml
+++ b/src/main/webapp/opd/opd_pre_bill.xhtml
@@ -366,7 +366,7 @@
                                                 id="comment">
                                             </p:inputText>
                                             <div class="d-flex">
-                                                <h:panelGroup id="gpLocalForeign" layout="block"  class="col-md-4" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Save the Patient with Patient Status')}">
+                                                <h:panelGroup id="gpLocalForeign" layout="block"  class="col-md-4" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Mark Foreigner and Mark Local Buttons in Billing', true)}">
                                                     <p:commandButton 
                                                         value="Mark Foreigner" 
                                                         class="mx-1"


### PR DESCRIPTION
## Summary

- The "Mark Foreigner"/"Mark Local" buttons in OPD Billing (and 8 other screens) were gated behind the config option `Save the Patient with Patient Status`, which is meant to control a separate patient-status badge/toggle feature. When that option was enabled, the buttons disappeared everywhere with no independent way to bring them back for a patient already selected mid-bill.
- Introduces a new, dedicated boolean config option `Show Mark Foreigner and Mark Local Buttons in Billing` (default `true` — buttons shown unless explicitly turned off), applied consistently across all 9 affected screens: OPD Billing, OPD Orders, OPD Billing for Cashier, Channel Booking (by date/month), Manage Booking (by date/month), Clinic Sessions, and Inward Service Bill.
- Registers the new key in `OpdBillController.registerPageMetadata()` and documents it in `developer_docs/configuration/application-options.md`.
- Adds a new wiki article: [Admin — Mark Foreigner / Mark Local Buttons Configuration](https://github.com/hmislk/hmis/wiki/Admin-Mark-Foreigner-Local-Buttons-Configuration).

No Java business logic changed — only the `rendered` condition on the button panel and the page-metadata registration.

## Test plan

Verified locally via Playwright + DB against local Payara/MySQL (department: OPD, CareCode Model Hospital, Galle):

- [x] Rebuilt and redeployed locally; server log clean, no deployment errors
- [x] Confirmed new config option auto-creates in `CONFIGOPTION` with `OPTIONVALUE='true'`, `VALUETYPE='BOOLEAN'`, `SCOPE='APPLICATION'` on first page load
- [x] `opd_bill_ac.xhtml` (the screen named in #22311): Mark Foreigner button visible by default
- [x] Toggled the new option off via Application Options admin screen (Edit Option → Save) → button correctly disappears
- [x] Toggled back on → button correctly reappears
- [x] Spot-checked a second screen (`opd_pre_bill.xhtml`) — same toggle behavior confirmed

Screenshot evidence (before/after) posted on the issue: https://github.com/hmislk/hmis/issues/22311#issuecomment-5041543359

Closes #22311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated configuration option to show or hide the **Mark Foreigner** and **Mark Local** buttons.
  * Applied the setting across OPD Billing, Channel Booking, Clinic Sessions, and Inward Service Billing screens.
  * Buttons are enabled by default and can be controlled independently from patient-status settings.

* **Documentation**
  * Documented the new billing display configuration and its supported screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->