### PR TITLE
feat(api): add Investigation Components CRUD API

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationComponentDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationComponentDTO.java
@@ -1,0 +1,21 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationComponentDTO {
+
+    private Long id;
+    private Long investigationId;
+    private String componentName;
+    private String message;
+
+    public InvestigationComponentDTO() {
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getInvestigationId() { return investigationId; }
+    public void setInvestigationId(Long investigationId) { this.investigationId = investigationId; }
+    public String getComponentName() { return componentName; }
+    public void setComponentName(String componentName) { this.componentName = componentName; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/core/facade/InvestigationComponentFacade.java
+++ b/src/main/java/com/divudi/core/facade/InvestigationComponentFacade.java
@@ -1,0 +1,30 @@
+/*
+* Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.lab.InvestigationComponent;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class InvestigationComponentFacade extends AbstractFacade<InvestigationComponent> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        if(em == null){}return em;
+    }
+
+    public InvestigationComponentFacade() {
+        super(InvestigationComponent.class);
+    }
+
+}

--- a/src/main/java/com/divudi/service/investigation/InvestigationComponentApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationComponentApiService.java
@@ -93,11 +93,12 @@ public class InvestigationComponentApiService implements Serializable {
     }
 
     private InvestigationComponent loadComponent(Long componentId, Long investigationId) throws Exception {
+        Investigation investigation = loadInvestigation(investigationId);
         InvestigationComponent c = investigationComponentFacade.find(componentId);
         if (c == null) {
             throw new Exception("Component not found with ID: " + componentId);
         }
-        if (c.getInvestigation() == null || !c.getInvestigation().getId().equals(investigationId)) {
+        if (c.getInvestigation() == null || !investigation.getId().equals(c.getInvestigation().getId())) {
             throw new Exception("Component " + componentId + " does not belong to investigation " + investigationId);
         }
         return c;

--- a/src/main/java/com/divudi/service/investigation/InvestigationComponentApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationComponentApiService.java
@@ -1,0 +1,116 @@
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.dto.investigation.InvestigationComponentDTO;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.entity.lab.InvestigationComponent;
+import com.divudi.core.facade.InvestigationComponentFacade;
+import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.core.facade.InvestigationItemFacade;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Stateless
+public class InvestigationComponentApiService implements Serializable {
+
+    @EJB
+    private InvestigationFacade investigationFacade;
+    @EJB
+    private InvestigationComponentFacade investigationComponentFacade;
+    @EJB
+    private InvestigationItemFacade investigationItemFacade;
+
+    // =========================================================================
+    // Components
+    // =========================================================================
+
+    public List<InvestigationComponentDTO> listComponents(Long investigationId) throws Exception {
+        loadInvestigation(investigationId);
+        Map<String, Object> m = new HashMap<>();
+        m.put("ixId", investigationId);
+        String j = "select c from InvestigationComponent c where c.investigation.id=:ixId order by c.componentName";
+        List<InvestigationComponent> rows = investigationComponentFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+        List<InvestigationComponentDTO> out = new ArrayList<>();
+        for (InvestigationComponent row : rows) {
+            out.add(toDTO(row, null));
+        }
+        return out;
+    }
+
+    public InvestigationComponentDTO createComponent(Long investigationId, InvestigationComponentDTO req, WebUser user) throws Exception {
+        if (req == null || req.getComponentName() == null || req.getComponentName().trim().isEmpty()) {
+            throw new Exception("componentName is required");
+        }
+        Investigation ix = loadInvestigation(investigationId);
+        InvestigationComponent c = new InvestigationComponent();
+        c.setInvestigation(ix);
+        c.setComponentName(req.getComponentName().trim());
+        investigationComponentFacade.createAndFlush(c);
+        return toDTO(c, "Component created successfully");
+    }
+
+    public InvestigationComponentDTO updateComponent(Long investigationId, Long componentId, InvestigationComponentDTO req, WebUser user) throws Exception {
+        if (req == null || req.getComponentName() == null || req.getComponentName().trim().isEmpty()) {
+            throw new Exception("componentName is required");
+        }
+        InvestigationComponent c = loadComponent(componentId, investigationId);
+        c.setComponentName(req.getComponentName().trim());
+        investigationComponentFacade.edit(c);
+        return toDTO(c, "Component updated successfully");
+    }
+
+    public InvestigationComponentDTO deleteComponent(Long investigationId, Long componentId, WebUser user) throws Exception {
+        InvestigationComponent c = loadComponent(componentId, investigationId);
+        Map<String, Object> m = new HashMap<>();
+        m.put("compId", componentId);
+        String j = "select count(i) from InvestigationItem i where i.investigationComponent.id=:compId";
+        long usageCount = investigationItemFacade.findLongByJpql(j, m, TemporalType.TIMESTAMP);
+        if (usageCount > 0) {
+            throw new Exception("Cannot delete component: " + usageCount + " report item(s) still reference it");
+        }
+        InvestigationComponentDTO dto = toDTO(c, "Component deleted successfully");
+        investigationComponentFacade.remove(c);
+        return dto;
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private Investigation loadInvestigation(Long id) throws Exception {
+        Investigation ix = investigationFacade.find(id);
+        if (ix == null || ix.isRetired()) {
+            throw new Exception("Investigation not found with ID: " + id);
+        }
+        return ix;
+    }
+
+    private InvestigationComponent loadComponent(Long componentId, Long investigationId) throws Exception {
+        InvestigationComponent c = investigationComponentFacade.find(componentId);
+        if (c == null) {
+            throw new Exception("Component not found with ID: " + componentId);
+        }
+        if (c.getInvestigation() == null || !c.getInvestigation().getId().equals(investigationId)) {
+            throw new Exception("Component " + componentId + " does not belong to investigation " + investigationId);
+        }
+        return c;
+    }
+
+    private InvestigationComponentDTO toDTO(InvestigationComponent c, String msg) {
+        InvestigationComponentDTO dto = new InvestigationComponentDTO();
+        dto.setId(c.getId());
+        if (c.getInvestigation() != null) {
+            dto.setInvestigationId(c.getInvestigation().getId());
+        }
+        dto.setComponentName(c.getComponentName());
+        dto.setMessage(msg);
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -62,6 +62,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.institution.InstitutionApi.class);
         resources.add(com.divudi.ws.institution.SiteApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationApi.class);
+        resources.add(com.divudi.ws.investigation.InvestigationComponentApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -411,6 +411,13 @@ public class CapabilityStatementResource {
                         + "Sub-resources: /items, /items/{itemId}/values, /calculations, /flags, /dynamic-labels.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Investigation Components", "/api/investigations/{investigationId}/components",
+                        "Manage InvestigationComponent groupings used to organize report items within an investigation's format "
+                        + "(componentName only). GET lists components for the investigation. POST creates one. "
+                        + "PUT /{componentId} renames one. DELETE /{componentId} permanently removes one — rejected with an error "
+                        + "if any report item (InvestigationItem) still references it.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories. "
                         + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "

--- a/src/main/java/com/divudi/ws/investigation/InvestigationComponentApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationComponentApi.java
@@ -1,0 +1,150 @@
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.investigation.InvestigationComponentDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.InvestigationComponentApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Path("investigations/{investigationId}/components")
+@RequestScoped
+public class InvestigationComponentApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private InvestigationComponentApiService componentService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listComponents(@PathParam("investigationId") Long investigationId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(componentService.listComponents(investigationId));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createComponent(@PathParam("investigationId") Long investigationId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            InvestigationComponentDTO req = gson.fromJson(body, InvestigationComponentDTO.class);
+            InvestigationComponentDTO dto = componentService.createComponent(investigationId, req, user);
+            return Response.status(201).entity(gson.toJson(successData(dto, 201))).build();
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/{componentId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateComponent(@PathParam("investigationId") Long investigationId,
+                                     @PathParam("componentId") Long componentId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            InvestigationComponentDTO req = gson.fromJson(body, InvestigationComponentDTO.class);
+            return successResponse(componentService.updateComponent(investigationId, componentId, req, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/{componentId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deleteComponent(@PathParam("investigationId") Long investigationId,
+                                     @PathParam("componentId") Long componentId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(componentService.deleteComponent(investigationId, componentId, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        return successData(data, 200);
+    }
+
+    private Map<String, Object> successData(Object data, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", statusCode);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
Part of #464 (Full API + AI-Agent-Driven Investigation Authoring).

New sub-resource `/investigations/{investigationId}/components` for `InvestigationComponent` (used to group report items within an investigation's format):
- `GET /investigations/{investigationId}/components` — list components
- `POST /investigations/{investigationId}/components` — create (`componentName`)
- `PUT /investigations/{investigationId}/components/{componentId}` — rename
- `DELETE /investigations/{investigationId}/components/{componentId}` — remove; rejected with a clear error if any `InvestigationItem` still references the component (checked via `findLongByJpql` COUNT query)

Follows the existing `InvestigationFormatApi` pattern: same `Finance` API-key header auth, `{status, code, timestamp, data}` response envelope, and DTO/service split (`InvestigationComponentDTO`, `InvestigationComponentApiService`, `InvestigationComponentFacade`). `CapabilityStatementResource` updated to document the new endpoint.

## Test plan
Verified end-to-end via curl against local Payara (`rh` domain) + local `coop` MySQL DB, using a pre-existing test investigation (`Test FBC Investigation 22360`, id `13839293`) left over from #22360's testing:

- [x] `GET .../components` on an investigation with none → empty list
- [x] `POST .../components` with `componentName` → 201, row created and visible via `find`
- [x] `GET .../components` → returns the created component
- [x] `POST .../components` a second component → both listed, ordered by `componentName`
- [x] `PUT .../components/{id}` rename → updated name persisted and returned
- [x] `POST` with blank `componentName` → clear validation error (not a raw exception)
- [x] Request with no `Finance` header → `401 Not a valid key`
- [x] `PUT`/`DELETE` a component id that belongs to a *different* investigation → rejected with "does not belong to investigation" error (path scoping enforced)
- [x] Request against a nonexistent `investigationId` → clear "Investigation not found" error
- [x] Created a real `InvestigationItem` via the existing `/format/items` endpoint, linked it to a component, then `DELETE`'d the component → rejected with "Cannot delete component: 1 report item(s) still reference it"
- [x] Unlinked the item, retried `DELETE` → succeeded
- [x] Cleaned up all test data created during verification (components removed, test format item retired)
- [x] `mvn clean package -DskipTests` — builds clean
- [x] Local redeploy to Payara `rh` domain — deployed without errors (checked `server.log`)

Closes #22361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support for managing investigation components.
  * Components can be listed, created, updated, and deleted for an investigation.
  * Added API-key authentication for all component operations.
  * Added validation for required component details and investigation ownership.
  * Component deletion is prevented when referenced by existing report items.

* **Documentation**
  * Added capability information for the investigation components endpoint, including supported operations and access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->