### PR TITLE
Add per-item hold/unhold for individual professional payments

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -327,6 +327,7 @@ public class InwardStaffPaymentBillController implements Serializable {
                 + " and bf.bill.cancelled=false "
                 + " and bf.bill.createdAt between :fd and :td "
                 + " and (bf.feeValue - bf.paidValue) > 0 "
+                + " and (bf.feePaymentOnHold=false or bf.feePaymentOnHold is null) "
                 + " and bf.staff=:stf "
                 + " order by bf.createdAt desc";
 
@@ -1293,6 +1294,7 @@ public class InwardStaffPaymentBillController implements Serializable {
                 + " and b.bill.cancelled=false "
                 //                + " and b.bill.refunded=false "
                 + " and (b.feeValue - b.paidValue) > 0 "
+                + " and (b.feePaymentOnHold=false or b.feePaymentOnHold is null) "
                 + " and b.staff=:stf ";
 //            h.put("btp", BillType.ChannelPaid);
         h.put("stf", currentStaff);
@@ -1480,6 +1482,12 @@ public class InwardStaffPaymentBillController implements Serializable {
                 if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
                         && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
                     JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
+                    return true;
+                }
+                if (bf.isFeePaymentOnHold()
+                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
+                    JsfUtil.addErrorMessage("Cannot pay: this professional payment is individually on hold"
+                            + (pe != null ? " (BHT " + pe.getBhtNo() + ")" : "") + ".");
                     return true;
                 }
             }

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -168,8 +168,9 @@ public class InwardSurgeryPaymentBillController implements Serializable {
                 + " and bf.bill.cancelled=false "
                 + " and bf.bill.createdAt between :fd and :td "
                 + " and (bf.feeValue - bf.paidValue) > 0 "
+                + " and (bf.feePaymentOnHold=false or bf.feePaymentOnHold is null) "
                 + " and bf.staff=:stf ";
-        
+
         sql += " order by bf.createdAt desc";
 
         h.put("fd", fromDate);
@@ -342,6 +343,12 @@ public class InwardSurgeryPaymentBillController implements Serializable {
                 if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
                         && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
                     JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
+                    return true;
+                }
+                if (bf.isFeePaymentOnHold()
+                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
+                    JsfUtil.addErrorMessage("Cannot pay: this professional payment is individually on hold"
+                            + (pe != null ? " (BHT " + pe.getBhtNo() + ")" : "") + ".");
                     return true;
                 }
             }

--- a/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
+++ b/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
@@ -1,0 +1,218 @@
+package com.divudi.bean.inward;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.AuditService;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Report of professional payments (ward + surgery {@code BillFee} rows) for a
+ * single admission, with multi-select hold/unhold of individual professional
+ * payments — a finer-grained complement to the whole-BHT hold in
+ * {@link ProfessionalPaymentHoldController}. (Issue #22383)
+ */
+@Named
+@SessionScoped
+public class ProfessionalFeeHoldController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private BillFeeFacade billFeeFacade;
+
+    @EJB
+    private AuditService auditService;
+
+    @Inject
+    private SessionController sessionController;
+
+    @Inject
+    private WebUserController webUserController;
+
+    private PatientEncounter currentEncounter;
+    private List<BillFee> professionalFees;
+    private List<BillFee> selectedFees;
+    private String holdNotes;
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    public String navigateToProfessionalFeeHold(PatientEncounter pe) {
+        this.currentEncounter = pe;
+        this.selectedFees = new ArrayList<>();
+        this.holdNotes = null;
+        loadProfessionalFees();
+        return "/inward/inward_professional_fee_hold?faces-redirect=true";
+    }
+
+    // -------------------------------------------------------------------------
+    // Loading
+    // -------------------------------------------------------------------------
+
+    public void loadProfessionalFees() {
+        professionalFees = new ArrayList<>();
+        if (currentEncounter == null || currentEncounter.getId() == null) {
+            return;
+        }
+        String jpql = "select bf from BillFee bf where "
+                + " bf.retired=false "
+                + " and bf.bill.cancelled=false "
+                + " and bf.patienEncounter=:pe "
+                + " and bf.staff is not null "
+                + " and (bf.bill.billType=:btp or bf.bill.billType=:btp2) "
+                + " order by bf.staff.person.name, bf.createdAt";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", currentEncounter);
+        params.put("btp", BillType.InwardBill);
+        params.put("btp2", BillType.InwardProfessional);
+        professionalFees = billFeeFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    // -------------------------------------------------------------------------
+    // Hold / Release (multi-select bulk actions)
+    // -------------------------------------------------------------------------
+
+    public void holdSelected() {
+        if (!webUserController.hasPrivilege("InwardHoldProfessionalPayments")) {
+            JsfUtil.addErrorMessage("You do not have privileges to hold professional payments.");
+            return;
+        }
+        if (selectedFees == null || selectedFees.isEmpty()) {
+            JsfUtil.addErrorMessage("Please select at least one professional payment to hold.");
+            return;
+        }
+        int held = 0;
+        for (BillFee bf : selectedFees) {
+            if (bf.isFeePaymentOnHold()) {
+                continue;
+            }
+            Map<String, Object> before = feeHoldStateMap(bf);
+            bf.setFeePaymentOnHold(Boolean.TRUE);
+            bf.setFeePaymentHoldDateTime(new Date());
+            bf.setFeePaymentHoldBy(sessionController.getLoggedUser());
+            bf.setFeePaymentHoldNotes(holdNotes);
+            billFeeFacade.edit(bf);
+            auditService.logEncounterAudit(currentEncounter, "Professional Fee Payment Hold",
+                    before, feeHoldStateMap(bf), sessionController.getLoggedUser(), "BillFee", bf.getId());
+            held++;
+        }
+        selectedFees = new ArrayList<>();
+        holdNotes = null;
+        loadProfessionalFees();
+        if (held > 0) {
+            JsfUtil.addSuccessMessage(held + " professional payment(s) held.");
+        } else {
+            JsfUtil.addErrorMessage("Selected payment(s) are already on hold.");
+        }
+    }
+
+    public void releaseHoldSelected() {
+        if (!webUserController.hasPrivilege("InwardHoldProfessionalPayments")) {
+            JsfUtil.addErrorMessage("You do not have privileges to release the hold on professional payments.");
+            return;
+        }
+        if (selectedFees == null || selectedFees.isEmpty()) {
+            JsfUtil.addErrorMessage("Please select at least one professional payment to release.");
+            return;
+        }
+        int released = 0;
+        for (BillFee bf : selectedFees) {
+            if (!bf.isFeePaymentOnHold()) {
+                continue;
+            }
+            Map<String, Object> before = feeHoldStateMap(bf);
+            bf.setFeePaymentOnHold(Boolean.FALSE);
+            bf.setFeePaymentHoldDateTime(null);
+            bf.setFeePaymentHoldBy(null);
+            bf.setFeePaymentHoldNotes(null);
+            billFeeFacade.edit(bf);
+            auditService.logEncounterAudit(currentEncounter, "Professional Fee Payment Hold Released",
+                    before, feeHoldStateMap(bf), sessionController.getLoggedUser(), "BillFee", bf.getId());
+            released++;
+        }
+        selectedFees = new ArrayList<>();
+        loadProfessionalFees();
+        if (released > 0) {
+            JsfUtil.addSuccessMessage(released + " professional payment(s) released from hold.");
+        } else {
+            JsfUtil.addErrorMessage("Selected payment(s) are not currently on hold.");
+        }
+    }
+
+    /**
+     * Snapshot of a BillFee's hold fields for audit before/after events.
+     */
+    private Map<String, Object> feeHoldStateMap(BillFee bf) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        if (bf == null) {
+            return m;
+        }
+        m.put("billFeeId", bf.getId());
+        m.put("staff", bf.getStaff() != null ? bf.getStaff().getName() : null);
+        m.put("feeValue", bf.getFeeValue());
+        m.put("feePaymentOnHold", bf.isFeePaymentOnHold());
+        m.put("feePaymentHoldDateTime", bf.getFeePaymentHoldDateTime());
+        m.put("feePaymentHoldBy", bf.getFeePaymentHoldBy() != null ? bf.getFeePaymentHoldBy().getName() : null);
+        m.put("feePaymentHoldNotes", bf.getFeePaymentHoldNotes());
+        return m;
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public PatientEncounter getCurrentEncounter() {
+        return currentEncounter;
+    }
+
+    public void setCurrentEncounter(PatientEncounter currentEncounter) {
+        this.currentEncounter = currentEncounter;
+    }
+
+    public List<BillFee> getProfessionalFees() {
+        if (professionalFees == null) {
+            professionalFees = new ArrayList<>();
+        }
+        return professionalFees;
+    }
+
+    public void setProfessionalFees(List<BillFee> professionalFees) {
+        this.professionalFees = professionalFees;
+    }
+
+    public List<BillFee> getSelectedFees() {
+        if (selectedFees == null) {
+            selectedFees = new ArrayList<>();
+        }
+        return selectedFees;
+    }
+
+    public void setSelectedFees(List<BillFee> selectedFees) {
+        this.selectedFees = selectedFees;
+    }
+
+    public String getHoldNotes() {
+        return holdNotes;
+    }
+
+    public void setHoldNotes(String holdNotes) {
+        this.holdNotes = holdNotes;
+    }
+}

--- a/src/main/java/com/divudi/bean/inward/ProfessionalPaymentHoldController.java
+++ b/src/main/java/com/divudi/bean/inward/ProfessionalPaymentHoldController.java
@@ -5,7 +5,10 @@ import com.divudi.bean.common.WebUserController;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.service.AuditService;
 import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -34,6 +37,9 @@ public class ProfessionalPaymentHoldController implements Serializable {
 
     @EJB
     private PatientEncounterFacade patientEncounterFacade;
+
+    @EJB
+    private AuditService auditService;
 
     @Inject
     private SessionController sessionController;
@@ -69,10 +75,13 @@ public class ProfessionalPaymentHoldController implements Serializable {
             JsfUtil.addErrorMessage("Professional payments are already on hold for this BHT.");
             return;
         }
+        Map<String, Object> before = holdStateMap();
         currentEncounter.setProfessionalPaymentsOnHold(Boolean.TRUE);
         currentEncounter.setProfessionalPaymentsHoldDateTime(new Date());
         currentEncounter.setProfessionalPaymentsHoldBy(sessionController.getLoggedUser());
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Professional Payments Hold (BHT)",
+                before, holdStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Professional payments held for BHT " + currentEncounter.getBhtNo() + ".");
     }
 
@@ -89,12 +98,31 @@ public class ProfessionalPaymentHoldController implements Serializable {
             JsfUtil.addErrorMessage("Professional payments are not currently on hold for this BHT.");
             return;
         }
+        Map<String, Object> before = holdStateMap();
         currentEncounter.setProfessionalPaymentsOnHold(Boolean.FALSE);
         currentEncounter.setProfessionalPaymentsHoldDateTime(null);
         currentEncounter.setProfessionalPaymentsHoldBy(null);
         currentEncounter.setProfessionalPaymentsHoldNotes(null);
         patientEncounterFacade.edit(currentEncounter);
+        auditService.logEncounterAudit(currentEncounter, "Professional Payments Hold Released (BHT)",
+                before, holdStateMap(), sessionController.getLoggedUser());
         JsfUtil.addSuccessMessage("Professional payments hold released for BHT " + currentEncounter.getBhtNo() + ".");
+    }
+
+    /**
+     * Snapshot of the BHT-level hold fields for audit before/after events (#22383).
+     */
+    private Map<String, Object> holdStateMap() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        if (currentEncounter == null) {
+            return m;
+        }
+        m.put("professionalPaymentsOnHold", currentEncounter.isProfessionalPaymentsOnHold());
+        m.put("professionalPaymentsHoldDateTime", currentEncounter.getProfessionalPaymentsHoldDateTime());
+        m.put("professionalPaymentsHoldBy", currentEncounter.getProfessionalPaymentsHoldBy() != null
+                ? currentEncounter.getProfessionalPaymentsHoldBy().getName() : null);
+        m.put("professionalPaymentsHoldNotes", currentEncounter.getProfessionalPaymentsHoldNotes());
+        return m;
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -16,6 +16,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Temporal;
 import javax.persistence.Transient;
@@ -118,6 +119,16 @@ public class BillFee implements Serializable, RetirableEntity {
     
     // Indicates if the fee has been collected directly by the surgeon/doctor
     private boolean feeCollectedByDoctor;
+
+    // Per-item professional payment hold — blocks payment of this specific fee only
+    // (mirrors PatientEncounter.professionalPaymentsOnHold, which holds the whole BHT). (Issue #22383)
+    private Boolean feePaymentOnHold = false;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date feePaymentHoldDateTime;
+    @ManyToOne
+    private WebUser feePaymentHoldBy;
+    @Lob
+    private String feePaymentHoldNotes;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private BillItem referenceBillItem;
@@ -916,6 +927,42 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setFeeCollectedByDoctor(boolean feeCollectedByDoctor) {
         this.feeCollectedByDoctor = feeCollectedByDoctor;
+    }
+
+    public Boolean getFeePaymentOnHold() {
+        return feePaymentOnHold;
+    }
+
+    public boolean isFeePaymentOnHold() {
+        return Boolean.TRUE.equals(feePaymentOnHold);
+    }
+
+    public void setFeePaymentOnHold(Boolean feePaymentOnHold) {
+        this.feePaymentOnHold = feePaymentOnHold;
+    }
+
+    public Date getFeePaymentHoldDateTime() {
+        return feePaymentHoldDateTime;
+    }
+
+    public void setFeePaymentHoldDateTime(Date feePaymentHoldDateTime) {
+        this.feePaymentHoldDateTime = feePaymentHoldDateTime;
+    }
+
+    public WebUser getFeePaymentHoldBy() {
+        return feePaymentHoldBy;
+    }
+
+    public void setFeePaymentHoldBy(WebUser feePaymentHoldBy) {
+        this.feePaymentHoldBy = feePaymentHoldBy;
+    }
+
+    public String getFeePaymentHoldNotes() {
+        return feePaymentHoldNotes;
+    }
+
+    public void setFeePaymentHoldNotes(String feePaymentHoldNotes) {
+        this.feePaymentHoldNotes = feePaymentHoldNotes;
     }
 
 }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -474,6 +474,18 @@
                                         styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
                                     </p:commandButton>
                                 </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        id="btnProfessionalFeeHold"
+                                        value="Professional Payments Report"
+                                        ajax="false"
+                                        action="#{professionalFeeHoldController.navigateToProfessionalFeeHold(admissionController.current)}"
+                                        icon="fa fa-list-check"
+                                        title="Report and per-item hold/unhold of professional payments for this admission"
+                                        rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                        styleClass="w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                </div>
                             </div>
                         </p:panel>
 

--- a/src/main/webapp/inward/inward_professional_fee_hold.xhtml
+++ b/src/main/webapp/inward/inward_professional_fee_hold.xhtml
@@ -1,0 +1,172 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+
+                <h:form id="formProfessionalFeeHold"
+                        onkeydown="if(event.key==='Enter'&amp;&amp;event.target.tagName!=='TEXTAREA'){event.preventDefault();return false;}">
+
+                    <p:growl id="growl" life="4000"/>
+
+                    <!-- Navigation bar -->
+                    <div class="row">
+                        <div class="col-12 px-4">
+                            <p:commandButton
+                                id="btnDashboard"
+                                value="Inpatient Dashboard"
+                                ajax="false"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"
+                                icon="fa fa-id-card"
+                                class="p-0 m-1">
+                                <f:setPropertyActionListener
+                                    value="#{professionalFeeHoldController.currentEncounter}"
+                                    target="#{admissionController.current}" />
+                            </p:commandButton>
+                        </div>
+                    </div>
+
+                    <!-- Access denied panel -->
+                    <h:panelGroup id="pnlAccessDenied" layout="block" rendered="#{not webUserController.hasPrivilege('InwardHoldProfessionalPayments')}">
+                        <div class="row px-4">
+                            <div class="col-12">
+                                <p:panel class="m-1">
+                                    <h:outputText value="You do not have permission to hold or release professional payments." />
+                                </p:panel>
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                    <!-- Main content -->
+                    <h:panelGroup id="pnlMain" layout="block" rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}">
+
+                        <div class="row px-4 py-2">
+                            <div class="col-12">
+
+                                <p:panel class="w-100 m-1">
+                                    <f:facet name="header">
+                                        <div class="d-flex justify-content-between align-items-center w-100">
+                                            <div>
+                                                <i class="fa fa-user-md mr-2"/>
+                                                <h:outputText value="Professional Payments — BHT: " />
+                                                <h:outputText value="#{professionalFeeHoldController.currentEncounter.bhtNo}" style="font-weight: bold;"/>
+                                                <h:outputText value=" — " />
+                                                <h:outputText value="#{professionalFeeHoldController.currentEncounter.patient.person.nameWithTitle}" style="font-weight: bold;"/>
+                                            </div>
+                                        </div>
+                                    </f:facet>
+
+                                    <p:outputLabel for="txtFeeHoldNotes" value="Hold Notes (applied to newly held payments):" styleClass="font-weight-bold" />
+                                    <p:inputTextarea
+                                        id="txtFeeHoldNotes"
+                                        value="#{professionalFeeHoldController.holdNotes}"
+                                        class="w-100"
+                                        autoResize="true"
+                                        rows="3"
+                                        placeholder="Reason for holding the selected professional payment(s), e.g. pending investigation, billing dispute, awaiting clarification, etc." />
+
+                                    <p:dataTable
+                                        id="tblProfessionalFees"
+                                        value="#{professionalFeeHoldController.professionalFees}"
+                                        selection="#{professionalFeeHoldController.selectedFees}"
+                                        class="w-100 m-1 mt-3"
+                                        rows="20"
+                                        paginator="true"
+                                        paginatorPosition="bottom"
+                                        paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                        currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                        rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
+                                        emptyMessage="No professional payments found for this admission."
+                                        var="bf"
+                                        rowKey="#{bf.id}">
+
+                                        <p:column selectionBox="true" width="20"/>
+
+                                        <p:column headerText="Consultant" sortBy="#{bf.staff.person.name}">
+                                            <h:outputLabel value="#{bf.staff.person.nameWithTitle}" styleClass="fw-bold text-dark"/>
+                                        </p:column>
+
+                                        <p:column headerText="Speciality" sortBy="#{bf.speciality.name}">
+                                            <h:outputLabel value="#{bf.speciality.name}" rendered="#{bf.speciality ne null}"/>
+                                        </p:column>
+
+                                        <p:column headerText="Source" sortBy="#{bf.bill.billTypeAtomic}">
+                                            <h:outputLabel value="#{bf.bill.billTypeAtomic.label}"/>
+                                        </p:column>
+
+                                        <p:column headerText="Bill No">
+                                            <h:outputLabel value="#{bf.bill.deptId}"/>
+                                        </p:column>
+
+                                        <p:column headerText="Fee Date" sortBy="#{bf.feeAt}">
+                                            <h:outputLabel value="#{bf.feeAt}">
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Fee" styleClass="text-end" sortBy="#{bf.feeValue}">
+                                            <h:outputLabel value="#{bf.feeValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Paid" styleClass="text-end" sortBy="#{bf.paidValue}">
+                                            <h:outputLabel value="#{bf.paidValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Hold Status">
+                                            <h:panelGroup layout="block" rendered="#{bf.feePaymentOnHold}">
+                                                <span class="ui-tag ui-tag-danger" title="#{bf.feePaymentHoldNotes}">
+                                                    On Hold since
+                                                    <h:outputText value="#{bf.feePaymentHoldDateTime}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
+                                                    </h:outputText>
+                                                    by #{bf.feePaymentHoldBy.name}
+                                                </span>
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" rendered="#{not bf.feePaymentOnHold}">
+                                                <span class="ui-tag ui-tag-success">Payable</span>
+                                            </h:panelGroup>
+                                        </p:column>
+
+                                    </p:dataTable>
+
+                                    <!-- Action buttons -->
+                                    <h:panelGroup id="pnlActionButtons" layout="block"
+                                                  styleClass="d-flex justify-content-end my-2">
+                                        <p:commandButton
+                                            id="btnHoldSelected"
+                                            value="Hold Selected"
+                                            ajax="false"
+                                            action="#{professionalFeeHoldController.holdSelected()}"
+                                            icon="fa fa-lock"
+                                            class="ui-button-danger mx-1"
+                                            onclick="return confirm('Hold payment for the selected professional payment(s)? They will be excluded from professional payment runs until released.')" />
+                                        <p:commandButton
+                                            id="btnReleaseHoldSelected"
+                                            value="Release Hold on Selected"
+                                            ajax="false"
+                                            action="#{professionalFeeHoldController.releaseHoldSelected()}"
+                                            icon="fa fa-unlock"
+                                            class="ui-button-success mx-1"
+                                            onclick="return confirm('Release the hold on the selected professional payment(s)?')" />
+                                    </h:panelGroup>
+
+                                </p:panel>
+
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -205,6 +205,17 @@
                                                                 rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
                                                                 styleClass="w-100 #{admissionController.current.professionalPaymentsOnHold ? 'ui-button-danger' : 'ui-button-secondary'}">
                                                             </p:commandButton>
