### PR TITLE
fix(lab): microbiology report spacing and bold-sensitive config

### DIFF
--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -83,6 +83,35 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
         this.lobValue = lobValue;
     }
 
+    /**
+     * One "blank unit" that a rich-text editor (or plain typing) leaves
+     * behind for an empty line: an empty paragraph/div (optionally
+     * containing just a &lt;br&gt; or &amp;nbsp;), a bare &lt;br&gt;,
+     * &amp;nbsp;, a literal "\n" escape sequence, or real whitespace.
+     */
+    private static final String LOB_VALUE_BLANK_UNIT
+            = "(?:<p[^>]*>(?:\\s|&nbsp;|<br\\s*/?>)*</p>"
+            + "|<div[^>]*>(?:\\s|&nbsp;|<br\\s*/?>)*</div>"
+            + "|<br\\s*/?>"
+            + "|&nbsp;"
+            + "|\\\\n"
+            + "|\\s)";
+
+    /**
+     * lobValue with leading/trailing blank lines removed, so printed reports
+     * do not show empty gaps caused by blank lines (typed as literal "\n",
+     * real newline characters, or empty rich-text paragraphs/breaks) left
+     * over from data entry.
+     */
+    public String getLobValuePrintable() {
+        if (lobValue == null) {
+            return null;
+        }
+        String trimmed = lobValue.replaceAll("(?i)^(?:" + LOB_VALUE_BLANK_UNIT + ")+", "");
+        trimmed = trimmed.replaceAll("(?i)(?:" + LOB_VALUE_BLANK_UNIT + ")+$", "");
+        return trimmed;
+    }
+
     public byte[] getBaImage() {
         return baImage;
     }

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -105,7 +105,7 @@
                                             <div style="float: left;width: 4%; text-align: center;" >:</div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
-                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
+                                                               style="#{prv.strValue eq 'SENSITIVE' and configOptionApplicationController.getBooleanValueByKey('Microbiology Antibiotic Result - Bold Sensitive Result', true) ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                             </div>
 
                                         </h:panelGroup>
@@ -127,7 +127,7 @@
                                             <div style="float: left;width: 4%; text-align: center;" >:</div>
                                             <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                 <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
-                                                               style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
+                                                               style="#{prv.strValue eq 'SENSITIVE' and configOptionApplicationController.getBooleanValueByKey('Microbiology Antibiotic Result - Bold Sensitive Result', true) ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                             </div>
 
                                         </h:panelGroup>
@@ -173,7 +173,7 @@
                                                     <div style="float: left;width: 4%; text-align: center;" >:</div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
-                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
+                                                                       style="#{prv.strValue eq 'SENSITIVE' and configOptionApplicationController.getBooleanValueByKey('Microbiology Antibiotic Result - Bold Sensitive Result', true) ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                                     </div>
 
                                                 </h:panelGroup>
@@ -202,7 +202,7 @@
                                                     <div style="float: left;width: 4%; text-align: center;" >:</div>
                                                     <div style=" text-align: left; float:left;width: 30%;padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
                                                         <h:outputLabel value="#{fn:toLowerCase(prv.strValue)}" escape="false"
-                                                                       style="#{prv.strValue eq 'SENSITIVE' ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
+                                                                       style="#{prv.strValue eq 'SENSITIVE' and configOptionApplicationController.getBooleanValueByKey('Microbiology Antibiotic Result - Bold Sensitive Result', true) ? 'font-weight: bold;' : ''} text-transform: #{configOptionApplicationController.getShortTextValueByKey('Microbiology Antibiotic Result Text Transform (uppercase/lowercase/capitalize/none)', 'uppercase')};" />
                                                     </div>
                                                 </h:panelGroup>
                                             </h:panelGroup>

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -69,19 +69,19 @@
                     <div style="margin-left:5%; text-align: left;">
                         <h:outputLabel 
                             value="#{patientReportController.currentPatientReport.patientInvestigation.investigation.printName}"
-                            style="font-weight: bold;font-size: 21px!important; text-decoration: underline; "/>
+                            style="font-weight: bold;font-size: 18px!important; text-decoration: underline; "/>
                     </div>
                     <div id="labelsAndValues" style="left:5%; margin-top: 7px; width: 90%; display: inline-block; vertical-align: top; " >
                         <div style="vertical-align: top; width: 100%; padding: 1px;margin: auto;display: inline-block;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 15px; margin-bottom: 12px;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop lt 50 }" >
