### PR TITLE
Fix blank-page print bug: popup print() races stylesheet load

### DIFF
--- a/src/main/webapp/resources/optician/saleBill_Header.xhtml
+++ b/src/main/webapp/resources/optician/saleBill_Header.xhtml
@@ -348,8 +348,13 @@ function printBill() {
         printWindow.close();
     };
 
-    // Trigger the print functionality for the print window
-    printWindow.print();
+    // Wait for the popup (including the linked stylesheet) to finish loading
+    // before printing - printing immediately after document.close() races the
+    // browser's rendering of the popup and can produce a blank page.
+    printWindow.onload = function() {
+        printWindow.focus();
+        printWindow.print();
+    };
 }
 </script>
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header.xhtml
@@ -366,8 +366,13 @@ function printBill() {
         printWindow.close();
     };
 
-    // Trigger the print functionality for the print window
-    printWindow.print();
+    // Wait for the popup (including the linked stylesheet) to finish loading
+    // before printing - printing immediately after document.close() races the
+    // browser's rendering of the popup and can produce a blank page.
+    printWindow.onload = function() {
+        printWindow.focus();
+        printWindow.print();
+    };
 }
 </script>
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Cancel.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Cancel.xhtml
@@ -414,8 +414,13 @@ function printBill() {
         printWindow.close();
     };
 
-    // Trigger the print functionality for the print window
-    printWindow.print();
+    // Wait for the popup (including the linked stylesheet) to finish loading
+    // before printing - printing immediately after document.close() races the
+    // browser's rendering of the popup and can produce a blank page.
+    printWindow.onload = function() {
+        printWindow.focus();
+        printWindow.print();
+    };
 }
 </script>
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Inward.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Inward.xhtml
@@ -366,8 +366,13 @@ function printBill() {
         printWindow.close();
     };
 
-    // Trigger the print functionality for the print window
-    printWindow.print();
+    // Wait for the popup (including the linked stylesheet) to finish loading
+    // before printing - printing immediately after document.close() races the
+    // browser's rendering of the popup and can produce a blank page.
+    printWindow.onload = function() {
+        printWindow.focus();
+        printWindow.print();
+    };
 }
 </script>
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
@@ -366,8 +366,13 @@ function printBill() {
         printWindow.close();
     };
 
-    // Trigger the print functionality for the print window
-    printWindow.print();
+    // Wait for the popup (including the linked stylesheet) to finish loading
+    // before printing - printing immediately after document.close() races the
+    // browser's rendering of the popup and can produce a blank page.
+    printWindow.onload = function() {
+        printWindow.focus();
+        printWindow.print();
+    };
 }
 </script>
     </cc:implementation>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Transfer.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Transfer.xhtml
@@ -302,8 +302,13 @@
                     printWindow.close();
                 };
 
-                // Trigger the print functionality for the print window
-                printWindow.print();
+                // Wait for the popup (including the linked stylesheet) to finish loading
+                // before printing - printing immediately after document.close() races the
+                // browser's rendering of the popup and can produce a blank page.
+                printWindow.onload = function () {
+                    printWindow.focus();
+                    printWindow.print();
+                };
             }
         </script>
     </cc:implementation>


### PR DESCRIPTION
## Summary
- The native-printer `printBill()` JS function intermittently printed a blank page: it opened a popup via `window.open('', '_blank')`, wrote the bill HTML plus a linked stylesheet via `document.write`/`document.close()`, then called `printWindow.print()` **immediately** afterward — racing the popup's own load of the linked stylesheet. When the popup hadn't finished loading/painting yet (network/cache timing dependent), Chrome handed the print pipeline an unrendered document, producing a blank printed page.
- Fixed by deferring `print()` until the popup's own `onload` event fires, i.e. after its linked stylesheet has actually loaded.
- Applied identically to all 6 affected composites: `saleBill_Header.xhtml`, `saleBill_Header_Cancel.xhtml`, `saleBill_Header_Inward.xhtml`, `saleBill_Header_Return.xhtml`, `saleBill_Header_Transfer.xhtml` (pharmacy), and the optician `saleBill_Header.xhtml`.
- This ports the identical fix already merged on `southernlanka-prod` (PR #22340) to `development`.

## Test plan
- JSF/JS-only change (no Java, no schema) — per project convention this does not require a Java rebuild/redeploy.
- Not verified via Playwright: the native print flow opens a real browser print dialog, which automated browser tooling cannot reliably dismiss, so this was verified by direct code comparison against the already-merged and working fix on `southernlanka-prod` rather than a fresh browser pass.
- [x] Diff matches the already-merged, production-verified fix on `southernlanka-prod` (PR #22340) line-for-line across all 6 files.

Closes #22342

🤖 Generated with [Claude Code](https://claude.com/claude-code)