### PR TITLE
feat(api): add Investigation Validators CRUD API

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationValidatorDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationValidatorDTO.java
@@ -1,0 +1,27 @@
+package com.divudi.core.data.dto.investigation;
+
+public class InvestigationValidatorDTO {
+
+    private Long id;
+    private Long investigationId;
+    private String name;
+    private Double maximumValue;
+    private Double minimumValue;
+    private String message;
+
+    public InvestigationValidatorDTO() {
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getInvestigationId() { return investigationId; }
+    public void setInvestigationId(Long investigationId) { this.investigationId = investigationId; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public Double getMaximumValue() { return maximumValue; }
+    public void setMaximumValue(Double maximumValue) { this.maximumValue = maximumValue; }
+    public Double getMinimumValue() { return minimumValue; }
+    public void setMinimumValue(Double minimumValue) { this.minimumValue = minimumValue; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/service/investigation/InvestigationValidatorApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationValidatorApiService.java
@@ -64,6 +64,7 @@ public class InvestigationValidatorApiService implements Serializable {
         v.setName(req.getName().trim());
         v.setMaximumValue(req.getMaximumValue());
         v.setMinimumValue(req.getMinimumValue());
+        validateRange(v.getMinimumValue(), v.getMaximumValue());
         v.setCreater(user);
         v.setCreatedAt(new Date());
         investigationValidatorFacade.createAndFlush(v);
@@ -75,6 +76,14 @@ public class InvestigationValidatorApiService implements Serializable {
         if (req == null) {
             throw new Exception("Request body is required");
         }
+        // Validate the prospective merged range before mutating the managed
+        // entity — `v` is JPA-managed here, so any setter call is dirty-tracked
+        // and will be flushed at transaction commit even if this method later
+        // throws, since a checked Exception does not trigger EJB CMT rollback.
+        Double effectiveMax = req.getMaximumValue() != null ? req.getMaximumValue() : v.getMaximumValue();
+        Double effectiveMin = req.getMinimumValue() != null ? req.getMinimumValue() : v.getMinimumValue();
+        validateRange(effectiveMin, effectiveMax);
+
         if (req.getName() != null && !req.getName().trim().isEmpty()) {
             v.setName(req.getName().trim());
         }
@@ -102,6 +111,12 @@ public class InvestigationValidatorApiService implements Serializable {
     // =========================================================================
     // Private helpers
     // =========================================================================
+
+    private void validateRange(Double minimumValue, Double maximumValue) throws Exception {
+        if (minimumValue != null && maximumValue != null && minimumValue > maximumValue) {
+            throw new Exception("minimumValue cannot exceed maximumValue");
+        }
+    }
 
     private Investigation loadInvestigation(Long id) throws Exception {
         Investigation ix = investigationFacade.find(id);

--- a/src/main/java/com/divudi/service/investigation/InvestigationValidatorApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationValidatorApiService.java
@@ -1,0 +1,138 @@
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.dto.investigation.InvestigationValidatorDTO;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.Investigation;
+import com.divudi.core.entity.lab.InvestigationValidator;
+import com.divudi.core.facade.InvestigationFacade;
+import com.divudi.core.facade.InvestigationValidatorFacade;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST API service for Investigation result-validator (min/max range) CRUD.
+ * See issue #22364.
+ *
+ * The {@code InvestigationValidaterComponent} relation (and both directions
+ * of the bidirectional link between it and {@code InvestigationValidator})
+ * is dead code — no bean or xhtml in the app ever reads or writes it, and
+ * its facade is never injected anywhere. Confirmed by repo-wide search
+ * before implementing this API; deliberately not exposed here. The live UI
+ * (`InvestigationValidatorComponentController.addNewValidator()`) always
+ * sets {@code InvestigationValidator.item} to the investigation itself, so
+ * this service does the same rather than accepting a separate item
+ * reference from the client.
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class InvestigationValidatorApiService implements Serializable {
+
+    @EJB
+    private InvestigationFacade investigationFacade;
+    @EJB
+    private InvestigationValidatorFacade investigationValidatorFacade;
+
+    public List<InvestigationValidatorDTO> listValidators(Long investigationId) throws Exception {
+        loadInvestigation(investigationId);
+        Map<String, Object> m = new HashMap<>();
+        m.put("ixId", investigationId);
+        String j = "select v from InvestigationValidator v where v.item.id=:ixId and v.retired=false order by v.name";
+        List<InvestigationValidator> rows = investigationValidatorFacade.findByJpql(j, m, TemporalType.TIMESTAMP);
+        List<InvestigationValidatorDTO> out = new ArrayList<>();
+        for (InvestigationValidator row : rows) {
+            out.add(toDTO(row, null));
+        }
+        return out;
+    }
+
+    public InvestigationValidatorDTO createValidator(Long investigationId, InvestigationValidatorDTO req, WebUser user) throws Exception {
+        if (req == null || req.getName() == null || req.getName().trim().isEmpty()) {
+            throw new Exception("name is required");
+        }
+        Investigation ix = loadInvestigation(investigationId);
+        InvestigationValidator v = new InvestigationValidator();
+        v.setItem(ix);
+        v.setName(req.getName().trim());
+        v.setMaximumValue(req.getMaximumValue());
+        v.setMinimumValue(req.getMinimumValue());
+        v.setCreater(user);
+        v.setCreatedAt(new Date());
+        investigationValidatorFacade.createAndFlush(v);
+        return toDTO(v, "Validator created successfully");
+    }
+
+    public InvestigationValidatorDTO updateValidator(Long investigationId, Long validatorId, InvestigationValidatorDTO req, WebUser user) throws Exception {
+        InvestigationValidator v = loadValidator(validatorId, investigationId);
+        if (req == null) {
+            throw new Exception("Request body is required");
+        }
+        if (req.getName() != null && !req.getName().trim().isEmpty()) {
+            v.setName(req.getName().trim());
+        }
+        if (req.getMaximumValue() != null) {
+            v.setMaximumValue(req.getMaximumValue());
+        }
+        if (req.getMinimumValue() != null) {
+            v.setMinimumValue(req.getMinimumValue());
+        }
+        v.setEditor(user);
+        v.setEditedAt(new Date());
+        investigationValidatorFacade.edit(v);
+        return toDTO(v, "Validator updated successfully");
+    }
+
+    public InvestigationValidatorDTO deleteValidator(Long investigationId, Long validatorId, WebUser user) throws Exception {
+        InvestigationValidator v = loadValidator(validatorId, investigationId);
+        v.setRetired(true);
+        v.setRetirer(user);
+        v.setRetiredAt(new Date());
+        investigationValidatorFacade.edit(v);
+        return toDTO(v, "Validator deleted successfully");
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private Investigation loadInvestigation(Long id) throws Exception {
+        Investigation ix = investigationFacade.find(id);
+        if (ix == null || ix.isRetired()) {
+            throw new Exception("Investigation not found with ID: " + id);
+        }
+        return ix;
+    }
+
+    private InvestigationValidator loadValidator(Long validatorId, Long investigationId) throws Exception {
+        Investigation investigation = loadInvestigation(investigationId);
+        InvestigationValidator v = investigationValidatorFacade.find(validatorId);
+        if (v == null || v.isRetired()) {
+            throw new Exception("Validator not found with ID: " + validatorId);
+        }
+        if (v.getItem() == null || !investigation.getId().equals(v.getItem().getId())) {
+            throw new Exception("Validator " + validatorId + " does not belong to investigation " + investigationId);
+        }
+        return v;
+    }
+
+    private InvestigationValidatorDTO toDTO(InvestigationValidator v, String msg) {
+        InvestigationValidatorDTO dto = new InvestigationValidatorDTO();
+        dto.setId(v.getId());
+        if (v.getItem() != null) {
+            dto.setInvestigationId(v.getItem().getId());
+        }
+        dto.setName(v.getName());
+        dto.setMaximumValue(v.getMaximumValue());
+        dto.setMinimumValue(v.getMinimumValue());
+        dto.setMessage(msg);
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -65,6 +65,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationComponentApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFeeApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
+        resources.add(com.divudi.ws.investigation.InvestigationValidatorApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -427,6 +427,15 @@ public class CapabilityStatementResource {
                         + "total/totalForForeigner and are rejected against a retired investigation.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Investigation Validators", "/api/investigations/{investigationId}/validators",
+                        "Manage InvestigationValidator result-range checks (name, maximumValue, minimumValue) for an "
+                        + "investigation. GET lists non-retired validators. POST creates one. "
+                        + "PUT /{validatorId} updates one (only non-null/non-blank fields are applied). "
+                        + "DELETE /{validatorId} soft-deletes (retires) one. All mutations are rejected against a "
+                        + "retired investigation. Note: the legacy InvestigationValidaterComponent relation is dead "
+                        + "code in the app today and is intentionally not exposed by this API.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories. "
                         + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "

--- a/src/main/java/com/divudi/ws/investigation/InvestigationValidatorApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationValidatorApi.java
@@ -1,0 +1,150 @@
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.investigation.InvestigationValidatorDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.InvestigationValidatorApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Path("investigations/{investigationId}/validators")
+@RequestScoped
+public class InvestigationValidatorApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private InvestigationValidatorApiService validatorService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listValidators(@PathParam("investigationId") Long investigationId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(validatorService.listValidators(investigationId));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createValidator(@PathParam("investigationId") Long investigationId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            InvestigationValidatorDTO req = gson.fromJson(body, InvestigationValidatorDTO.class);
+            InvestigationValidatorDTO dto = validatorService.createValidator(investigationId, req, user);
+            return Response.status(201).entity(gson.toJson(successData(dto, 201))).build();
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/{validatorId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateValidator(@PathParam("investigationId") Long investigationId,
+                                     @PathParam("validatorId") Long validatorId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            InvestigationValidatorDTO req = gson.fromJson(body, InvestigationValidatorDTO.class);
+            return successResponse(validatorService.updateValidator(investigationId, validatorId, req, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/{validatorId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deleteValidator(@PathParam("investigationId") Long investigationId,
+                                     @PathParam("validatorId") Long validatorId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(validatorService.deleteValidator(investigationId, validatorId, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        return successData(data, 200);
+    }
+
+    private Map<String, Object> successData(Object data, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", statusCode);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
- Part of #464 (Full API + AI-Agent-Driven Investigation Authoring). Closes #22364.
- New `/investigations/{investigationId}/validators` sub-resource (GET / POST / PUT `{validatorId}` / DELETE `{validatorId}`) for `InvestigationValidator` result-range checks (`name`, `maximumValue`, `minimumValue`).
- **Investigated before designing the DTO**, per the issue's own uncertainty flag: `InvestigationValidator` and `InvestigationValidaterComponent` (note the persisted typo — not "fixed", per CLAUDE.md's backward-compatibility rule) have a doubled bidirectional relationship (a singular `@ManyToOne` + plural `@OneToMany` in each direction). A repo-wide search of `src/main/java/com/divudi/bean` and `src/main/webapp` found **zero real usage** of any of the four relationship accessors — the component facade (`InvestigationValueComponentFacade`) is never injected anywhere, and the one bean field that references `InvestigationValidaterComponent` (`InvestigationValidatorComponentController.current`) is never set or rendered. The only live code path (`addNewValidator()`) always sets `InvestigationValidator.item` to the investigation itself.
- Per user decision (asked directly given this is an architecturally significant finding that changes scope from the issue's literal wording), this API **intentionally does not expose `validate-components`** — it only exposes the fields with real usage: `name`, `maximumValue`, `minimumValue`, scoped to the investigation via the path parameter (mirroring the one live UI behavior rather than resurrecting dead entity relationships).
- DELETE soft-retires (`retired`/`retirer`/`retiredAt`), since `InvestigationValidator` already carries full audit/retire fields — unlike `InvestigationComponent` (no retire fields, hence permanent delete in #22361). Every `load*` helper re-validates the parent investigation isn't retired, per the gap CodeRabbit caught in #22387.

## Files changed
- `InvestigationValidatorDTO.java` (new)
- `InvestigationValidatorApiService.java` (new) — investigation existence/retired guard, validator existence/ownership guard
- `InvestigationValidatorApi.java` (new) — REST resource, `Finance`-header auth, standard success/error envelope
- `ApplicationConfig.java` — registers the new JAX-RS resource
- `CapabilityStatementResource.java` — documents the new `/api/investigations/{investigationId}/validators` resource, including the validate-components scoping note

## Test plan
Verified end-to-end against the local Payara `rh` domain / `coop` database using investigation `A.P.T.T` (id 87589):
- [x] `GET /investigations/87589/validators` — empty list initially
- [x] `POST /investigations/87589/validators` (`{"name":"APTT Range Check","maximumValue":45,"minimumValue":25}`) — 201, DB confirms row in `INVESTIGATIONVALIDATOR` with `ITEM_ID=87589`
- [x] `GET` — returns the created validator
- [x] `PUT /investigations/87589/validators/1` (`{"maximumValue":50}`) — 200, only `maximumValue` changed, `minimumValue`/`name` untouched
- [x] `DELETE /investigations/87589/validators/1` — 200, DB confirms `RETIRED=1`; subsequent `GET` list no longer includes it
- [x] Mutating validators on a retired investigation (flipped `RETIRED=1` on test investigation 13839294 via SQL + redeploy per the EclipseLink L2 cache gotcha, then reverted) — 500 `"Investigation not found with ID: ..."` for both `GET` and `POST`
- [x] Nonexistent investigation id — 500 (matches `InvestigationComponentApi`'s flat error-status convention, since this is a fresh owned sub-resource rather than one delegating to an existing sibling service like #22362's fees)
- [x] Missing `Finance` header — 401
- [x] `GET /api/capabilities` — confirms the new "Investigation Validators" resource entry is present
- [x] `mvn clean package -DskipTests` — builds clean, no compile errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated API endpoints to list, create, update, and delete investigation validators for a given investigation.
  * Validators now support defining a name plus minimum/maximum range and returning consistent validation outcomes.
* **API & UX Improvements**
  * Standardized request/response handling, including unified success/error payloads with timestamps and data/message fields.
  * Expanded the capability statement to advertise the new `/api/investigations/{investigationId}/validators` operations.
* **Bug Fixes**
  * Improved enforcement of retired/invalid investigation and validator states during validator mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->