### PR TITLE
Make inward service fees discoverable and site-scoped per department like OPD

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -6050,6 +6050,9 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
             case FUND_SHIFT_SHORTAGE_BILL:
             case FUND_SHIFT_SHORTAGE_SETTLEMENT_BILL:
                 return navigateToViewCashierShiftShortageBill(bill);
+            case INWARD_SERVICE_BILL:
+            case INWARD_SERVICE_BATCH_BILL:
+                return navigateToInwardSearchService();
             //                opdBillController.setBill(bill);
 //                return opdBillController.navigateToViewPackageBatchBill();
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -17,6 +17,7 @@ import com.divudi.bean.common.ItemApplicationController;
 import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.ItemFeeManager;
 import com.divudi.bean.common.ItemMappingController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
@@ -27,7 +28,11 @@ import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.FeeType;
+import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.data.inward.SurgeryBillType;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.core.entity.Bill;
@@ -79,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -116,6 +122,8 @@ public class BillBhtController implements Serializable {
     DepartmentController departmentController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    PageMetadataRegistry pageMetadataRegistry;
     /////////////////
     @EJB
     private ItemFeeFacade itemFeeFacade;
@@ -192,6 +200,108 @@ public class BillBhtController implements Serializable {
     
     private Priority currentBillItemPriority;
     private Double currentBillItemQty;
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata();
+        metadata.setPagePath("inward/inward_bill_service");
+        metadata.setPageName("Inward Add Services");
+        metadata.setDescription("Adds services, investigations, and their fees to an inpatient's bill");
+        metadata.setControllerClass("BillBhtController");
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Bill Fees are based on the site for " + sessionController.getDepartment().getName(),
+                "Uses site-specific bill fees (falling back to base fees when none exist for the site) when adding services to the inward bill. Mirrors the equivalent OPD option.",
+                "BillBhtController.java: billFeeFromBillItemWithMatrix() method",
+                OptionScope.DEPARTMENT
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Use Sample Management for Inward Service and Investigations",
+                "Routes the print-preview 'Manage Samples' action to sample management instead of direct label printing",
+                "inward_bill_service.xhtml: print-preview action buttons",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is POS Paper",
+                "Uses POS paper format for the inward service bill print preview",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is A4 Paper",
+                "Uses A4 paper format for the inward service bill print preview",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is A4Printed Paper",
+                "Uses A4 pre-printed paper format for the inward service bill print preview",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is FiveFiveCustom3 Paper",
+                "Uses the FiveFiveCustom3 paper format for the inward service bill print preview",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is 5x8 inch Paper",
+                "Uses the 5x8 inch paper format for the inward service bill print preview",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Inward Servise Bill size is FiveFivePrinted paper",
+                "Uses the FiveFive pre-printed paper format for the inward service bill print preview (this is also the fallback default when the paper type preference is unset)",
+                "inward_bill_service.xhtml: bill print-preview paper format selection",
+                OptionScope.APPLICATION
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+                "NursingWorkBench",
+                "Access to the Nursing WorkBench navigation button",
+                "inward_bill_service.xhtml: 'Nursing WorkBench' buttons"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+                "InwardSearch",
+                "Access to Search Patients, Patient Profile, and Inpatient Dashboard navigation buttons",
+                "inward_bill_service.xhtml: patient navigation button group"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+                "ShowServiceCharges",
+                "View rate, gross value, discount, service charge, VAT, and net value columns/details for inward services and fees",
+                "inward_bill_service.xhtml: Bill Items and Fees tab columns, Bill Details panel"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+                "ShowInwardFee",
+                "Allows editing the Total Gross value of an inward fee directly in the Fees tab",
+                "inward_bill_service.xhtml: Fees tab, Total Gross input"
+        ));
+
+        pageMetadataRegistry.registerPage(metadata);
+    }
 
     public String navigateToAddServiceFromMenu() {
         resetBillData();
@@ -1036,7 +1146,12 @@ public class BillBhtController implements Serializable {
     public List<BillFee> billFeeFromBillItemWithMatrix(BillItem billItem, PatientEncounter patientEncounter, Department matrixDepartment, PaymentMethod paymentMethod) {
 
         List<BillFee> billFeeList = new ArrayList<>();
-        boolean siteBasedBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site", false);
+        // Falls back to the old application-wide key so any pre-existing configuration
+        // (set before this option was made discoverable/per-department) keeps working.
+        boolean legacyGlobalSiteBasedBillFees = configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site", false);
+        boolean siteBasedBillFees = sessionController.getDepartment() != null
+                ? configOptionApplicationController.getBooleanValueByKey("Inward Bill Fees are based on the site for " + sessionController.getDepartment().getName(), legacyGlobalSiteBasedBillFees)
+                : legacyGlobalSiteBasedBillFees;
         Institution site = sessionController.getDepartment() != null ? sessionController.getDepartment().getSite() : null;
         List<ItemFee> itemFee;
 

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -199,10 +199,22 @@
                             <div>
                                 <h:outputText styleClass=" fa-solid fa-screwdriver-wrench fa-lg" />
                                 <p:outputLabel value="Inward Add Services" class="mx-2 mt-1"/>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                    <p:commandButton
+                                        value="Config"
+                                        icon="fa fa-cog"
+                                        title="Page Configuration Management"
+                                        action="#{pageAdminController.navigateToPageAdmin('inward/inward_bill_service')}"
+                                        ajax="false"
+                                        immediate="true"
+                                        styleClass="ui-button-secondary ui-button-sm p-button-outlined"
+                                        style="font-size: 0.8rem; padding: 0.25rem 0.5rem;">
+                                    </p:commandButton>
+                                </h:panelGroup>
                             </div>
                             <div class="d-flex gap-2">
                                 <p:commandButton
-                                    class="ui-button-warning"
+                                    class="ui-button-primary"
                                     action="#{billBhtController.resetBillData}"
                                     icon="fa fa-plus"
                                     ajax="false"
@@ -210,10 +222,10 @@
                                 </p:commandButton>
 
                                 <p:commandButton
-                                    class="ui-button-secondary"
+                                    class="ui-button-info ui-button-outlined"
                                     value="Go To Add Outside"
                                     ajax="false"
-                                    icon="fa fa-plus"
+                                    icon="fa fa-arrow-right"
                                     action="/inward/inward_bill_outside_charge?faces-redirect=true" >
                                 </p:commandButton>
 
@@ -223,7 +235,7 @@
                                             ajax="false"
                                             value="Search Patients"
                                             icon="fa fa-search"
-                                            class="ui-button-warning "
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToSearchPatients()}"
                                             >
                                         </p:commandButton>
@@ -231,7 +243,7 @@
                                             ajax="false"
                                             value="Patient Profile"
                                             icon="fa fa-user"
-                                            class="ui-button-success"
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{patientController.navigateToOpdPatientProfile()}"
                                             >
                                             <f:setPropertyActionListener
@@ -243,7 +255,7 @@
                                             ajax="false"
                                             value="Inpatient Dashboard"
                                             icon="fa fa-id-card"
-                                            class="ui-button-secondary"
+                                            class="ui-button-info ui-button-outlined"
                                             action="#{bhtSummeryController.navigateToInpatientProfile()}"
                                             >
                                             <f:setPropertyActionListener
@@ -917,7 +929,7 @@
                                             <f:selectItem itemLabel="Select Format" />
                                             <f:selectItems value="#{enumController.paperTypes}" var="pt" itemLabel="#{pt.label}" itemValue="#{pt}" />
                                         </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button-warning" title="Redraw Bill"></p:commandButton>
                                     </div>
                                     <p:commandButton
                                         value="Print"
@@ -1092,8 +1104,7 @@
                                                         title="Manage Bill"
                                                         class="ui-button-warning m-1"
                                                         icon="fa fa-file-invoice"
-                                                        action="#{billSearch.navigateToInwardSearchService()}">
-                                                        <f:setPropertyActionListener value="#{b}" target="#{billSearch.bill}"/>
+                                                        action="#{billSearch.navigateToManageBillByAtomicBillTypeByBillId(b.id)}">
                                                     </p:commandButton>
                                                     <p:commandButton
                                                         title="To Sample Management"


### PR DESCRIPTION
## Summary

Closes #22344.

Users reported that fees on the Inward service billing page (`inward/inward_bill_service.xhtml`) don't get scoped per site the way OPD fees do. Investigation found the underlying mechanism already existed in `BillBhtController.billFeeFromBillItemWithMatrix()`, gated by a config key, but:

- It was never registered with `PageMetadataRegistry`, so the page had **no "Config" button at all** (confirmed live on QA — OPD has one, Inward didn't), leaving admins with no way to discover or toggle it.
- It was a single **application-wide** flag instead of scoped per department/ward like OPD's three equivalent keys.
- The page's "Manage Bill" button (print-preview bill list) bypassed the documented `billSearch` navigation pattern (`developer_docs/billing/bill-preview-navigation-guide.md`), and tracing that further showed `BillSearch.navigateToManageBillByAtomicBillType()` had no case at all for `INWARD_SERVICE_BILL` / `INWARD_SERVICE_BATCH_BILL` — a latent gap independent of this page.

## Changes

- **`BillBhtController.java`**: register `PageMetadata`/`ConfigOptionInfo`/`PrivilegeInfo` for `inward/inward_bill_service` (mirroring `OpdBillController`'s pattern), and change the fee-scope key to `"Inward Bill Fees are based on the site for " + department name`, falling back to the old global key as the default so any pre-existing configuration keeps working.
- **`inward_bill_service.xhtml`**: add a "Config" button next to the page title (Admin-privilege gated, same placement/style as OPD); standardize a few button colors/icons per `developer_docs/ui/comprehensive-ui-guidelines.md` (navigation buttons → `ui-button-info ui-button-outlined`, "New Bill" → `ui-button-primary` to match OPD's "New OPD Bill"); switch the "Manage Bill" button to the documented `billSearch.navigateToManageBillByAtomicBillTypeByBillId(id)` pattern.
- **`BillSearch.java`**: add `INWARD_SERVICE_BILL` / `INWARD_SERVICE_BATCH_BILL` cases to `navigateToManageBillByAtomicBillType()` delegating to the existing `navigateToInwardSearchService()`, fixing the latent gap above.
- Wiki: documented the new per-department option in `Price-in-OPD.md` (`hmis.wiki`) alongside the existing OPD pricing write-up.

## Test plan

- [x] `mvn compile` — BUILD SUCCESS
- [x] Rebuilt and redeployed to local Payara; logged in and verified:
  - The Config button appears on `inward_bill_service.xhtml` and opens Page Configuration Management, listing the new fee-scope option (scoped "for Inward") plus the page's other config keys and privileges
  - Adding an inward service item (DOCTOR CHARGES) still produces the correct fee (250.00) after the fee-fetch code change — no regression
  - Standardized button colors render as expected