+                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 14px; margin-bottom: 0;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop lt 50 }" >
                                     <div style="display: inline-block; float: left; width: 1%; clear: left; " ></div>
                                     <div style="display: inline-block; top: 0px; float: left; width: 30%; text-align: left; padding-top: 0.1%; padding-bottom: 0.1%; ">
                                         <h:outputLabel value="#{prv.investigationItem.name}"   escape="false"/>
                                     </div>
                                     <div style="display: inline-block; float: left; width: 3%; " ></div>
                                     <div class="micMemoValue" style="display: inline-block; text-align: left; float:left; width: 60%; padding-top: 0.1%; padding-bottom: 0.1%; ">
-                                        <h:outputLabel value="#{fn:replace(prv.lobValue,'\\n','&lt;br/&gt;')}"   escape="false"   />
+                                        <h:outputLabel value="#{fn:replace(prv.lobValuePrintable,'\\n','&lt;br/&gt;')}"   escape="false"   />
                                     </div>
                                 </h:panelGroup>
                             </ui:repeat>
@@ -94,8 +94,9 @@
                                     <ui:repeat  
                                         value="#{patientInvestigationController.column1AntibioticList}" 
                                         var="prv" >
-                                        <h:panelGroup 
-                                            style="font-size: 15px;"
+                                        <h:panelGroup
+                                            layout="block"
+                                            style="font-size: 14px;"
                                             rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                             <div style="float: left;width: 5%; clear: left;" ></div>
                                             <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
@@ -112,11 +113,12 @@
                                 </div>
 
                                 <div class="col-6">
-                                    <ui:repeat  
-                                        value="#{patientInvestigationController.column2AntibioticList}" 
+                                    <ui:repeat
+                                        value="#{patientInvestigationController.column2AntibioticList}"
                                         var="prv" >
-                                        <h:panelGroup 
-                                            style="font-size: 16px;"
+                                        <h:panelGroup
+                                            layout="block"
+                                            style="font-size: 14px;"
                                             rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                             <div style="float: left;width: 5%; clear: left;" ></div>
                                             <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
@@ -142,11 +144,11 @@
                                        var="group"   
                                        >
 
-                                <div style="vertical-align: top; text-align: left;  padding-top: 1%; padding-bottom: 0%; clear: left;">
+                                <div style="vertical-align: top; text-align: left;  padding-top: 0.1%; padding-bottom: 0%; clear: left;">
                                     <h:outputLabel 
                                         value="#{group.groupName}" 
                                         rendered="#{patientReportController.currentPatientReport.transHasAbst}"
-                                        style="font-size: 135%; margin-top: 5px; font-weight: bold;">
+                                        style="font-size: 135%; margin-top: 2px; font-weight: bold;">
                                     </h:outputLabel>
                                 </div>
                                 <div class="row">
@@ -155,12 +157,14 @@
                                             value="#{patientInvestigationController.column1AntibioticList}" 
                                             var="prv" >
 
-                                            <h:panelGroup 
+                                            <h:panelGroup
+                                                layout="block"
                                                 rendered="#{prv.patientReportGroup.groupName eq group.groupName}" >
 
 
-                                                <h:panelGroup 
-                                                    style="font-size: 15px;"
+                                                <h:panelGroup
+                                                    layout="block"
+                                                    style="font-size: 14px;"
                                                     rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                                     <div style="float: left;width: 5%; clear: left;" ></div>
                                                     <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
@@ -179,15 +183,17 @@
                                     </div>
 
                                     <div class="col-6">
-                                        <ui:repeat  
-                                            value="#{patientInvestigationController.column2AntibioticList}" 
+                                        <ui:repeat
+                                            value="#{patientInvestigationController.column2AntibioticList}"
                                             var="prv" >
 
-                                            <h:panelGroup 
+                                            <h:panelGroup
+                                                layout="block"
                                                 rendered="#{prv.patientReportGroup.groupName eq group.groupName}" >
 
-                                                <h:panelGroup 
-                                                    style="font-size: 16px;"
+                                                <h:panelGroup
+                                                    layout="block"
+                                                    style="font-size: 14px;"
                                                     rendered="#{prv.investigationItem.ixItemType eq 'Antibiotic' and prv.investigationItem.retired ne true and prv.strValue ne '' and prv.strValue ne null  }" >
                                                     <div style="float: left;width: 5%; clear: left;" ></div>
                                                     <div style=" float: left; text-align: left; width: 61%; padding-left: 1px; padding-right: 1px; padding-top: 2px; vertical-align: top;">
@@ -213,7 +219,7 @@
                             </h:panelGroup>
                         </div>
 
-                        <div style="vertical-align: top; text-align: left; font-size: 16px;  padding-top: 0%; padding-bottom: 0%; clear: left;">
+                        <div style="vertical-align: top; text-align: left; font-size: 14px;  padding-top: 0%; padding-bottom: 0%; clear: left;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
                                 <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div style="float: left;width: 5%; " ></div>
