### PR TITLE
feat(pharmacy): show bill/item/prescription comments on BHT issue and reprint pages

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/pharmacy/BhtIssueRequestItemPrintDto.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/BhtIssueRequestItemPrintDto.java
@@ -9,6 +9,8 @@ public class BhtIssueRequestItemPrintDto implements Serializable {
     private String itemName = "";
     private double qty;
     private String directions = "";
+    private String instructions = "";
+    private String prescriptionComment = "";
 
     public String getItemName() {
         return itemName;
@@ -32,5 +34,21 @@ public class BhtIssueRequestItemPrintDto implements Serializable {
 
     public void setDirections(String directions) {
         this.directions = directions;
+    }
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(String instructions) {
+        this.instructions = instructions;
+    }
+
+    public String getPrescriptionComment() {
+        return prescriptionComment;
+    }
+
+    public void setPrescriptionComment(String prescriptionComment) {
+        this.prescriptionComment = prescriptionComment;
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/BhtIssueRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/BhtIssueRequestNativeSqlService.java
@@ -90,9 +90,10 @@ public class BhtIssueRequestNativeSqlService {
     @SuppressWarnings("unchecked")
     private List<BhtIssueRequestItemPrintDto> loadItems(long billId) {
         List<BhtIssueRequestItemPrintDto> items = new ArrayList<>();
-        String jpql = "SELECT i.name, bi.qty, bi.descreption "
+        String jpql = "SELECT i.name, bi.qty, bi.descreption, bi.instructions, p.comment "
                 + "FROM BillItem bi "
                 + "LEFT JOIN bi.item i "
+                + "LEFT JOIN bi.prescription p "
                 + "WHERE bi.bill.id = :billId AND bi.retired = false "
                 + "ORDER BY bi.id";
         List<Object[]> rows = em.createQuery(jpql).setParameter("billId", billId).getResultList();
@@ -103,6 +104,8 @@ public class BhtIssueRequestNativeSqlService {
             item.setQty(r[col] != null ? ((Number) r[col]).doubleValue() : 0.0);
             col++;
             item.setDirections(str(r[col++]));
+            item.setInstructions(str(r[col++]));
+            item.setPrescriptionComment(str(r[col++]));
             items.add(item);
         }
         return items;

--- a/src/main/webapp/resources/pharmacy/print/bht_issue_request_receipt.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/bht_issue_request_receipt.xhtml
@@ -121,7 +121,7 @@
 
                 <table class="biq-items">
                     <thead>
-                        <tr><th>#</th><th>Item</th><th>Quantity</th><th>Directions</th></tr>
+                        <tr><th>#</th><th>Item</th><th>Quantity</th><th>Directions</th><th>Comment</th></tr>
                     </thead>
                     <tbody>
                         <ui:repeat value="#{cc.attrs.dto.items}" var="bii" varStatus="st">
@@ -130,6 +130,14 @@
                                 <td><h:outputText value="#{bii.itemName}"/></td>
                                 <td><h:outputText value="#{bii.qty}"><f:convertNumber pattern="#,##0"/></h:outputText></td>
                                 <td><h:outputText value="#{bii.directions}"/></td>
+                                <td>
+                                    <h:panelGroup rendered="#{bii.instructions ne null and bii.instructions ne ''}" layout="block">
+                                        <h:outputText value="#{bii.instructions}"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{bii.prescriptionComment ne null and bii.prescriptionComment ne ''}" layout="block">
+                                        <h:outputText value="Rx: #{bii.prescriptionComment}"/>
+                                    </h:panelGroup>
+                                </td>
                             </tr>
                         </ui:repeat>
                     </tbody>
@@ -201,13 +209,21 @@
                 <hr/>
 
                 <table class="biq-items">
-                    <thead><tr><th>Item</th><th>Qty</th><th>Directions</th></tr></thead>
+                    <thead><tr><th>Item</th><th>Qty</th><th>Directions</th><th>Comment</th></tr></thead>
                     <tbody>
                         <ui:repeat value="#{cc.attrs.dto.items}" var="bii">
                             <tr>
                                 <td><h:outputText value="#{bii.itemName}"/></td>
                                 <td><h:outputText value="#{bii.qty}"><f:convertNumber pattern="#,##0"/></h:outputText></td>
                                 <td><h:outputText value="#{bii.directions}"/></td>
+                                <td>
+                                    <h:panelGroup rendered="#{bii.instructions ne null and bii.instructions ne ''}" layout="block">
+                                        <h:outputText value="#{bii.instructions}"/>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{bii.prescriptionComment ne null and bii.prescriptionComment ne ''}" layout="block">
+                                        <h:outputText value="Rx: #{bii.prescriptionComment}"/>
+                                    </h:panelGroup>
+                                </td>
                             </tr>
                         </ui:repeat>
                     </tbody>
@@ -266,6 +282,16 @@
                             <td>&#160;&#160;Qty: <h:outputText value="#{bii.qty}"><f:convertNumber pattern="#,##0"/></h:outputText></td>
                             <td><h:outputText value="#{bii.directions}"/></td>
                         </tr>
+                        <ui:fragment rendered="#{bii.instructions ne null and bii.instructions ne ''}">
+                            <tr>
+                                <td colspan="2">&#160;&#160;<h:outputText value="Comment: #{bii.instructions}"/></td>
+                            </tr>
+                        </ui:fragment>
+                        <ui:fragment rendered="#{bii.prescriptionComment ne null and bii.prescriptionComment ne ''}">
+                            <tr>
+                                <td colspan="2">&#160;&#160;<h:outputText value="Rx: #{bii.prescriptionComment}"/></td>
+                            </tr>
+                        </ui:fragment>
                     </ui:repeat>
                 </table>
                 <hr/>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -368,6 +368,15 @@
                             </h:panelGroup>
                         </p:column>
 
+                        <p:column headerText="Comment" style="width: 50px!important; padding: 6px;">
+                            <h:outputText value="#{bItm.referanceBillItem.instructions}" />
+                            <h:panelGroup layout="block"
+                                          rendered="#{bItm.referanceBillItem.hasPrescription() and bItm.referanceBillItem.prescription.comment ne null and bItm.referanceBillItem.prescription.comment ne ''}"
+                                          style="font-size:0.85em;color:#555;margin-top:2px;">
+                                <h:outputText value="Rx: #{bItm.referanceBillItem.prescription.comment}" />
+                            </h:panelGroup>
+                        </p:column>
+
                         <p:column headerText="Batch No"  style="width:50px!important; text-align: right; padding: 6px;">
                             <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.batchNo}" id="batchNo"/>
                         </p:column>

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -178,7 +178,7 @@
                             </p:column>
                             <p:column>
                                 <f:facet name="header">Comment</f:facet>
-                                <p:outputLabel value="#{bip.instructions}" ></p:outputLabel>
+                                <h:outputText value="#{bip.instructions}" />
                                 <h:panelGroup layout="block"
                                               rendered="#{bip.hasPrescription() and bip.prescription.comment ne null and bip.prescription.comment ne ''}"
                                               style="font-size:0.85em;color:#555;margin-top:2px;">

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_request.xhtml
@@ -176,6 +176,15 @@
                                      blank Prescription during rendering.) -->
                                 <p:outputLabel value="#{bip.descreption}" ></p:outputLabel>
                             </p:column>
+                            <p:column>
+                                <f:facet name="header">Comment</f:facet>
+                                <p:outputLabel value="#{bip.instructions}" ></p:outputLabel>
+                                <h:panelGroup layout="block"
+                                              rendered="#{bip.hasPrescription() and bip.prescription.comment ne null and bip.prescription.comment ne ''}"
+                                              style="font-size:0.85em;color:#555;margin-top:2px;">
+                                    <h:outputText value="Rx: #{bip.prescription.comment}" />
+                                </h:panelGroup>
+                            </p:column>
                         </p:dataTable>
                     </p:panel>
                 </p:panel>


### PR DESCRIPTION
## Summary

- Adds a **Comment** column to the "Available Items" table on `ward_pharmacy_bht_issue.xhtml` (pharmacy issue page), showing item-level comment (`BillItem.instructions`) and prescription-level comment (`Prescription.comment`, guarded with `hasPrescription()`).
- Adds the same **Comment** column to the "Bill Item Details" table on `ward_pharmacy_reprint_bht_issue_request.xhtml` (reprint/preview page).
- Extends `BhtIssueRequestNativeSqlService.loadItems()` / `BhtIssueRequestItemPrintDto` to also select `bi.instructions` and the linked `Prescription.comment`, so the shared print composite (`resources/pharmacy/print/bht_issue_request_receipt.xhtml`, used by both pages' "View Request"/preview dialog, all 3 print format variants) shows item and prescription comments too.
- Bill-level comment (`Bill.comments`) already rendered correctly on both pages — no change needed there.

Closes #22380

## Test plan

Verified end-to-end with Playwright against a local deployment (CareCode Model Hospital demo data) + direct DB checks:

- [x] Created a BHT pharmacy issue request via `ward_pharmacy_bht_issue_request_bill.xhtml` with a bill-level comment and an item-level comment (Dispense Only path), settled it.
- [x] Confirmed `BILLITEM.INSTRUCTIONS` in the DB matched what was entered.
- [x] Logged in as Main Pharmacy, opened the request from **BHT Issue Requests**:
  - [x] Issue page ("Issue Medicines"): new Comment column shows the item comment; "View Request" dialog (print composite) shows it too.
  - [x] Reprint page ("View Request"): new Comment column shows the item comment; print preview shows it too.
- [x] Since the local dev DB has no `FrequencyUnit`/`DurationUnit` seed data (blocks the prescription "Calculate & Add" UI path locally), linked a test `Prescription.comment` directly to the same `BillItem` via SQL to verify the prescription-comment code path (`hasPrescription()` guard, `Rx:` prefix) renders on all four surfaces, then cleaned up the test row.
- [x] `mvn clean package` — full build + existing test suite (178 tests, including `BhtIssueRequestNativeSqlServiceTest`) passes.

Screenshots (issue comment has the same, with before/after context):

Issue page — item + prescription comment:
![Issue page Rx comment](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22380_issue_page_rx_comment.png)

Reprint page — item + prescription comment (table + print preview):
![Reprint page Rx comment](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22380_reprint_page_rx_comment.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-item “Comment” details to BHT pharmacy issue displays, including prescription-related notes.
  * Updated BHT issue receipts and reprints to show item instructions and an optional “Rx:” prescription comment when available.
  * Enhanced comment visibility across A4, FiveFive, and POS layouts, including the available-items table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->