### PR TITLE
Fix dynamic-form radio column count and edit-from-list read-only default

### DIFF
--- a/docs/superpowers/plans/2026-07-24-discharge-checklist-form-fixes.md
+++ b/docs/superpowers/plans/2026-07-24-discharge-checklist-form-fixes.md
@@ -289,4 +289,4 @@ Expected: command prints the created PR URL.
 
 ## After This Plan
 
-Once the PR is merged and rh staging (`http://124.43.4.189:8010/rhLocal`) is redeployed, proceed with Phase 2 from the design spec (`docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md`): create the discharge checklist form template, fields, and choices via the `/api/forms` REST API using the `Finance` header, verify it in the browser, and write the wiki page. This is data/content work, not code, and does not need its own TDD-style plan.
+Once the PR is merged and rh staging (`<rh staging URL — see C:\Credentials\>`) is redeployed, proceed with Phase 2 from the design spec (`docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md`): create the discharge checklist form template, fields, and choices via the `/api/forms` REST API using the `Finance` header, verify it in the browser, and write the wiki page. This is data/content work, not code, and does not need its own TDD-style plan.

--- a/docs/superpowers/plans/2026-07-24-discharge-checklist-form-fixes.md
+++ b/docs/superpowers/plans/2026-07-24-discharge-checklist-form-fixes.md
@@ -1,0 +1,292 @@
+# Discharge Checklist Dynamic-Form Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two dynamic-form defects in the inward admission-forms feature (radio button column count hardcoded to 2; edit-from-list not defaulting to read-only view) so a 22-row Yes/No/N/A discharge checklist can later be created via the `/api/forms` REST API and render/behave correctly.
+
+**Architecture:** Both fixes are localized to `InwardFormController.java` (a `@SessionScoped` JSF managed bean) and its single view, `admission_forms.xhtml`. No new entities, no new REST endpoints, no DB schema changes. Fix 1 adds one pure static helper method (unit-testable in isolation, no EJB dependencies) plus one instance method that reads live choice count; Fix 2 is a one-line change to an existing instance method.
+
+**Tech Stack:** Java 11, JSF 2.x / PrimeFaces, JUnit 5, Maven.
+
+## Global Constraints
+
+- Base the branch on `origin/development`, never `master` (per project rules).
+- JPQL only for any DB queries — not applicable here (no new queries added), but `getChoicesFor()` (already JPQL-based) must not be changed.
+- Do not modify existing constructors — not applicable, no constructors touched.
+- Commit messages should include `Closes #<issue-number>` once the GitHub issue is filed (Task 0).
+
+---
+
+### Task 0: File the GitHub issue
+
+**Files:** none (GitHub only)
+
+- [ ] **Step 1: Create the issue**
+
+Run (replace `<repo>` is already `hmislk/hmis`):
+
+```bash
+gh issue create --repo hmislk/hmis \
+  --title "Dynamic forms: radio column count hardcoded to 2; edit-from-list opens in edit mode instead of read-only" \
+  --body "$(cat <<'EOF'
+## Problem
+
+Two defects found while preparing a 22-row Yes/No/N/A discharge checklist as a dynamic form (`DesignComponent`/`CaptureComponent`, `/api/forms` REST API):
+
+### 1. Hardcoded radio column count
+
+`src/main/webapp/inward/admission_forms.xhtml` hardcodes:
+```xml
+<p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
+                  rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
+```
+`columns="2"` is fixed regardless of how many choices the field actually has. A 3-choice field (e.g. Yes/No/N/A) wraps awkwardly — 2 options on one row, the 3rd dangling onto a second row — instead of sitting inline on one row.
+
+**Fix:** derive the column count from the field's live choice count, clamped to a sane range.
+
+### 2. Edit-from-list doesn't default to read-only
+
+`InwardFormController.editForm(PatientFormEntry entry)` never touches the `viewMode` field, so opening an already-filled form from the entries list inherits whatever `viewMode` was last left at in the session (e.g. `false`, left over from a prior `startNewForm()`/`cancelForm()` call), rather than deterministically opening read-only. Filled-in forms should always open in read-only View Mode when opened from the list; the existing "Switch to Edit Mode" button should remain the only way to make them editable.
+
+**Fix:** set `viewMode = true` at the start of `editForm()`.
+
+## Also noted (not fixed here, future enhancement)
+
+The dynamic form system (`DesignComponent`/`CaptureComponent`, C3 hybrid layout — see `developer_docs/forms/custom-layout-guide.md`) has no first-class "matrix/table checklist" component: there's no way to render a single shared header row (e.g. "YES / NO / N/A") spanning many fields' worth of radio/checkbox inputs — each field is a fully independent row. Not a blocker for Yes/No/N/A-style checklists since each radio row already labels its own options, but worth tracking as a future form-designer/API enhancement if more complex matrix-style clinical forms are needed.
+EOF
+)"
+```
+
+Expected: command prints the created issue URL, e.g. `https://github.com/hmislk/hmis/issues/22346`.
+
+- [ ] **Step 2: Record the issue number**
+
+Note the issue number from the URL — it's referenced in every commit message below as `#<issue-number>`.
+
+---
+
+### Task 1: Add a testable radio-column clamp helper
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/inward/InwardFormController.java`
+- Test: `src/test/java/com/divudi/bean/inward/InwardFormControllerTest.java` (new)
+
+**Interfaces:**
+- Produces: `static int InwardFormController.clampRadioColumns(int choiceCount)` — pure function, no side effects, no EJB dependency. Returns `choiceCount` clamped to `[1, 4]`.
+- Produces: `public int InwardFormController.getRadioColumns(CaptureComponent cc)` — instance method used from the xhtml; returns `clampRadioColumns(getChoicesFor(cc).size())`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/com/divudi/bean/inward/InwardFormControllerTest.java`:
+
+```java
+package com.divudi.bean.inward;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InwardFormControllerTest {
+
+    @Test
+    void clampRadioColumns_returnsChoiceCount_whenWithinRange() {
+        assertEquals(3, InwardFormController.clampRadioColumns(3));
+    }
+
+    @Test
+    void clampRadioColumns_returnsOne_whenChoiceCountIsZero() {
+        assertEquals(1, InwardFormController.clampRadioColumns(0));
+    }
+
+    @Test
+    void clampRadioColumns_returnsOne_whenChoiceCountIsNegative() {
+        assertEquals(1, InwardFormController.clampRadioColumns(-5));
+    }
+
+    @Test
+    void clampRadioColumns_capsAtFour_whenChoiceCountIsLarge() {
+        assertEquals(4, InwardFormController.clampRadioColumns(9));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q test -Dtest=InwardFormControllerTest`
+
+Expected: FAIL — compile error, `clampRadioColumns` is not defined on `InwardFormController`.
+
+- [ ] **Step 3: Add the pure helper and the instance method**
+
+In `src/main/java/com/divudi/bean/inward/InwardFormController.java`, add both methods near `getChoicesFor` (after line 490, right before `navigateBackToAdmissionProfile`):
+
+```java
+    /**
+     * Column count for a SelectOneRadio field's PrimeFaces grid layout,
+     * derived from how many choices the field actually has (clamped so a
+     * 2-choice field doesn't get 1 column and a 10-choice field doesn't
+     * get 10 columns).
+     */
+    static int clampRadioColumns(int choiceCount) {
+        return Math.max(1, Math.min(4, choiceCount));
+    }
+
+    public int getRadioColumns(CaptureComponent cc) {
+        return clampRadioColumns(getChoicesFor(cc).size());
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q test -Dtest=InwardFormControllerTest`
+
+Expected: PASS — 4 tests, 0 failures.
+
+- [ ] **Step 5: Wire the xhtml to use the new method**
+
+In `src/main/webapp/inward/admission_forms.xhtml`, replace the line (around line 167):
+
+```xml
+                        <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
+                                          rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
+```
+
+with:
+
+```xml
+                        <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid"
+                                          columns="#{inwardFormController.getRadioColumns(cc)}"
+                                          rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
+```
+
+- [ ] **Step 6: Compile the full project to confirm no regressions**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q compile`
+
+Expected: `BUILD SUCCESS`, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/inward/InwardFormController.java src/test/java/com/divudi/bean/inward/InwardFormControllerTest.java src/main/webapp/inward/admission_forms.xhtml
+git commit -m "$(cat <<'EOF'
+Derive SelectOneRadio column count from field choice count
+
+3-option fields (e.g. Yes/No/N/A checklists) previously wrapped
+awkwardly under the hardcoded columns="2". clampRadioColumns() keeps
+the layout sane for any choice count between 1 and 4.
+
+Closes #<issue-number>
+EOF
+)"
+```
+
+(Replace `<issue-number>` with the number from Task 0.)
+
+---
+
+### Task 2: Default to read-only when opening a filled form from the list
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/inward/InwardFormController.java:200-216` (`editForm` method)
+
+**Interfaces:**
+- Consumes: existing `private boolean viewMode` field, existing `isViewMode()`/`setViewMode()` accessors (already present at lines 551-557).
+- Produces: no new public interface — behavior change only.
+
+- [ ] **Step 1: Make the change**
+
+In `src/main/java/com/divudi/bean/inward/InwardFormController.java`, in `editForm(PatientFormEntry entry)` (currently lines 200-216), add `viewMode = true;` right after the null check:
+
+```java
+    public void editForm(PatientFormEntry entry) {
+        if (entry == null) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        viewMode = true;
+        currentEntry = entry;
+        selectedTemplate = entry.getDesignComponent();
+        String jpql = "select cc "
+                + " from CaptureComponent cc "
+                + " where cc.patientFormEntry=:pfe "
+                + " and cc.retired=:ret "
+                + " order by cc.designComponent.orderNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("pfe", entry);
+        m.put("ret", false);
+        currentCaptureComponents = captureComponentFacade.findByJpql(jpql, m);
+    }
+```
+
+- [ ] **Step 2: Compile to confirm no regressions**
+
+Run: `"D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" -q compile`
+
+Expected: `BUILD SUCCESS`, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/inward/InwardFormController.java
+git commit -m "$(cat <<'EOF'
+Default to read-only view when opening a filled form from the list
+
+editForm() previously left viewMode untouched, so a filled-in form
+opened from the entries list could inherit an editable state from
+earlier session actions. Filled forms now always open read-only;
+"Switch to Edit Mode" remains the explicit way to edit.
+
+Closes #<issue-number>
+EOF
+)"
+```
+
+(Same issue number as Task 1 — one issue covers both fixes.)
+
+---
+
+### Task 3: Push and open the PR
+
+**Files:** none (git/GitHub only)
+
+**Interfaces:**
+- Consumes: the two commits from Task 1 and Task 2, already on branch `22345-discharge-checklist-sample-form`.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin 22345-discharge-checklist-sample-form
+```
+
+Expected: push succeeds, prints the new remote branch ref.
+
+- [ ] **Step 2: Open the PR targeting development**
+
+```bash
+gh pr create --repo hmislk/hmis --base development \
+  --title "Fix dynamic-form radio column count and edit-from-list read-only default" \
+  --body "$(cat <<'EOF'
+## Summary
+- SelectOneRadio fields now size their PrimeFaces grid columns to the field's actual choice count (clamped 1-4) instead of a hardcoded 2, so 3-option fields (e.g. Yes/No/N/A) render inline on one row.
+- Opening an already-filled form from the inward forms list now always defaults to read-only View Mode; "Switch to Edit Mode" remains the explicit way to edit.
+
+Prepares the dynamic form system for a 22-row Yes/No/N/A discharge checklist to be created via the `/api/forms` REST API.
+
+Closes #<issue-number>
+
+## Test plan
+- [x] `InwardFormControllerTest` (4 new unit tests for `clampRadioColumns`) passes
+- [x] `mvn compile` succeeds
+- [ ] Manual verification on rh staging after merge: a 3-choice radio field renders inline; opening a filled form from the list opens read-only
+EOF
+)"
+```
+
+Expected: command prints the created PR URL.
+
+---
+
+## After This Plan
+
+Once the PR is merged and rh staging (`http://124.43.4.189:8010/rhLocal`) is redeployed, proceed with Phase 2 from the design spec (`docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md`): create the discharge checklist form template, fields, and choices via the `/api/forms` REST API using the `Finance` header, verify it in the browser, and write the wiki page. This is data/content work, not code, and does not need its own TDD-style plan.

