### PR TITLE
#18560 Bill numbers are not clickable to view bill details  

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
@@ -85,6 +85,7 @@ public class ReportsTransfer implements Serializable {
 
     @Inject
     private ReportTimerController reportTimerController;
+    private Bill selectedTransferBill;
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">
     @EJB
@@ -543,6 +544,14 @@ public class ReportsTransfer implements Serializable {
         previewBill = null;
         return "/pharmacy/pharmacy_report_bht_issue_bill?faces-redirect=true";
     }
+    
+    public Bill getSelectedTransferBill() {
+        return selectedTransferBill;
+    }
+
+    public void setSelectedTransferBill(Bill selectedTransferBill) {
+        this.selectedTransferBill = selectedTransferBill;
+    }
 
     /**
      * Methods
@@ -852,6 +861,7 @@ public class ReportsTransfer implements Serializable {
 
         jpql.append("select new com.divudi.core.data.dto.PharmacyTransferIssueBillItemDTO(")
                 .append("TYPE(b), ")
+                .append("b.id, ")
                 .append("b.deptId, b.createdAt, it.name, it.code,")
                 .append(" bi.qty, ib.costRate, bfd.valueAtCostRate,")
                 .append(" p.retailRate, bfd.valueAtRetailRate,")
@@ -915,7 +925,6 @@ public class ReportsTransfer implements Serializable {
                 }
             }
         }
-
     }
 
     public void fillDepartmentTransfersReceiveByBillItem() {
@@ -932,6 +941,7 @@ public class ReportsTransfer implements Serializable {
         StringBuilder jpql = new StringBuilder();
 
         jpql.append("select new com.divudi.core.data.dto.PharmacyTransferReceiveBillItemDTO(")
+                .append("b.id, ")
                 .append("TYPE(b), ")  // ADDED: Bill class discriminator to identify CancelledBill
                 .append("b.deptId, b.createdAt, it.name, it.code,")
                 .append(" bi.qty, ib.costRate, bfd.valueAtCostRate,")
@@ -996,7 +1006,6 @@ public class ReportsTransfer implements Serializable {
                 }
             }
         }
-
     }
 
 
@@ -3818,6 +3827,24 @@ public class ReportsTransfer implements Serializable {
 
     public void setDisposalIssueBillItemDtos(List<PharmacyItemPurchaseDTO> disposalIssueBillItemDtos) {
         this.disposalIssueBillItemDtos = disposalIssueBillItemDtos;
+    }
+    
+    public String navigateToTransferBill(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("Bill could not be identified.");
+            return null;
+        }
+
+        Bill bill = BillFacade.find(billId);
+
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Bill could not be found.");
+            return null;
+        }
+
+        selectedTransferBill = bill;
+
+        return "/pharmacy/pharmacy_transfer_issue_bill_view?faces-redirect=true";
     }
 
 }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
@@ -7,6 +7,7 @@ import java.util.Date;
  * DTO for Pharmacy Transfer Issue Bill Items
  */
 public class PharmacyTransferIssueBillItemDTO implements Serializable {
+    private Long billId;
     private String billClassSimpleName; // Simple name of Bill class for row styling
     private String deptId;
     private Date createdAt;
@@ -73,12 +74,22 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
     // TYPE(b), b.deptId, b.createdAt, it.name, it.code, bi.qty, ib.costRate, bfd.valueAtCostRate,
     // p.retailRate, bfd.valueAtRetailRate, p.purchaseRate, bfd.valueAtPurchaseRate, bfd.lineGrossRate, bfd.lineGrossTotal
     public PharmacyTransferIssueBillItemDTO(Object billClass,
-                                            String deptId, Date createdAt, String itemName, String itemCode,
-                                            Double qty, Double costRate, java.math.BigDecimal costValue,
-                                            Double retailRate, java.math.BigDecimal retailValue,
-                                            Double purchaseRate, java.math.BigDecimal purchaseValue,
-                                            java.math.BigDecimal transferRate, java.math.BigDecimal transferValue) {
+                                            Long billId,
+                                            String deptId,
+                                            Date createdAt,
+                                            String itemName,
+                                            String itemCode,
+                                            Double qty,
+                                            Double costRate,
+                                            java.math.BigDecimal costValue,
+                                            Double retailRate,
+                                            java.math.BigDecimal retailValue,
+                                            Double purchaseRate,
+                                            java.math.BigDecimal purchaseValue,
+                                            java.math.BigDecimal transferRate,
+                                            java.math.BigDecimal transferValue) {
         this.billClassSimpleName = extractSimpleClassName(billClass);
+        this.billId = billId;
         this.deptId = deptId;
         this.createdAt = createdAt;
         this.itemName = itemName;
@@ -93,7 +104,15 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
         this.transferRate = transferRate != null ? transferRate.doubleValue() : null;
         this.transferValue = transferValue != null ? transferValue.doubleValue() : null;
     }
+    
+    public Long getBillId() {
+        return billId;
+    }
 
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+    
     public String getDeptId() {
         return deptId;
     }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceiveBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceiveBillItemDTO.java
@@ -10,6 +10,7 @@ import java.util.Date;
  * cancelled receive bill items in reports.
  */
 public class PharmacyTransferReceiveBillItemDTO implements Serializable {
+    private Long billId;
     private String billClassSimpleName; // ADDED for Issue #15797: Simple class name (e.g., "Bill", "CancelledBill")
     private String deptId;
     private Date createdAt;
@@ -72,13 +73,24 @@ public class PharmacyTransferReceiveBillItemDTO implements Serializable {
     /**
      * NEW Constructor for Issue #15797: Includes TYPE(b) to distinguish cancelled receive items.
      */
-    public PharmacyTransferReceiveBillItemDTO(Object billClass, String deptId, Date createdAt, String itemName, String itemCode,
-                                            Double qty, Double costRate, java.math.BigDecimal costValue,
-                                            Double retailRate, java.math.BigDecimal retailValue,
-                                            Double purchaseRate, java.math.BigDecimal purchaseValue,
-                                            java.math.BigDecimal transferRate, java.math.BigDecimal transferValue) {
+    public PharmacyTransferReceiveBillItemDTO(Long billId,
+                                              Object billClass,
+                                              String deptId,
+                                              Date createdAt,
+                                              String itemName,
+                                              String itemCode,
+                                              Double qty,
+                                              Double costRate,
+                                              java.math.BigDecimal costValue,
+                                              Double retailRate,
+                                              java.math.BigDecimal retailValue,
+                                              Double purchaseRate,
+                                              java.math.BigDecimal purchaseValue,
+                                              java.math.BigDecimal transferRate,
+                                              java.math.BigDecimal transferValue) {
         // Extract simple class name from TYPE(b)
         this.billClassSimpleName = extractSimpleClassName(billClass);
+        this.billId = billId;
         this.deptId = deptId;
         this.createdAt = createdAt;
         this.itemName = itemName;
@@ -114,7 +126,15 @@ public class PharmacyTransferReceiveBillItemDTO implements Serializable {
 
         return fullClassName;
     }
+    
+    public Long getBillId() {
+        return billId;
+    }
 
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+    
     public String getDeptId() {
         return deptId;
     }

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill.xhtml
@@ -105,7 +105,12 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Bill No"  style="padding: 0px!important; margin: 0px!important;" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.deptId}"  style="padding: 0px!important; margin: 0px!important;"/>
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{i.deptId}"
+                                        title="View issue #{i.deptId}"
+                                        styleClass="text-primary text-decoration-underline"
+                                        action="#{transferIssueNativeSqlController.viewByBillId(i.id)}"/>
                                 </p:column>
 
 

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
@@ -151,7 +151,12 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Bill No" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.deptId}"/>
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{i.deptId}"
+                                        title="View issue #{i.deptId}"
+                                        styleClass="text-primary text-decoration-underline"
+                                        action="#{transferIssueNativeSqlController.viewByBillId(i.billId)}"/>
                                 </p:column>
 
                                 <p:column headerText="Date">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
@@ -164,7 +164,12 @@
                                 <f:facet name="header">
                                     <h:outputLabel value="Bill No"/>
                                 </f:facet>
-                                <h:outputLabel value="#{i.deptId}" ></h:outputLabel>
+                                <p:commandLink
+                                    ajax="false"
+                                    value="#{i.deptId}"
+                                    title="View issue #{i.deptId}"
+                                    styleClass="text-primary text-decoration-underline"
+                                    action="#{transferIssueNativeSqlController.viewByBillId(i.billId)}"/>
                             </p:column>
 
                             <p:column headerText="Date"

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
@@ -146,7 +146,14 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Bill No" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.deptId}"/>
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{i.deptId}"
+                                        title="View receive bill #{i.deptId}"
+                                        styleClass="text-primary text-decoration-underline"
+                                        action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferReceiveById()}">
+                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.billId}" value="#{i.billId}" />
+                                    </p:commandLink>
                                 </p:column>
 
                                 <p:column headerText="Date">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
@@ -158,7 +158,12 @@
                                 <f:facet name="header">
                                     <h:outputLabel value="Bill No"/>
                                 </f:facet>
-                                <h:outputLabel value="#{i.deptId}" ></h:outputLabel>
+                                <p:commandLink
+                                    ajax="false"
+                                    value="#{i.deptId}"
+                                    title="View issue #{i.deptId}"
+                                    styleClass="text-primary text-decoration-underline"
+                                    action="#{transferIssueNativeSqlController.viewByBillId(i.billId)}"/>
                             </p:column>
 
                             <p:column headerText="Date"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bill numbers in pharmacy transfer issue and receive reports are now clickable.
  * Open the corresponding transfer bill or reprint its details directly from report listings.
  * Transfer reports now maintain bill-level identification for more accurate navigation.

* **Bug Fixes**
  * Improved bill matching in item-level transfer issue and receive reports.
  * Reports better distinguish bills and their statuses when displaying transfer records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->