### PR TITLE
fix(inward): stop burning BHT/OPD-card numbers on staff override, add audit trail and reset API

### DIFF
--- a/developer_docs/api/API_ADMISSION_NUMBERS.md
+++ b/developer_docs/api/API_ADMISSION_NUMBERS.md
@@ -1,0 +1,90 @@
+# Admission Number Counters API
+
+REST endpoint for viewing and resetting the BHT/OPD-card admission-number sequence counter (`AdmissionNumber`) for a given admission type (and institution, when institution-based numbering is enabled).
+
+**Purpose:** Staff sometimes type their own override into the BHT/OPD-card number field at admission time instead of accepting the auto-generated number. When that happens the system's counter is intentionally left untouched (issue #22336), so the next auto-generated number may fall behind the highest number actually printed/used. This endpoint lets an administrator (or the AI chat assistant, on explicit instruction) check the counter and, once the correct next number is known, realign the counter so future admissions continue from the right point.
+
+**Authentication:** `Finance` header (API key)
+
+---
+
+## GET — View the current counter
+
+```
+GET /api/admission-numbers?admissionTypeId=1192&institutionId=
+```
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| admissionTypeId | Yes | Numeric `AdmissionType` ID (e.g. `1192` for OPD Card) |
+| institutionId | No | Numeric `Institution` ID. Only relevant when "Generate Separate BHT Number Series for Each Institution" is enabled; otherwise ignored |
+
+**Response 200:**
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "admissionTypeId": 1192,
+    "admissionTypeName": "OPD Card",
+    "institutionId": null,
+    "institutionBased": false,
+    "lastAdmissionNumber": 48213,
+    "nextAdmissionNumber": 48214
+  }
+}
+```
+
+`lastAdmissionNumber` is the last number actually issued by the counter; `nextAdmissionNumber` is what the next call to the generator would hand out. If no counter row exists yet, both values are computed from the current admission count for that series (the same self-initialization logic the generator itself uses) without creating a row.
+
+---
+
+## PUT — Reset the counter
+
+```
+PUT /api/admission-numbers?admissionTypeId=1192&institutionId=
+Content-Type: application/json
+```
+
+```json
+{ "lastAdmissionNumber": 48250 }
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| lastAdmissionNumber | Yes | The corrected **last-used** number, not the next number. The next auto-generated number will be this value + 1 |
+
+**Response 200:**
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "admissionTypeId": 1192,
+    "admissionTypeName": "OPD Card",
+    "institutionId": null,
+    "institutionBased": false,
+    "previousLastAdmissionNumber": 48213,
+    "lastAdmissionNumber": 48250,
+    "nextAdmissionNumber": 48251
+  }
+}
+```
+
+If no counter row exists yet for the series, one is created with `lastAdmissionNumber` set to the value supplied.
+
+**Errors:**
+- `400` — missing `admissionTypeId` query param, missing/invalid JSON body, or missing `lastAdmissionNumber` in the body
+- `401` — invalid or missing `Finance` API key
+- `404` — `admissionTypeId` or `institutionId` does not resolve to an existing record
+- `500` — unexpected server error
+
+Every successful reset is written to the audit log (`AdmissionNumber`, event `Admission Number Counter Reset`) recording the previous and new `lastAdmissionNumber` along with the acting user.
+
+---
+
+## Notes
+
+- Uses the same in-JVM lock, cache-bypass read, and immediate-flush write as the internal number generator (`BillNumberGenerator`), so a reset is visible to the very next admission on any app instance.
+- This endpoint does not itself change any `Admission` record — it only affects future number generation.
+- Related: `AdmissionController.saveSelected()` no longer draws (and burns) a counter value when staff have overridden the suggested BHT/OPD-card text at admission time.

--- a/developer_docs/api/API_ADMISSION_NUMBERS.md
+++ b/developer_docs/api/API_ADMISSION_NUMBERS.md
@@ -47,12 +47,13 @@ Content-Type: application/json
 ```
 
 ```json
-{ "lastAdmissionNumber": 48250 }
+{ "lastAdmissionNumber": 48250, "expectedLastAdmissionNumber": 48213 }
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | lastAdmissionNumber | Yes | The corrected **last-used** number, not the next number. The next auto-generated number will be this value + 1 |
+| expectedLastAdmissionNumber | Yes | Compare-and-set precondition: the `lastAdmissionNumber` value most recently observed via `GET`. The reset only applies if the counter's current effective value still matches this — otherwise it means an admission was issued after the `GET` and the reset is rejected (`409`) rather than silently rewinding the sequence past a number already handed out |
 
 **Response 200:**
 ```json
