### PR TITLE
Generalize ServiceApi fee endpoints to support Investigation (and any Item subtype)

### DIFF
--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -28,6 +28,7 @@ import com.divudi.core.entity.inward.InwardService;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.InwardServiceFacade;
+import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.ItemFeeFacade;
 import com.divudi.core.facade.ServiceCategoryFacade;
 import com.divudi.core.facade.ServiceFacade;
@@ -65,6 +66,9 @@ public class ServiceApiService implements Serializable {
 
     @EJB
     private ServiceCategoryFacade serviceCategoryFacade;
+
+    @EJB
+    private ItemFacade itemFacade;
 
     @EJB
     private ItemFeeFacade itemFeeFacade;
@@ -440,11 +444,11 @@ public class ServiceApiService implements Serializable {
     // =========================================================================
 
     /**
-     * List all non-retired fees for a service.
+     * List all non-retired fees for any Item (Service, InwardService, Investigation, etc.).
      */
     public List<ItemFeeDTO> listFees(Long serviceId) throws Exception {
-        Service service = loadAndValidateService(serviceId);
-        List<ItemFee> fees = fetchFeesForItem(service);
+        Item item = loadAndValidateItem(serviceId);
+        List<ItemFee> fees = fetchFeesForItem(item);
         List<ItemFeeDTO> dtos = new ArrayList<>();
         for (ItemFee fee : fees) {
             dtos.add(buildItemFeeDTO(fee));
@@ -453,7 +457,7 @@ public class ServiceApiService implements Serializable {
     }
 
     /**
-     * Add a new fee to a service and recalculate the service total.
+     * Add a new fee to any Item (Service, InwardService, Investigation, etc.) and recalculate its total.
      */
     public ServiceResponseDTO addFee(Long serviceId, ItemFeeCreateRequestDTO request, WebUser user) throws Exception {
         if (request == null || !request.isValid()) {
@@ -463,7 +467,7 @@ public class ServiceApiService implements Serializable {
             throw new Exception("User is required for adding fee");
         }
 
-        Service service = loadAndValidateService(serviceId);
+        Item item = loadAndValidateItem(serviceId);
 
         FeeType feeType;
         try {
@@ -473,7 +477,7 @@ public class ServiceApiService implements Serializable {
         }
 
         ItemFee itemFee = new ItemFee();
-        itemFee.setItem(service);
+        itemFee.setItem(item);
         itemFee.setName(request.getName().trim());
         itemFee.setFeeType(feeType);
         if (request.getFee() == null || request.getFee() < 0) {
@@ -524,15 +528,16 @@ public class ServiceApiService implements Serializable {
 
         itemFeeFacade.create(itemFee);
 
-        // Recalculate service totals
-        recalculateServiceTotal(service);
+        // Recalculate item totals
+        recalculateItemTotal(item);
 
-        List<ItemFee> fees = fetchFeesForItem(service);
-        return buildServiceResponseDTO(service, fees, "Fee added successfully");
+        List<ItemFee> fees = fetchFeesForItem(item);
+        return buildServiceResponseDTO(item, fees, "Fee added successfully");
     }
 
     /**
-     * Update an existing fee and recalculate the service total.
+     * Update an existing fee and recalculate the parent item's total.
+     * Works for any Item subtype (Service, InwardService, Investigation, etc.).
      */
     public ServiceResponseDTO updateFee(Long serviceId, Long feeId, ItemFeeUpdateRequestDTO request, WebUser user) throws Exception {
         if (request == null || !request.isValid()) {
@@ -542,8 +547,8 @@ public class ServiceApiService implements Serializable {
             throw new Exception("User is required for updating fee");
         }
 
-        Service service = loadAndValidateService(serviceId);
-        ItemFee itemFee = loadAndValidateFee(feeId, service);
+        Item item = loadAndValidateItem(serviceId);
+        ItemFee itemFee = loadAndValidateFee(feeId, item);
 
         // Snapshot before-state for audit
         Map<String, Object> beforeFlags = new HashMap<>();
@@ -620,34 +625,35 @@ public class ServiceApiService implements Serializable {
             auditService.logAudit(beforeFlags, afterFlags, user, "ItemFee", "FEE_FLAG_UPDATED", feeId);
         }
 
-        // Recalculate service totals
-        recalculateServiceTotal(service);
+        // Recalculate item totals
+        recalculateItemTotal(item);
 
-        List<ItemFee> fees = fetchFeesForItem(service);
-        return buildServiceResponseDTO(service, fees, "Fee updated successfully");
+        List<ItemFee> fees = fetchFeesForItem(item);
+        return buildServiceResponseDTO(item, fees, "Fee updated successfully");
     }
 
     /**
-     * Remove a fee (soft-delete) and recalculate the service total.
+     * Remove a fee (soft-delete) and recalculate the parent item's total.
+     * Works for any Item subtype (Service, InwardService, Investigation, etc.).
      */
     public ServiceResponseDTO removeFee(Long serviceId, Long feeId, WebUser user) throws Exception {
         if (user == null) {
             throw new Exception("User is required for removing fee");
         }
 
-        Service service = loadAndValidateService(serviceId);
-        ItemFee itemFee = loadAndValidateFee(feeId, service);
+        Item item = loadAndValidateItem(serviceId);
+        ItemFee itemFee = loadAndValidateFee(feeId, item);
 
         itemFee.setRetired(true);
         itemFee.setRetirer(user);
         itemFee.setRetiredAt(Calendar.getInstance().getTime());
         itemFeeFacade.edit(itemFee);
 
-        // Recalculate service totals
-        recalculateServiceTotal(service);
+        // Recalculate item totals
+        recalculateItemTotal(item);
 
-        List<ItemFee> fees = fetchFeesForItem(service);
-        return buildServiceResponseDTO(service, fees, "Fee removed successfully");
+        List<ItemFee> fees = fetchFeesForItem(item);
+        return buildServiceResponseDTO(item, fees, "Fee removed successfully");
     }
 
     // =========================================================================
@@ -905,6 +911,25 @@ public class ServiceApiService implements Serializable {
         return service;
     }
 
+    /**
+     * Load any Item by ID (Service, InwardService, Investigation, etc.), ensuring
+     * it is not retired. Used by fee-management methods, which operate on ItemFee
+     * generically since ItemFee.item is typed as Item, not Service.
+     */
+    private Item loadAndValidateItem(Long id) throws Exception {
+        if (id == null) {
+            throw new Exception("Item ID is required");
+        }
+        Item item = itemFacade.find(id);
+        if (item == null) {
+            throw new Exception("Item not found with ID: " + id);
+        }
+        if (item.isRetired()) {
+            throw new Exception("Item with ID " + id + " is retired");
+        }
+        return item;
+    }
+
     private void validateVatPercentage(Double vatPercentage) throws Exception {
         if (vatPercentage != null && (vatPercentage < 0 || vatPercentage > 100)) {
             throw new Exception("vatPercentage must be between 0 and 100");
@@ -912,9 +937,9 @@ public class ServiceApiService implements Serializable {
     }
 
     /**
-     * Load an ItemFee by ID, ensuring it belongs to the given service and is not retired.
+     * Load an ItemFee by ID, ensuring it belongs to the given item and is not retired.
      */
-    private ItemFee loadAndValidateFee(Long feeId, Service service) throws Exception {
+    private ItemFee loadAndValidateFee(Long feeId, Item item) throws Exception {
         if (feeId == null) {
             throw new Exception("Fee ID is required");
         }
@@ -925,8 +950,8 @@ public class ServiceApiService implements Serializable {
         if (fee.isRetired()) {
             throw new Exception("Fee with ID " + feeId + " is already retired");
         }
-        if (fee.getItem() == null || !fee.getItem().getId().equals(service.getId())) {
-            throw new Exception("Fee with ID " + feeId + " does not belong to service with ID " + service.getId());
+        if (fee.getItem() == null || !fee.getItem().getId().equals(item.getId())) {
+            throw new Exception("Fee with ID " + feeId + " does not belong to item with ID " + item.getId());
         }
         return fee;
     }
@@ -953,20 +978,21 @@ public class ServiceApiService implements Serializable {
     }
 
     /**
-     * Recalculate service total and totalForForeigner by summing non-retired fees.
-     * Mirrors ItemFeeManager.updateFee() logic.
+     * Recalculate an item's total and totalForForeigner by summing non-retired fees.
+     * Mirrors ItemFeeManager.updateFee() logic. Works for any Item subtype
+     * (Service, InwardService, Investigation, etc.) via the generic ItemFacade.
      */
-    private void recalculateServiceTotal(Service service) {
-        List<ItemFee> fees = fetchFeesForItem(service);
+    private void recalculateItemTotal(Item item) {
+        List<ItemFee> fees = fetchFeesForItem(item);
         double total = 0.0;
         double totalForForeigner = 0.0;
         for (ItemFee fee : fees) {
             total += fee.getFee();
             totalForForeigner += fee.getFfee();
         }
-        service.setTotal(total);
-        service.setTotalForForeigner(totalForForeigner);
-        saveService(service);
+        item.setTotal(total);
+        item.setTotalForForeigner(totalForForeigner);
+        itemFacade.edit(item);
     }
 
     /**
@@ -994,44 +1020,46 @@ public class ServiceApiService implements Serializable {
     }
 
     /**
-     * Build a ServiceResponseDTO from a Service entity and its fees.
+     * Build a ServiceResponseDTO from any Item entity and its fees.
+     * Used both by Service/InwardService endpoints and by the generalized fee-management
+     * endpoints, which accept any Item subtype (e.g. Investigation).
      */
-    private ServiceResponseDTO buildServiceResponseDTO(Service service, List<ItemFee> fees, String message) {
+    private ServiceResponseDTO buildServiceResponseDTO(Item item, List<ItemFee> fees, String message) {
         ServiceResponseDTO dto = new ServiceResponseDTO();
-        dto.setId(service.getId());
-        dto.setName(service.getName());
-        dto.setCode(service.getCode());
-        dto.setPrintName(service.getPrintName());
-        dto.setFullName(service.getFullName());
-        dto.setServiceType(service instanceof InwardService ? "Inward" : "OPD");
-        dto.setTotal(service.getTotal());
-        dto.setTotalForForeigner(service.getTotalForForeigner());
-        dto.setInactive(service.isInactive());
-        dto.setRetired(service.isRetired());
-        dto.setDiscountAllowed(service.isDiscountAllowed());
-        dto.setUserChangable(service.isUserChangable());
-        dto.setChargesVisibleForInward(service.isChargesVisibleForInward());
-        dto.setMarginNotAllowed(service.isMarginNotAllowed());
-        dto.setRequestForQuentity(service.isRequestForQuentity());
-        dto.setPatientNotRequired(service.isPatientNotRequired());
-        dto.setVatable(service.isVatable());
-        dto.setVatPercentage(service.getVatPercentage());
-        if (service.getInwardChargeType() != null) {
-            dto.setInwardChargeType(service.getInwardChargeType().name());
+        dto.setId(item.getId());
+        dto.setName(item.getName());
+        dto.setCode(item.getCode());
+        dto.setPrintName(item.getPrintName());
+        dto.setFullName(item.getFullName());
+        dto.setServiceType(deriveServiceType(item));
+        dto.setTotal(item.getTotal());
+        dto.setTotalForForeigner(item.getTotalForForeigner());
+        dto.setInactive(item.isInactive());
+        dto.setRetired(item.isRetired());
+        dto.setDiscountAllowed(item.isDiscountAllowed());
+        dto.setUserChangable(item.isUserChangable());
+        dto.setChargesVisibleForInward(item.isChargesVisibleForInward());
+        dto.setMarginNotAllowed(item.isMarginNotAllowed());
+        dto.setRequestForQuentity(item.isRequestForQuentity());
+        dto.setPatientNotRequired(item.isPatientNotRequired());
+        dto.setVatable(item.isVatable());
+        dto.setVatPercentage(item.getVatPercentage());
+        if (item.getInwardChargeType() != null) {
+            dto.setInwardChargeType(item.getInwardChargeType().name());
         }
-        if (service.getCategory() != null) {
-            dto.setCategoryId(service.getCategory().getId());
-            dto.setCategoryName(service.getCategory().getName());
+        if (item.getCategory() != null) {
+            dto.setCategoryId(item.getCategory().getId());
+            dto.setCategoryName(item.getCategory().getName());
         }
-        if (service.getInstitution() != null) {
-            dto.setInstitutionId(service.getInstitution().getId());
-            dto.setInstitutionName(service.getInstitution().getName());
+        if (item.getInstitution() != null) {
+            dto.setInstitutionId(item.getInstitution().getId());
+            dto.setInstitutionName(item.getInstitution().getName());
         }
-        if (service.getDepartment() != null) {
-            dto.setDepartmentId(service.getDepartment().getId());
-            dto.setDepartmentName(service.getDepartment().getName());
+        if (item.getDepartment() != null) {
+            dto.setDepartmentId(item.getDepartment().getId());
+            dto.setDepartmentName(item.getDepartment().getName());
         }
-        dto.setCreatedAt(service.getCreatedAt());
+        dto.setCreatedAt(item.getCreatedAt());
 
         List<ItemFeeDTO> feeDtos = new ArrayList<>();
         for (ItemFee fee : fees) {
@@ -1040,6 +1068,20 @@ public class ServiceApiService implements Serializable {
         dto.setFees(feeDtos);
         dto.setMessage(message);
         return dto;
+    }
+
+    /**
+     * Derive a human-readable type label for an Item: "Inward" for InwardService,
+     * "OPD" for plain Service, otherwise the entity's simple class name (e.g. "Investigation").
+     */
+    private String deriveServiceType(Item item) {
+        if (item instanceof InwardService) {
+            return "Inward";
+        }
+        if (item.getClass() == Service.class) {
+            return "OPD";
+        }
+        return item.getClass().getSimpleName();
     }
 
     /**


### PR DESCRIPTION
## Summary
- `ServiceApi`'s fee endpoints (`GET/POST/PUT/DELETE /services/{id}/fees...`) were gated to `Service`/`InwardService` only, both via `ServiceFacade.find()` (which returns `null` for other DTYPEs under single-table inheritance) and an explicit type guard.
- `ItemFee` already stores fees generically against `Item`, and `Investigation` is a sibling subclass of `Item` alongside `Service` — so investigation fees (e.g. lab test pricing) had no way to be read or updated via the API.
- The four fee methods (`listFees`, `addFee`, `updateFee`, `removeFee`) now load the parent via the generic `ItemFacade` instead of `ServiceFacade`, with no subtype restriction. Non-fee Service CRUD endpoints (create/update/retire/activate/search) are unchanged and remain Service/InwardService-only.
- `serviceType` in the response DTO is now derived correctly per entity type ("Inward" / "OPD" / actual simple class name, e.g. "Investigation") instead of defaulting every non-InwardService item to "OPD".
- No new endpoints, no URL changes — same `/services/{id}/fees` routes now also accept Investigation (and other Item subtype) IDs.

Closes #22335

## Test plan
- [x] `mvn compile` succeeds
- [x] Deployed locally against local `coop` DB copy
- [x] `GET /api/services/{investigationId}/fees` returns the investigation's fees (verified against real investigation "A.P.T.T", ID 87589 — Hospital/Regent/Other fee rows)
- [x] `PUT /api/services/{investigationId}/fees/{feeId}` updates the fee and recalculates the item's `total`/`totalForForeigner`; verified against DB directly
- [x] Regression: `GET /api/services/{serviceId}` and `/fees` still work unchanged for a real `Service` (serviceType: "OPD")
- [x] Regression: `/fees` works for an `InwardService` (serviceType: "Inward")
- [x] Retired item correctly rejected with a clear error message
- [x] Nonexistent item ID returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fee management now supports a broader range of item types, including services, inward services, and investigations.
  * Fee responses display the appropriate item category.

* **Bug Fixes**
  * Improved validation ensures fees belong to the selected item.
  * Totals are recalculated consistently after fee changes.
  * Retired items can no longer be used for fee management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->