--- a/docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md
+++ b/docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md
@@ -7,7 +7,7 @@ line items plus a few free-text/date fields, with handwritten amendments in
 green ink) needs to be recreated as a dynamic form via the existing
 `/api/forms` REST API (see `developer_docs/forms/form-api-guide.md` and
 `developer_docs/forms/custom-layout-guide.md`), for trial use on rh staging
-(`http://124.43.4.189:8010/rhLocal`).
+(`<rh staging URL — see C:\Credentials\>`).
 
 Investigation of `admission_forms.xhtml` and `InwardFormController.java`
 confirmed the dynamic form system (`DesignComponent`/`CaptureComponent`) can
@@ -63,8 +63,8 @@ CI/CD per project rules — not done manually here).
 
 ## Phase 2 — Sample Form via API (after merge + staging redeploy)
 
-Using `curl` with the `Finance` header (`a6d817d5-d3d9-4ab9-9e2f-76ac37b91bb3`)
-against `http://124.43.4.189:8010/rhLocal/api/forms`, create:
+Using `curl` with the `Finance` header (`<Finance API key — see C:\Credentials\>`)
+against `<rh staging URL — see C:\Credentials\>/api/forms`, create:
 
 **Form template** — title makes clear this is a sample/trial form for
 evaluating the form-design system, e.g.

