### PR TITLE
API: Investigation category, sample, container & analyzer linking

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
@@ -9,6 +9,14 @@ public class InvestigationCreateRequestDTO {
     private Boolean bypassSampleWorkflow;
     private Boolean vatable;
     private Double vatPercentage;
+    private Long categoryId;
+    private String categoryName;
+    private Long sampleId;
+    private String sampleName;
+    private Long containerId;
+    private String containerName;
+    private Long analyzerId;
+    private String analyzerName;
 
     public boolean isValid() { return name != null && !name.trim().isEmpty(); }
     public String getName() { return name; }
@@ -27,4 +35,20 @@ public class InvestigationCreateRequestDTO {
     public void setVatable(Boolean vatable) { this.vatable = vatable; }
     public Double getVatPercentage() { return vatPercentage; }
     public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
+    public Long getCategoryId() { return categoryId; }
+    public void setCategoryId(Long categoryId) { this.categoryId = categoryId; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public Long getSampleId() { return sampleId; }
+    public void setSampleId(Long sampleId) { this.sampleId = sampleId; }
+    public String getSampleName() { return sampleName; }
+    public void setSampleName(String sampleName) { this.sampleName = sampleName; }
+    public Long getContainerId() { return containerId; }
+    public void setContainerId(Long containerId) { this.containerId = containerId; }
+    public String getContainerName() { return containerName; }
+    public void setContainerName(String containerName) { this.containerName = containerName; }
+    public Long getAnalyzerId() { return analyzerId; }
+    public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
+    public String getAnalyzerName() { return analyzerName; }
+    public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
@@ -10,6 +10,14 @@ public class InvestigationSearchResultDTO {
     private Boolean bypassSampleWorkflow;
     private Boolean vatable;
     private Double vatPercentage;
+    private Long categoryId;
+    private String categoryName;
+    private Long sampleId;
+    private String sampleName;
+    private Long containerId;
+    private String containerName;
+    private Long analyzerId;
+    private String analyzerName;
 
     public InvestigationSearchResultDTO() {}
 
@@ -40,4 +48,20 @@ public class InvestigationSearchResultDTO {
     public void setVatable(Boolean vatable) { this.vatable = vatable; }
     public Double getVatPercentage() { return vatPercentage; }
     public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
+    public Long getCategoryId() { return categoryId; }
+    public void setCategoryId(Long categoryId) { this.categoryId = categoryId; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public Long getSampleId() { return sampleId; }
+    public void setSampleId(Long sampleId) { this.sampleId = sampleId; }
+    public String getSampleName() { return sampleName; }
+    public void setSampleName(String sampleName) { this.sampleName = sampleName; }
+    public Long getContainerId() { return containerId; }
+    public void setContainerId(Long containerId) { this.containerId = containerId; }
+    public String getContainerName() { return containerName; }
+    public void setContainerName(String containerName) { this.containerName = containerName; }
+    public Long getAnalyzerId() { return analyzerId; }
+    public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
+    public String getAnalyzerName() { return analyzerName; }
+    public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
@@ -9,10 +9,20 @@ public class InvestigationUpdateRequestDTO {
     private Boolean bypassSampleWorkflow;
     private Boolean vatable;
     private Double vatPercentage;
+    private Long categoryId;
+    private String categoryName;
+    private Long sampleId;
+    private String sampleName;
+    private Long containerId;
+    private String containerName;
+    private Long analyzerId;
+    private String analyzerName;
 
     public boolean isValid() {
         return name != null || code != null || printName != null || inactive != null || reportType != null
-                || bypassSampleWorkflow != null || vatable != null || vatPercentage != null;
+                || bypassSampleWorkflow != null || vatable != null || vatPercentage != null
+                || categoryId != null || categoryName != null || sampleId != null || sampleName != null
+                || containerId != null || containerName != null || analyzerId != null || analyzerName != null;
     }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -30,4 +40,20 @@ public class InvestigationUpdateRequestDTO {
     public void setVatable(Boolean vatable) { this.vatable = vatable; }
     public Double getVatPercentage() { return vatPercentage; }
     public void setVatPercentage(Double vatPercentage) { this.vatPercentage = vatPercentage; }
+    public Long getCategoryId() { return categoryId; }
+    public void setCategoryId(Long categoryId) { this.categoryId = categoryId; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public Long getSampleId() { return sampleId; }
+    public void setSampleId(Long sampleId) { this.sampleId = sampleId; }
+    public String getSampleName() { return sampleName; }
+    public void setSampleName(String sampleName) { this.sampleName = sampleName; }
+    public Long getContainerId() { return containerId; }
+    public void setContainerId(Long containerId) { this.containerId = containerId; }
+    public String getContainerName() { return containerName; }
+    public void setContainerName(String containerName) { this.containerName = containerName; }
+    public Long getAnalyzerId() { return analyzerId; }
+    public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
+    public String getAnalyzerName() { return analyzerName; }
+    public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
 }

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -4,7 +4,15 @@ import com.divudi.core.data.InvestigationReportType;
 import com.divudi.core.data.dto.investigation.*;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.entity.lab.InvestigationCategory;
+import com.divudi.core.entity.lab.InvestigationTube;
+import com.divudi.core.entity.lab.Machine;
+import com.divudi.core.entity.lab.Sample;
+import com.divudi.core.facade.InvestigationCategoryFacade;
 import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.core.facade.InvestigationTubeFacade;
+import com.divudi.core.facade.MachineFacade;
+import com.divudi.core.facade.SampleFacade;
 import com.divudi.core.util.CommonFunctions;
 
 import javax.ejb.EJB;
@@ -16,6 +24,10 @@ import java.util.*;
 @Stateless
 public class InvestigationApiService implements Serializable {
     @EJB private InvestigationFacade investigationFacade;
+    @EJB private InvestigationCategoryFacade investigationCategoryFacade;
+    @EJB private SampleFacade sampleFacade;
+    @EJB private InvestigationTubeFacade investigationTubeFacade;
+    @EJB private MachineFacade machineFacade;
 
     public List<InvestigationSearchResultDTO> search(String query, Boolean inactive, int limit) {
         Map<String, Object> m = new HashMap<>();
@@ -49,6 +61,14 @@ public class InvestigationApiService implements Serializable {
         validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
+        InvestigationCategory category = resolveCategory(req.getCategoryId(), req.getCategoryName(), user);
+        if (category != null) i.setCategory(category);
+        Sample sample = resolveSample(req.getSampleId(), req.getSampleName(), user);
+        if (sample != null) i.setSample(sample);
+        InvestigationTube container = resolveContainer(req.getContainerId(), req.getContainerName(), user);
+        if (container != null) i.setInvestigationTube(container);
+        Machine analyzer = resolveAnalyzer(req.getAnalyzerId(), req.getAnalyzerName(), user);
+        if (analyzer != null) i.setMachine(analyzer);
         i.setCreater(user); i.setCreatedAt(new Date()); i.setRetired(false);
         investigationFacade.create(i); i.setBilledAs(i); i.setReportedAs(i); investigationFacade.edit(i);
         return toResponse(i, "Investigation created successfully");
@@ -66,6 +86,18 @@ public class InvestigationApiService implements Serializable {
         validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
+        if (req.getCategoryId() != null || req.getCategoryName() != null) {
+            i.setCategory(resolveCategory(req.getCategoryId(), req.getCategoryName(), user));
+        }
+        if (req.getSampleId() != null || req.getSampleName() != null) {
+            i.setSample(resolveSample(req.getSampleId(), req.getSampleName(), user));
+        }
+        if (req.getContainerId() != null || req.getContainerName() != null) {
+            i.setInvestigationTube(resolveContainer(req.getContainerId(), req.getContainerName(), user));
+        }
+        if (req.getAnalyzerId() != null || req.getAnalyzerName() != null) {
+            i.setMachine(resolveAnalyzer(req.getAnalyzerId(), req.getAnalyzerName(), user));
+        }
         i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
         return toResponse(i, "Investigation updated successfully");
     }
@@ -77,6 +109,102 @@ public class InvestigationApiService implements Serializable {
 
     private Investigation load(Long id) throws Exception { Investigation i = investigationFacade.find(id); if (i == null || i.isRetired()) throw new Exception("Investigation not found with ID: " + id); return i; }
 
+    private InvestigationCategory resolveCategory(Long id, String name, WebUser user) throws Exception {
+        if (id != null) {
+            InvestigationCategory c = investigationCategoryFacade.find(id);
+            if (c == null || c.isRetired()) throw new Exception("Category not found with ID: " + id);
+            return c;
+        }
+        if (name != null && !name.trim().isEmpty()) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("ret", false);
+            m.put("name", name.trim());
+            InvestigationCategory c = investigationCategoryFacade.findFirstByJpql(
+                    "select c from InvestigationCategory c where c.retired=:ret and c.name=:name order by c.name", m);
+            if (c == null) {
+                c = new InvestigationCategory();
+                c.setName(name.trim());
+                c.setCreatedAt(new Date());
+                c.setCreater(user);
+                investigationCategoryFacade.createAndFlush(c);
+            }
+            return c;
+        }
+        return null;
+    }
+
+    private Sample resolveSample(Long id, String name, WebUser user) throws Exception {
+        if (id != null) {
+            Sample s = sampleFacade.find(id);
+            if (s == null || s.isRetired()) throw new Exception("Sample not found with ID: " + id);
+            return s;
+        }
+        if (name != null && !name.trim().isEmpty()) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("ret", false);
+            m.put("name", name.trim());
+            Sample s = sampleFacade.findFirstByJpql(
+                    "select s from Sample s where s.retired=:ret and s.name=:name order by s.name", m);
+            if (s == null) {
+                s = new Sample();
+                s.setName(name.trim());
+                s.setCreatedAt(new Date());
+                s.setCreater(user);
+                sampleFacade.createAndFlush(s);
+            }
+            return s;
+        }
+        return null;
+    }
+
+    private InvestigationTube resolveContainer(Long id, String name, WebUser user) throws Exception {
+        if (id != null) {
+            InvestigationTube t = investigationTubeFacade.find(id);
+            if (t == null || t.isRetired()) throw new Exception("Container not found with ID: " + id);
+            return t;
+        }
+        if (name != null && !name.trim().isEmpty()) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("ret", false);
+            m.put("name", name.trim());
+            InvestigationTube t = investigationTubeFacade.findFirstByJpql(
+                    "select t from InvestigationTube t where t.retired=:ret and t.name=:name order by t.name", m);
+            if (t == null) {
+                t = new InvestigationTube();
+                t.setName(name.trim());
+                t.setCreatedAt(new Date());
+                t.setCreater(user);
+                investigationTubeFacade.createAndFlush(t);
+            }
+            return t;
+        }
+        return null;
+    }
+
+    private Machine resolveAnalyzer(Long id, String name, WebUser user) throws Exception {
+        if (id != null) {
+            Machine ma = machineFacade.find(id);
+            if (ma == null || ma.isRetired()) throw new Exception("Analyzer not found with ID: " + id);
+            return ma;
+        }
+        if (name != null && !name.trim().isEmpty()) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("ret", false);
+            m.put("name", name.trim());
+            Machine ma = machineFacade.findFirstByJpql(
+                    "select ma from Machine ma where ma.retired=:ret and ma.name=:name order by ma.name", m);
+            if (ma == null) {
+                ma = new Machine();
+                ma.setName(name.trim());
+                ma.setCreatedAt(new Date());
+                ma.setCreater(user);
+                machineFacade.createAndFlush(ma);
+            }
+            return ma;
+        }
+        return null;
+    }
+
     private void validateVatPercentage(Double vatPercentage) throws Exception {
         if (vatPercentage != null && (vatPercentage < 0 || vatPercentage > 100)) {
             throw new Exception("vatPercentage must be between 0 and 100");
@@ -86,12 +214,32 @@ public class InvestigationApiService implements Serializable {
         InvestigationSearchResultDTO dto = new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow());
         dto.setVatable(i.isVatable());
         dto.setVatPercentage(i.getVatPercentage());
+        populateLinks(dto, i);
         return dto;
     }
     private InvestigationResponseDTO toResponse(Investigation i, String m) {
         InvestigationResponseDTO dto = new InvestigationResponseDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow(), m);
         dto.setVatable(i.isVatable());
         dto.setVatPercentage(i.getVatPercentage());
+        populateLinks(dto, i);
         return dto;
+    }
+    private void populateLinks(InvestigationSearchResultDTO dto, Investigation i) {
+        if (i.getCategory() != null) {
+            dto.setCategoryId(i.getCategory().getId());
+            dto.setCategoryName(i.getCategory().getName());
+        }
+        if (i.getSample() != null) {
+            dto.setSampleId(i.getSample().getId());
+            dto.setSampleName(i.getSample().getName());
+        }
+        if (i.getInvestigationTube() != null) {
+            dto.setContainerId(i.getInvestigationTube().getId());
+            dto.setContainerName(i.getInvestigationTube().getName());
+        }
+        if (i.getMachine() != null) {
+            dto.setAnalyzerId(i.getMachine().getId());
+            dto.setAnalyzerName(i.getMachine().getName());
+        }
     }
 }

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -86,17 +86,21 @@ public class InvestigationApiService implements Serializable {
         validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
-        if (req.getCategoryId() != null || req.getCategoryName() != null) {
-            i.setCategory(resolveCategory(req.getCategoryId(), req.getCategoryName(), user));
+        if (req.getCategoryId() != null || (req.getCategoryName() != null && !req.getCategoryName().trim().isEmpty())) {
+            InvestigationCategory category = resolveCategory(req.getCategoryId(), req.getCategoryName(), user);
+            if (category != null) i.setCategory(category);
         }
-        if (req.getSampleId() != null || req.getSampleName() != null) {
-            i.setSample(resolveSample(req.getSampleId(), req.getSampleName(), user));
+        if (req.getSampleId() != null || (req.getSampleName() != null && !req.getSampleName().trim().isEmpty())) {
+            Sample sample = resolveSample(req.getSampleId(), req.getSampleName(), user);
+            if (sample != null) i.setSample(sample);
         }
-        if (req.getContainerId() != null || req.getContainerName() != null) {
-            i.setInvestigationTube(resolveContainer(req.getContainerId(), req.getContainerName(), user));
+        if (req.getContainerId() != null || (req.getContainerName() != null && !req.getContainerName().trim().isEmpty())) {
+            InvestigationTube container = resolveContainer(req.getContainerId(), req.getContainerName(), user);
+            if (container != null) i.setInvestigationTube(container);
         }
-        if (req.getAnalyzerId() != null || req.getAnalyzerName() != null) {
-            i.setMachine(resolveAnalyzer(req.getAnalyzerId(), req.getAnalyzerName(), user));
+        if (req.getAnalyzerId() != null || (req.getAnalyzerName() != null && !req.getAnalyzerName().trim().isEmpty())) {
+            Machine analyzer = resolveAnalyzer(req.getAnalyzerId(), req.getAnalyzerName(), user);
+            if (analyzer != null) i.setMachine(analyzer);
         }
         i.setEditer(user); i.setEditedAt(new Date()); investigationFacade.edit(i);
         return toResponse(i, "Investigation updated successfully");
@@ -118,9 +122,9 @@ public class InvestigationApiService implements Serializable {
         if (name != null && !name.trim().isEmpty()) {
             Map<String, Object> m = new HashMap<>();
             m.put("ret", false);
-            m.put("name", name.trim());
+            m.put("name", name.trim().toLowerCase());
             InvestigationCategory c = investigationCategoryFacade.findFirstByJpql(
-                    "select c from InvestigationCategory c where c.retired=:ret and c.name=:name order by c.name", m);
+                    "select c from InvestigationCategory c where c.retired=:ret and lower(c.name)=:name order by c.name", m);
             if (c == null) {
                 c = new InvestigationCategory();
                 c.setName(name.trim());
@@ -142,9 +146,9 @@ public class InvestigationApiService implements Serializable {
         if (name != null && !name.trim().isEmpty()) {
             Map<String, Object> m = new HashMap<>();
             m.put("ret", false);
-            m.put("name", name.trim());
+            m.put("name", name.trim().toLowerCase());
             Sample s = sampleFacade.findFirstByJpql(
-                    "select s from Sample s where s.retired=:ret and s.name=:name order by s.name", m);
+                    "select s from Sample s where s.retired=:ret and lower(s.name)=:name order by s.name", m);
             if (s == null) {
                 s = new Sample();
                 s.setName(name.trim());
@@ -166,9 +170,9 @@ public class InvestigationApiService implements Serializable {
         if (name != null && !name.trim().isEmpty()) {
             Map<String, Object> m = new HashMap<>();
             m.put("ret", false);
-            m.put("name", name.trim());
+            m.put("name", name.trim().toLowerCase());
             InvestigationTube t = investigationTubeFacade.findFirstByJpql(
-                    "select t from InvestigationTube t where t.retired=:ret and t.name=:name order by t.name", m);
+                    "select t from InvestigationTube t where t.retired=:ret and lower(t.name)=:name order by t.name", m);
             if (t == null) {
                 t = new InvestigationTube();
                 t.setName(name.trim());
@@ -190,9 +194,9 @@ public class InvestigationApiService implements Serializable {
         if (name != null && !name.trim().isEmpty()) {
             Map<String, Object> m = new HashMap<>();
             m.put("ret", false);
-            m.put("name", name.trim());
+            m.put("name", name.trim().toLowerCase());
             Machine ma = machineFacade.findFirstByJpql(
-                    "select ma from Machine ma where ma.retired=:ret and ma.name=:name order by ma.name", m);
+                    "select ma from Machine ma where ma.retired=:ret and lower(ma.name)=:name order by ma.name", m);
             if (ma == null) {
                 ma = new Machine();
                 ma.setName(name.trim());

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -398,7 +398,10 @@ public class CapabilityStatementResource {
                         "API Key",
                         "GET", "POST", "DELETE"))
                                 .add(resource("Investigations", "/api/investigations",
-                        "Investigation master management including search, create, update, and activate/deactivate for item import workflows",
+                        "Investigation master management including search, create, update, and activate/deactivate for item import workflows. "
+                        + "Category/sample/container(tube)/analyzer(machine) can each be set via an ID referencing an existing row "
+                        + "(categoryId, sampleId, containerId, analyzerId — errors if not found) or a name "
+                        + "(categoryName, sampleName, containerName, analyzerName — found-or-created by name if no matching row exists).",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH"))
                 .add(resource("Investigation Format", "/api/investigations/{investigationId}/format",


### PR DESCRIPTION
## Summary
- First sub-issue under #464 (Full API + AI-Agent-Driven Investigation Authoring). Adds the ability to set an `Investigation`'s category, sample, container (`investigationTube`), and analyzer (`machine`) via the REST API — previously only settable through the "Manage" UI tab.
- `InvestigationCreateRequestDTO`/`InvestigationUpdateRequestDTO` each gain 8 new fields: `categoryId`/`categoryName`, `sampleId`/`sampleName`, `containerId`/`containerName`, `analyzerId`/`analyzerName`. An id must reference an existing non-retired row (errors otherwise); a name is resolved by find-or-create, reusing the same JPQL pattern already used by `InvestigationCategoryController`/`SampleController`/`InvestigationTubeController`/`MachineController` for Excel-based imports (`DataUploadController.readInvestigationsFromExcel`).
- `InvestigationSearchResultDTO` (base of `InvestigationResponseDTO`) gains the same 8 fields on read, so `GET /investigations/{id}` and `GET /investigations/search` both surface the resolved links.
- `CapabilityStatementResource`'s `/api/investigations` entry documents the new id-or-name fields.
- Along the way, fixed the new find-or-create helpers to use `createAndFlush` (matching the convention already used in `InvestigationFormatApiService`) instead of `create`, so a newly-created category/sample/container/analyzer reliably has its generated id populated in the same response — without this, the id was only present when a later create() elsewhere in the request happened to trigger a JPA auto-flush first.

Out of scope (tracked in other #464 sub-issues): components, pricing/fees, validators, bundled export, and AI Chat tool registration (#22366).

## Test plan
Pure REST API change with no XHTML/UI surface — verified locally against Payara (`rh` domain) + the local `coop` MySQL database via `curl` with a `Finance` API-key header:
- [x] `POST /api/investigations` with all 4 fields as brand-new `*Name` values → response includes matching ids (`categoryId`, `sampleId`, `containerId`, `analyzerId`) and names.
- [x] `POST` again reusing the same names → same ids returned; confirmed via direct DB query (`SELECT ... FROM CATEGORY WHERE NAME=...`) that exactly one row exists per name (no duplicates from find-or-create).
- [x] `PUT /api/investigations/{id}` using `containerId`/`analyzerId` referencing the rows created above → response reflects the update.
- [x] `PUT` with a bogus `categoryId` → clean 4xx/5xx JSON error (`"Category not found with ID: ..."`), no stack trace leaked, no silent no-op.
- [x] `GET /api/investigations/{id}` and `GET /api/investigations/search` → both include all 8 new fields.
- [x] `mvn clean package -DskipTests` builds clean; redeployed and checked `server.log` for exceptions during the above calls — none from this code path.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investigations now support category, sample, container/tube, and analyzer/machine details.
  * Related records can be selected by ID or provided by name, with missing named records created automatically.
  * Investigation responses now include these related details.
* **Bug Fixes**
  * Invalid or retired related records are rejected during investigation creation and updates.
* **Documentation**
  * Updated API capability details to describe relationship handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->