### PR TITLE
fix(inward): fix print truncation on Inpatient Service Summary Report

### DIFF
--- a/src/main/webapp/inward/report_md_inward_item.xhtml
+++ b/src/main/webapp/inward/report_md_inward_item.xhtml
@@ -162,7 +162,28 @@
             </p:panel>
 
             <p:panel id="reportPrint">
-                <p:dataTable id="tbl" value="#{mdInwardReportController.itemWithFees}" rowIndexVar="i" var="iwf" >
+                <style>
+                    @media screen {
+                        .printOnlyReport { display: none; }
+                    }
+                    @media print {
+                        @page { size: A4 landscape; }
+                        .noPrintButton { display: none !important; }
+                        .printOnlyReport { display: block; }
+                        .printOnlyReport table {
+                            width: 100%;
+                            border-collapse: collapse;
+                            font-size: 9pt;
+                        }
+                        .printOnlyReport th, .printOnlyReport td {
+                            border: 1px solid #000;
+                            padding: 2px 4px;
+                            text-align: left;
+                        }
+                    }
+                </style>
+
+                <p:dataTable id="tbl" styleClass="noPrintButton" value="#{mdInwardReportController.itemWithFees}" rowIndexVar="i" var="iwf" >
                     <p:column headerText="No">
                         <h:outputLabel value="#{i+1}"/>
                     </p:column>
@@ -215,6 +236,67 @@
                         </f:facet>
                     </p:column>
                 </p:dataTable>
+
+                <h:panelGroup layout="block" id="printReport" styleClass="printOnlyReport">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th><h:outputText value="No"/></th>
+                                <th><h:outputText value="Institution"/></th>
+                                <th><h:outputText value="Department"/></th>
+                                <th><h:outputText value="Parent Categoy"/></th>
+                                <th><h:outputText value="Categoy"/></th>
+                                <th><h:outputText value="Name"/></th>
+                                <th><h:outputText value="Count"/></th>
+                                <th><h:outputText value="Hospital Fee"/></th>
+                                <th><h:outputText value="Professional Fee"/></th>
+                                <th><h:outputText value="Total"/></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <ui:repeat value="#{mdInwardReportController.itemWithFees}" var="iwf" varStatus="i">
+                                <tr>
+                                    <td><h:outputText value="#{i.index+1}"/></td>
+                                    <td><h:outputText value="#{iwf.item.institution.name}"/></td>
+                                    <td><h:outputText value="#{iwf.item.department.name}"/></td>
+                                    <td><h:outputText value="#{iwf.item.category.parentCategory.name}"/></td>
+                                    <td><h:outputText value="#{iwf.item.category.name}"/></td>
+                                    <td><h:outputText value="#{iwf.item.name}"/></td>
+                                    <td><h:outputText value="#{iwf.count}"/></td>
+                                    <td style="text-align: right;"><h:outputText value="#{iwf.hospitalFee}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText></td>
+                                    <td style="text-align: right;"><h:outputText value="#{iwf.proFee}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText></td>
+                                    <td style="text-align: right;"><h:outputText value="#{iwf.hospitalFee+iwf.proFee}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputText></td>
+                                </tr>
+                            </ui:repeat>
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="7" style="text-align: right; font-weight: bold;">Total</td>
+                                <td style="text-align: right; font-weight: bold;">
+                                    <h:outputText value="#{mdInwardReportController.itemHospitalTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right; font-weight: bold;">
+                                    <h:outputText value="#{mdInwardReportController.itemProfessionalTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                                <td style="text-align: right; font-weight: bold;">
+                                    <h:outputText value="#{mdInwardReportController.itemHospitalTotal+mdInwardReportController.itemProfessionalTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </h:panelGroup>
             </p:panel>
 
         </h:form>

--- a/src/main/webapp/inward/report_md_inward_item.xhtml
+++ b/src/main/webapp/inward/report_md_inward_item.xhtml
@@ -179,6 +179,7 @@
                             border: 1px solid #000;
                             padding: 2px 4px;
                             text-align: left;
+                            overflow-wrap: anywhere;
                         }
                     }
                 </style>
@@ -277,7 +278,7 @@
                         </tbody>
                         <tfoot>
                             <tr>
-                                <td colspan="7" style="text-align: right; font-weight: bold;">Total</td>
+                                <td colspan="7" style="text-align: right; font-weight: bold;"><h:outputText value="Total"/></td>
                                 <td style="text-align: right; font-weight: bold;">
                                     <h:outputText value="#{mdInwardReportController.itemHospitalTotal}">
                                         <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
## Summary
- Fixes #22315 — the Inpatient Service Summary report's print output was truncating text/numbers, same root cause as #22316 (fixed in #22318): `p:printer` printed the `p:dataTable` in default portrait orientation with no `@page` sizing, clipping the 10-column table at the page edge.
- Mirrors the exact fix pattern from `inward_report_timed_service.xhtml` (#22318): added `@media print { @page { size: A4 landscape; } }` plus `noPrintButton`/`printOnlyReport` toggle classes.
- The interactive `p:dataTable` is now hidden during print (`noPrintButton`); a plain HTML `<table>` (`ui:repeat`-driven, with a totals `<tfoot>`) is shown instead for print output.
- Preserved the existing "Categoy"/"Parent Categoy" header typos per project convention (never "fix" existing text/typos).
- No Java changes — only `src/main/webapp/inward/report_md_inward_item.xhtml` was touched; this is a JSF-only change.

## Test plan
- [x] Rebuilt (`mvn clean package -DskipTests`) and redeployed to local Payara — no errors in `server.log`.
- [x] Logged in locally, selected the **Inward** department, navigated to Inpatient Analytics → Service Report → Inpatient Service Summary.
- [x] Ran the report against real historical Inward data in the local `coop` DB (68 rows, no synthetic data needed).
- [x] Confirmed on-screen `p:dataTable` renders unchanged (screenshot below).
- [x] Emulated `@media print` (Playwright `page.emulateMedia`) and confirmed via computed styles that `#tbl` (`p:dataTable`) becomes `display:none` and `#printReport` (plain table) becomes `display:block`, and vice-versa under `@media screen`.
- [x] Verified the print table renders all 10 columns without clipping, and footer totals (Hospital Fee 626,453.60 / Professional Fee 5,000.00 / Total 631,453.60) land under the correct columns — confirming the `<tfoot>` colspan arithmetic (7+1+1+1=10) is correct (this exact off-by-one mistake was caught by CodeRabbit on the sibling #22318 PR).

**Screen view** (unchanged interactive table):
![normal view](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_22315_report_normal_view.png)

**Print view** (`@media print` emulated — landscape, plain table, no clipping):
![print view](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_22315_report_print_view.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a print-optimized report view for inpatient service summaries.
  * Included formatted hospital, professional, and total fees, along with aggregated totals.

* **Bug Fixes**
  * Prevented interactive report controls from appearing in printed output.
  * Improved print layout by displaying only print-specific content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->