--- a/docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md
+++ b/docs/superpowers/specs/2026-07-24-discharge-checklist-form-design.md
@@ -1,0 +1,128 @@
+# Discharge Checklist Sample Form + Dynamic Form Fixes — Design
+
+## Background
+
+A printed "items handed over to patient at discharge" checklist (22 Yes/No/N/A
+line items plus a few free-text/date fields, with handwritten amendments in
+green ink) needs to be recreated as a dynamic form via the existing
+`/api/forms` REST API (see `developer_docs/forms/form-api-guide.md` and
+`developer_docs/forms/custom-layout-guide.md`), for trial use on rh staging
+(`http://124.43.4.189:8010/rhLocal`).
+
+Investigation of `admission_forms.xhtml` and `InwardFormController.java`
+confirmed the dynamic form system (`DesignComponent`/`CaptureComponent`) can
+represent this form — each checklist row becomes a `SelectOneRadio` field
+with `Yes` / `No` / `N/A` choices, which is self-labeling per row without
+needing a shared table header. Two real defects were found that must be
+fixed first so the form renders and behaves correctly.
+
+## Phase 1 — Code Fixes
+
+### Fix 1: Hardcoded radio column count
+
+`admission_forms.xhtml` line 167 hardcodes
+`<p:selectOneRadio layout="grid" columns="2">` for every `SelectOneRadio`
+field regardless of how many choices it has. A 3-choice Yes/No/N/A field
+wraps awkwardly (2 options on one row, the 3rd dangling) instead of sitting
+inline.
+
+**Fix:** add `InwardFormController.getRadioColumns(CaptureComponent cc)`
+returning the field's live choice count (via `getChoicesFor(cc).size()`),
+clamped to `[1, 4]`. Reference it from the xhtml:
+`columns="#{inwardFormController.getRadioColumns(cc)}"` in place of the
+literal `"2"`.
+
+### Fix 2: Edit-from-list doesn't default to read-only
+
+`InwardFormController.editForm(PatientFormEntry entry)` never touches
+`viewMode`, so opening an already-filled form from the entries list inherits
+whatever `viewMode` was last left at (e.g. `false` from a previous
+`startNewForm()`/`saveForm()`/`cancelForm()` call in the same session),
+rather than deterministically opening read-only.
+
+**Fix:** set `viewMode = true;` at the start of `editForm()`. Filled forms
+opened from the list always start in read-only View Mode; the existing
+"Switch to Edit Mode" button remains the only way to make it editable.
+`startNewForm()` is unaffected — new/unfilled forms still open in Edit Mode
+(`viewMode = false`), since there's nothing to view yet.
+
+### Issue
+
+One GitHub issue tracking both fixes, filed against `hmislk/hmis`, plus a
+note that the dynamic form system has no first-class "matrix/table
+checklist" component (a shared YES/NO/N/A header row spanning many fields) —
+not a blocker for this form since each radio row labels its own options, but
+worth tracking as a future form-designer/API enhancement.
+
+### Rollout
+
+Branch from `origin/development` (never `master`), apply both fixes, commit,
+push, open a PR targeting `development` referencing `Closes #<issue>`. The
+user merges the PR and redeploys rh staging themselves (deploys go through
+CI/CD per project rules — not done manually here).
+
+## Phase 2 — Sample Form via API (after merge + staging redeploy)
+
+Using `curl` with the `Finance` header (`a6d817d5-d3d9-4ab9-9e2f-76ac37b91bb3`)
+against `http://124.43.4.189:8010/rhLocal/api/forms`, create:
+
+**Form template** — title makes clear this is a sample/trial form for
+evaluating the form-design system, e.g.
+`"[Sample] Patient Discharge Checklist — Form Design Trial"`. The existing,
+unrelated form template already in the system is left untouched.
+
+**Fields** (in order), each a `SelectOneRadio` with choices `Yes` / `No` /
+`N/A` unless noted. Handwritten green amendments from the source image are
+folded directly into the printed labels (not modeled as separate data):
+
+1. Bill Settled (and Payment Receipt Checked)
+2. Diagnosis Card
+3. Medical Certificate
+4. Claims Forms
+5. Doctor's Prescription
+6. IV Cannulae (Removed)
+7. Drains / Catheters (Removed)
+8. Laboratory Reports
+9. ECG Reports
+10. EEG Reports
+11. Scan Reports (MRI/CAT Scan)
+12. X-Ray
+13. Echocardiography
+14. Special Investigation (Endoscopy Reports)
+15. OPD Review
+16. Medication on Discharge
+17. Admission Letter from Doctor
+18. Maternity
+19. Birth Registration Form
+20. CHDR (Child Health and Development Record)
+21. Death Certificate Issued (if applicable only)
+22. Biopsy Report / Any Other Report to be Collected
+
+Then trailing fields:
+
+23. Instruction Given by Dr (for the cannula/catheter/drain left in) —
+    `Input_text_Area`
+24. Days to be Left In — `Input_Number` (or `Spinner`)
+25. Signature & Name of Person Receiving the Reports — `Input_text`
+26. Date — `Calendar`
+27. Time — `Input_text`
+28. Name of the Nursing Sister/Nurse in Charge — `Input_text`
+
+Custom `editHtml`/`viewHtml` per field (C3 hybrid pattern) styled as a
+compact single-column checklist row (label left, Yes/No/N/A inline right),
+`formCssClass` = single-column row.
+
+### Verification
+
+Confirm on rh staging:
+- New form appears in the "Select Form" dropdown on
+  `inward/admission_forms.xhtml`.
+- Filling it in and saving produces a read-only view by default when
+  reopened from the list (Fix 2), with a working edit toggle.
+- The 3-choice radio rows render inline on one line (Fix 1).
+
+### Wiki
+
+Write a user-facing page in `../hmis.wiki` (sibling directory, never inside
+the main repo) describing the sample checklist form for end users — no
+GitHub issue/PR references per wiki conventions.

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -131,6 +131,7 @@ public class InwardFormController implements Serializable {
             JsfUtil.addErrorMessage("Please select a form to fill");
             return;
         }