+
+                                                            <p:commandButton
+                                                                id="btnProfessionalFeeHold"
+                                                                value="Professional Payments Report"
+                                                                ajax="false"
+                                                                action="#{professionalFeeHoldController.navigateToProfessionalFeeHold(admissionController.current)}"
+                                                                icon="fa fa-list-check"
+                                                                title="Report and per-item hold/unhold of professional payments for this admission"
+                                                                rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}"
+                                                                styleClass="w-100 ui-button-secondary">
+                                                            </p:commandButton>
                                                         </div>
                                                     </div>
 

--- a/src/main/webapp/theater/surgery_professional_fees_list.xhtml
+++ b/src/main/webapp/theater/surgery_professional_fees_list.xhtml
@@ -110,6 +110,13 @@
                                             target="#{admissionController.current}"/>
                                     </p:commandButton>
                                 </h:panelGroup>
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardHoldProfessionalPayments')}">
+                                    <p:commandButton id="btnProfessionalFeeHold" value="Professional Payments Report" icon="fa fa-list-check"
+                                                     ajax="false" immediate="true"
+                                                     title="Report and per-item hold/unhold of professional payments for this admission"
+                                                     action="#{professionalFeeHoldController.navigateToProfessionalFeeHold(inwardProfessionalBillController.selectedSurgeryBill.patientEncounter)}"
+                                                     styleClass="ui-button-info ui-button-outlined"/>
+                                </h:panelGroup>
                             </div>
 
                             <!-- RIGHT: actions, left=least important → right=primary -->


### PR DESCRIPTION
Adds a per-BillFee hold flag (feePaymentOnHold/HoldDateTime/HoldBy/HoldNotes, mirroring PatientEncounter's whole-BHT hold fields) alongside the existing BHT-level hold, plus a new admission-scoped "Professional Payments Report" (ProfessionalFeeHoldController + inward_professional_fee_hold.xhtml) listing ward and surgery professional BillFee rows for one admission, sortable by consultant, with multi-select Hold Selected / Release Hold on Selected bulk actions. Reachable from the admission dashboard and surgery dashboard.

Held fees are excluded from the due-fees queries in InwardStaffPaymentBillController and InwardSurgeryPaymentBillController, and their errorCheck() methods block payment of an individually held fee unless the payer holds the existing InwardPayProfessionalFeesWhileOnHold privilege (reusing the existing BHT-level privileges rather than adding new ones).

Also fixes a gap noted in the issue: the existing whole-BHT hold/unhold (ProfessionalPaymentHoldController) previously wrote no audit trail; both whole-BHT and per-item hold/unhold now log AuditEvent entries via AuditService, visible on the admission's event history timeline.

Closes #22383


Claude-Session: https://claude.ai/code/session_017eP3UjUWXLSwDZHPG2RC92