@@ -223,7 +229,7 @@
                                 </h:panelGroup>
                                 <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div class="micMemoValue" style=" text-align: left; float:left; margin-left: 5%; width: 90%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
-                                        <h:outputLabel value="#{fn:replace(prv.lobValue,'\\n','&lt;br/&gt;')}"    escape="false" />
+                                        <h:outputLabel value="#{fn:replace(prv.lobValuePrintable,'\\n','&lt;br/&gt;')}"    escape="false" />
                                     </div>
                                 </h:panelGroup>
                             </ui:repeat>

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -74,7 +74,7 @@
                     <div id="labelsAndValues" style="left:5%; margin-top: 7px; width: 90%; display: inline-block; vertical-align: top; " >
                         <div style="vertical-align: top; width: 100%; padding: 1px;margin: auto;display: inline-block;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 14px; margin-bottom: 0;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop lt 50 }" >
+                                <h:panelGroup style="display: inline-block; clear: left; float: left; width: 100%; vertical-align: top; font-size: 14px; margin-bottom: 0;" layout="block"  rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValuePrintable ne '' and prv.lobValuePrintable ne null and prv.investigationItem.riTop lt 50 }" >
                                     <div style="display: inline-block; float: left; width: 1%; clear: left; " ></div>
                                     <div style="display: inline-block; top: 0px; float: left; width: 30%; text-align: left; padding-top: 0.1%; padding-bottom: 0.1%; ">
                                         <h:outputLabel value="#{prv.investigationItem.name}"   escape="false"/>
@@ -221,13 +221,13 @@
 
                         <div style="vertical-align: top; text-align: left; font-size: 14px;  padding-top: 0%; padding-bottom: 0%; clear: left;">
                             <ui:repeat  value="#{patientReportController.currentPatientReport.patientReportItemValues}" var="prv" >
-                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
+                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValuePrintable ne '' and prv.lobValuePrintable ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div style="float: left;width: 5%; " ></div>
                                     <div style=" float: left; text-align: left; width: 20%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
                                         <h:outputLabel value="#{prv.investigationItem.name}"  escape="false" />
                                     </div>
                                 </h:panelGroup>
-                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValue ne '' and prv.lobValue ne null and prv.investigationItem.riTop gt 50 }" >
+                                <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValuePrintable ne '' and prv.lobValuePrintable ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div class="micMemoValue" style=" text-align: left; float:left; margin-left: 5%; width: 90%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
                                         <h:outputLabel value="#{fn:replace(prv.lobValuePrintable,'\\n','&lt;br/&gt;')}"    escape="false" />
                                     </div>


### PR DESCRIPTION
## Summary
Merges the COOP hotfix (#22323, applied to `coop-prod`) into `development` so the fix isn't lost on the next release.

Closes #22322

### Issue Details
1. **Extra blank space between result rows** in the URINE CULTURE & ABST-style report — MACROSCOPY / MICROSCOPY / CULTURE / COLONY COUNT rows showed a large gap after each value before the next label. Caused by (a) excess `margin-bottom` on each memo row, and (b) trailing blank lines left in the stored memo value (literal `\n`, real newline, or an empty rich-text paragraph/`<br>`) being rendered as-is.
2. **No control over bolding of "SENSITIVE" antibiotic results** — the report always bolded the value when it equalled `SENSITIVE`, with no way to disable it via configuration.

### Changes
- `PatientReportItemValue.java`: new `getLobValuePrintable()` strips leading/trailing blank lines (literal `\n`, whitespace, empty `<p>`/`<div>`/`<br>`) from `lobValue` before rendering.
- `microbiology_patient_report.xhtml`:
  - Tightened row spacing on the MACROSCOPY/MICROSCOPY/CULTURE/COLONY COUNT section and switched to `lobValuePrintable`.
  - Added `layout="block"` to antibiotic result row `h:panelGroup`s to remove an inline-whitespace line-height gap between rows.
  - Added application config option **"Microbiology Antibiotic Result - Bold Sensitive Result"** (boolean, default `true`) to control bolding of `SENSITIVE` results.

## Test plan
- [ ] Rebuild/redeploy and view a microbiology patient report to confirm the blank gaps are gone
- [ ] Confirm SENSITIVE antibiotic results are bold by default
- [ ] Set "Microbiology Antibiotic Result - Bold Sensitive Result" to false and confirm bolding is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved microbiology report readability by trimming blank content around memo-style investigation values.
  * Added a configuration option to control whether “SENSITIVE” antibiotic results are displayed in bold (enabled by default).

* **Style**
  * Refined typography, spacing, and layout across microbiology report sections, including updated memo and antibiotic row rendering for a more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->