+        viewMode = false;
         currentEntry = new PatientFormEntry();
         currentEntry.setPatientEncounter(patientEncounter);
         currentEntry.setDesignComponent(selectedTemplate);

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -202,6 +202,7 @@ public class InwardFormController implements Serializable {
             JsfUtil.addErrorMessage("Nothing selected");
             return;
         }
+        viewMode = true;
         currentEntry = entry;
         selectedTemplate = entry.getDesignComponent();
         String jpql = "select cc "

--- a/src/main/java/com/divudi/bean/inward/InwardFormController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardFormController.java
@@ -489,6 +489,19 @@ public class InwardFormController implements Serializable {
         return designComponentChoiceFacade.findByJpql(jpql, m);
     }
 
+    /**
+     * Column count for a SelectOneRadio field's PrimeFaces grid layout,
+     * derived from how many choices the field actually has (clamped so a
+     * 2-choice field doesn't get 1 column and a 10-choice field doesn't
+     * get 10 columns).
+     */
+    static int clampRadioColumns(int choiceCount) {
+        return Math.max(1, Math.min(4, choiceCount));
+    }
+
+    public int getRadioColumns(CaptureComponent cc) {
+        return clampRadioColumns(getChoicesFor(cc).size());
+    }
 
     public String navigateBackToAdmissionProfile() {
         return "/inward/admission_profile?faces-redirect=true";

--- a/src/main/webapp/inward/admission_forms.xhtml
+++ b/src/main/webapp/inward/admission_forms.xhtml
@@ -164,7 +164,8 @@
                                            var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />
                         </p:selectOneMenu>
 
-                        <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid" columns="2"
+                        <p:selectOneRadio value="#{cc.shortTextValue}" layout="grid"
+                                          columns="#{inwardFormController.getRadioColumns(cc)}"
                                           rendered="#{cc.componentPresentationType eq 'SelectOneRadio'}">
                             <f:selectItems value="#{inwardFormController.getChoicesFor(cc)}"
                                            var="ch" itemLabel="#{ch.label}" itemValue="#{ch.value}" />

--- a/src/test/java/com/divudi/bean/inward/InwardFormControllerTest.java
+++ b/src/test/java/com/divudi/bean/inward/InwardFormControllerTest.java
@@ -1,0 +1,28 @@
+package com.divudi.bean.inward;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InwardFormControllerTest {
+
+    @Test
+    void clampRadioColumns_returnsChoiceCount_whenWithinRange() {
+        assertEquals(3, InwardFormController.clampRadioColumns(3));
+    }
+
+    @Test
+    void clampRadioColumns_returnsOne_whenChoiceCountIsZero() {
+        assertEquals(1, InwardFormController.clampRadioColumns(0));
+    }
+
+    @Test
+    void clampRadioColumns_returnsOne_whenChoiceCountIsNegative() {
+        assertEquals(1, InwardFormController.clampRadioColumns(-5));
+    }
+
+    @Test
+    void clampRadioColumns_capsAtFour_whenChoiceCountIsLarge() {
+        assertEquals(4, InwardFormController.clampRadioColumns(9));
+    }
+}


### PR DESCRIPTION
## Summary
- SelectOneRadio fields now size their PrimeFaces grid columns to the field's actual choice count (clamped 1-4) instead of a hardcoded 2, so 3-option fields (e.g. Yes/No/N/A) render inline on one row.
- Opening an already-filled form from the inward forms list now always defaults to read-only View Mode; "Switch to Edit Mode" remains the explicit way to edit.
- Fixed a regression introduced by the above: loading a brand-new form after viewing a filled-in one previously inherited the read-only state instead of opening editable. `startNewForm()` now resets to edit mode explicitly.

Prepares the dynamic form system for a 22-row Yes/No/N/A discharge checklist to be created via the `/api/forms` REST API (tracked separately once this merges).

Closes #22389

## Test plan
- [x] `InwardFormControllerTest` (4 unit tests for `clampRadioColumns`) passes
- [x] `mvn compile` succeeds
- [x] Verified end-to-end on local Payara via Playwright: created a test form with a 3-choice Yes/No/N/A radio field via the `/api/forms` API, confirmed it renders inline in one row, confirmed opening a filled entry via "Edit" defaults to read-only, confirmed loading a new form afterward stays editable. Test form/entry cleaned up afterward.