### PR TITLE
feat(client-portal): self-service phone-OTP registration

### DIFF
--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalPhoneRegistrationController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalPhoneRegistrationController.java
@@ -1,0 +1,356 @@
+package com.divudi.bean.clientportal;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.SecurityController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.ClientAccountCreationChannel;
+import com.divudi.core.data.MessageType;
+import com.divudi.core.entity.ClientAccount;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.Person;
+import com.divudi.core.entity.Sms;
+import com.divudi.core.facade.ClientAccountFacade;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.facade.SmsFacade;
+import com.divudi.core.util.ClientPortalMatcher;
+import com.divudi.core.util.ClientPortalOtpGenerator;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.SmsManagerEjb;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ViewScoped
+public class ClientPortalPhoneRegistrationController implements Serializable {
+
+    @EJB
+    private SmsFacade smsFacade;
+    @EJB
+    private SmsManagerEjb smsManager;
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private ClientAccountFacade clientAccountFacade;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private SecurityController securityController;
+
+    private String phoneNumber;
+    private String enteredOtp;
+    private String otp;
+    private Date otpSentTime;
+    private boolean otpSendSuccess;
+    private boolean otpVerified;
+
+    private List<Patient> matchedPatients;
+    private ClientPortalMatcher.MatchResult matchResult;
+    private Patient selectedPatient;
+    private boolean noMatchRejected;
+
+    private String password;
+    private String passwordConfirm;
+    private boolean registrationComplete;
+    private boolean duplicateAccountBlocked;
+
+    private void clearMessages() {
+        java.util.Iterator<javax.faces.application.FacesMessage> iter = javax.faces.context.FacesContext.getCurrentInstance().getMessages();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+    }
+
+    public void sendOtp() {
+        clearMessages();
+        registrationComplete = false;
+        duplicateAccountBlocked = false;
+        if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Mobile number is required.");
+            return;
+        }
+        if (!phoneNumber.trim().matches("^(07[0-9]{8}|\\+[1-9][0-9]{6,14})$")) {
+            JsfUtil.addErrorMessage("Invalid mobile number. Enter a local number (e.g. 0712345678) or international format with country code (e.g. +447911123456).");
+            return;
+        }
+
+        otp = ClientPortalOtpGenerator.generate(getOtpLength());
+        otpSendSuccess = false;
+
+        Sms sms = new Sms();
+        sms.setCreatedAt(new Date());
+        sms.setCreater(sessionController.getLoggedUser());
+        sms.setReceipientNumber(phoneNumber);
+        sms.setSendingMessage(smsBody(otp));
+        sms.setPending(false);
+        sms.setSmsType(MessageType.ClientPortalRegistrationOTP);
+        sms.setOtp(otp);
+        smsFacade.create(sms);
+
+        Boolean sent = smsManager.sendSms(sms);
+        // Matches PatientPortalController.sendOtp(): when no SMS gateway is configured
+        // (e.g. local dev), sendSms() always returns false. The OTP is still persisted
+        // on the Sms row above, so advance to the verify step regardless of delivery
+        // status rather than permanently blocking the flow when no gateway is set up.
+        otpSendSuccess = true;
+        otpSentTime = new Date();
+        if (Boolean.TRUE.equals(sent)) {
+            JsfUtil.addSuccessMessage("OTP sent successfully.");
+        } else {
+            JsfUtil.addErrorMessage("OTP SMS failed to send.");
+        }
+        sms.setSentSuccessfully(sent);
+        smsFacade.edit(sms);
+    }
+
+    public String smsBody(String otpCode) {
+        String template = configOptionApplicationController.getLongTextValueByKey("Client Portal - Custom SMS Body Message for Send OTP");
+        if (template != null && !template.trim().isEmpty()) {
+            return template.replace("\\n", "\n").replace("{otp}", otpCode);
+        }
+        return "Your Client Portal registration code is " + otpCode;
+    }
+
+    public void verifyOtp() {
+        clearMessages();
+
+        if (otpSentTime != null && System.currentTimeMillis() > getOtpExpiryEpochMs()) {
+            JsfUtil.addErrorMessage("OTP has expired. Please request a new OTP.");
+            otp = null;
+            enteredOtp = null;
+            otpSentTime = null;
+            otpSendSuccess = false;
+            return;
+        }
+
+        String jpql = "select s from Sms s where s.retired=false and s.receipientNumber=:mobile and s.smsType=:type order by s.id desc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("mobile", phoneNumber);
+        params.put("type", MessageType.ClientPortalRegistrationOTP);
+        Sms lastSms = smsFacade.findFirstByJpql(jpql, params);
+
+        if (lastSms == null) {
+            JsfUtil.addErrorMessage("No OTP request found. Please request a new OTP.");
+            return;
+        }
+        if (enteredOtp == null || enteredOtp.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter the authentication code.");
+            return;
+        }
+        if (!enteredOtp.equalsIgnoreCase(lastSms.getOtp())) {
+            JsfUtil.addErrorMessage("Enter correct authentication code.");
+            enteredOtp = null;
+            return;
+        }
+
+        otpVerified = true;
+        findMatchingPatients();
+    }
+
+    private void findMatchingPatients() {
+        Long phoneAsLong = CommonFunctions.convertStringToLongOrZero(phoneNumber);
+        String jpql = "select p from Patient p where p.retired=false and p.patientPhoneNumber=:pp";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pp", phoneAsLong);
+        matchedPatients = patientFacade.findByJpql(jpql, params);
+
+        matchResult = ClientPortalMatcher.classify(matchedPatients);
+        switch (matchResult) {
+            case NO_MATCH:
+                noMatchRejected = true;
+                JsfUtil.addErrorMessage("No existing patient record matches this phone number. Please use the kiosk or ask staff to create your portal account.");
+                break;
+            case SINGLE_MATCH:
+                selectPatientProfile(matchedPatients.get(0));
+                break;
+            case MULTIPLE_MATCH:
+                // rendered as a list for selectPatientProfile(Patient)
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void selectPatientProfile(Patient patient) {
+        this.selectedPatient = patient;
+        checkDuplicateAccount();
+    }
+
+    private void checkDuplicateAccount() {
+        if (selectedPatient == null || selectedPatient.getPerson() == null) {
+            return;
+        }
+        ClientAccount existing = clientAccountFacade.findByPerson(selectedPatient.getPerson().getId());
+        duplicateAccountBlocked = existing != null;
+    }
+
+    public void register() {
+        clearMessages();
+        if (selectedPatient == null || selectedPatient.getPerson() == null) {
+            JsfUtil.addErrorMessage("Error in Development.");
+            return;
+        }
+        if (password == null || password.length() < 6) {
+            JsfUtil.addErrorMessage("Password must be at least 6 characters.");
+            return;
+        }
+        if (!password.equals(passwordConfirm)) {
+            JsfUtil.addErrorMessage("Password and confirmation do not match.");
+            return;
+        }
+
+        Person person = selectedPatient.getPerson();
+
+        ClientAccount account = new ClientAccount();
+        account.setPerson(person);
+        account.setPasswordHash(securityController.hashAndCheck(password));
+        account.setVerifiedPhone(phoneNumber);
+        account.setPhoneVerified(true);
+        account.setCreatedVia(ClientAccountCreationChannel.SELF_PHONE);
+        account.setCreatedAt(new Date());
+        account.setRetired(false);
+
+        ClientAccount created = clientAccountFacade.createIfNoActiveAccount(person.getId(), account);
+        if (created == null) {
+            duplicateAccountBlocked = true;
+            JsfUtil.addErrorMessage("A portal account already exists for this person. Please log in or reset your password instead.");
+            return;
+        }
+
+        registrationComplete = true;
+    }
+
+    public int getOtpLength() {
+        Long configured = configOptionApplicationController.getLongValueByKey("Client Portal - OTP Length", 6L);
+        if (configured == null || configured < 1L || configured > 12L) {
+            return 6;
+        }
+        return configured.intValue();
+    }
+
+    public int getOtpTimeoutMinutes() {
+        return configOptionApplicationController.getIntegerValueByKey("Client Portal - OTP Timeout Minutes", 2);
+    }
+
+    public long getOtpExpiryEpochMs() {
+        if (otpSentTime == null) {
+            return 0;
+        }
+        return otpSentTime.getTime() + ((long) getOtpTimeoutMinutes() * 60 * 1000L);
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getEnteredOtp() {
+        return enteredOtp;
+    }
+
+    public void setEnteredOtp(String enteredOtp) {
+        this.enteredOtp = enteredOtp;
+    }
+
+    public boolean isOtpSendSuccess() {
+        return otpSendSuccess;
+    }
+
+    public void setOtpSendSuccess(boolean otpSendSuccess) {
+        this.otpSendSuccess = otpSendSuccess;
+    }
+
+    public boolean isOtpVerified() {
+        return otpVerified;
+    }
+
+    public void setOtpVerified(boolean otpVerified) {
+        this.otpVerified = otpVerified;
+    }
+
+    public List<Patient> getMatchedPatients() {
+        if (matchedPatients == null) {
+            return new ArrayList<>();
+        }
+        return matchedPatients;
+    }
+
+    public void setMatchedPatients(List<Patient> matchedPatients) {
+        this.matchedPatients = matchedPatients;
+    }
+
+    public ClientPortalMatcher.MatchResult getMatchResult() {
+        return matchResult;
+    }
+
+    public void setMatchResult(ClientPortalMatcher.MatchResult matchResult) {
+        this.matchResult = matchResult;
+    }
+
+    public boolean isMultipleMatch() {
+        return matchResult == ClientPortalMatcher.MatchResult.MULTIPLE_MATCH;
+    }
+
+    public boolean isNoMatchRejected() {
+        return noMatchRejected;
+    }
+
+    public void setNoMatchRejected(boolean noMatchRejected) {
+        this.noMatchRejected = noMatchRejected;
+    }
+
+    public Patient getSelectedPatient() {
+        return selectedPatient;
+    }
+
+    public void setSelectedPatient(Patient selectedPatient) {
+        this.selectedPatient = selectedPatient;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getPasswordConfirm() {
+        return passwordConfirm;
+    }
+
+    public void setPasswordConfirm(String passwordConfirm) {
+        this.passwordConfirm = passwordConfirm;
+    }
+
+    public boolean isRegistrationComplete() {
+        return registrationComplete;
+    }
+
+    public void setRegistrationComplete(boolean registrationComplete) {
+        this.registrationComplete = registrationComplete;
+    }
+
+    public boolean isDuplicateAccountBlocked() {
+        return duplicateAccountBlocked;
+    }
+
+    public void setDuplicateAccountBlocked(boolean duplicateAccountBlocked) {
+        this.duplicateAccountBlocked = duplicateAccountBlocked;
+    }
+}

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalPhoneRegistrationController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalPhoneRegistrationController.java
@@ -126,15 +126,6 @@ public class ClientPortalPhoneRegistrationController implements Serializable {
     public void verifyOtp() {
         clearMessages();
 
-        if (otpSentTime != null && System.currentTimeMillis() > getOtpExpiryEpochMs()) {
-            JsfUtil.addErrorMessage("OTP has expired. Please request a new OTP.");
-            otp = null;
-            enteredOtp = null;
-            otpSentTime = null;
-            otpSendSuccess = false;
-            return;
-        }
-
         String jpql = "select s from Sms s where s.retired=false and s.receipientNumber=:mobile and s.smsType=:type order by s.id desc";
         Map<String, Object> params = new HashMap<>();
         params.put("mobile", phoneNumber);
@@ -145,6 +136,19 @@ public class ClientPortalPhoneRegistrationController implements Serializable {
             JsfUtil.addErrorMessage("No OTP request found. Please request a new OTP.");
             return;
         }
+
+        // Checked against the persisted Sms.createdAt, not the view-scoped otpSentTime,
+        // so a page refresh mid-flow (which resets otpSentTime) can't bypass expiry.
+        long ageMs = System.currentTimeMillis() - lastSms.getCreatedAt().getTime();
+        if (ageMs > getOtpTimeoutMinutes() * 60_000L) {
+            JsfUtil.addErrorMessage("OTP has expired. Please request a new OTP.");
+            otp = null;
+            enteredOtp = null;
+            otpSentTime = null;
+            otpSendSuccess = false;
+            return;
+        }
+
         if (enteredOtp == null || enteredOtp.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Enter the authentication code.");
             return;
@@ -234,7 +238,7 @@ public class ClientPortalPhoneRegistrationController implements Serializable {
 
     public int getOtpLength() {
         Long configured = configOptionApplicationController.getLongValueByKey("Client Portal - OTP Length", 6L);
-        if (configured == null || configured < 1L || configured > 12L) {
+        if (configured == null || configured < 4L || configured > 12L) {
             return 6;
         }
         return configured.intValue();

--- a/src/main/java/com/divudi/core/facade/ClientAccountFacade.java
+++ b/src/main/java/com/divudi/core/facade/ClientAccountFacade.java
@@ -1,11 +1,13 @@
 package com.divudi.core.facade;
 
 import com.divudi.core.entity.ClientAccount;
+import com.divudi.core.entity.Person;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
 import javax.persistence.PersistenceContext;
 
 @Stateless
@@ -32,5 +34,21 @@ public class ClientAccountFacade extends AbstractFacade<ClientAccount> {
             return null;
         }
         return results.get(0);
+    }
+
+    /**
+     * Locks the Person row for the duration of the check-then-create so two
+     * concurrent registration attempts for the same person can't both
+     * succeed (design spec §3 concurrency note, option (a)). Returns null if
+     * an active ClientAccount already exists for this person.
+     */
+    public ClientAccount createIfNoActiveAccount(Long personId, ClientAccount newAccount) {
+        getEntityManager().find(Person.class, personId, LockModeType.PESSIMISTIC_WRITE);
+        ClientAccount existing = findByPerson(personId);
+        if (existing != null) {
+            return null;
+        }
+        create(newAccount);
+        return newAccount;
     }
 }

--- a/src/main/webapp/client_portal/register_phone.xhtml
+++ b/src/main/webapp/client_portal/register_phone.xhtml
@@ -1,0 +1,985 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:a="http://xmlns.jcp.org/jsf/passthrough">
+    <h:head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+        <title>Client Portal Registration</title>
+
+        <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as the Patient Portal precedent -->
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+        <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&amp;family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&amp;display=swap" rel="stylesheet"/>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"/>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+              integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"/>
+
+        <style>
+            /* ================================================
+               CLIENT PORTAL REGISTRATION  ·  Forest Health Aesthetic
+               Structural/CSS pattern copied from patient_portal/portal_login.xhtml
+               Responsive: mobile-first, split layout on ≥992px
+               ================================================ */
+
+            :root {
+                --forest-mid:    #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')};
+                --forest-deep:   color-mix(in srgb, var(--forest-mid) 60%, #000);
+                --forest-bright: color-mix(in srgb, var(--forest-mid) 80%, #fff);
+                --emerald:       color-mix(in hsl, var(--forest-mid), white 55%);
+                --emerald-light: color-mix(in hsl, var(--forest-mid), white 65%);
+                --cream:         color-mix(in srgb, var(--forest-mid) 5%, #fff);
+                --white:         #ffffff;
+                --text-dark:     color-mix(in srgb, var(--forest-mid) 12%, #111);
+                --text-muted:    color-mix(in srgb, var(--forest-mid) 20%, #555);
+                --border:        color-mix(in srgb, var(--forest-mid) 12%, #fff);
+                --shadow-lg:     0 24px 64px color-mix(in srgb, var(--forest-mid) 20%, transparent);
+                --radius-sm:     10px;
+            }
+
+            *, *::before, *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            body, html {
+                font-family: 'DM Sans', sans-serif;
+                background: var(--cream);
+                min-height: 100vh;
+                color: var(--text-dark);
+            }
+
+            /* ── PAGE WRAPPER ────────────────────────────────────── */
+            .portal-wrapper {
+                min-height: 100vh;
+                display: flex;
+                align-items: stretch;
+            }
+
+            /* ── LEFT HERO PANEL  (visible ≥992px only) ──────────── */
+            .portal-hero {
+                display: none;
+                position: relative;
+                overflow: hidden;
+                flex-direction: column;
+                justify-content: space-between;
+                align-items: flex-start;
+                padding: 3rem 3.5rem;
+                --hero-color: var(--forest-mid);
+                background: linear-gradient(155deg,
+                    color-mix(in srgb, var(--hero-color) 55%, #000) 0%,
+                    var(--hero-color) 55%,
+                    color-mix(in srgb, var(--hero-color) 75%, #fff) 100%);
+            }
+
+            @media (min-width: 992px) {
+                .portal-hero {
+                    display: flex;
+                    width: 44%;
+                    min-width: 400px;
+                    max-width: 540px;
+                }
+            }
+
+            .hero-dots {
+                position: absolute;
+                inset: 0;
+                background-image: radial-gradient(circle, color-mix(in srgb, var(--emerald-light) 22%, transparent) 1px, transparent 1px);
+                background-size: 30px 30px;
+            }
+
+            .hero-ring {
+                position: absolute;
+                border-radius: 50%;
+                border: 1px solid color-mix(in srgb, var(--emerald) 13%, transparent);
+            }
+            .hero-ring-1 { width: 500px; height: 500px; top: -140px; right: -190px; }
+            .hero-ring-2 { width: 330px; height: 330px; top: -60px; right: -110px; border-color: color-mix(in srgb, var(--emerald) 20%, transparent); }
+            .hero-ring-3 { width: 620px; height: 620px; bottom: -220px; left: -220px; }
+            .hero-ring-4 {
+                width: 380px; height: 380px; bottom: -100px; left: -80px; border: none;
+                background: radial-gradient(circle, color-mix(in srgb, var(--emerald) 7%, transparent) 0%, transparent 70%);
+            }
+
+            .hero-cross { position: absolute; width: 26px; height: 26px; }
+            .hero-cross::before, .hero-cross::after { content: ''; position: absolute; background: var(--emerald-light); border-radius: 2px; }
+            .hero-cross::before { width: 4px; height: 26px; left: 11px; top: 0; }
+            .hero-cross::after  { width: 26px; height: 4px; top: 11px; left: 0; }
+
+            .hero-cross-lg { position: absolute; bottom: 2.5rem; right: 2.5rem; width: 72px; height: 72px; opacity: 0.07; }
+            .hero-cross-lg::before { content: ''; position: absolute; background: white; border-radius: 3px; width: 18px; height: 72px; left: 27px; top: 0; }
+            .hero-cross-lg::after  { content: ''; position: absolute; background: white; border-radius: 3px; width: 72px; height: 18px; top: 27px; left: 0; }
+
+            .hero-content { position: relative; z-index: 2; }
+
+            .hero-logo-wrap {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0.85rem 1.25rem;
+                margin-bottom: 2rem;
+                backdrop-filter: blur(4px);
+                width: 100%;
+            }
+            .hero-logo-img { width: 80%; height: 80%; object-fit: contain; object-position: left center; display: block; }
+
+            .mobile-logo-img { max-width: 220px; max-height: 120px; object-fit: contain; display: block; margin: 0 auto 0.75rem; }
+
+            .hero-badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                background: color-mix(in srgb, var(--emerald) 14%, transparent);
+                border: 1px solid color-mix(in srgb, var(--emerald) 28%, transparent);
+                border-radius: 100px;
+                padding: 0.32rem 1rem;
+                font-size: 0.7rem;
+                color: var(--emerald-light);
+                font-weight: 500;
+                letter-spacing: 0.07em;
+                text-transform: uppercase;
+                margin-bottom: 1.75rem;
+            }
+            .hero-badge-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--emerald); animation: blink 2s infinite; }
+
+            @keyframes blink {
+                0%, 100% { opacity: 1; transform: scale(1); }
+                50%      { opacity: 0.4; transform: scale(0.75); }
+            }
+
+            .hero-title {
+                font-family: 'Syne', sans-serif;
+                font-size: 3.25rem;
+                font-weight: 800;
+                color: var(--white);
+                line-height: 1.08;
+                letter-spacing: -0.025em;
+                margin-bottom: 1rem;
+            }
+            .hero-title .accent { color: var(--emerald-light); }
+
+            .hero-desc {
+                font-size: 0.95rem;
+                color: rgba(255,255,255,0.6);
+                line-height: 1.75;
+                margin-bottom: 2.25rem;
+                max-width: 320px;
+                font-weight: 300;
+            }
+
+            .hero-features { list-style: none; display: flex; flex-direction: column; gap: 0.85rem; }
+            .hero-features li { display: flex; align-items: center; gap: 0.75rem; color: rgba(255,255,255,0.78); font-size: 0.9rem; }
+            .feat-icon {
+                width: 32px; height: 32px;
+                background: color-mix(in srgb, var(--emerald) 18%, transparent);
+                border-radius: 8px;
+                display: flex; align-items: center; justify-content: center;
+                color: var(--emerald-light);
+                font-size: 0.82rem;
+                flex-shrink: 0;
+            }
+
+            /* ── RIGHT FORM PANEL ────────────────────────────────── */
+            .portal-form-panel {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 2.5rem 1.5rem;
+                background: var(--cream);
+            }
+
+            .form-container { width: 100%; max-width: 480px; }
+            @media (min-width: 992px) { .form-container { max-width: 560px; } }
+
+            .mobile-brand-header { text-align: center; margin-bottom: 2rem; }
+            @media (min-width: 992px) { .mobile-brand-header { display: none; } }
+            .mobile-icon {
+                width: 64px; height: 64px;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                border-radius: 18px;
+                display: inline-flex; align-items: center; justify-content: center;
+                font-size: 1.75rem; color: white; margin-bottom: 0.75rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 28%, transparent);
+            }
+            .mobile-inst-name { display: block; font-family: 'Syne', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--forest-mid); }
+            .mobile-portal-label { display: block; font-size: 0.78rem; color: var(--text-muted); margin-top: 0.15rem; letter-spacing: 0.05em; text-transform: uppercase; }
+
+            /* ── CARDS ────────────────────────────────────────────── */
+            .otp-card, .patient-select-card, .welcome-card {
+                background: var(--white);
+                border-radius: 22px;
+                padding: 2.25rem 2rem;
+                box-shadow: var(--shadow-lg);
+                border: 1px solid var(--border);
+                animation: fadeUp 0.45s ease forwards;
+                width: 100%;
+            }
+            .patient-select-card, .welcome-card { max-width: 480px; text-align: left; }
+            .welcome-card { text-align: center; padding: 2.5rem 2rem; }
+            @media (min-width: 992px) {
+                .patient-select-card, .welcome-card { max-width: 560px; }
+            }
+
+            @keyframes fadeUp {
+                from { opacity: 0; transform: translateY(22px); }
+                to   { opacity: 1; transform: translateY(0); }
+            }
+
+            .card-lead-icon {
+                width: 52px; height: 52px;
+                background: linear-gradient(135deg, color-mix(in srgb, var(--emerald) 20%, white), color-mix(in srgb, var(--emerald) 35%, white));
+                border-radius: 13px;
+                display: flex; align-items: center; justify-content: center;
+                font-size: 1.3rem; color: var(--forest-mid);
+                margin-bottom: 1.1rem;
+            }
+
+            .card-title { font-family: 'Syne', sans-serif; font-size: 1.5rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.35rem; line-height: 1.2; }
+            .card-subtitle { font-size: 0.87rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 1.75rem; font-weight: 400; }
+
+            /* ── STEP INDICATORS ─────────────────────────────────── */
+            .steps-bar { display: flex; align-items: center; margin-bottom: 1.75rem; }
+            .step-item { display: flex; align-items: center; gap: 0.45rem; }
+            .step-connector { flex: 1; height: 2px; background: var(--border); margin: 0 0.6rem; }
+            .step-dot {
+                width: 26px; height: 26px; border-radius: 50%;
+                background: var(--border);
+                display: flex; align-items: center; justify-content: center;
+                font-size: 0.72rem; font-weight: 700; color: var(--text-muted);
+                flex-shrink: 0; transition: all 0.3s;
+            }
+            .step-dot.active { background: var(--forest-mid); color: white; box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-mid) 15%, transparent); }
+            .step-label { font-size: 0.72rem; color: var(--text-muted); font-weight: 500; white-space: nowrap; }
+
+            /* ── FORM FIELDS ─────────────────────────────────────── */
+            .field-group { margin-bottom: 1.1rem; }
+            .field-label { display: block; font-size: 0.8rem; font-weight: 600; color: var(--text-dark); margin-bottom: 0.45rem; letter-spacing: 0.025em; }
+            .field-wrap { position: relative; }
+            .field-wrap .f-icon { position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%); color: var(--text-muted); font-size: 0.88rem; pointer-events: none; z-index: 1; }
+
+            .portal-form-panel .ui-inputtext {
+                width: 100% !important;
+                padding: 0.8rem 1rem 0.8rem 2.6rem !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'DM Sans', sans-serif !important;
+                font-size: 0.97rem !important;
+                color: var(--text-dark) !important;
+                background: color-mix(in srgb, var(--forest-mid) 5%, white) !important;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s !important;
+                box-shadow: none !important;
+                outline: none !important;
+                min-width: unset !important;
+            }
+            .portal-form-panel .ui-inputtext:hover { border-color: var(--emerald) !important; }
+            .portal-form-panel .ui-inputtext:focus {
+                border-color: var(--forest-bright) !important;
+                background: var(--white) !important;
+                box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent) !important;
+            }
+            /* p:password wraps the input in a span; strip padding-left icon offset when no icon present */
+            .field-wrap .ui-password { width: 100%; display: block; }
+
+            /* ── PRIMARY BUTTON ──────────────────────────────────── */
+            .btn-send .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid) 0%, var(--forest-bright) 100%) !important;
+                border: none !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: white !important;
+                cursor: pointer !important;
+                transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+                box-shadow: 0 4px 16px color-mix(in srgb, var(--forest-mid) 28%, transparent) !important;
+                letter-spacing: 0.01em !important;
+                min-width: unset !important;
+            }
+            .btn-send .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 7px 22px color-mix(in srgb, var(--forest-mid) 34%, transparent) !important; }
+            .btn-send .ui-button:active { transform: translateY(0) !important; }
+            .btn-send .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-send .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 6px !important; }
+
+            /* ── SECONDARY BUTTON ────────────────────────────────── */
+            .btn-verify .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: var(--cream) !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: var(--forest-mid) !important;
+                cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                min-width: unset !important;
+            }
+            .btn-verify .ui-button:hover { border-color: var(--emerald) !important; background: color-mix(in srgb, var(--emerald) 12%, white) !important; color: var(--forest-deep) !important; }
+            .btn-verify .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-verify .ui-button .ui-icon { color: var(--forest-mid) !important; margin-right: 6px !important; }
+
+            /* ── RESEND LINK ─────────────────────────────────────── */
+            .resend-wrap { text-align: center; font-size: 0.85rem; color: var(--text-muted); margin-top: 1.25rem; }
+            .resend-wrap .ui-commandlink { color: var(--forest-bright) !important; font-weight: 600 !important; text-decoration: none !important; font-family: 'DM Sans', sans-serif !important; transition: color 0.2s !important; }
+            .resend-wrap .ui-commandlink:hover { color: var(--emerald) !important; text-decoration: underline !important; }
+
+            /* ── GLOBAL TOP MESSAGES ─────────────────────────────── */
+            .global-messages-wrap { margin-bottom: 1.25rem; }
+            .portal-error-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fff5f5; color: #c0392b; border: 1px solid #f5c6cb; border-left: 4px solid #e74c3c;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; text-align: left; box-shadow: 0 2px 8px rgba(192,57,43,0.08);
+            }
+            .portal-error-msg::before { content: '\f071'; font-family: 'Font Awesome 6 Free'; font-weight: 900; font-size: 0.82rem; flex-shrink: 0; }
+            .portal-info-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #f0f7ff; color: #1a6fb3; border: 1px solid #bee3f8; border-left: 4px solid #3498db;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(52,152,219,0.08);
+            }
+            .portal-warn-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fffbf0; color: #b45309; border: 1px solid #fcd34d; border-left: 4px solid #f59e0b;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(245,158,11,0.08);
+            }
+
+            /* ── OTP COUNTDOWN ───────────────────────────────────── */
+            .otp-countdown-wrap { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin-bottom: 1.25rem; }
+            .otp-countdown-label { font-size: 0.82rem; color: var(--text-muted); }
+            .otp-countdown-timer {
+                font-family: 'Syne', sans-serif; font-size: 1.1rem; font-weight: 700; color: var(--forest-mid);
+                background: color-mix(in srgb, var(--emerald) 10%, white);
+                border: 1.5px solid var(--border); border-radius: 8px;
+                padding: 0.2rem 0.7rem; min-width: 3.5rem; text-align: center;
+                transition: color 0.3s, background 0.3s, border-color 0.3s;
+            }
+            .otp-countdown-timer.warning { color: #b45309; background: #fef3c7; border-color: #fcd34d; }
+            .otp-countdown-timer.expired { color: #dc2626; background: #fee2e2; border-color: #fca5a5; }
+
+            /* ── FOOTER NOTE ─────────────────────────────────────── */
+            .portal-footer-note { display: flex; align-items: center; justify-content: center; gap: 0.4rem; font-size: 0.73rem; color: var(--text-muted); margin-top: 1.5rem; }
+            .portal-footer-note i { color: var(--emerald); }
+
+            /* ── OTP DIGIT BOXES ─────────────────────────────────── */
+            .otp-boxes-wrap { display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.4rem; margin-bottom: 1rem; }
+            .otp-box {
+                width: 2.8rem; height: 3.2rem; text-align: center; font-size: 1.35rem; font-weight: 700;
+                font-family: 'Syne', sans-serif; border: 2px solid var(--border); border-radius: 10px;
+                background: var(--white); color: var(--forest-deep); outline: none;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+                caret-color: var(--forest-bright); -webkit-appearance: none; -moz-appearance: textfield;
+            }
+            .otp-box::-webkit-inner-spin-button, .otp-box::-webkit-outer-spin-button { -webkit-appearance: none; }
+            .otp-box:focus { border-color: var(--forest-bright); box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent); }
+            .otp-box.filled { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 6%, white); }
+
+            /* ── RESPONSIVE TWEAKS ───────────────────────────────── */
+            @media (max-width: 480px) {
+                .otp-card, .patient-select-card, .welcome-card { padding: 1.75rem 1.25rem; border-radius: 18px; }
+                .otp-box { width: 2.3rem; height: 2.8rem; font-size: 1.1rem; border-radius: 8px; gap: 0.35rem; }
+                .card-title { font-size: 1.3rem; }
+                .step-label { display: none; }
+                .patient-row { padding: 0.7rem 0.75rem; gap: 0.6rem; }
+                .patient-avatar { width: 34px; height: 34px; font-size: 0.85rem; }
+                .patient-name { font-size: 0.85rem; }
+                .patient-meta-pill { font-size: 0.65rem; padding: 0.1rem 0.4rem; }
+            }
+            @media (max-width: 360px) { .portal-form-panel { padding: 1.5rem 0.85rem; } }
+
+            /* ── MATCHED PATIENTS LIST ────────────────────────────── */
+            .patient-select-title { font-family: 'Syne', sans-serif; font-size: 1.4rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.3rem; }
+            .patient-select-subtitle { font-size: 0.87rem; color: var(--text-muted); margin-bottom: 1.5rem; line-height: 1.6; }
+
+            /* strip default PrimeFaces dataTable chrome so it reads as a plain card list
+               (selectors kept broad/generic since exact DOM class names can vary by PF version) */
+            .matched-patients-table.ui-datatable,
+            .matched-patients-table.ui-datatable .ui-widget-content,
+            .matched-patients-table.ui-datatable table,
+            .matched-patients-table.ui-datatable table tr,
+            .matched-patients-table.ui-datatable table td {
+                border: none !important;
+                background: transparent !important;
+            }
+            .matched-patients-table.ui-datatable table td {
+                padding: 0 0 0.75rem 0 !important;
+            }
+            .matched-patients-table.ui-datatable table tr:last-child td {
+                padding-bottom: 0 !important;
+            }
+
+            .patient-row {
+                display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+                padding: 0.9rem 1rem; border: 2px solid var(--border); border-radius: var(--radius-sm);
+                background: color-mix(in srgb, var(--forest-mid) 4%, white);
+                transition: all 0.2s ease;
+            }
+            .patient-row:hover { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 10%, white); }
+
+            .patient-avatar {
+                width: 42px; height: 42px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; color: white; font-size: 1rem; flex-shrink: 0;
+            }
+            .patient-info { flex: 1; min-width: 0; }
+            .patient-name { font-family: 'Syne', sans-serif; font-weight: 600; font-size: 0.95rem; color: var(--forest-deep); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+            .patient-meta { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.25rem; }
+            .patient-meta-pill {
+                display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--text-muted);
+                background: var(--cream); border: 1px solid var(--border); border-radius: 100px; padding: 0.15rem 0.55rem; font-weight: 500;
+            }
+            .patient-meta-pill i { font-size: 0.65rem; color: var(--emerald); }
+
+            .btn-select-patient .ui-button {
+                padding: 0.45rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid), var(--forest-bright)) !important;
+                border: none !important; border-radius: 8px !important;
+                font-family: 'Syne', sans-serif !important; font-weight: 600 !important; font-size: 0.82rem !important;
+                color: white !important; white-space: nowrap !important; cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                box-shadow: 0 2px 8px color-mix(in srgb, var(--forest-mid) 22%, transparent) !important;
+                min-width: unset !important;
+            }
+            .btn-select-patient .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 4px 12px color-mix(in srgb, var(--forest-mid) 30%, transparent) !important; }
+            .btn-select-patient .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-select-patient .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 4px !important; }
+
+            /* ── MESSAGE CARD (no-match / duplicate-blocked) ──────── */
+            .message-card-wrap { text-align: center; padding: 1rem 0 0.25rem; }
+            .message-card-wrap i.big-icon { font-size: 2.75rem; color: var(--emerald); margin-bottom: 1rem; display: block; }
+            .message-card-wrap p { font-size: 0.92rem; color: var(--text-muted); line-height: 1.7; }
+            .message-card-wrap p strong { color: var(--text-dark); }
+
+            /* ── WELCOME / COMPLETE CARD ──────────────────────────── */
+            .welcome-avatar {
+                width: 72px; height: 72px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; font-size: 1.8rem; color: white;
+                margin: 0 auto 1.25rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 25%, transparent);
+            }
+            .welcome-greeting { font-size: 0.82rem; font-weight: 600; color: var(--emerald); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.35rem; }
+            .welcome-name { font-family: 'Syne', sans-serif; font-size: 1.6rem; font-weight: 800; color: var(--forest-deep); margin-bottom: 0.75rem; }
+            .welcome-subtitle { font-size: 0.88rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 0.5rem; }
+        </style>
+        <script type="text/javascript">
+            //<![CDATA[
+            function otpBoxInput(el, index, total) {
+                el.value = el.value.replace(/\D/g, '').slice(0, 1);
+                if (el.value.length === 1) {
+                    el.classList.add('filled');
+                    if (index < total - 1) {
+                        var next = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                        if (next) { next.focus(); next.select(); }
+                    }
+                } else {
+                    el.classList.remove('filled');
+                }
+                assembleOtp(total);
+            }
+
+            function otpBoxKeydown(el, index, event, total) {
+                if (event.key === 'Backspace') {
+                    if (el.value === '' && index > 0) {
+                        var prev = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                        if (prev) { prev.value = ''; prev.classList.remove('filled'); prev.focus(); prev.select(); }
+                        assembleOtp(total);
+                    }
+                } else if (event.key === 'ArrowLeft' && index > 0) {
+                    var prevBox = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                    if (prevBox) prevBox.focus();
+                } else if (event.key === 'ArrowRight' && index < total - 1) {
+                    var nextBox = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                    if (nextBox) nextBox.focus();
+                }
+            }
+
+            function otpBoxPaste(event, total) {
+                event.preventDefault();
+                var text = (event.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '');
+                var boxes = document.querySelectorAll('.otp-box');
+                for (var i = 0; i < boxes.length && i < text.length; i++) {
+                    boxes[i].value = text[i];
+                    boxes[i].classList.add('filled');
+                }
+                assembleOtp(total);
+                var lastIdx = Math.min(text.length, total) - 1;
+                if (lastIdx >= 0) {
+                    var lastBox = document.querySelector('.otp-box[data-index="' + lastIdx + '"]');
+                    if (lastBox) lastBox.focus();
+                }
+            }
+
+            function assembleOtp(total) {
+                var otp = '';
+                for (var i = 0; i < total; i++) {
+                    var box = document.querySelector('.otp-box[data-index="' + i + '"]');
+                    otp += (box && box.value) ? box.value : '';
+                }
+                var hidden = document.getElementById('form:otpHiddenInput');
+                if (hidden) hidden.value = otp;
+            }
+
+            function initOtpBoxes(total) {
+                var container = document.getElementById('otpBoxesContainer');
+                if (!container) return;
+                container.innerHTML = '';
+                for (var i = 0; i < total; i++) {
+                    var inp = document.createElement('input');
+                    inp.type = 'text';
+                    inp.className = 'otp-box';
+                    inp.maxLength = 1;
+                    inp.setAttribute('inputmode', 'numeric');
+                    inp.setAttribute('pattern', '[0-9]*');
+                    inp.autocomplete = 'off';
+                    inp.setAttribute('data-index', i);
+                    (function(idx) {
+                        inp.oninput    = function()  { otpBoxInput(this, idx, total); };
+                        inp.onkeydown  = function(e) { otpBoxKeydown(this, idx, e, total); };
+                        inp.onpaste    = function(e) { otpBoxPaste(e, total); };
+                        inp.onfocus    = function()  { this.select(); };
+                    })(i);
+                    container.appendChild(inp);
+                }
+            }
+
+            var otpCountdownInterval = null;
+
+            function startOtpCountdown(expiryEpochMs) {
+                clearInterval(otpCountdownInterval);
+                var el = document.getElementById('otpCountdownTimer');
+                if (!el)
+                    return;
+                function tick() {
+                    var remaining = expiryEpochMs - Date.now();
+                    if (remaining <= 0) {
+                        clearInterval(otpCountdownInterval);
+                        el.textContent = 'OTP Expired';
+                        el.className = 'otp-countdown-timer expired';
+                        var label = document.querySelector('.otp-countdown-label');
+                        if (label)
+                            label.style.display = 'none';
+                        return;
+                    }
+                    var mins = Math.floor(remaining / 60000);
+                    var secs = Math.floor((remaining % 60000) / 1000);
+                    el.textContent = mins + ':' + (secs < 10 ? '0' : '') + secs;
+                    el.className = 'otp-countdown-timer' + (remaining < 30000 ? ' warning' : '');
+                }
+                tick();
+                otpCountdownInterval = setInterval(tick, 1000);
+            }
+            //]]>
+        </script>
+    </h:head>
+
+    <h:body style="margin:0; padding:0;">
+        <h:form id="form">
+
+            <!-- ═══════════════════════════════════════════
+                 MAIN WRAPPER  (hero left + form right)
+                 ═══════════════════════════════════════════ -->
+            <div class="portal-wrapper">
+
+                <!-- ── LEFT HERO PANEL (desktop ≥992px only) ── -->
+                <div class="portal-hero" style="--hero-color: #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')}">
+                    <div class="hero-dots"/>
+                    <div class="hero-ring hero-ring-1"/>
+                    <div class="hero-ring hero-ring-2"/>
+                    <div class="hero-ring hero-ring-3"/>
+                    <div class="hero-ring hero-ring-4"/>
+                    <div class="hero-cross-lg"/>
+                    <div class="hero-cross" style="top:16%; right:22%; opacity:0.22;"/>
+                    <div class="hero-cross" style="bottom:28%; right:14%; opacity:0.14;"/>
+                    <div class="hero-cross" style="top:52%; left:8%;  opacity:0.12;"/>
+
+                    <div class="hero-content">
+                        <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}" layout="block" styleClass="hero-logo-wrap">
+                            <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                 alt="Hospital Logo"
+                                 class="hero-logo-img"/>
+                        </h:panelGroup>
+
+                        <div class="hero-badge">
+                            <div class="hero-badge-dot"/>
+                            Client Self-Service
+                        </div>
+
+                        <div class="hero-title">
+                            Create Your<br/>
+                            <span class="accent">Client Portal</span><br/>
+                            Account.
+                        </div>
+
+                        <p class="hero-desc">
+                            Verify your mobile number and set a password to
+                            access your Client Portal account — a quick, secure,
+                            self-service registration.
+                        </p>
+
+                        <ul class="hero-features">
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-shield-halved"/></span>
+                                Secure OTP Mobile Verification
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-id-card"/></span>
+                                Matched to Your Patient Record
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-lock"/></span>
+                                Set Your Own Password
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <!-- END HERO PANEL -->
+
+                <!-- ── RIGHT FORM PANEL ───────────────────── -->
+                <div class="portal-form-panel">
+                    <div class="form-container">
+
+                        <!-- Mobile brand header (hidden on desktop) -->
+                        <div class="mobile-brand-header">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                     alt="Hospital Logo"
+                                     class="mobile-logo-img"/>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <div class="mobile-icon"><i class="fas fa-user-shield"/></div>
+                            </h:panelGroup>
+                            <span class="mobile-portal-label">Client Portal Registration</span>
+                        </div>
+
+                        <!-- Global messages (middle-top, all steps) -->
+                        <h:panelGroup id="globalMessages" layout="block" styleClass="global-messages-wrap">
+                            <h:messages
+                                layout="list"
+                                showDetail="true"
+                                showSummary="false"
+                                errorClass="portal-error-msg"
+                                warnClass="portal-warn-msg"
+                                infoClass="portal-info-msg"/>
+                        </h:panelGroup>
+
+                        <!-- Main switchable content panel -->
+                        <h:panelGroup id="portalContentPanel" layout="block">
+
+                            <!-- STEP 1: Phone entry -->
+                            <h:panelGroup rendered="#{!clientPortalPhoneRegistrationController.otpSendSuccess}" layout="block">
+                                <div class="otp-card">
+                                    <div class="card-lead-icon"><i class="fas fa-mobile-screen-button"/></div>
+                                    <div class="card-title">Register for Client Portal</div>
+
+                                    <div class="steps-bar">
+                                        <div class="step-item">
+                                            <div class="step-dot active">1</div>
+                                            <span class="step-label">Phone</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot">2</div>
+                                            <span class="step-label">Verify</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot">3</div>
+                                            <span class="step-label">Password</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="card-subtitle">
+                                        Enter your mobile number to receive a secure
+                                        one-time verification code.
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:phoneNumberInput">Mobile Number</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-phone f-icon"/>
+                                            <h:inputText id="phoneNumberInput"
+                                                         value="#{clientPortalPhoneRegistrationController.phoneNumber}"
+                                                         onfocus="this.select()"
+                                                         a:placeholder="0712345678"
+                                                         a:autocomplete="tel"
+                                                         a:inputmode="tel"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="btn-send">
+                                        <p:commandButton id="sendOtpButton"
+                                                          value="Send OTP"
+                                                          icon="fas fa-paper-plane"
+                                                          action="#{clientPortalPhoneRegistrationController.sendOtp}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Send OTP to mobile number"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 2: OTP entry -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.otpSendSuccess and !clientPortalPhoneRegistrationController.otpVerified}" layout="block">
+                                <div class="otp-card">
+                                    <script type="text/javascript">
+                                        //<![CDATA[
+                                        startOtpCountdown(#{clientPortalPhoneRegistrationController.otpExpiryEpochMs});
+                                        //]]>
+                                    </script>
+
+                                    <div class="card-lead-icon"><i class="fas fa-shield-halved"/></div>
+                                    <div class="card-title">Verify Your Number</div>
+
+                                    <div class="steps-bar">
+                                        <div class="step-item">
+                                            <div class="step-dot">1</div>
+                                            <span class="step-label">Phone</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot active">2</div>
+                                            <span class="step-label">Verify</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot">3</div>
+                                            <span class="step-label">Password</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="card-subtitle">
+                                        OTP sent to <strong>#{clientPortalPhoneRegistrationController.phoneNumber}</strong>.
+                                        Enter it below to continue.
+                                    </div>
+
+                                    <div class="otp-countdown-wrap">
+                                        <span class="otp-countdown-label">OTP expires in</span>
+                                        <span id="otpCountdownTimer" class="otp-countdown-timer">
+                                            #{clientPortalPhoneRegistrationController.otpTimeoutMinutes}:00
+                                        </span>
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="otpBoxesContainer">One-Time Password</label>
+                                        <div class="otp-boxes-wrap" id="otpBoxesContainer"/>
+                                        <script type="text/javascript">
+                                            //<![CDATA[
+                                            initOtpBoxes(#{clientPortalPhoneRegistrationController.otpLength});
+                                            //]]>
+                                        </script>
+                                        <h:inputHidden id="otpHiddenInput" value="#{clientPortalPhoneRegistrationController.enteredOtp}"/>
+                                    </div>
+
+                                    <div class="btn-verify">
+                                        <p:commandButton id="verifyOtpButton"
+                                                          value="Verify OTP"
+                                                          icon="fas fa-circle-check"
+                                                          action="#{clientPortalPhoneRegistrationController.verifyOtp}"
+                                                          update="globalMessages portalContentPanel"
+                                                          onclick="assembleOtp(#{clientPortalPhoneRegistrationController.otpLength})"
+                                                          title="Verify entered OTP"/>
+                                    </div>
+
+                                    <div class="resend-wrap">
+                                        Didn't receive it?&#160;
+                                        <p:commandLink id="resendOtpLink"
+                                                        value="Resend OTP"
+                                                        action="#{clientPortalPhoneRegistrationController.sendOtp}"
+                                                        update="globalMessages portalContentPanel"
+                                                        title="Resend OTP"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 3: No-match rejection -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.noMatchRejected}" layout="block">
+                                <div class="otp-card">
+                                    <div class="message-card-wrap">
+                                        <i class="fas fa-user-slash big-icon"/>
+                                        <h:panelGroup layout="block" styleClass="card-title">No Matching Patient Record</h:panelGroup>
+                                        <p>
+                                            We could not find an existing patient record for mobile
+                                            number <strong>#{clientPortalPhoneRegistrationController.phoneNumber}</strong>.
+                                            Client Portal registration is only available to patients
+                                            who already have a record with us. Please visit our
+                                            registration kiosk, or ask our front-desk staff to create
+                                            your patient record, then try registering again.
+                                        </p>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 4: Multi-match picker -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.otpVerified and clientPortalPhoneRegistrationController.multipleMatch and clientPortalPhoneRegistrationController.selectedPatient eq null}" layout="block">
+                                <div class="patient-select-card">
+                                    <div class="card-lead-icon"><i class="fas fa-users"/></div>
+                                    <div class="patient-select-title">Select Your Profile</div>
+                                    <div class="patient-select-subtitle">
+                                        We found multiple patient records for
+                                        <strong>#{clientPortalPhoneRegistrationController.phoneNumber}</strong>.
+                                        Select the profile that is you.
+                                    </div>
+
+                                    <p:dataTable id="matchedPatientsTable"
+                                                 widgetVar="matchedPatientsTableWidget"
+                                                 value="#{clientPortalPhoneRegistrationController.matchedPatients}"
+                                                 var="pt"
+                                                 rowKey="#{pt.id}"
+                                                 styleClass="matched-patients-table">
+                                        <p:column>
+                                            <div class="patient-row" title="Patient #{pt.person.nameWithTitle}">
+                                                <div class="patient-avatar"><i class="fas fa-user"/></div>
+                                                <div class="patient-info">
+                                                    <div class="patient-name">#{pt.person.nameWithTitle}</div>
+                                                    <div class="patient-meta">
+                                                        <span class="patient-meta-pill">
+                                                            <i class="fas fa-mobile-screen-button"/>
+                                                            #{pt.person.mobile}
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                                <div class="btn-select-patient">
+                                                    <p:commandButton value="This is me"
+                                                                      icon="fas fa-arrow-right"
+                                                                      action="#{clientPortalPhoneRegistrationController.selectPatientProfile(pt)}"
+                                                                      update=":form:globalMessages :form:portalContentPanel"
+                                                                      title="Select patient #{pt.person.nameWithTitle}"/>
+                                                </div>
+                                            </div>
+                                        </p:column>
+                                    </p:dataTable>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 5: Duplicate account blocked -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.duplicateAccountBlocked}" layout="block">
+                                <div class="otp-card">
+                                    <div class="message-card-wrap">
+                                        <i class="fas fa-triangle-exclamation big-icon"/>
+                                        <h:panelGroup layout="block" styleClass="card-title">Account Already Exists</h:panelGroup>
+                                        <p>
+                                            A Client Portal account already exists for this person.
+                                            Please log in with your existing credentials, or use the
+                                            password reset option instead.
+                                        </p>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 6: Password set -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.otpVerified and clientPortalPhoneRegistrationController.selectedPatient ne null and !clientPortalPhoneRegistrationController.duplicateAccountBlocked and !clientPortalPhoneRegistrationController.registrationComplete}" layout="block">
+                                <div class="otp-card">
+                                    <div class="card-lead-icon"><i class="fas fa-lock"/></div>
+                                    <div class="card-title">Set Your Password</div>
+
+                                    <div class="steps-bar">
+                                        <div class="step-item">
+                                            <div class="step-dot">1</div>
+                                            <span class="step-label">Phone</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot">2</div>
+                                            <span class="step-label">Verify</span>
+                                        </div>
+                                        <div class="step-connector"/>
+                                        <div class="step-item">
+                                            <div class="step-dot active">3</div>
+                                            <span class="step-label">Password</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="card-subtitle">
+                                        Create a password for
+                                        <strong>#{clientPortalPhoneRegistrationController.selectedPatient.person.nameWithTitle}</strong>
+                                        to finish setting up your Client Portal account.
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:passwordInput">Password</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-lock f-icon"/>
+                                            <p:password id="passwordInput"
+                                                        value="#{clientPortalPhoneRegistrationController.password}"
+                                                        feedback="false"
+                                                        toggleMask="true"
+                                                        a:placeholder="At least 6 characters"
+                                                        a:autocomplete="new-password"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:passwordConfirmInput">Confirm Password</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-lock f-icon"/>
+                                            <p:password id="passwordConfirmInput"
+                                                        value="#{clientPortalPhoneRegistrationController.passwordConfirm}"
+                                                        feedback="false"
+                                                        toggleMask="true"
+                                                        a:placeholder="Re-enter password"
+                                                        a:autocomplete="new-password"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="btn-send">
+                                        <p:commandButton id="registerButton"
+                                                          value="Create Account"
+                                                          icon="fas fa-user-check"
+                                                          action="#{clientPortalPhoneRegistrationController.register}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Create Client Portal account"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 7: Registration complete -->
+                            <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.registrationComplete}" layout="block">
+                                <div class="welcome-card">
+                                    <div class="welcome-avatar"><i class="fas fa-circle-check"/></div>
+                                    <div class="welcome-greeting">Registration Complete</div>
+                                    <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.selectedPatient ne null}" layout="block" styleClass="welcome-name">
+                                        Welcome, #{clientPortalPhoneRegistrationController.selectedPatient.person.nameWithTitle}!
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{clientPortalPhoneRegistrationController.selectedPatient eq null}" layout="block" styleClass="welcome-name">
+                                        Welcome!
+                                    </h:panelGroup>
+                                    <p class="welcome-subtitle">
+                                        Your Client Portal account has been created
+                                        successfully. You can now use your mobile
+                                        number and password to log in.
+                                    </p>
+                                </div>
+                            </h:panelGroup>
+
+                        </h:panelGroup>
+                        <!-- END portalContentPanel -->
+
+                        <!-- Footer note -->
+                        <div class="portal-footer-note">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}"
+                                     alt="CareCode"
+                                     style="height:28px; vertical-align:middle; margin-right:6px;"/>
+                            </h:panelGroup>
+                            Powered by CareCode (Pvt) Ltd.
+                        </div>
+
+                    </div>
+                </div>
+                <!-- END FORM PANEL -->
+
+            </div>
+            <!-- END PORTAL WRAPPER -->
+
+        </h:form>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
- Implements channel 2 of the Client Portal Registration design spec (issue #22367, part of master tracking issue #22359): a client enters a phone number that must already match an existing patient, verifies via OTP, and sets a password to create their `ClientAccount`.
- `ClientAccountFacade.createIfNoActiveAccount(personId, newAccount)` locks the `Person` row (`PESSIMISTIC_WRITE`) for the duration of the check-then-create, per the design spec's concurrency note — first implementation of that pattern; #22363/#22368/#22369 can reuse it.
- New `ClientPortalPhoneRegistrationController` (`com.divudi.bean.clientportal`, `@ViewScoped`) extends the existing `PatientPortalController` OTP-send/verify/match pattern, tagged with the (already-merged) `MessageType.ClientPortalRegistrationOTP` so it doesn't collide with the existing channel-booking-payment OTP flow.
- New public, standalone `client_portal/register_phone.xhtml` page (same structural/CSS pattern as `patient_portal/portal_login.xhtml`).

## Test plan
Verified end-to-end against local Payara + DB via Playwright (screenshots on the linked issue):
- [x] Single-match happy path — OTP send → verify → auto-select → password set → confirmation card; `CLIENTACCOUNT` row inserted with correct `person_id`, hashed `passwordhash`, `createdvia='SELF_PHONE'`, `phoneverified=1`.
- [x] Zero-match rejection — phone with no matching `Patient` → rejected with a message pointing to kiosk/staff-assisted channels; no account created.
- [x] Duplicate-account block — re-registering the same person a second time is blocked right after OTP verification; confirmed via DB no second row was created.
- [x] Multi-match picker — a phone shared by 2 patients renders a picker; selecting either advances correctly and creates the account against the right `person_id`.
- [x] `mvn clean compile` — no errors.

Full verification detail and evidence: hmislk/hmis#22367 (comment).

## Notes for reviewers
- `CLIENTACCOUNT` table doesn't exist in the shared/CI schema yet — DDL regeneration is deliberately deferred to #22371 per the master issue #22359's sequencing (one shared `generate-ddl` pass after all 6 channel issues land). For this PR's local testing, the table was hand-created locally only (not committed).
- Found and fixed a real JSF bug during testing: a `p:commandButton` inside a `p:dataTable` row (a `NamingContainer`) used a relative `update=` target for siblings outside the table, which JSF can't resolve — silent `ComponentNotFoundException` server-side, stuck-disabled button client-side with no console error. Fixed with absolute ids. Matches a previously-documented gotcha (workflow doc §42).

Closes #22367

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phone-based client portal registration.
  * Users can receive and verify an OTP by SMS.
  * Added patient matching and selection when multiple profiles are found.
  * Added password creation and confirmation for new accounts.
  * Prevents duplicate active account registration.
  * Added responsive registration screens with OTP countdown and completion messaging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->