### PR TITLE
fix(pharmacy): add printer Settings dialog to fast retail sale pages (#22349)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyConfigController.java
@@ -216,6 +216,18 @@ public class PharmacyConfigController implements Serializable {
     private boolean bhtIssueRequestReceiptFiveFive;
     private boolean bhtIssueRequestReceiptPos;
 
+    // Fast Retail Sale Settings (pharmacy_fast_retail_sale*.xhtml, issue #22349)
+    private boolean fastSalePosPaper;
+    private boolean fastSaleWithItemsPaper;
+    private boolean fastSalePrabodhaPaper;
+    private boolean fastSaleFiveFivePaper;
+    private boolean fastSalePosHeaderPaper;
+    private boolean fastSaleCustom3Paper;
+
+    // Fast Retail Sale for Cashier Settings (pharmacy_fast_retail_sale_for_cashier.xhtml, issue #22349)
+    private boolean fastSaleCashierPosPaper;
+    private boolean fastSaleCashierCustom3Paper;
+
     public PharmacyConfigController() {
     }
     
@@ -414,6 +426,18 @@ public class PharmacyConfigController implements Serializable {
         bhtIssueRequestReceiptA4 = configOptionApplicationController.getBooleanValueByKey("Pharmacy BHT Issue Request Receipt is A4", false);
         bhtIssueRequestReceiptFiveFive = configOptionApplicationController.getBooleanValueByKey("Pharmacy BHT Issue Request Receipt is FiveFive", true);
         bhtIssueRequestReceiptPos = configOptionApplicationController.getBooleanValueByKey("Pharmacy BHT Issue Request Receipt is POS", false);
+
+        // Fast Retail Sale Settings (issue #22349) — application-wide, matches existing pharmacy_fast_retail_sale*.xhtml keys
+        fastSalePosPaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill is PosPaper", true);
+        fastSaleWithItemsPaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill with Items is PosPaper", true);
+        fastSalePrabodhaPaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill is PosPaper(prabodha)", true);
+        fastSaleFiveFivePaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill is FiveFivePaper", true);
+        fastSalePosHeaderPaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill is PosHeaderPaper", true);
+        fastSaleCustom3Paper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Retail Sale Bill is FiveFiveCustom3", true);
+
+        // Fast Retail Sale for Cashier Settings (issue #22349) — application-wide, matches existing pharmacy_fast_retail_sale_for_cashier.xhtml keys
+        fastSaleCashierPosPaper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Sale for Cashier Bill is Pos paper", false);
+        fastSaleCashierCustom3Paper = configOptionApplicationController.getBooleanValueByKey("Pharmacy Sale for cashier Bill is FiveFiveCustom3", false);
 
     }
 
@@ -967,6 +991,45 @@ public class PharmacyConfigController implements Serializable {
             loadCurrentConfig();
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error saving print format settings: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Fast Retail Sale configuration changes specifically (issue #22349)
+     */
+    public void saveFastRetailSaleConfig() {
+        try {
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is PosPaper", fastSalePosPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill with Items is PosPaper", fastSaleWithItemsPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is PosPaper(prabodha)", fastSalePrabodhaPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is FiveFivePaper", fastSaleFiveFivePaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is PosHeaderPaper", fastSalePosHeaderPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is FiveFiveCustom3", fastSaleCustom3Paper);
+
+            JsfUtil.addSuccessMessage("Fast Retail Sale configuration saved successfully");
+
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Fast Retail Sale configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save Fast Retail Sale for Cashier configuration changes specifically (issue #22349)
+     */
+    public void saveFastSaleCashierConfig() {
+        try {
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Sale for Cashier Bill is Pos paper", fastSaleCashierPosPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Retail Sale Bill is PosHeaderPaper", fastSalePosHeaderPaper);
+            configOptionApplicationController.setBooleanValueByKey("Pharmacy Sale for cashier Bill is FiveFiveCustom3", fastSaleCashierCustom3Paper);
+
+            JsfUtil.addSuccessMessage("Fast Retail Sale for Cashier configuration saved successfully");
+
+            loadCurrentConfig();
+
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Fast Retail Sale for Cashier configuration: " + e.getMessage());
         }
     }
 
@@ -2004,6 +2067,71 @@ public class PharmacyConfigController implements Serializable {
 
     public void setBhtIssueRequestReceiptPos(boolean bhtIssueRequestReceiptPos) {
         this.bhtIssueRequestReceiptPos = bhtIssueRequestReceiptPos;
+    }
+
+    // Fast Retail Sale Getters and Setters (issue #22349)
+    public boolean isFastSalePosPaper() {
+        return fastSalePosPaper;
+    }
+
+    public void setFastSalePosPaper(boolean fastSalePosPaper) {
+        this.fastSalePosPaper = fastSalePosPaper;
+    }
+
+    public boolean isFastSaleWithItemsPaper() {
+        return fastSaleWithItemsPaper;
+    }
+
+    public void setFastSaleWithItemsPaper(boolean fastSaleWithItemsPaper) {
+        this.fastSaleWithItemsPaper = fastSaleWithItemsPaper;
+    }
+
+    public boolean isFastSalePrabodhaPaper() {
+        return fastSalePrabodhaPaper;
+    }
+
+    public void setFastSalePrabodhaPaper(boolean fastSalePrabodhaPaper) {
+        this.fastSalePrabodhaPaper = fastSalePrabodhaPaper;
+    }
+
+    public boolean isFastSaleFiveFivePaper() {
+        return fastSaleFiveFivePaper;
+    }
+
+    public void setFastSaleFiveFivePaper(boolean fastSaleFiveFivePaper) {
+        this.fastSaleFiveFivePaper = fastSaleFiveFivePaper;
+    }
+
+    public boolean isFastSalePosHeaderPaper() {
+        return fastSalePosHeaderPaper;
+    }
+
+    public void setFastSalePosHeaderPaper(boolean fastSalePosHeaderPaper) {
+        this.fastSalePosHeaderPaper = fastSalePosHeaderPaper;
+    }
+
+    public boolean isFastSaleCustom3Paper() {
+        return fastSaleCustom3Paper;
+    }
+
+    public void setFastSaleCustom3Paper(boolean fastSaleCustom3Paper) {
+        this.fastSaleCustom3Paper = fastSaleCustom3Paper;
+    }
+
+    public boolean isFastSaleCashierPosPaper() {
+        return fastSaleCashierPosPaper;
+    }
+
+    public void setFastSaleCashierPosPaper(boolean fastSaleCashierPosPaper) {
+        this.fastSaleCashierPosPaper = fastSaleCashierPosPaper;
+    }
+
+    public boolean isFastSaleCashierCustom3Paper() {
+        return fastSaleCashierCustom3Paper;
+    }
+
+    public void setFastSaleCashierCustom3Paper(boolean fastSaleCashierCustom3Paper) {
+        this.fastSaleCashierCustom3Paper = fastSaleCashierCustom3Paper;
     }
 
 }

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale.xhtml
@@ -1173,12 +1173,12 @@
                                         class="ui-button-warning mx-2"
                                         actionListener="#{cachedController.resetAll()}" ></p:commandButton>
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('fastSaleConfigDialog').show();" />
                                     </h:panelGroup>
                                     <p:spacer width="20em" ></p:spacer>
                                     <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1"  action="pharmacy_fast_retail_sale?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" />
@@ -1226,6 +1226,75 @@
                             </h:panelGroup>
                         </p:panel>
                     </h:form>
+
+                    <!-- Fast Retail Sale Configuration Dialog (issue #22349) -->
+                    <p:dialog id="fastSaleConfigDialog"
+                              rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                              header="Pharmacy Fast Retail Sale Printer Configuration"
+                              widgetVar="fastSaleConfigDialog"
+                              modal="true"
+                              width="600"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="fastSaleConfigForm" />
+
+                        <h:form id="fastSaleConfigForm">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Fast Retail Sale Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosPaper" value="#{pharmacyConfigController.fastSalePosPaper}" />
+                                        <h:outputLabel for="fastSalePosPaper" value="POS Paper (without items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleWithItemsPaper" value="#{pharmacyConfigController.fastSaleWithItemsPaper}" />
+                                        <h:outputLabel for="fastSaleWithItemsPaper" value="POS Paper (with items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePrabodhaPaper" value="#{pharmacyConfigController.fastSalePrabodhaPaper}" />
+                                        <h:outputLabel for="fastSalePrabodhaPaper" value="POS Paper (Prabodha format)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleFiveFivePaper" value="#{pharmacyConfigController.fastSaleFiveFivePaper}" />
+                                        <h:outputLabel for="fastSaleFiveFivePaper" value="5x5 Paper" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosHeaderPaper" value="#{pharmacyConfigController.fastSalePosHeaderPaper}" />
+                                        <h:outputLabel for="fastSalePosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCustom3Paper" value="#{pharmacyConfigController.fastSaleCustom3Paper}" />
+                                        <h:outputLabel for="fastSaleCustom3Paper" value="5x5 Custom Format 3" class="ms-2" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="card mt-3">
+                                <div class="card-body">
+                                    <p:messages id="fastSaleConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyConfigController.saveFastRetailSaleConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('fastSaleConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
+
                 </h:panelGroup>
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_1.xhtml
@@ -1142,12 +1142,12 @@
                                         class="ui-button-warning mx-2"
                                         actionListener="#{cachedController.resetAll()}" ></p:commandButton>
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('fastSaleConfigDialog').show();" />
                                     </h:panelGroup>
                                     <p:spacer width="20em" ></p:spacer>
                                     <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 2"  action="pharmacy_fast_retail_sale_1?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" />
@@ -1194,6 +1194,75 @@
                             </h:panelGroup>
                         </p:panel>
                     </h:form>
+
+                    <!-- Fast Retail Sale Configuration Dialog (issue #22349) -->
+                    <p:dialog id="fastSaleConfigDialog"
+                              rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                              header="Pharmacy Fast Retail Sale Printer Configuration"
+                              widgetVar="fastSaleConfigDialog"
+                              modal="true"
+                              width="600"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="fastSaleConfigForm" />
+
+                        <h:form id="fastSaleConfigForm">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Fast Retail Sale Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosPaper" value="#{pharmacyConfigController.fastSalePosPaper}" />
+                                        <h:outputLabel for="fastSalePosPaper" value="POS Paper (without items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleWithItemsPaper" value="#{pharmacyConfigController.fastSaleWithItemsPaper}" />
+                                        <h:outputLabel for="fastSaleWithItemsPaper" value="POS Paper (with items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePrabodhaPaper" value="#{pharmacyConfigController.fastSalePrabodhaPaper}" />
+                                        <h:outputLabel for="fastSalePrabodhaPaper" value="POS Paper (Prabodha format)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleFiveFivePaper" value="#{pharmacyConfigController.fastSaleFiveFivePaper}" />
+                                        <h:outputLabel for="fastSaleFiveFivePaper" value="5x5 Paper" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosHeaderPaper" value="#{pharmacyConfigController.fastSalePosHeaderPaper}" />
+                                        <h:outputLabel for="fastSalePosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCustom3Paper" value="#{pharmacyConfigController.fastSaleCustom3Paper}" />
+                                        <h:outputLabel for="fastSaleCustom3Paper" value="5x5 Custom Format 3" class="ms-2" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="card mt-3">
+                                <div class="card-body">
+                                    <p:messages id="fastSaleConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyConfigController.saveFastRetailSaleConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('fastSaleConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
+
                 </h:panelGroup>
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_2.xhtml
@@ -1148,12 +1148,12 @@
                                         class="ui-button-warning mx-2"
                                         actionListener="#{cachedController.resetAll()}" ></p:commandButton>
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('fastSaleConfigDialog').show();" />
                                     </h:panelGroup>
                                     <p:spacer width="20em" ></p:spacer>
                                     <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 3"  action="pharmacy_fast_retail_sale_2?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" />
@@ -1199,6 +1199,75 @@
                             </h:panelGroup>
                         </p:panel>
                     </h:form>
+
+                    <!-- Fast Retail Sale Configuration Dialog (issue #22349) -->
+                    <p:dialog id="fastSaleConfigDialog"
+                              rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                              header="Pharmacy Fast Retail Sale Printer Configuration"
+                              widgetVar="fastSaleConfigDialog"
+                              modal="true"
+                              width="600"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="fastSaleConfigForm" />
+
+                        <h:form id="fastSaleConfigForm">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Fast Retail Sale Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosPaper" value="#{pharmacyConfigController.fastSalePosPaper}" />
+                                        <h:outputLabel for="fastSalePosPaper" value="POS Paper (without items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleWithItemsPaper" value="#{pharmacyConfigController.fastSaleWithItemsPaper}" />
+                                        <h:outputLabel for="fastSaleWithItemsPaper" value="POS Paper (with items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePrabodhaPaper" value="#{pharmacyConfigController.fastSalePrabodhaPaper}" />
+                                        <h:outputLabel for="fastSalePrabodhaPaper" value="POS Paper (Prabodha format)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleFiveFivePaper" value="#{pharmacyConfigController.fastSaleFiveFivePaper}" />
+                                        <h:outputLabel for="fastSaleFiveFivePaper" value="5x5 Paper" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosHeaderPaper" value="#{pharmacyConfigController.fastSalePosHeaderPaper}" />
+                                        <h:outputLabel for="fastSalePosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCustom3Paper" value="#{pharmacyConfigController.fastSaleCustom3Paper}" />
+                                        <h:outputLabel for="fastSaleCustom3Paper" value="5x5 Custom Format 3" class="ms-2" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="card mt-3">
+                                <div class="card-body">
+                                    <p:messages id="fastSaleConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyConfigController.saveFastRetailSaleConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('fastSaleConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
+
                 </h:panelGroup>
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_3.xhtml
@@ -1149,12 +1149,12 @@
                                         class="ui-button-warning mx-2"
                                         actionListener="#{cachedController.resetAll()}" ></p:commandButton>
                                     <h:panelGroup rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
-                                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" id='ph' style="width: 13em;">
-                                            <f:selectItem itemLabel="Please Select Paper Type" />
-                                            <f:selectItems value="#{enumController.paperTypes}" />
-                                        </p:selectOneMenu>
-                    <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('fastSaleConfigDialog').show();" />
                                     </h:panelGroup>
                                     <p:spacer width="20em" ></p:spacer>
                                     <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 4"  action="pharmacy_fast_retail_sale_3?faces-redirect=true" rendered="#{webUserController.hasPrivilege('PharmacySaleQuick')}" />
@@ -1200,6 +1200,75 @@
                             </h:panelGroup>
                         </p:panel>
                     </h:form>
+
+                    <!-- Fast Retail Sale Configuration Dialog (issue #22349) -->
+                    <p:dialog id="fastSaleConfigDialog"
+                              rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                              header="Pharmacy Fast Retail Sale Printer Configuration"
+                              widgetVar="fastSaleConfigDialog"
+                              modal="true"
+                              width="600"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="fastSaleConfigForm" />
+
+                        <h:form id="fastSaleConfigForm">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Fast Retail Sale Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosPaper" value="#{pharmacyConfigController.fastSalePosPaper}" />
+                                        <h:outputLabel for="fastSalePosPaper" value="POS Paper (without items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleWithItemsPaper" value="#{pharmacyConfigController.fastSaleWithItemsPaper}" />
+                                        <h:outputLabel for="fastSaleWithItemsPaper" value="POS Paper (with items)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePrabodhaPaper" value="#{pharmacyConfigController.fastSalePrabodhaPaper}" />
+                                        <h:outputLabel for="fastSalePrabodhaPaper" value="POS Paper (Prabodha format)" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleFiveFivePaper" value="#{pharmacyConfigController.fastSaleFiveFivePaper}" />
+                                        <h:outputLabel for="fastSaleFiveFivePaper" value="5x5 Paper" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSalePosHeaderPaper" value="#{pharmacyConfigController.fastSalePosHeaderPaper}" />
+                                        <h:outputLabel for="fastSalePosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCustom3Paper" value="#{pharmacyConfigController.fastSaleCustom3Paper}" />
+                                        <h:outputLabel for="fastSaleCustom3Paper" value="5x5 Custom Format 3" class="ms-2" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="card mt-3">
+                                <div class="card-body">
+                                    <p:messages id="fastSaleConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyConfigController.saveFastRetailSaleConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('fastSaleConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
+
                 </h:panelGroup>
             </ui:define>
         </ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_fast_retail_sale_for_cashier.xhtml
@@ -943,6 +943,12 @@
                                             <f:selectItems value="#{enumController.paperTypes}" />
                                         </p:selectOneMenu>
                                         <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button" title="Redraw Bill"></p:commandButton>
+                                        <p:commandButton
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('fastSaleCashierConfigDialog').show();" />
                                     </h:panelGroup>
 
                                     <p:commandButton
@@ -1100,6 +1106,63 @@
                             </h:panelGroup>
                         </p:panel>
                     </h:form>
+
+                    <!-- Fast Retail Sale for Cashier Configuration Dialog (issue #22349) -->
+                    <p:dialog id="fastSaleCashierConfigDialog"
+                              rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                              header="Pharmacy Fast Retail Sale for Cashier Printer Configuration"
+                              widgetVar="fastSaleCashierConfigDialog"
+                              modal="true"
+                              width="600"
+                              resizable="true"
+                              maximizable="true"
+                              closeOnEscape="true">
+
+                        <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="fastSaleCashierConfigForm" />
+
+                        <h:form id="fastSaleCashierConfigForm">
+                            <div class="card config-section">
+                                <div class="card-header">
+                                    <h6><i class="fas fa-file-alt"></i> Fast Retail Sale for Cashier Paper Settings</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCashierPosPaper" value="#{pharmacyConfigController.fastSaleCashierPosPaper}" />
+                                        <h:outputLabel for="fastSaleCashierPosPaper" value="POS Paper" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCashierPosHeaderPaper" value="#{pharmacyConfigController.fastSalePosHeaderPaper}" />
+                                        <h:outputLabel for="fastSaleCashierPosHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                                    </div>
+                                    <div class="mb-3">
+                                        <h:selectBooleanCheckbox id="fastSaleCashierCustom3Paper" value="#{pharmacyConfigController.fastSaleCashierCustom3Paper}" />
+                                        <h:outputLabel for="fastSaleCashierCustom3Paper" value="5x5 Custom Format 3" class="ms-2" />
+                                    </div>
+                                    <p:outputLabel value="5x5 Paper is controlled by the Paper Type dropdown above (no config option yet)." styleClass="text-muted d-block mt-2" style="font-size: 0.85em;" />
+                                </div>
+                            </div>
+
+                            <div class="card mt-3">
+                                <div class="card-body">
+                                    <p:messages id="fastSaleCashierConfigMessages" showDetail="true" closable="true" />
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{pharmacyConfigController.saveFastSaleCashierConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('fastSaleCashierConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
 
                 </h:panelGroup>
             </ui:define>


### PR DESCRIPTION
## Summary

Issue #22349 asked for the printer-configuration ("Settings" gear) dialog to be added to the pharmacy sale reprint page.

- **`pharmacy_reprint_bill_sale.xhtml`**: investigation confirmed the gear-icon `retailSaleConfigDialog` is already present on `development` (added October 2025) and fully wired to `PharmacyConfigController`. No code change needed for the literal issue ask.
- **`pharmacy_search_sale_bill.xhtml`**: only links to the reprint page; it has no bill preview/print of its own, so no dialog is needed there.
- **Additional scope requested**: check whether "fast sale" and "native SQL retail sale" pages have the same Settings dialog.
  - `pharmacy_bill_retail_sale_native.xhtml` — already had it, no change.
  - `pharmacy_fast_retail_sale.xhtml`, `_1`, `_2`, `_3`, and `_for_cashier.xhtml` — did **not** have it, still used the deprecated Paper Type dropdown. This PR adds the standard gear-button/dialog pattern to all five, reusing each page's existing app-wide config keys (`configOptionApplicationController`) so default behavior is unchanged until a department opens Settings. Added the required `PharmacyConfigController` fields and two new save methods (`saveFastRetailSaleConfig`, `saveFastSaleCashierConfig`), additive only.
  - On the cashier page specifically, the 5x5 paper format has no existing config-key equivalent (only reachable via the legacy dropdown), so that dropdown was kept in place alongside the new Settings dialog rather than removed, to avoid making that format unreachable. Flagging this as a known gap for a possible follow-up.

## Verification

- `mvn clean compile` and `mvn clean package -DskipTests` both succeed.
- All 5 edited XHTML files verified as well-formed XML.
- No Playwright/manual UI pass this round — QA will verify per the reporter's instructions.

Closes #22349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fast Retail Sale printer configuration settings for standard and cashier workflows.
  * Users with the appropriate permission can open a Settings dialog and enable supported receipt paper formats.
  * Added options for POS, header, itemized, Prabodha, 5x5, and custom receipt formats.
  * Configuration changes can be applied or canceled without leaving the billing screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->