### PR TITLE
feat(api): add Investigation Pricing/Fees CRUD API

### DIFF
--- a/src/main/java/com/divudi/service/investigation/InvestigationFeeApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationFeeApiService.java
@@ -1,0 +1,68 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.dto.service.ItemFeeCreateRequestDTO;
+import com.divudi.core.data.dto.service.ItemFeeDTO;
+import com.divudi.core.data.dto.service.ItemFeeUpdateRequestDTO;
+import com.divudi.core.data.dto.service.ServiceResponseDTO;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.service.service.ServiceApiService;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Service for Investigation Pricing/Fees API operations.
+ * Delegates the actual fee CRUD to {@link ServiceApiService}, which already
+ * operates generically on any {@code Item} subtype (Service, InwardService,
+ * Investigation, etc.) via {@code ItemFee}. This class only adds the
+ * investigation-specific existence/retired guard, matching the pattern used
+ * by {@link InvestigationComponentApiService}.
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class InvestigationFeeApiService implements Serializable {
+
+    @EJB
+    private InvestigationFacade investigationFacade;
+
+    @EJB
+    private ServiceApiService serviceApiService;
+
+    public List<ItemFeeDTO> listFees(Long investigationId) throws Exception {
+        loadInvestigation(investigationId);
+        return serviceApiService.listFees(investigationId);
+    }
+
+    public ServiceResponseDTO addFee(Long investigationId, ItemFeeCreateRequestDTO request, WebUser user) throws Exception {
+        loadInvestigation(investigationId);
+        return serviceApiService.addFee(investigationId, request, user);
+    }
+
+    public ServiceResponseDTO updateFee(Long investigationId, Long feeId, ItemFeeUpdateRequestDTO request, WebUser user) throws Exception {
+        loadInvestigation(investigationId);
+        return serviceApiService.updateFee(investigationId, feeId, request, user);
+    }
+
+    public ServiceResponseDTO removeFee(Long investigationId, Long feeId, WebUser user) throws Exception {
+        loadInvestigation(investigationId);
+        return serviceApiService.removeFee(investigationId, feeId, user);
+    }
+
+    private Investigation loadInvestigation(Long id) throws Exception {
+        Investigation ix = investigationFacade.find(id);
+        if (ix == null || ix.isRetired()) {
+            throw new Exception("Investigation not found with ID: " + id);
+        }
+        return ix;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -63,6 +63,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.institution.SiteApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationComponentApi.class);
+        resources.add(com.divudi.ws.investigation.InvestigationFeeApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -418,6 +418,15 @@ public class CapabilityStatementResource {
                         + "if any report item (InvestigationItem) still references it.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Investigation Fees", "/api/investigations/{investigationId}/fees",
+                        "Manage investigation pricing (ItemFee), mirroring the Services /fees sub-resource. "
+                        + "GET lists non-retired fees for the investigation. POST adds a fee "
+                        + "(body: name, feeType, fee, ffee, discountAllowed, institutionId, departmentId, specialityId, staffId). "
+                        + "PUT /{feeId} updates a fee (only non-null fields are applied). "
+                        + "DELETE /{feeId} soft-deletes (retires) a fee. All mutations recalculate the investigation's "
+                        + "total/totalForForeigner and are rejected against a retired investigation.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories. "
                         + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "

--- a/src/main/java/com/divudi/ws/investigation/InvestigationFeeApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationFeeApi.java
@@ -1,0 +1,216 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.service.ItemFeeCreateRequestDTO;
+import com.divudi.core.data.dto.service.ItemFeeUpdateRequestDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.InvestigationFeeApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * REST API for Investigation pricing/fees, mirroring {@code ServiceApi}'s
+ * {@code /fees} sub-resource. See issue #22362.
+ *
+ * @author Buddhika
+ */
+@Path("investigations/{investigationId}/fees")
+@RequestScoped
+public class InvestigationFeeApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private InvestigationFeeApiService investigationFeeApiService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * List all non-retired fees for an investigation.
+     * GET /api/investigations/{investigationId}/fees
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listFees(@PathParam("investigationId") Long investigationId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(investigationFeeApiService.listFees(investigationId));
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Add a fee to an investigation.
+     * POST /api/investigations/{investigationId}/fees
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addFee(@PathParam("investigationId") Long investigationId, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+
+            ItemFeeCreateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, ItemFeeCreateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            return Response.status(201)
+                    .entity(gson.toJson(successData(investigationFeeApiService.addFee(investigationId, request, user), 201)))
+                    .build();
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Update a fee.
+     * PUT /api/investigations/{investigationId}/fees/{feeId}
+     */
+    @PUT
+    @Path("/{feeId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateFee(@PathParam("investigationId") Long investigationId,
+                               @PathParam("feeId") Long feeId, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+
+            ItemFeeUpdateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, ItemFeeUpdateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            return successResponse(investigationFeeApiService.updateFee(investigationId, feeId, request, user));
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Remove a fee (soft-delete/retire).
+     * DELETE /api/investigations/{investigationId}/fees/{feeId}
+     */
+    @DELETE
+    @Path("/{feeId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response removeFee(@PathParam("investigationId") Long investigationId, @PathParam("feeId") Long feeId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+
+            return successResponse(investigationFeeApiService.removeFee(investigationId, feeId, user));
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        return successData(data, 200);
+    }
+
+    private Map<String, Object> successData(Object data, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", statusCode);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
- Part of #464 (Full API + AI-Agent-Driven Investigation Authoring). Closes #22362.
- New `/investigations/{investigationId}/fees` sub-resource (GET / POST / PUT `{feeId}` / DELETE `{feeId}`), mirroring `ServiceApi`'s existing `/fees` implementation exactly as the issue requested.
- Investigation pricing (`ItemFee`) could previously only be set via the "Manage Prices" UI screen — this exposes it to the API/AI-chat workflow like the rest of the item's fields already are.
- Implementation reuses `ServiceApiService`'s existing fee CRUD methods (`listFees`/`addFee`/`updateFee`/`removeFee`), which already operate generically on any `Item` subtype (Service, InwardService, Investigation) via `ItemFee`. The new `InvestigationFeeApiService` only adds the investigation-specific existence/retired guard, matching the pattern established by `InvestigationComponentApiService` in #22361 (including the "reject mutations against a retired investigation" behavior from that PR's follow-up fix).
- No AI Chat tool wiring in this PR — that's explicitly deferred to #22366 ("do last") per the master issue's sub-issue breakdown, matching how #22360/#22361 were shipped.

## Files changed
- `InvestigationFeeApi.java` (new) — REST resource, `Finance`-header auth, standard success/error envelope
- `InvestigationFeeApiService.java` (new) — investigation existence/retired guard, delegates to `ServiceApiService`
- `ApplicationConfig.java` — registers the new JAX-RS resource
- `CapabilityStatementResource.java` — documents the new `/api/investigations/{investigationId}/fees` resource

## Test plan
Verified end-to-end against the local Payara `rh` domain / `coop` database using a real investigation (`A.P.T.T`, id 87589, 3 pre-existing fees totaling 960):
- [x] `GET /investigations/87589/fees` — returns the 3 existing fees
- [x] `POST /investigations/87589/fees` (`{"name":"Test API Fee","feeType":"Additional","fee":50,"discountAllowed":true}`) — 201, fee created, investigation `total`/`totalForForeigner` recalculated 960 → 1010
- [x] `PUT /investigations/87589/fees/{feeId}` (`{"fee":75}`) — 200, only `fee` updated (not `ffee`), total recalculated to 1035
- [x] `DELETE /investigations/87589/fees/{feeId}` — 200, DB confirms `RETIRED=1` on the `FEE` row, total correctly back to 960
- [x] Mutating fees on a **retired** investigation (id 83876) — 404 `"Investigation not found with ID: 83876"`
- [x] Nonexistent investigation id — 404
- [x] Missing `Finance` header — 401
- [x] `GET /api/capabilities` — confirms the new "Investigation Fees" resource entry is present
- [x] `mvn clean package` — builds clean, no compile errors

🤖 Generated with [Claude Code](https://claude.ai/code)