### PR TITLE
feat(inward): add privilege-gated search scope buttons to Inpatient Search

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -248,6 +248,14 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchProfessionalBill, "Search Professional Bill"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchFinalBill, "Search Final Bill"), searchNode);
 
+        TreeNode admissionSearchScopeNode = new DefaultTreeNode(new PrivilegeHolder(null, "Admission Search Scope"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute, "By Admitted Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute, "By Admitted Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment, "By Admitted Department - Logged Department"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentAnyInstitute, "By Current Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute, "By Current Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment, "By Current Department - Logged Department"), admissionSearchScopeNode);
+
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardReport, "Inward Reports"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdministration, "Administration"), inwardNode);
 

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -215,7 +215,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private ClinicalFindingValue currentPatientAllergy;
     private Institution lastCreditCompany;
     private Department loggedDepartment;
-    private Department currentDepartmentForSearch;
     private Institution site;
 
     private PaymentMethod paymentMethod;
@@ -1080,6 +1079,20 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public void searchAdmissions() {
+        searchAdmissions(null, null);
+    }
+
+    /**
+     * @param currentRoomInstitutionFilter when non-null, restricts to admissions whose
+     * current room belongs to this institution (RoomFacilityCharge.company), independent
+     * of the admitted-time institutionForSearch field.
+     * @param currentRoomDepartmentFilter when non-null, restricts to admissions whose
+     * current room's department is this department or a child of it
+     * (RoomFacilityCharge.department / .superDepartment). Passed as a method parameter
+     * rather than an instance field so a scoped search never silently persists into a
+     * later plain Search click on this @SessionScoped bean.
+     */
+    private void searchAdmissions(Institution currentRoomInstitutionFilter, Department currentRoomDepartmentFilter) {
         if (fromDate == null || toDate == null) {
             JsfUtil.addErrorMessage("Please select date");
             return;
@@ -1174,10 +1187,15 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             m.put("dept", loggedDepartment);
         }
 
-        if (currentDepartmentForSearch != null) {
+        if (currentRoomInstitutionFilter != null) {
+            j += "  and c.currentPatientRoom.roomFacilityCharge.company=:curIns ";
+            m.put("curIns", currentRoomInstitutionFilter);
+        }
+
+        if (currentRoomDepartmentFilter != null) {
             j += "  and (c.currentPatientRoom.roomFacilityCharge.department=:curDept "
                     + " or c.currentPatientRoom.roomFacilityCharge.department.superDepartment=:curDept) ";
-            m.put("curDept", currentDepartmentForSearch);
+            m.put("curDept", currentRoomDepartmentFilter);
         }
 
         if (parentAdmission != null) {
@@ -1195,9 +1213,21 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     /**
      * Search-scope shortcut buttons (issue #22382). Each is gated by its own
-     * privilege in the XHTML; the field resets here are a defense-in-depth
-     * check so a request forged without the button can't widen the search
-     * scope beyond what the privilege allows.
+     * privilege in the XHTML; the privilege re-check here is defense-in-depth
+     * so a request forged without the button can't widen the search scope
+     * beyond what the privilege allows.
+     *
+     * "By Admitted Department" scopes restrict on the admission-time
+     * institution/department (institutionForSearch / loggedDepartment,
+     * reused from the manual search fields — same as the plain Search
+     * button). "By Current Department" scopes restrict on the patient's
+     * current room instead (RoomFacilityCharge.company / .department),
+     * passed as parameters to the private searchAdmissions() overload
+     * rather than stored on the bean, so they can never leak into a later
+     * plain Search click. At the "Any Institute" level neither grouping
+     * applies an institution/department restriction, so both groups are
+     * intentionally equivalent there — the distinction only matters once a
+     * specific institute/department is being matched.
      */
     public void searchAdmissionsByAdmittedDepartmentAnyInstitute() {
         if (!webUserController.hasPrivilege("InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute")) {
@@ -1205,8 +1235,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         institutionForSearch = null;
         loggedDepartment = null;
-        currentDepartmentForSearch = null;
-        searchAdmissions();
+        searchAdmissions(null, null);
     }
 
     public void searchAdmissionsByAdmittedDepartmentLoggedInstitute() {
@@ -1215,8 +1244,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         institutionForSearch = sessionController.getInstitution();
         loggedDepartment = null;
-        currentDepartmentForSearch = null;
-        searchAdmissions();
+        searchAdmissions(null, null);
     }
 
     public void searchAdmissionsByAdmittedDepartmentLoggedDepartment() {
@@ -1225,8 +1253,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         institutionForSearch = sessionController.getInstitution();
         loggedDepartment = sessionController.getDepartment();
-        currentDepartmentForSearch = null;
-        searchAdmissions();
+        searchAdmissions(null, null);
     }
 
     public void searchAdmissionsByCurrentDepartmentAnyInstitute() {
@@ -1235,28 +1262,25 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         institutionForSearch = null;
         loggedDepartment = null;
-        currentDepartmentForSearch = null;
-        searchAdmissions();
+        searchAdmissions(null, null);
     }
 
     public void searchAdmissionsByCurrentDepartmentLoggedInstitute() {
         if (!webUserController.hasPrivilege("InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute")) {
             return;
         }
-        institutionForSearch = sessionController.getInstitution();
+        institutionForSearch = null;
         loggedDepartment = null;
-        currentDepartmentForSearch = null;
-        searchAdmissions();
+        searchAdmissions(sessionController.getInstitution(), null);
     }
 
     public void searchAdmissionsByCurrentDepartmentLoggedDepartment() {
         if (!webUserController.hasPrivilege("InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment")) {
             return;
         }
-        institutionForSearch = sessionController.getInstitution();
+        institutionForSearch = null;
         loggedDepartment = null;
-        currentDepartmentForSearch = sessionController.getDepartment();
-        searchAdmissions();
+        searchAdmissions(sessionController.getInstitution(), sessionController.getDepartment());
     }
 
     public void searchAdmissionsWithoutRoom() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -16,6 +16,7 @@ import com.divudi.bean.common.ControllerWithPatient;
 import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.PatientInsuranceController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PatientRegistrationSource;
 import com.divudi.core.data.admin.ConfigOptionInfo;
@@ -122,6 +123,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     PageMetadataRegistry pageMetadataRegistry;
+    @Inject
+    WebUserController webUserController;
 
     ////////////
     @EJB
@@ -212,6 +215,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private ClinicalFindingValue currentPatientAllergy;
     private Institution lastCreditCompany;
     private Department loggedDepartment;
+    private Department currentDepartmentForSearch;
     private Institution site;
 
     private PaymentMethod paymentMethod;
@@ -1170,6 +1174,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             m.put("dept", loggedDepartment);
         }
 
+        if (currentDepartmentForSearch != null) {
+            j += "  and (c.currentPatientRoom.roomFacilityCharge.department=:curDept "
+                    + " or c.currentPatientRoom.roomFacilityCharge.department.superDepartment=:curDept) ";
+            m.put("curDept", currentDepartmentForSearch);
+        }
+
         if (parentAdmission != null) {
             j += "  and c.parentEncounter=:pent ";
             m.put("pent", parentAdmission);
@@ -1181,6 +1191,72 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         items = getFacade().findByJpql(j, m, TemporalType.TIMESTAMP);
+    }
+
+    /**
+     * Search-scope shortcut buttons (issue #22382). Each is gated by its own
+     * privilege in the XHTML; the field resets here are a defense-in-depth
+     * check so a request forged without the button can't widen the search
+     * scope beyond what the privilege allows.
+     */
+    public void searchAdmissionsByAdmittedDepartmentAnyInstitute() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute")) {
+            return;
+        }
+        institutionForSearch = null;
+        loggedDepartment = null;
+        currentDepartmentForSearch = null;
+        searchAdmissions();
+    }
+
+    public void searchAdmissionsByAdmittedDepartmentLoggedInstitute() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute")) {
+            return;
+        }
+        institutionForSearch = sessionController.getInstitution();
+        loggedDepartment = null;
+        currentDepartmentForSearch = null;
+        searchAdmissions();
+    }
+
+    public void searchAdmissionsByAdmittedDepartmentLoggedDepartment() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment")) {
+            return;
+        }
+        institutionForSearch = sessionController.getInstitution();
+        loggedDepartment = sessionController.getDepartment();
+        currentDepartmentForSearch = null;
+        searchAdmissions();
+    }
+
+    public void searchAdmissionsByCurrentDepartmentAnyInstitute() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByCurrentDepartmentAnyInstitute")) {
+            return;
+        }
+        institutionForSearch = null;
+        loggedDepartment = null;
+        currentDepartmentForSearch = null;
+        searchAdmissions();
+    }
+
+    public void searchAdmissionsByCurrentDepartmentLoggedInstitute() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute")) {
+            return;
+        }
+        institutionForSearch = sessionController.getInstitution();
+        loggedDepartment = null;
+        currentDepartmentForSearch = null;
+        searchAdmissions();
+    }
+
+    public void searchAdmissionsByCurrentDepartmentLoggedDepartment() {
+        if (!webUserController.hasPrivilege("InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment")) {
+            return;
+        }
+        institutionForSearch = sessionController.getInstitution();
+        loggedDepartment = null;
+        currentDepartmentForSearch = sessionController.getDepartment();
+        searchAdmissions();
     }
 
     public void searchAdmissionsWithoutRoom() {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -100,6 +100,13 @@ public enum Privileges {
     InwardSearchServiceBillUnrestrictedAccess("Inward Search Service Bill Without Restricted"),
     InwardSearchProfessionalBill("Inward Search Professional Bill"),
     InwardSearchFinalBill("Inward Search Final Bill"),
+    // Admission search scope buttons (issue #22382)
+    InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute("Inward Search Admissions By Admitted Department - Any Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute("Inward Search Admissions By Admitted Department - Logged Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment("Inward Search Admissions By Admitted Department - Logged Department"),
+    InwardSearchAdmissionsByCurrentDepartmentAnyInstitute("Inward Search Admissions By Current Department - Any Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute("Inward Search Admissions By Current Department - Logged Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment("Inward Search Admissions By Current Department - Logged Department"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
     InwardSettleFinalBill("Inward Settle Final Bill"),
     InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -66,7 +66,7 @@
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment')}">
-                                    <p:outputLabel value="Search By Admitted Department" style="font-weight:bold" />
+                                    <h:outputText value="Search By Admitted Department" style="font-weight:bold" />
                                     <p:commandButton
                                         ajax="false"
                                         value="Any Institute"
@@ -94,7 +94,7 @@
                                 </h:panelGroup>
 
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentAnyInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment')}">
-                                    <p:outputLabel value="Search By Current Department" style="font-weight:bold" />
+                                    <h:outputText value="Search By Current Department" style="font-weight:bold" />
                                     <p:commandButton
                                         ajax="false"
                                         value="Any Institute"

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -65,6 +65,62 @@
                                     class="mt-2 w-100 mb-3 ui-button-warning">
                                 </p:commandButton>
 
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment')}">
+                                    <p:outputLabel value="Search By Admitted Department" style="font-weight:bold" />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Any Institute"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute')}"
+                                        action="#{admissionController.searchAdmissionsByAdmittedDepartmentAnyInstitute}"
+                                        class="mt-1 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Logged Institute"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute')}"
+                                        action="#{admissionController.searchAdmissionsByAdmittedDepartmentLoggedInstitute}"
+                                        class="mt-1 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Logged Department"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment')}"
+                                        action="#{admissionController.searchAdmissionsByAdmittedDepartmentLoggedDepartment}"
+                                        class="mt-1 mb-3 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentAnyInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute') or webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment')}">
+                                    <p:outputLabel value="Search By Current Department" style="font-weight:bold" />
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Any Institute"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentAnyInstitute')}"
+                                        action="#{admissionController.searchAdmissionsByCurrentDepartmentAnyInstitute}"
+                                        class="mt-1 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Logged Institute"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute')}"
+                                        action="#{admissionController.searchAdmissionsByCurrentDepartmentLoggedInstitute}"
+                                        class="mt-1 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Logged Department"
+                                        icon="fas fa-search"
+                                        rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment')}"
+                                        action="#{admissionController.searchAdmissionsByCurrentDepartmentLoggedDepartment}"
+                                        class="mt-1 mb-3 w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                </h:panelGroup>
+
                                 <p:outputLabel value="BHT No" ></p:outputLabel>
                                 <p:inputText
                                     class="w-100"


### PR DESCRIPTION
## Summary

Closes #22382.

`inward/inpatient_search.xhtml` previously showed all admissions with a single "unrestricted access" privilege + config toggle controlling whether the Institution/Site/Department dropdowns were visible. This PR adds 6 new fine-grained privileges, each rendering its own one-click search-scope button:

**By Admitted Department** (`Admission`/`PatientEncounter.department`, set at admission time):
1. `InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute`
2. `InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute`
3. `InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment`

**By Current Department** (the department of the patient's current room — `currentPatientRoom.roomFacilityCharge.department` — or that department's `superDepartment`):
4. `InwardSearchAdmissionsByCurrentDepartmentAnyInstitute`
5. `InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute`
6. `InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment`

A user only sees the buttons for privileges they hold. Each button reuses whatever other filters are already entered on the page (date range, patient name, BHT no, etc.) and forces its own institution/department scope, ignoring the manual Institution/Site/Department dropdowns for that click.

"Logged Institute"/"Logged Department" scope use `sessionController.getInstitution()`/`getDepartment()` (the user's current session institution/department — same source used elsewhere in the Inward module, e.g. `ItemRequestApprovalController`). "Logged Department" matching for the Current Department group includes beds under the logged department's sub-departments (`room.department == loggedDept OR room.department.superDepartment == loggedDept`), mirroring the existing building→ward hierarchy pattern in `BedBoardController`.

## Design notes / things left alone

- The existing "Search" button, the Institution/Site/Department dropdowns, and the existing `InwardSearchServiceBillUnrestrictedAccess` privilege + config-key restriction (`Restirct Inward Admission Search to Logged Department of the User`) are all untouched — the new buttons are purely additive. Consolidating/replacing that older single-privilege mechanism with these 6 is intentionally deferred to a follow-up issue.
- New privileges are registered in `UserPrivilageController.createPrivilegeHolderTreeNodes()` under **Inward > Search > Admission Search Scope**, so admins can assign them from the existing User Privileges admin UI — no other UI changes needed.
- Controller action methods (`AdmissionController.searchAdmissionsBy*`) re-check the privilege server-side before running the query, as defense-in-depth against a forged request that skips the button.

## Testing

This session runs in a cloud sandbox without a local Payara/Windows dev environment, so I was not able to do a full Maven build or a Playwright/browser pass end-to-end. `mvn compile` also can't run in this sandbox because `com.github.hmislk:lims-middleware-libraries` is fetched from `jitpack.io`, which this environment's egress policy blocks (403) — this is a pre-existing sandbox limitation unrelated to this change, not something new here.

What I did verify manually instead:
- Cross-checked every new privilege name and controller method name is spelled identically across `Privileges.java`, `UserPrivilageController.java`, `AdmissionController.java`, and `inpatient_search.xhtml` (6-for-6 match).
- Confirmed the JPQL path `c.currentPatientRoom.roomFacilityCharge.department.superDepartment` is valid — all four hops (`currentPatientRoom`, `roomFacilityCharge`, `department`, `superDepartment`) are single-valued `@ManyToOne` associations, and the same `currentPatientRoom.roomFacilityCharge.*` chain is already used elsewhere in this file (e.g. `a.currentPatientRoom.roomFacilityCharge.name` in the existing "Current Room" column).
- Read through the full diff for balanced braces/tags and matching method signatures.

**Please run this through CI (which has jitpack.io access) and a local build/Playwright pass before merging** — I'd appreciate a flag if CI turns up anything my manual review missed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLxsXUhgVvw1odBPytWo11)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added department-based admission search options for both **Admitted Department** and **Current Department**.
  * Search results can now be scoped to any institute, the logged-in institute, or the logged-in department.
  * Available search options are shown according to assigned access privileges.
  * Added new admission search permissions to support controlled access to each filtering scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->