### PR TITLE
Guard patient room actions with privileges and warn on room time overlaps

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -181,6 +181,7 @@ public class BhtSummeryController implements Serializable {
     List<PatientItem> patientItems;
     private List<ChargeItemTotal> chargeItemTotals;
     List<PatientRoom> patientRooms;
+    private PatientRoom pendingOverlapRoom;
     private List<CreditCompanyAllocation> creditCompanyAllocations;
     private EncounterCreditCompany newEncounterCreditCompany;
     private boolean creatingNewVersion;
@@ -1548,6 +1549,82 @@ public class BhtSummeryController implements Serializable {
         createPatientItems();
         createChargeItemTotals();
 
+    }
+
+    /**
+     * Entry point for the "Save Changes" button. If the room's current
+     * admitted/discharged times overlap another (non-Guardian/Theatre) room
+     * period for the same patient or bed, ask for confirmation before saving
+     * instead of saving immediately.
+     */
+    public void checkBeforeUpdatePatientRoom(PatientRoom patientRoom) {
+        if (hasOverlap(patientRoom)) {
+            pendingOverlapRoom = patientRoom;
+            PrimeFaces.current().executeScript("PF('dlgRoomOverlapConfirm').show();");
+            return;
+        }
+        updatePatientRoom(patientRoom);
+    }
+
+    public void confirmUpdatePatientRoomWithOverlap() {
+        updatePatientRoom(pendingOverlapRoom);
+        pendingOverlapRoom = null;
+    }
+
+    public PatientRoom getPendingOverlapRoom() {
+        return pendingOverlapRoom;
+    }
+
+    /**
+     * True when this room's admitted/discharged time range overlaps another
+     * non-Guardian/Theatre room period for the same patient encounter or the
+     * same bed (RoomFacilityCharge). Used both to gate the save confirmation
+     * and to render a persistent warning on the room row.
+     */
+    public boolean hasOverlap(PatientRoom patientRoom) {
+        if (patientRoom == null || patientRoom.getAdmittedAt() == null || patientRoom.getPatientEncounter() == null) {
+            return false;
+        }
+        if (patientRoom instanceof GuardianRoom || patientRoom instanceof TheatreRoom) {
+            return false;
+        }
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT COUNT(pr2) FROM PatientRoom pr2 WHERE pr2.retired = false ");
+        jpql.append("AND TYPE(pr2) != :guardianClass AND TYPE(pr2) != :theatreClass ");
+        Map<String, Object> params = new HashMap<>();
+        params.put("guardianClass", GuardianRoom.class);
+        params.put("theatreClass", TheatreRoom.class);
+        if (patientRoom.getId() != null) {
+            jpql.append("AND pr2.id != :excludeId ");
+            params.put("excludeId", patientRoom.getId());
+        }
+        if (patientRoom.getRoomFacilityCharge() != null) {
+            jpql.append("AND (pr2.patientEncounter = :pe OR pr2.roomFacilityCharge = :rfc) ");
+            params.put("rfc", patientRoom.getRoomFacilityCharge());
+        } else {
+            jpql.append("AND pr2.patientEncounter = :pe ");
+        }
+        params.put("pe", patientRoom.getPatientEncounter());
+        if (patientRoom.getDischargedAt() != null) {
+            jpql.append("AND pr2.admittedAt < :to ");
+            params.put("to", patientRoom.getDischargedAt());
+        }
+        jpql.append("AND (pr2.dischargedAt IS NULL OR pr2.dischargedAt > :from)");
+        params.put("from", patientRoom.getAdmittedAt());
+        long count = getPatientRoomFacade().findLongByJpql(jpql.toString(), params);
+        return count > 0;
+    }
+
+    public boolean isAnyRoomOverlapping() {
+        if (patientRooms == null) {
+            return false;
+        }
+        for (PatientRoom pr : patientRooms) {
+            if (hasOverlap(pr)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void updatePatientRoom(PatientRoom patientRoom) {

--- a/src/main/webapp/inward/inward_patient_room_details.xhtml
+++ b/src/main/webapp/inward/inward_patient_room_details.xhtml
@@ -37,6 +37,24 @@
                             icon="fa fa-times"/>
                     </p:confirmDialog>
 
+                    <p:dialog id="dlgRoomOverlapConfirm" widgetVar="dlgRoomOverlapConfirm" header="&#9888; Room Time Overlap Warning"
+                              modal="true" resizable="false" closable="true" style="width:480px">
+                        <div style="padding:12px">
+                            <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
+                                &#9888; WARNING: This room's time range overlaps another room period for this patient or bed.
+                            </p>
+                            <p>Are you sure you want to save this room with the overlapping time range?</p>
+                            <div class="d-flex justify-content-end gap-2 mt-3">
+                                <p:commandButton value="Cancel" icon="fa fa-times" class="ui-button-secondary"
+                                                 onclick="PF('dlgRoomOverlapConfirm').hide(); return false;"/>
+                                <p:commandButton value="Yes, Save Anyway" icon="fa fa-exclamation-triangle" class="ui-button-danger"
+                                                 update="@form"
+                                                 action="#{bhtSummeryController.confirmUpdatePatientRoomWithOverlap()}"
+                                                 oncomplete="PF('dlgRoomOverlapConfirm').hide();"/>
+                            </div>
+                        </div>
+                    </p:dialog>
+
                     <p:panel>
                         <f:facet name="header">
                             <div class="d-flex justify-content-between align-items-center">
@@ -44,6 +62,8 @@
                                     <i class="fa-solid fa-bed fa-lg text-primary me-3"></i>
                                     <div>
                                         <h:outputText value="Patient Room Details" styleClass="text-primary fw-bold"/>
+                                        <p:tag styleClass="ms-2" value="Room Time Overlap Detected" icon="fa fa-exclamation-triangle" severity="danger"
+                                               rendered="#{bhtSummeryController.anyRoomOverlapping}"/>
                                         <h:panelGroup rendered="#{bhtSummeryController.patientEncounter ne null}" layout="block">
                                             <small class="text-muted">
                                                 <h:outputText value="#{bhtSummeryController.patientEncounter.patient.person.nameWithTitle}"/>
@@ -136,6 +156,9 @@
                                                 <h:panelGroup rendered="#{not rm.discharged}">
                                                     <p:badge value="Active" severity="warning"/>
                                                 </h:panelGroup>
+                                                <h:panelGroup rendered="#{bhtSummeryController.hasOverlap(rm)}">
+                                                    <p:tag value="Overlap" icon="fa fa-exclamation-triangle" severity="danger"/>
+                                                </h:panelGroup>
                                             </div>
                                         </p:column>
 
@@ -215,26 +238,26 @@
                                                     icon="fa fa-save"
                                                     title="Save Changes"
                                                     class="ui-button-info"
-                                                    disabled="#{bhtSummeryController.patientEncounter.discharged}"
-                                                    action="#{bhtSummeryController.updatePatientRoom(rm)}">
+                                                    disabled="#{bhtSummeryController.patientEncounter.discharged or !webUserController.hasPrivilege('InwardRoomRoomChange')}"
+                                                    action="#{bhtSummeryController.checkBeforeUpdatePatientRoom(rm)}">
                                                 </p:commandButton>
 
                                                 <p:commandButton
                                                     update="@form"
                                                     icon="fa fa-calculator"
                                                     title="Update Charges from Room Rates"
-                                                    disabled="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    disabled="#{bhtSummeryController.patientEncounter.discharged or !webUserController.hasPrivilege('InwardRoomRoomChange')}"
                                                     class="ui-button-success"
                                                     action="#{bhtSummeryController.updateChargesForRoom(rm)}">
                                                 </p:commandButton>
-                                                
+
                                                 <p:commandButton
                                                     process="@this"
                                                     update="@form"
                                                     icon="fa fa-check-square"
                                                     title="Discharge from Room"
                                                     rendered="#{not rm.discharged}"
-                                                    disabled="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    disabled="#{bhtSummeryController.patientEncounter.discharged or !webUserController.hasPrivilege('InwardRoomDischarge')}"
                                                     class="ui-button-warning"
                                                     action="#{roomChangeController.dischargeWithCurrentTime(rm)}">
                                                     <p:confirm header="Confirm Discharge"
@@ -248,7 +271,7 @@
                                                     icon="fa fa-times-circle"
                                                     title="Cancel Room Discharge"
                                                     rendered="#{rm.discharged}"
-                                                    disabled="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    disabled="#{bhtSummeryController.patientEncounter.discharged or !webUserController.hasPrivilege('InwardRoomDischarge')}"
                                                     class="ui-button-danger"
                                                     action="#{roomChangeController.dischargeCancel(rm)}">
                                                     <p:confirm header="Confirm Cancel Discharge"
@@ -270,7 +293,7 @@
                                                     update="@form"
                                                     icon="fa fa-trash"
                                                     title="Remove Room"
-                                                    disabled="#{bhtSummeryController.patientEncounter.discharged}"
+                                                    disabled="#{bhtSummeryController.patientEncounter.discharged or !webUserController.hasPrivilege('InwardRoomRoomChange')}"
                                                     class="ui-button-danger mx-2"
                                                     action="#{roomChangeController.removeRoom(rm)}">
                                                     <p:confirm header="Confirm Room Removal"


### PR DESCRIPTION
## Summary

On `inward/inward_patient_room_details.xhtml` (backed by `BhtSummeryController` and `RoomChangeController`), the room actions were previously not privilege-gated and there was no overlap detection for room time periods.

- **Privilege guards** (disabled-not-hidden pattern, matching `inward_cancel_admission.xhtml`): Save Changes, Update Charges, and Remove Room now require `InwardRoomRoomChange`; Discharge and Cancel Discharge now require `InwardRoomDischarge`. Both privileges already exist and are already wired into the privilege tree (`UserPrivilageController`), so no new privileges were added.
- **Overlap confirmation dialog**: `BhtSummeryController.checkBeforeUpdatePatientRoom(rm)` (now bound to the Save button instead of `updatePatientRoom` directly) runs a new `hasOverlap(PatientRoom)` JPQL check — modeled on `AppointmentScheduleTemplateController.hasTimeOverlap` — that flags a half-open-interval time overlap against another room period for the *same patient encounter* or the *same bed* (`RoomFacilityCharge`), excluding `GuardianRoom`/`TheatreRoom` rows (via `TYPE(pr2) != :class`, the same idiom already used in `RoomChangeController.createPatientRoom`). If an overlap is found, a confirm dialog (`dlgRoomOverlapConfirm`, modeled on `SurgeryBillController`'s existing `dlgDupConfirm` pattern) is shown before the save proceeds; otherwise the save happens immediately.
- **Persistent overlap warning**: an "Overlap" `p:tag` is now shown next to the existing Guardian/Theatre/Left/Active badges on any room row with a live overlap, plus a page-header-level "Room Time Overlap Detected" tag when any room in the list overlaps.

## Files changed
- `src/main/java/com/divudi/bean/inward/BhtSummeryController.java`
- `src/main/webapp/inward/inward_patient_room_details.xhtml`

## Testing

This session runs in an isolated cloud container without access to the maintainer's local Windows/Payara/MySQL dev setup, and the container's network policy blocks the jitpack.io-hosted dependency this project needs to build (`com.github.hmislk:lims-middleware-libraries`), so I could not run a full Maven build, redeploy to local Payara, or drive the page with Playwright as the project's usual dev workflow expects.

Instead I did a careful manual review of the diff against the actual method signatures, imports, and privilege enum entries in the repo (not assumptions):
- Confirmed `WebUserController.hasPrivilege(String)` and the `Privileges.InwardRoomRoomChange` / `Privileges.InwardRoomDischarge` enum entries exist and are already used with the same `disabled="... or !webUserController.hasPrivilege('X')"` pattern elsewhere (e.g. `inward_cancel_admission.xhtml`).
- Confirmed `PatientRoomFacade`/`AbstractFacade.findLongByJpql(String, Map)` exists and returns `long`, per the count-query convention in this repo's CLAUDE.md.
- Confirmed `GuardianRoom`/`TheatreRoom` are already imported in `BhtSummeryController.java`, and used the same `TYPE(pr) != :class` JPQL idiom already proven working in `RoomChangeController.createPatientRoom`, rather than an untested `TYPE(...) NOT IN (...)` parameter form.
- Verified the XHTML edits keep the file well-formed (balanced tags/dialogs) by re-reading the full modified sections.

Given the build/deploy limitation, please have CI and a local test pass verify the actual runtime behavior (privilege-based button disabling, the overlap confirm dialog appearing/not appearing correctly, and the persistent warning tags) before merging.

---

Closes #22384


---
_Generated by [Claude Code](https://claude.ai/code/session_01B7Mx1hdGpcZN2ncgUq3vQV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when patient room periods overlap, allowing staff to cancel or save despite the overlap.
  * Room history now displays an “Overlap” indicator where applicable.

* **Access Control**
  * Added privilege checks for changing room details, updating room charges, removing rooms, and managing discharge actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->