### PR TITLE
fix(pharmacy): show per-item value in Search Pharmacy Issue Bill Items

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -5674,7 +5674,7 @@ public class SearchController implements Serializable {
         jpql.append("bi.bill.institution.name, bi.bill.department.name, bi.bill.toDepartment.name, ");
         jpql.append("bi.bill.billType, bi.bill.total, bi.bill.netTotal, bi.bill.discount, ");
         jpql.append("bi.item.id, bi.item.name, bi.item.code, ");
-        jpql.append("bi.qty, bi.pharmaceuticalBillItem.freeQty) ");
+        jpql.append("bi.qty, bi.pharmaceuticalBillItem.freeQty, bi.netValue) ");
         jpql.append(" from BillItem bi");
         jpql.append(" where bi.bill.billTypeAtomic in :bts");
         jpql.append(" and bi.bill.createdAt between :fd and :td");

--- a/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyItemPurchaseDTO.java
@@ -34,6 +34,7 @@ public class PharmacyItemPurchaseDTO implements Serializable {
     private Long itemId;
     private String itemName;
     private String itemCode;
+    private Double itemValue;
     
     // Batch and pricing information
     private String batchNo;
@@ -72,6 +73,31 @@ public class PharmacyItemPurchaseDTO implements Serializable {
         this.itemCode = itemCode;
         this.qty = qty;
         this.freeQty = freeQty;
+    }
+
+    // Constructor for Pharmacy Issue Bill Item search table with the bill item's own net value (16 parameters)
+    public PharmacyItemPurchaseDTO(Long billId, String billDeptId, Date billCreatedAt,
+                                   String billInstitutionName, String billDepartmentName,
+                                   String billFromInstitutionName, BillType billType,
+                                   Double billTotal, Double billNetTotal, Double billDiscount,
+                                   Long itemId, String itemName, String itemCode,
+                                   Double qty, Double freeQty, Double itemValue) {
+        this.billId = billId;
+        this.billDeptId = billDeptId;
+        this.billCreatedAt = billCreatedAt;
+        this.billInstitutionName = billInstitutionName;
+        this.billDepartmentName = billDepartmentName;
+        this.billFromInstitutionName = billFromInstitutionName;
+        this.billType = billType;
+        this.billTotal = billTotal;
+        this.billNetTotal = billNetTotal;
+        this.billDiscount = billDiscount;
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.freeQty = freeQty;
+        this.itemValue = itemValue;
     }
 
     // Constructor for BY_BILL report (no item details)
@@ -342,6 +368,9 @@ public class PharmacyItemPurchaseDTO implements Serializable {
 
     public String getItemCode() { return itemCode; }
     public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+
+    public Double getItemValue() { return itemValue; }
+    public void setItemValue(Double itemValue) { this.itemValue = itemValue; }
 
     // Getter and setter methods for batch information
     public String getBatchNo() { return batchNo; }

--- a/src/main/webapp/pharmacy/pharmacy_search_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_search_issue_bill_item.xhtml
@@ -107,7 +107,7 @@
                                     </p:column>   
 
                                     <p:column headerText="Item Value" width="15em">
-                                        <h:outputLabel value="#{row.billNetTotal}" >
+                                        <h:outputLabel value="#{row.itemValue}" >
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
                                     </p:column>


### PR DESCRIPTION
## Summary
- Fixes the "Item Value" column on the Search Pharmacy Issue Bill Items screen, which showed the whole bill's net total for every row of a multi-item disposal bill instead of that item's own value.
- Added a new `itemValue` field + constructor to `PharmacyItemPurchaseDTO` (existing constructors left untouched).
- `SearchController.createPharmacyIssueBillItemTable()` now also selects `bi.netValue` (the bill item's own net value), matching what the "Item Value" search filter already queries against.
- `pharmacy_search_issue_bill_item.xhtml` now binds the "Item Value" column to `row.itemValue` instead of `row.billNetTotal`.

## Test plan
- [ ] Create a disposal bill with 2+ items at different quantities/rates.
- [ ] Navigate to Search Pharmacy Issue Bill Items and search for that bill.
- [ ] Confirm each row's Item Value shows that item's own value (qty × rate), not the bill's total.
- [ ] Confirm the "Item Value" search filter still works (searches against the same bi.netValue).

Closes #22331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Pharmacy Issue Bill Item search results to display each item’s net value in the “Item Value” column.
  * Improved result data accuracy by including item-level net values alongside quantity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->