@@ -71,12 +72,13 @@ Content-Type: application/json
 }
 ```
 
-If no counter row exists yet for the series, one is created with `lastAdmissionNumber` set to the value supplied.
+If no counter row exists yet for the series, one is created with `lastAdmissionNumber` set to the value supplied. In that case the "current effective value" checked against `expectedLastAdmissionNumber` is the same self-initializing, count-based value `GET` would have reported (not `null`).
 
 **Errors:**
-- `400` — missing `admissionTypeId` query param, missing/invalid JSON body, or missing `lastAdmissionNumber` in the body
+- `400` — missing `admissionTypeId` query param, missing/invalid JSON body, or missing/non-numeric/negative `lastAdmissionNumber` or missing/non-numeric `expectedLastAdmissionNumber`
 - `401` — invalid or missing `Finance` API key
 - `404` — `admissionTypeId` or `institutionId` does not resolve to an existing record
+- `409` — `expectedLastAdmissionNumber` no longer matches the counter's current value (an admission was issued after the caller's last `GET`) — re-fetch via `GET` and retry with the current value
 - `500` — unexpected server error
 
 Every successful reset is written to the audit log (`AdmissionNumber`, event `Admission Number Counter Reset`) recording the previous and new `lastAdmissionNumber` along with the acting user.

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2245,6 +2245,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
         String oldBhtNo = null;
+        Long oldBhtLong = null;
         if (current.getId() != null) {
             HashMap<String, Object> bhtParams = new HashMap<>();
             bhtParams.put("id", current.getId());
@@ -2253,16 +2254,24 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             if (persisted != null && !persisted.isEmpty()) {
                 oldBhtNo = persisted.get(0);
             }
+            List<Long> persistedBhtLong = getFacade().findLongList(
+                    "select a.bhtLong from Admission a where a.id=:id", bhtParams);
+            if (persistedBhtLong != null && !persistedBhtLong.isEmpty()) {
+                oldBhtLong = persistedBhtLong.get(0);
+            }
         }
         addPatient();
         addGuardian();
         addPatientRoom();
         getFacade().edit(current);
-        if (oldBhtNo != null && !oldBhtNo.equals(current.getBhtNo())) {
+        if ((oldBhtNo != null && !oldBhtNo.equals(current.getBhtNo()))
+                || (oldBhtLong == null ? current.getBhtLong() != 0 : oldBhtLong.longValue() != current.getBhtLong())) {
             Map<String, Object> before = new LinkedHashMap<>();
             before.put("bhtNo", oldBhtNo);
+            before.put("bhtLong", oldBhtLong);
             Map<String, Object> after = new LinkedHashMap<>();
             after.put("bhtNo", current.getBhtNo());
+            after.put("bhtLong", current.getBhtLong());
             auditService.logEncounterAudit(current, "BHT Number Changed",
                     before, after, getSessionController().getLoggedUser());
         }
@@ -2479,19 +2488,26 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         savePatient();
         savePatientAllergies();
         saveGuardian();
-        // Always reserve the next BHT number from the counter
-        String generatedBht = getInwardBean().getBhtText(getCurrent().getAdmissionType());
         boolean bhtCanBeEdited = configOptionApplicationController.getBooleanValueByKey("BHT Number can be edited at the time of admission");
-        if (bhtCanBeEdited && bhtText != null && !bhtText.trim().isEmpty()
-                && !bhtText.trim().equals(generatedBht)) {
-            // User explicitly overrode the BHT text — keep their value
+        String suggestedBht = getInwardBean().getBhtTextPreview(getCurrent().getAdmissionType());
+        boolean userOverrodeBht = bhtCanBeEdited && bhtText != null && !bhtText.trim().isEmpty()
+                && !bhtText.trim().equals(suggestedBht);
+
+        long oldBhtLong = getCurrent().getBhtLong();
+        String oldBhtNo = getCurrent().getBhtNo();
+
+        if (userOverrodeBht) {
+            // Staff-entered value — do not draw a counter number, do not touch bhtLong.
+            getCurrent().setBhtNo(bhtText);
         } else {
+            String generatedBht = getInwardBean().getBhtText(getCurrent().getAdmissionType()); // mutates, only when it will be used
             bhtText = generatedBht;
+            getCurrent().setBhtNo(bhtText);
+            if (getInwardBean().getLastGeneratedBhtLong() != null) {
+                getCurrent().setBhtLong(getInwardBean().getLastGeneratedBhtLong());
+            }
         }
-        getCurrent().setBhtNo(getBhtText());
-        if (getInwardBean().getLastGeneratedBhtLong() != null) {
-            getCurrent().setBhtLong(getInwardBean().getLastGeneratedBhtLong());
-        }
+
         getCurrent().setPaymentScheme(paymentScheme);
         getCurrent().setForiegner(patientForiegner);
 
@@ -2505,6 +2521,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             getCurrent().setDepartment(sessionController.getDepartment());
             getFacade().create(getCurrent());
             JsfUtil.addSuccessMessage("Patient admitted successfully with BHT No: " + getCurrent().getBhtNo());
+        }
+
+        // Logged after create()/edit() so getCurrent().getId() is populated and the
+        // audit event can be traced back to this admission (objectId/patientEncounterId).
+        if ((oldBhtNo == null ? getCurrent().getBhtNo() != null : !oldBhtNo.equals(getCurrent().getBhtNo()))
+                || oldBhtLong != getCurrent().getBhtLong()) {
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("bhtNo", oldBhtNo);
+            before.put("bhtLong", oldBhtLong);
+            Map<String, Object> after = new LinkedHashMap<>();
+            after.put("bhtNo", getCurrent().getBhtNo());
+            after.put("bhtLong", getCurrent().getBhtLong());
+            auditService.logEncounterAudit(getCurrent(), "BHT Number Assigned", before, after,
+                    getSessionController().getLoggedUser());
         }
 
         // Only create a PatientRoom record when a facility charge is actually selected.

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -1204,6 +1204,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         
         m.put("encounterID", o.getId());
         m.put("bhtNo", o.getBhtNo());
+        m.put("bhtLong", o.getBhtLong());
         m.put("encounterType", o.getEncounterType());
         m.put("dateOfAdmission", o.getDateOfAdmission());
         m.put("paymentMethod", o.getPaymentMethod());

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -3799,6 +3799,9 @@ public class BillNumberGenerator {
      */
     public Object[] resetAdmissionNumber(AdmissionType admissionType, Institution institution,
             boolean institutionBased, Long newLastAdmissionNumber, Long expectedLastAdmissionNumber) {
+        if (institutionBased && institution == null) {
+            throw new IllegalArgumentException("Institution is required when institutionBased is true.");
+        }
         String lockKey = getBhtLockKey(admissionType, institution, institutionBased);
         ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
         lock.lock();

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -3771,6 +3771,52 @@ public class BillNumberGenerator {
         return an;
     }
 
+    /**
+     * Resets the stored counter for an admission-number series to an explicit
+     * value (e.g. after staff manually correct a printed BHT/OPD-card number
+     * and need the next auto-generated number to continue from the correction).
+     * Uses the same lock as the generator methods so it serializes against an
+     * in-flight fetchNextAdmissionNumber on this JVM, and the same cache-bypass
+     * read (findAdmissionNumberRecord -> findFreshByJpql) / immediate-flush write
+     * (createAndFlush/editAndFlush) already relied on elsewhere in this class, so
+     * every app instance sees the correction on its very next generation call.
+     *
+     * @return a two-element result: [0] = the previous lastAdmissionNumber
+     *         value (Long, null if no counter row existed yet), [1] = the
+     *         AdmissionNumber row's id (Long) so the caller can audit-log
+     *         against the actual entity, not the AdmissionType.
+     */
+    public Object[] resetAdmissionNumber(AdmissionType admissionType, Institution institution,
+            boolean institutionBased, Long newLastAdmissionNumber) {
+        String lockKey = getBhtLockKey(admissionType, institution, institutionBased);
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            AdmissionNumber an = findAdmissionNumberRecord(admissionType, institution, institutionBased);
+            Long previous = an == null ? null : an.getLastAdmissionNumber();
+            if (an == null) {
+                an = new AdmissionNumber();
+                if (admissionType != null && admissionType.isGenerateSeparateAdmissionNumber()) {
+                    an.setAdmissionType(admissionType);
+                }
+                if (admissionType != null) {
+                    an.setAdmissionTypeEnum(admissionType.getAdmissionTypeEnum());
+                }
+                if (institutionBased && institution != null) {
+                    an.setInstitution(institution);
+                }
+                an.setLastAdmissionNumber(newLastAdmissionNumber);
+                admissionNumberFacade.createAndFlush(an);
+            } else {
+                an.setLastAdmissionNumber(newLastAdmissionNumber);
+                admissionNumberFacade.editAndFlush(an);
+            }
+            return new Object[]{previous, an.getId()};
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private AdmissionNumber findAdmissionNumberRecord(AdmissionType admissionType, Institution institution, boolean institutionBased) {
         StringBuilder sql = new StringBuilder("SELECT an FROM AdmissionNumber an WHERE an.retired=false");
         HashMap<String, Object> hm = new HashMap<>();

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -3781,19 +3781,44 @@ public class BillNumberGenerator {
      * (createAndFlush/editAndFlush) already relied on elsewhere in this class, so
      * every app instance sees the correction on its very next generation call.
      *
-     * @return a two-element result: [0] = the previous lastAdmissionNumber
-     *         value (Long, null if no counter row existed yet), [1] = the
-     *         AdmissionNumber row's id (Long) so the caller can audit-log
+     * @param expectedLastAdmissionNumber compare-and-set precondition: the
+     *        value the caller last observed (e.g. via {@link #peekNextAdmissionNumber}
+     *        minus 1, or this method's own previous-value result). If non-null
+     *        and it no longer matches the counter's current effective value
+     *        (checked inside the same lock a normal generation call would use),
+     *        the reset is rejected with a {@link java.util.ConcurrentModificationException}
+     *        instead of silently rewinding the sequence past numbers already
+     *        issued by a concurrent admission. Pass null to skip the check.
+     * @return a two-element result: [0] = the previous effective lastAdmissionNumber
+     *         value (Long — the self-initialized count-based value when no counter
+     *         row exists yet, matching what peekNextAdmissionNumber would report),
+     *         [1] = the AdmissionNumber row's id (Long) so the caller can audit-log
      *         against the actual entity, not the AdmissionType.
+     * @throws java.util.ConcurrentModificationException if expectedLastAdmissionNumber
+     *         is supplied and does not match the counter's current effective value
      */
     public Object[] resetAdmissionNumber(AdmissionType admissionType, Institution institution,
-            boolean institutionBased, Long newLastAdmissionNumber) {
+            boolean institutionBased, Long newLastAdmissionNumber, Long expectedLastAdmissionNumber) {
         String lockKey = getBhtLockKey(admissionType, institution, institutionBased);
         ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
         lock.lock();
         try {
             AdmissionNumber an = findAdmissionNumberRecord(admissionType, institution, institutionBased);
-            Long previous = an == null ? null : an.getLastAdmissionNumber();
+            Long previous;
+            if (an == null) {
+                Long count = computeAdmissionCount(admissionType, institution, institutionBased);
+                long addition = (admissionType != null) ? admissionType.getAdditionToCount() : 0;
+                previous = count + addition;
+            } else {
+                previous = an.getLastAdmissionNumber();
+            }
+
+            if (expectedLastAdmissionNumber != null && !expectedLastAdmissionNumber.equals(previous)) {
+                throw new java.util.ConcurrentModificationException(
+                        "Counter changed since it was last read: expected " + expectedLastAdmissionNumber
+                        + " but current value is " + previous);
+            }
+
             if (an == null) {
                 an = new AdmissionNumber();
                 if (admissionType != null && admissionType.isGenerateSeparateAdmissionNumber()) {

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -348,7 +348,11 @@ public class AnthropicApiService implements Serializable {
                 .add("description",
                         "View or reset the BHT/OPD-card admission-number sequence counter for an admission type. "
                         + "Use GET to check the current counter and next number. Use PUT only when staff have manually "
-                        + "corrected a printed BHT/OPD-card number and confirmed what the next number should be.")
+                        + "corrected a printed BHT/OPD-card number and confirmed what the next number should be. "
+                        + "This resets a live, shared numbering sequence used by all staff admitting patients under "
+                        + "this admission type — before calling PUT, always state the current last/next number (from "
+                        + "GET) and the requested new last/next number back to the user, and wait for their explicit "
+                        + "confirmation in the same conversation. Never call PUT speculatively or without that confirmation.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")
                         .add("properties", Json.createObjectBuilder()
@@ -364,7 +368,10 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "Numeric Institution ID (optional, only relevant if institution-based numbering is enabled)."))
                                 .add("lastAdmissionNumber", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "The corrected last-used number. Required for PUT; the next generated number will be this + 1.")))
+                                        .add("description", "The corrected last-used number. Required for PUT; the next generated number will be this + 1."))
+                                .add("expectedLastAdmissionNumber", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Required for PUT. The lastAdmissionNumber value most recently observed via GET — used as a compare-and-set precondition so the reset is rejected (409) if the counter changed since it was read.")))
                         .add("required", Json.createArrayBuilder().add("method").add("admissionTypeId")))
                 .build();
 
@@ -1844,7 +1851,8 @@ public class AnthropicApiService implements Serializable {
                     String admissionTypeId = toolInput.containsKey("admissionTypeId") ? toolInput.getString("admissionTypeId", "") : "";
                     String institutionId = toolInput.containsKey("institutionId") ? toolInput.getString("institutionId", "") : "";
                     String lastAdmissionNumber = toolInput.containsKey("lastAdmissionNumber") ? toolInput.getString("lastAdmissionNumber", "") : "";
-                    return callAdmissionNumberApi(method, admissionTypeId, institutionId, lastAdmissionNumber, hmisBaseUrl, hmisApiKey);
+                    String expectedLastAdmissionNumber = toolInput.containsKey("expectedLastAdmissionNumber") ? toolInput.getString("expectedLastAdmissionNumber", "") : "";
+                    return callAdmissionNumberApi(method, admissionTypeId, institutionId, lastAdmissionNumber, expectedLastAdmissionNumber, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_clinical_metadata": {
                     String method = toolInput.getString("method", "GET");
@@ -2506,7 +2514,7 @@ public class AnthropicApiService implements Serializable {
     }
 
     private String callAdmissionNumberApi(String method, String admissionTypeId, String institutionId,
-            String lastAdmissionNumber, String hmisBaseUrl, String hmisApiKey) {
+            String lastAdmissionNumber, String expectedLastAdmissionNumber, String hmisBaseUrl, String hmisApiKey) {
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
             return "Error: HMIS base URL is not configured. Cannot call admission number API.";
         }
@@ -2541,6 +2549,10 @@ public class AnthropicApiService implements Serializable {
                     if (lastAdmissionNumber == null || lastAdmissionNumber.trim().isEmpty()) {
                         return "Error: lastAdmissionNumber is required for PUT.";
                     }
+                    if (expectedLastAdmissionNumber == null || expectedLastAdmissionNumber.trim().isEmpty()) {
+                        return "Error: expectedLastAdmissionNumber is required for PUT (the lastAdmissionNumber "
+                                + "value most recently observed via GET).";
+                    }
                     StringBuilder urlBuilder = new StringBuilder(base)
                             .append("?admissionTypeId=").append(URLEncoder.encode(admissionTypeId.trim(), StandardCharsets.UTF_8));
                     if (institutionId != null && !institutionId.trim().isEmpty()) {
@@ -2550,6 +2562,7 @@ public class AnthropicApiService implements Serializable {
                     httpMethod = "PUT";
                     javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
                     bodyBuilder.add("lastAdmissionNumber", Long.parseLong(lastAdmissionNumber.trim()));
+                    bodyBuilder.add("expectedLastAdmissionNumber", Long.parseLong(expectedLastAdmissionNumber.trim()));
                     requestBody = bodyBuilder.build().toString();
                     break;
                 }
@@ -2576,7 +2589,7 @@ public class AnthropicApiService implements Serializable {
             Thread.currentThread().interrupt();
             return "Admission number API call interrupted.";
         } catch (NumberFormatException e) {
-            return "Error: lastAdmissionNumber must be a whole number.";
+            return "Error: lastAdmissionNumber and expectedLastAdmissionNumber must be whole numbers.";
         } catch (Exception e) {
             return "Admission number API error: " + e.getMessage();
         }
@@ -5859,11 +5872,11 @@ public class AnthropicApiService implements Serializable {
                 });
 
         appendModule(sb, "Admission Number Counters", "/admission-numbers",
-                "View or reset the BHT/OPD-card admission-number sequence counter for a given admission type (and institution, if institution-based numbering is enabled). Use this only when staff have manually corrected a printed BHT/OPD-card number and need the system's next auto-generated number to continue from that correction.",
+                "View or reset the BHT/OPD-card admission-number sequence counter for a given admission type (and institution, if institution-based numbering is enabled). Use this only when staff have manually corrected a printed BHT/OPD-card number and need the system's next auto-generated number to continue from that correction. This resets a live, shared numbering sequence used by all staff admitting patients under this admission type — before calling PUT, always state the current last/next number (from GET) and the requested new last/next number back to the user, and wait for their explicit confirmation in the same conversation. Never call PUT speculatively or without that confirmation.",
                 null,
                 new String[][]{
                     {"GET", "/admission-numbers", "View the current counter and what the next generated number would be. Params: admissionTypeId (required), institutionId (optional)"},
-                    {"PUT", "/admission-numbers", "Reset the counter to an explicit corrected value so the next generated number is correction+1. Params: admissionTypeId (required), institutionId (optional). Body: {lastAdmissionNumber}"}
+                    {"PUT", "/admission-numbers", "Reset the counter to an explicit corrected value so the next generated number is correction+1. Requires explicit user confirmation of the old/new values before calling. Params: admissionTypeId (required), institutionId (optional). Body: {lastAdmissionNumber}"}
                 });
 
         // ── Clinical ──────────────────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -343,6 +343,31 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method").add("key")))
                 .build();
 
+        JsonObject admissionNumberTool = Json.createObjectBuilder()
+                .add("name", "manage_admission_number_counter")
+                .add("description",
+                        "View or reset the BHT/OPD-card admission-number sequence counter for an admission type. "
+                        + "Use GET to check the current counter and next number. Use PUT only when staff have manually "
+                        + "corrected a printed BHT/OPD-card number and confirmed what the next number should be.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("GET").add("PUT"))
+                                        .add("description", "HTTP method: GET to view, PUT to reset"))
+                                .add("admissionTypeId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Numeric AdmissionType ID. Required."))
+                                .add("institutionId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Numeric Institution ID (optional, only relevant if institution-based numbering is enabled)."))
+                                .add("lastAdmissionNumber", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "The corrected last-used number. Required for PUT; the next generated number will be this + 1.")))
+                        .add("required", Json.createArrayBuilder().add("method").add("admissionTypeId")))
+                .build();
+
         JsonObject clinicalMetadataTool = Json.createObjectBuilder()
                 .add("name", "manage_clinical_metadata")
                 .add("description",
@@ -1748,6 +1773,7 @@ public class AnthropicApiService implements Serializable {
                 .add(fetchFileTool)
                 .add(searchConfigTool)
                 .add(manageConfigOptionTool)
+                .add(admissionNumberTool)
                 .add(clinicalMetadataTool)
                 .add(itemRequestTool)
                 .add(collectingCentreFeesTool)
@@ -1812,6 +1838,13 @@ public class AnthropicApiService implements Serializable {
                     String key    = toolInput.containsKey("key")   ? toolInput.getString("key", "")   : "";
                     String value  = toolInput.containsKey("value") ? toolInput.getString("value", "") : null;
                     return manageConfigOption(method, key, value, hmisApiKey);
+                }
+                case "manage_admission_number_counter": {
+                    String method = toolInput.getString("method", "GET");
+                    String admissionTypeId = toolInput.containsKey("admissionTypeId") ? toolInput.getString("admissionTypeId", "") : "";
+                    String institutionId = toolInput.containsKey("institutionId") ? toolInput.getString("institutionId", "") : "";
+                    String lastAdmissionNumber = toolInput.containsKey("lastAdmissionNumber") ? toolInput.getString("lastAdmissionNumber", "") : "";
+                    return callAdmissionNumberApi(method, admissionTypeId, institutionId, lastAdmissionNumber, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_clinical_metadata": {
                     String method = toolInput.getString("method", "GET");
@@ -2470,6 +2503,83 @@ public class AnthropicApiService implements Serializable {
             return "***masked***";
         }
         return value;
+    }
+
+    private String callAdmissionNumberApi(String method, String admissionTypeId, String institutionId,
+            String lastAdmissionNumber, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured. Cannot call admission number API.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+        if (admissionTypeId == null || admissionTypeId.trim().isEmpty()) {
+            return "Error: admissionTypeId is required.";
+        }
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            String base = hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/admission-numbers";
+            String url;
+            String requestBody = null;
+            String httpMethod;
+
+            switch (method.toUpperCase()) {
+                case "GET": {
+                    StringBuilder urlBuilder = new StringBuilder(base)
+                            .append("?admissionTypeId=").append(URLEncoder.encode(admissionTypeId.trim(), StandardCharsets.UTF_8));
+                    if (institutionId != null && !institutionId.trim().isEmpty()) {
+                        urlBuilder.append("&institutionId=").append(URLEncoder.encode(institutionId.trim(), StandardCharsets.UTF_8));
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "GET";
+                    break;
+                }
+                case "PUT": {
+                    if (lastAdmissionNumber == null || lastAdmissionNumber.trim().isEmpty()) {
+                        return "Error: lastAdmissionNumber is required for PUT.";
+                    }
+                    StringBuilder urlBuilder = new StringBuilder(base)
+                            .append("?admissionTypeId=").append(URLEncoder.encode(admissionTypeId.trim(), StandardCharsets.UTF_8));
+                    if (institutionId != null && !institutionId.trim().isEmpty()) {
+                        urlBuilder.append("&institutionId=").append(URLEncoder.encode(institutionId.trim(), StandardCharsets.UTF_8));
+                    }
+                    url = urlBuilder.toString();
+                    httpMethod = "PUT";
+                    javax.json.JsonObjectBuilder bodyBuilder = Json.createObjectBuilder();
+                    bodyBuilder.add("lastAdmissionNumber", Long.parseLong(lastAdmissionNumber.trim()));
+                    requestBody = bodyBuilder.build().toString();
+                    break;
+                }
+                default:
+                    return "Error: Unknown method: " + method;
+            }
+
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .header("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                reqBuilder.method(httpMethod, HttpRequest.BodyPublishers.ofString(requestBody));
+            } else {
+                reqBuilder.GET();
+            }
+
+            HttpResponse<String> response = client.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Admission number API call interrupted.";
+        } catch (NumberFormatException e) {
+            return "Error: lastAdmissionNumber must be a whole number.";
+        } catch (Exception e) {
+            return "Admission number API error: " + e.getMessage();
+        }
     }
 
     private String callClinicalMetadataApi(String method, String type, String id,
@@ -5746,6 +5856,14 @@ public class AnthropicApiService implements Serializable {
                 null,
                 new String[][]{
                     {"GET", "/sap/inventory/sync", "Trigger SAP MM goods-receipt sync. Query params: fromDate (yyyy-MM-dd, optional), toDate (yyyy-MM-dd, optional)"}
+                });
+
+        appendModule(sb, "Admission Number Counters", "/admission-numbers",
+                "View or reset the BHT/OPD-card admission-number sequence counter for a given admission type (and institution, if institution-based numbering is enabled). Use this only when staff have manually corrected a printed BHT/OPD-card number and need the system's next auto-generated number to continue from that correction.",
+                null,
+                new String[][]{
+                    {"GET", "/admission-numbers", "View the current counter and what the next generated number would be. Params: admissionTypeId (required), institutionId (optional)"},
+                    {"PUT", "/admission-numbers", "Reset the counter to an explicit corrected value so the next generated number is correction+1. Params: admissionTypeId (required), institutionId (optional). Body: {lastAdmissionNumber}"}
                 });
 
         // ── Clinical ──────────────────────────────────────────────────────────

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -63,6 +63,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.institution.SiteApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
+        resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
         resources.add(com.divudi.ws.inward.InwardDocumentTemplateApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -146,6 +146,9 @@ public class CapabilityStatementResource {
                         "Inward patient workflows",
                         "API Key",
                         "GET", "POST"))
+                .add(resource("Admission Number Counters", "/api/admission-numbers",
+                        "View or reset the BHT/OPD-card admission-number sequence counter for an admission type.",
+                        "API Key (Finance header)", "GET", "PUT"))
                 .add(resource("Inward Discount Matrix", "/api/inward-discount-matrix",
                         "Manage inward discount matrix entries for services/investigations and pharmacy. "
                         + "Supports scope=service|pharmacy to restrict category types. "

--- a/src/main/java/com/divudi/ws/inward/AdmissionNumberApi.java
+++ b/src/main/java/com/divudi/ws/inward/AdmissionNumberApi.java
@@ -122,9 +122,12 @@ public class AdmissionNumberApi {
 
     /**
      * Reset the counter to an explicit corrected value so the next generated
-     * number is correction+1.
+     * number is correction+1. Requires expectedLastAdmissionNumber (the value
+     * last observed via GET) as a compare-and-set precondition, so a reset
+     * based on stale information is rejected (409) instead of silently
+     * rewinding the sequence past a number a concurrent admission already issued.
      * PUT /api/admission-numbers?admissionTypeId=&institutionId=
-     * Body: { "lastAdmissionNumber": 1234 }
+     * Body: { "lastAdmissionNumber": 1234, "expectedLastAdmissionNumber": 1230 }
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -154,7 +157,26 @@ public class AdmissionNumberApi {
             if (body == null || !body.has("lastAdmissionNumber")) {
                 return errorResponse("lastAdmissionNumber is required in the request body", 400);
             }
-            Long newLastAdmissionNumber = body.get("lastAdmissionNumber").getAsLong();
+            Long newLastAdmissionNumber;
+            try {
+                newLastAdmissionNumber = body.get("lastAdmissionNumber").getAsLong();
+            } catch (Exception e) {
+                return errorResponse("lastAdmissionNumber must be a numeric value", 400);
+            }
+            if (newLastAdmissionNumber < 0) {
+                return errorResponse("lastAdmissionNumber must not be negative", 400);
+            }
+            if (!body.has("expectedLastAdmissionNumber")) {
+                return errorResponse("expectedLastAdmissionNumber is required in the request body "
+                        + "(the lastAdmissionNumber value most recently observed via GET, used as a "
+                        + "compare-and-set precondition)", 400);
+            }
+            Long expectedLastAdmissionNumber;
+            try {
+                expectedLastAdmissionNumber = body.get("expectedLastAdmissionNumber").getAsLong();
+            } catch (Exception e) {
+                return errorResponse("expectedLastAdmissionNumber must be a numeric value", 400);
+            }
 
             boolean institutionBased = configOptionApplicationController.getBooleanValueByKey(
                     "Generate Separate BHT Number Series for Each Institution");
@@ -166,7 +188,23 @@ public class AdmissionNumberApi {
                 }
             }
 
-            Object[] result = billNumberGenerator.resetAdmissionNumber(admissionType, institution, institutionBased, newLastAdmissionNumber);
+            Object[] result;
+            try {
+                result = billNumberGenerator.resetAdmissionNumber(admissionType, institution, institutionBased,
+                        newLastAdmissionNumber, expectedLastAdmissionNumber);
+            } catch (Exception e) {
+                // BillNumberGenerator is an EJB — container wraps unchecked exceptions
+                // thrown from business methods in EJBException, so the compare-and-set
+                // conflict must be unwrapped from the cause chain here.
+                Throwable cause = e;
+                while (cause != null && !(cause instanceof java.util.ConcurrentModificationException)) {
+                    cause = cause.getCause();
+                }
+                if (cause != null) {
+                    return errorResponse(cause.getMessage() + " — re-fetch via GET and retry with the current value.", 409);
+                }
+                throw e;
+            }
             Long previous = (Long) result[0];
             Long admissionNumberId = (Long) result[1];
 

--- a/src/main/java/com/divudi/ws/inward/AdmissionNumberApi.java
+++ b/src/main/java/com/divudi/ws/inward/AdmissionNumberApi.java
@@ -1,0 +1,255 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.inward;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.AdmissionTypeFacade;
+import com.divudi.core.facade.InstitutionFacade;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.service.AuditService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * REST API for viewing and resetting the BHT/OPD-card admission-number
+ * sequence counter (AdmissionNumber) for a given AdmissionType (and
+ * Institution, when institution-based numbering is enabled).
+ *
+ * Intended for use after staff have manually corrected a printed BHT/OPD-card
+ * number, so the system's next auto-generated number can be realigned to
+ * continue from the correction (issue #22336).
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Path("admission-numbers")
+@RequestScoped
+public class AdmissionNumberApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private AdmissionTypeFacade admissionTypeFacade;
+
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    @EJB
+    private BillNumberGenerator billNumberGenerator;
+
+    @EJB
+    private AuditService auditService;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * View the current counter and what the next generated number would be.
+     * GET /api/admission-numbers?admissionTypeId=&institutionId=
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getCounter(@QueryParam("admissionTypeId") Long admissionTypeId,
+            @QueryParam("institutionId") Long institutionId) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (admissionTypeId == null) {
+                return errorResponse("admissionTypeId is required", 400);
+            }
+            AdmissionType admissionType = admissionTypeFacade.find(admissionTypeId);
+            if (admissionType == null) {
+                return errorResponse("Admission type not found: " + admissionTypeId, 404);
+            }
+            boolean institutionBased = configOptionApplicationController.getBooleanValueByKey(
+                    "Generate Separate BHT Number Series for Each Institution");
+            Institution institution = null;
+            if (institutionId != null) {
+                institution = institutionFacade.find(institutionId);
+                if (institution == null) {
+                    return errorResponse("Institution not found: " + institutionId, 404);
+                }
+            }
+            Long nextNumber = billNumberGenerator.peekNextAdmissionNumber(admissionType, institution, institutionBased);
+            Map<String, Object> data = new HashMap<>();
+            data.put("admissionTypeId", admissionType.getId());
+            data.put("admissionTypeName", admissionType.getName());
+            data.put("institutionId", institution != null ? institution.getId() : null);
+            data.put("institutionBased", institutionBased);
+            data.put("lastAdmissionNumber", nextNumber - 1);
+            data.put("nextAdmissionNumber", nextNumber);
+            return successResponse(data);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Reset the counter to an explicit corrected value so the next generated
+     * number is correction+1.
+     * PUT /api/admission-numbers?admissionTypeId=&institutionId=
+     * Body: { "lastAdmissionNumber": 1234 }
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response resetCounter(@QueryParam("admissionTypeId") Long admissionTypeId,
+            @QueryParam("institutionId") Long institutionId,
+            String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            if (admissionTypeId == null) {
+                return errorResponse("admissionTypeId is required", 400);
+            }
+            AdmissionType admissionType = admissionTypeFacade.find(admissionTypeId);
+            if (admissionType == null) {
+                return errorResponse("Admission type not found: " + admissionTypeId, 404);
+            }
+            JsonObject body;
+            try {
+                body = gson.fromJson(requestBody, JsonObject.class);
+            } catch (Exception e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null || !body.has("lastAdmissionNumber")) {
+                return errorResponse("lastAdmissionNumber is required in the request body", 400);
+            }
+            Long newLastAdmissionNumber = body.get("lastAdmissionNumber").getAsLong();
+
+            boolean institutionBased = configOptionApplicationController.getBooleanValueByKey(
+                    "Generate Separate BHT Number Series for Each Institution");
+            Institution institution = null;
+            if (institutionId != null) {
+                institution = institutionFacade.find(institutionId);
+                if (institution == null) {
+                    return errorResponse("Institution not found: " + institutionId, 404);
+                }
+            }
+
+            Object[] result = billNumberGenerator.resetAdmissionNumber(admissionType, institution, institutionBased, newLastAdmissionNumber);
+            Long previous = (Long) result[0];
+            Long admissionNumberId = (Long) result[1];
+
+            Map<String, Object> before = new HashMap<>();
+            before.put("admissionTypeId", admissionType.getId());
+            before.put("institutionId", institution != null ? institution.getId() : null);
+            before.put("lastAdmissionNumber", previous);
+            Map<String, Object> after = new HashMap<>();
+            after.put("admissionTypeId", admissionType.getId());
+            after.put("institutionId", institution != null ? institution.getId() : null);
+            after.put("lastAdmissionNumber", newLastAdmissionNumber);
+            auditService.logAudit(before, after, user, "AdmissionNumber", "Admission Number Counter Reset", admissionNumberId);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("admissionTypeId", admissionType.getId());
+            data.put("admissionTypeName", admissionType.getName());
+            data.put("institutionId", institution != null ? institution.getId() : null);
+            data.put("institutionBased", institutionBased);
+            data.put("previousLastAdmissionNumber", previous);
+            data.put("lastAdmissionNumber", newLastAdmissionNumber);
+            data.put("nextAdmissionNumber", newLastAdmissionNumber + 1);
+            return successResponse(data);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // Private helper methods
+
+    /**
+     * Validate API key and return associated user
+     * Follows same pattern as DepartmentApi
+     */
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) {
+            return null;
+        }
+
+        WebUser user = apiKey.getWebUser();
+        if (user == null) {
+            return null;
+        }
+
+        if (user.isRetired()) {
+            return null;
+        }
+
+        if (!user.isActivated()) {
+            return null;
+        }
+
+        // Treat null expiry date as expired
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) {
+            return null;
+        }
+
+        return user;
+    }
+
+    /**
+     * Create error response following DepartmentApi pattern
+     */
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    /**
+     * Create success response following DepartmentApi pattern
+     */
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.status(200).entity(gson.toJson(response)).build();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #22336 — BHT/OPD-card admission numbers at Galle Co-Operative Hospital were coming out "out of order," forcing staff to hand-edit numbers to keep their printed card sequence gap-free.

**Root cause:** `AdmissionController.saveSelected()` always drew a number from the shared `AdmissionType` counter (via the mutating `getBhtText()`) even when staff overrode the suggested BHT/OPD-card text, then unconditionally overwrote `bhtLong` with the now-discarded number. This silently burned counter values, creating permanent gaps in the visible sequence.

## Changes

1. **Fix (`AdmissionController.saveSelected()`)** — only draws a real counter number (mutating `getBhtText()`) when the auto-generated value is actually going to be used. When staff override the suggestion, the code now uses the non-mutating `getBhtTextPreview()` to detect the override and leaves the counter and `bhtLong` untouched (confirmed via `grep` that `bhtLong` is not read anywhere else in the codebase — no JPQL, no XHTML, no reports — so this is safe).

2. **Audit trail** — every BHT number assignment/change is now logged with both `bhtNo` and `bhtLong` before/after:
   - New audit call in `saveSelected()` (`"BHT Number Assigned"`), placed *after* `create()`/`edit()` so the audit event correctly links to the persisted admission's id.
   - `updateBHTNo()` extended to also capture/log `bhtLong` (previously only tracked `bhtNo`).
   - `BhtEditController.admissionToAuditMap(...)` now includes `bhtLong`, extending coverage to the `UpdateAdmission` diff and `Admission Cancelled` audit events.

3. **Admin reset API** — `BillNumberGenerator.resetAdmissionNumber(...)` plus a new `GET`/`PUT /api/admission-numbers` REST endpoint (`Finance` header auth, following `DepartmentApi` conventions) so staff corrections can be used to resync a counter after a manual fix. Uses the same in-JVM lock, cache-bypass read (`findAdmissionNumberRecord` → `findFreshByJpql`), and immediate-flush write (`createAndFlush`/`editAndFlush`) already relied on elsewhere in `BillNumberGenerator`, so a reset is visible to every app instance's very next generation call with no restart needed. Registered in `ApplicationConfig` and `CapabilityStatementResource`, documented in `developer_docs/api/API_ADMISSION_NUMBERS.md`, and wired into the AI chat assistant (`AnthropicApiService`) as the `manage_admission_number_counter` tool.

## Test plan (local `coop` DB + local Payara only — no production access)

- [x] Admitted a patient under "OPD Card", overrode the suggested `OPDCARD/43472` with `OPDCARD/99001`, saved — confirmed `bhtNo` = override, `bhtLong` stayed `0` (untouched), and the `AdmissionNumber` counter was **not** incremented (stayed at 43471).
- [x] Admitted a second patient without overriding — confirmed the counter incremented by exactly 1 (43471 → 43472), and `bhtNo`/`bhtLong` matched the generated value.
- [x] Confirmed `AUDITEVENT` rows (in the audit DB) for both saves: `"BHT Number Assigned"` with correct before/after JSON including `bhtLong`, correctly linked via `patientEncounterId`.
- [x] `GET /api/admission-numbers?admissionTypeId=1192` — confirmed reported counter matches DB.
- [x] `PUT /api/admission-numbers?admissionTypeId=1192` with a corrected value — confirmed immediate DB update (no restart), an `Admission Number Counter Reset` audit event with the correct `AdmissionNumber` row id (caught and fixed an initial bug where this was set to the `AdmissionType` id instead), then reset the test counter back to its correct value.
- [x] `mvn -q compile` clean.

Full verification writeup with screenshots: #22336 (comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Admission Number Counters** REST endpoints to **view (GET)** and **reset (PUT)** BHT/OPD admission-number sequences, including institution-based numbering when enabled.
  * Added compare-and-set safety on reset; returns **409** when the counter state has changed since the last fetch.
  * Extended assistant capabilities to view or reset the counters via the new endpoints.
* **Improvements**
  * Improved BHT handling by tracking both display and numeric forms, honoring user overrides during editing, and recording additional audit events when values change.
* **Documentation**
  * Documented the new endpoints, request/response fields, and **API key (Finance header)** authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->