### PR TITLE
feat(client-portal): add login and password reset (issue #22370)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1069,6 +1069,50 @@ Found while verifying issue #22310 (fee row hidden along with its item name
 when `ShowServiceCharges` is absent) — needed a throwaway non-privileged
 login to confirm the fix without touching any real staff account.
 
+## 45. `&&` written as `&amp;&amp;` inside a `<script><![CDATA[...]]>` block parses as valid XML but throws a JS `SyntaxError` at runtime, silently breaking every function in that script
+
+When copying a `<script>` block that lives inside `<![CDATA[ ... ]]>` into a
+new XHTML page, writing the literal characters `&amp;&amp;` (instead of `&&`)
+is easy to do by habit — most other XML/XHTML text content genuinely needs
+`&` escaped — but CDATA sections are explicitly exempt from entity
+expansion, so this is always wrong there. The bug hides unusually well:
+
+- `xml.etree.ElementTree` (or any XML well-formedness check) parses the file
+  without complaint — `&amp;` is perfectly valid character data whether or
+  not it's inside CDATA, so a "did the file parse" check gives a false all-clear.
+- Facelets' XML parser reads the CDATA content literally (per spec, no entity
+  expansion inside CDATA), so the in-memory text node keeps the literal
+  6-character sequence `&amp;`. When Facelets serializes the response back
+  out as plain text (not treating it as a CDATA passthrough), it re-escapes
+  `&` to `&amp;` — so the browser receives doubled-up `&amp;&amp;` in the
+  final HTML.
+- Because `<script>` is an HTML5 "raw text" element, the browser does **not**
+  decode entities inside it — it hands the literal text straight to the JS
+  parser, which throws `SyntaxError: Unexpected token ';'` trying to parse
+  `&amp;&amp;` as code. **This aborts parsing of the entire `<script>`
+  block**, so every function defined anywhere in that block — even ones
+  with no `&&` in them at all — ends up undefined, surfacing later as
+  unrelated-looking `ReferenceError: xyz is not defined` console errors when
+  something tries to call them (e.g. via a PrimeFaces AJAX partial update
+  that re-inserts an inline `<script>` calling one of those functions).
+
+Detection: `curl` the deployed page and `grep -c '&amp;&amp;'` vs
+`grep -c '&&'` in the raw response — if the doubled-entity count is nonzero,
+the source file has the bug. A quick sed fix:
+```bash
+sed -i "s/&amp;&amp;/\&\&/g" path/to/page.xhtml
+```
+(safe because it only touches doubled `&amp;&amp;`, leaving legitimate single
+`&amp;` — e.g. in URL query strings or "Bills &amp; Appointments" body
+text — untouched).
+
+Found while verifying issue #22370 (Client Portal login/password-reset):
+two new pages copied `register_phone.xhtml`'s OTP-digit-box `<script>` block,
+and the copy silently escaped `&&` to `&amp;&amp;`. The OTP boxes never
+rendered and the browser console showed `initOtpBoxes is not defined` and
+`startOtpCountdown is not defined` — errors that look like a missing/renamed
+JS function, not a stray HTML entity three screens away in the same script tag.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalLoginController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalLoginController.java
@@ -1,0 +1,94 @@
+package com.divudi.bean.clientportal;
+
+import com.divudi.bean.common.SecurityController;
+import com.divudi.core.entity.ClientAccount;
+import com.divudi.core.facade.ClientAccountFacade;
+import com.divudi.core.util.JsfUtil;
+import java.io.Serializable;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ViewScoped
+public class ClientPortalLoginController implements Serializable {
+
+    @EJB
+    private ClientAccountFacade clientAccountFacade;
+
+    @Inject
+    private ClientPortalSessionController clientPortalSessionController;
+
+    private String identifier;
+    private String password;
+
+    private void clearMessages() {
+        java.util.Iterator<javax.faces.application.FacesMessage> iter = javax.faces.context.FacesContext.getCurrentInstance().getMessages();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+    }
+
+    public void login() {
+        clearMessages();
+        if (identifier == null || identifier.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter your phone number or email.");
+            return;
+        }
+        if (password == null || password.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter your password.");
+            return;
+        }
+
+        List<ClientAccount> candidates = clientAccountFacade.findByVerifiedPhoneOrEmail(identifier.trim());
+
+        ClientAccount matched = null;
+        for (ClientAccount candidate : candidates) {
+            if (SecurityController.matchPassword(password, candidate.getPasswordHash())) {
+                matched = candidate;
+                break;
+            }
+        }
+
+        if (matched == null) {
+            JsfUtil.addErrorMessage("Incorrect phone/email or password.");
+            return;
+        }
+
+        clientPortalSessionController.login(matched);
+        password = null;
+    }
+
+    public void logout() {
+        clientPortalSessionController.logout();
+        identifier = null;
+        password = null;
+    }
+
+    public boolean isLoggedIn() {
+        return clientPortalSessionController.isLoggedIn();
+    }
+
+    public ClientAccount getLoggedInAccount() {
+        return clientPortalSessionController.getLoggedInAccount();
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
@@ -51,6 +51,7 @@ public class ClientPortalPasswordResetController implements Serializable {
     private Date otpSentTime;
     private boolean otpSendSuccess;
     private boolean otpVerified;
+    private Long verifiedSmsId;
 
     private String newPassword;
     private String newPasswordConfirm;
@@ -72,6 +73,7 @@ public class ClientPortalPasswordResetController implements Serializable {
         selectedAccount = null;
         otpSendSuccess = false;
         otpVerified = false;
+        verifiedSmsId = null;
         matchedAccounts = null;
 
         if (identifier == null || identifier.trim().isEmpty()) {
@@ -195,6 +197,7 @@ public class ClientPortalPasswordResetController implements Serializable {
         }
 
         otpVerified = true;
+        verifiedSmsId = lastSms.getId();
 
         // Only now — after OTP proves control of the phone number — do we reveal
         // which account(s) matched. A single match auto-selects; multiple matches
@@ -220,6 +223,28 @@ public class ClientPortalPasswordResetController implements Serializable {
             JsfUtil.addErrorMessage("Password and confirmation do not match.");
             return;
         }
+
+        // Re-bind the OTP proof at the moment of the credential change, rather than
+        // trusting the view-scoped otpVerified flag indefinitely: re-fetch the latest
+        // Sms for this identifier and confirm it's still the exact row that was
+        // verified (not a newer OTP requested since, which would leave a stale
+        // verification usable against a fresh code) and still within the expiry
+        // window (in case the view has been open longer than the OTP timeout).
+        String trimmed = identifier == null ? null : identifier.trim();
+        String jpql = "select s from Sms s where s.retired=false and s.receipientNumber=:mobile and s.smsType=:type order by s.id desc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("mobile", trimmed);
+        params.put("type", MessageType.ClientPortalPasswordResetOTP);
+        Sms latestSms = smsFacade.findFirstByJpql(jpql, params);
+        boolean proofStillValid = latestSms != null
+                && latestSms.getId().equals(verifiedSmsId)
+                && (System.currentTimeMillis() - latestSms.getCreatedAt().getTime()) <= getOtpTimeoutMinutes() * 60_000L;
+        if (!proofStillValid) {
+            otpVerified = false;
+            JsfUtil.addErrorMessage("Your verification has expired or a newer code was requested. Please verify your OTP again.");
+            return;
+        }
+
         String passwordHash = securityController.hashAndCheck(newPassword);
         if (passwordHash == null) {
             JsfUtil.addErrorMessage("Unable to reset the password. Please try again.");

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
@@ -72,43 +72,48 @@ public class ClientPortalPasswordResetController implements Serializable {
         selectedAccount = null;
         otpSendSuccess = false;
         otpVerified = false;
+        matchedAccounts = null;
 
         if (identifier == null || identifier.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Enter the phone number or email on your account.");
             return;
         }
         String trimmed = identifier.trim();
-        matchedAccounts = clientAccountFacade.findByVerifiedPhoneOrEmail(trimmed);
-        if (matchedAccounts == null || matchedAccounts.isEmpty()) {
+        List<ClientAccount> candidates = clientAccountFacade.findByVerifiedPhoneOrEmail(trimmed);
+        if (candidates == null || candidates.isEmpty()) {
             noAccountFound = true;
             JsfUtil.addErrorMessage("No Client Portal account found for that phone number or email. Please register first.");
             return;
         }
-        if (matchedAccounts.size() == 1) {
-            selectAccount(matchedAccounts.get(0));
-        }
-        // else: multiple matches (shared household phone) — rendered as a list in the XHTML, user calls selectAccount(candidate) directly
-    }
 
-    public void selectAccount(ClientAccount account) {
-        clearMessages();
-        this.selectedAccount = account;
-        String trimmed = identifier == null ? null : identifier.trim();
-        boolean matchesPhone = trimmed != null && trimmed.equals(account.getVerifiedPhone());
+        // Which account(s) matched, and their names, are NOT revealed here — only
+        // after OTP verification below, mirroring the registration flow's
+        // OTP-then-disambiguation order. Revealing account holder names to anyone
+        // who types a phone/email, before proving they control that phone/email,
+        // would be a pre-authentication PII disclosure.
+        boolean matchesPhone = candidates.stream().anyMatch(a -> trimmed.equals(a.getVerifiedPhone()));
         if (!matchesPhone) {
             emailResetUnsupported = true;
             JsfUtil.addErrorMessage("Password reset by email isn't available yet. Please use the phone number on your account, or contact support.");
             return;
         }
+
+        matchedAccounts = candidates;
         sendOtp();
+    }
+
+    public void selectAccount(ClientAccount account) {
+        clearMessages();
+        this.selectedAccount = account;
     }
 
     public void sendOtp() {
         clearMessages();
-        if (selectedAccount == null) {
+        if (identifier == null || identifier.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Error in Development.");
             return;
         }
+        String trimmed = identifier.trim();
 
         otp = ClientPortalOtpGenerator.generate(getOtpLength());
         otpSendSuccess = false;
@@ -116,7 +121,7 @@ public class ClientPortalPasswordResetController implements Serializable {
         Sms sms = new Sms();
         sms.setCreatedAt(new Date());
         sms.setCreater(sessionController.getLoggedUser());
-        sms.setReceipientNumber(selectedAccount.getVerifiedPhone());
+        sms.setReceipientNumber(trimmed);
         sms.setSendingMessage(smsBody(otp));
         sms.setPending(false);
         sms.setSmsType(MessageType.ClientPortalPasswordResetOTP);
@@ -150,14 +155,15 @@ public class ClientPortalPasswordResetController implements Serializable {
     public void verifyOtp() {
         clearMessages();
 
-        if (selectedAccount == null) {
+        if (identifier == null || identifier.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Error in Development.");
             return;
         }
+        String trimmed = identifier.trim();
 
         String jpql = "select s from Sms s where s.retired=false and s.receipientNumber=:mobile and s.smsType=:type order by s.id desc";
         Map<String, Object> params = new HashMap<>();
-        params.put("mobile", selectedAccount.getVerifiedPhone());
+        params.put("mobile", trimmed);
         params.put("type", MessageType.ClientPortalPasswordResetOTP);
         Sms lastSms = smsFacade.findFirstByJpql(jpql, params);
 
@@ -189,6 +195,15 @@ public class ClientPortalPasswordResetController implements Serializable {
         }
 
         otpVerified = true;
+
+        // Only now — after OTP proves control of the phone number — do we reveal
+        // which account(s) matched. A single match auto-selects; multiple matches
+        // (shared household phone) render a picker (see isMultipleMatch()) for the
+        // user to pick their own name, same as the registration flow's post-OTP
+        // disambiguation step.
+        if (matchedAccounts != null && matchedAccounts.size() == 1) {
+            selectedAccount = matchedAccounts.get(0);
+        }
     }
 
     public void resetPassword() {
@@ -205,7 +220,12 @@ public class ClientPortalPasswordResetController implements Serializable {
             JsfUtil.addErrorMessage("Password and confirmation do not match.");
             return;
         }
-        selectedAccount.setPasswordHash(securityController.hashAndCheck(newPassword));
+        String passwordHash = securityController.hashAndCheck(newPassword);
+        if (passwordHash == null) {
+            JsfUtil.addErrorMessage("Unable to reset the password. Please try again.");
+            return;
+        }
+        selectedAccount.setPasswordHash(passwordHash);
         clientAccountFacade.edit(selectedAccount);
         resetComplete = true;
     }
@@ -230,7 +250,7 @@ public class ClientPortalPasswordResetController implements Serializable {
     }
 
     public boolean isMultipleMatch() {
-        return matchedAccounts != null && matchedAccounts.size() > 1 && selectedAccount == null;
+        return otpVerified && matchedAccounts != null && matchedAccounts.size() > 1 && selectedAccount == null;
     }
 
     public String getIdentifier() {

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalPasswordResetController.java
@@ -1,0 +1,326 @@
+package com.divudi.bean.clientportal;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.SecurityController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.MessageType;
+import com.divudi.core.entity.ClientAccount;
+import com.divudi.core.entity.Sms;
+import com.divudi.core.facade.ClientAccountFacade;
+import com.divudi.core.facade.SmsFacade;
+import com.divudi.core.util.ClientPortalOtpGenerator;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.SmsManagerEjb;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ViewScoped
+public class ClientPortalPasswordResetController implements Serializable {
+
+    @EJB
+    private SmsFacade smsFacade;
+    @EJB
+    private SmsManagerEjb smsManager;
+    @EJB
+    private ClientAccountFacade clientAccountFacade;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private SecurityController securityController;
+
+    private String identifier;
+    private List<ClientAccount> matchedAccounts;
+    private ClientAccount selectedAccount;
+    private boolean noAccountFound;
+    private boolean emailResetUnsupported;
+
+    private String enteredOtp;
+    private String otp;
+    private Date otpSentTime;
+    private boolean otpSendSuccess;
+    private boolean otpVerified;
+
+    private String newPassword;
+    private String newPasswordConfirm;
+    private boolean resetComplete;
+
+    private void clearMessages() {
+        java.util.Iterator<javax.faces.application.FacesMessage> iter = javax.faces.context.FacesContext.getCurrentInstance().getMessages();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+    }
+
+    public void findAccount() {
+        clearMessages();
+        resetComplete = false;
+        noAccountFound = false;
+        emailResetUnsupported = false;
+        selectedAccount = null;
+        otpSendSuccess = false;
+        otpVerified = false;
+
+        if (identifier == null || identifier.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter the phone number or email on your account.");
+            return;
+        }
+        String trimmed = identifier.trim();
+        matchedAccounts = clientAccountFacade.findByVerifiedPhoneOrEmail(trimmed);
+        if (matchedAccounts == null || matchedAccounts.isEmpty()) {
+            noAccountFound = true;
+            JsfUtil.addErrorMessage("No Client Portal account found for that phone number or email. Please register first.");
+            return;
+        }
+        if (matchedAccounts.size() == 1) {
+            selectAccount(matchedAccounts.get(0));
+        }
+        // else: multiple matches (shared household phone) — rendered as a list in the XHTML, user calls selectAccount(candidate) directly
+    }
+
+    public void selectAccount(ClientAccount account) {
+        clearMessages();
+        this.selectedAccount = account;
+        String trimmed = identifier == null ? null : identifier.trim();
+        boolean matchesPhone = trimmed != null && trimmed.equals(account.getVerifiedPhone());
+        if (!matchesPhone) {
+            emailResetUnsupported = true;
+            JsfUtil.addErrorMessage("Password reset by email isn't available yet. Please use the phone number on your account, or contact support.");
+            return;
+        }
+        sendOtp();
+    }
+
+    public void sendOtp() {
+        clearMessages();
+        if (selectedAccount == null) {
+            JsfUtil.addErrorMessage("Error in Development.");
+            return;
+        }
+
+        otp = ClientPortalOtpGenerator.generate(getOtpLength());
+        otpSendSuccess = false;
+
+        Sms sms = new Sms();
+        sms.setCreatedAt(new Date());
+        sms.setCreater(sessionController.getLoggedUser());
+        sms.setReceipientNumber(selectedAccount.getVerifiedPhone());
+        sms.setSendingMessage(smsBody(otp));
+        sms.setPending(false);
+        sms.setSmsType(MessageType.ClientPortalPasswordResetOTP);
+        sms.setOtp(otp);
+        smsFacade.create(sms);
+
+        Boolean sent = smsManager.sendSms(sms);
+        // Matches PatientPortalController.sendOtp(): when no SMS gateway is configured
+        // (e.g. local dev), sendSms() always returns false. The OTP is still persisted
+        // on the Sms row above, so advance to the verify step regardless of delivery
+        // status rather than permanently blocking the flow when no gateway is set up.
+        otpSendSuccess = true;
+        otpSentTime = new Date();
+        if (Boolean.TRUE.equals(sent)) {
+            JsfUtil.addSuccessMessage("OTP sent successfully.");
+        } else {
+            JsfUtil.addErrorMessage("OTP SMS failed to send.");
+        }
+        sms.setSentSuccessfully(sent);
+        smsFacade.edit(sms);
+    }
+
+    public String smsBody(String otpCode) {
+        String template = configOptionApplicationController.getLongTextValueByKey("Client Portal - Custom SMS Body Message for Password Reset OTP");
+        if (template != null && !template.trim().isEmpty()) {
+            return template.replace("\\n", "\n").replace("{otp}", otpCode);
+        }
+        return "Your Client Portal password reset code is " + otpCode;
+    }
+
+    public void verifyOtp() {
+        clearMessages();
+
+        if (selectedAccount == null) {
+            JsfUtil.addErrorMessage("Error in Development.");
+            return;
+        }
+
+        String jpql = "select s from Sms s where s.retired=false and s.receipientNumber=:mobile and s.smsType=:type order by s.id desc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("mobile", selectedAccount.getVerifiedPhone());
+        params.put("type", MessageType.ClientPortalPasswordResetOTP);
+        Sms lastSms = smsFacade.findFirstByJpql(jpql, params);
+
+        if (lastSms == null) {
+            JsfUtil.addErrorMessage("No OTP request found. Please request a new OTP.");
+            return;
+        }
+
+        // Checked against the persisted Sms.createdAt, not the view-scoped otpSentTime,
+        // so a page refresh mid-flow (which resets otpSentTime) can't bypass expiry.
+        long ageMs = System.currentTimeMillis() - lastSms.getCreatedAt().getTime();
+        if (ageMs > getOtpTimeoutMinutes() * 60_000L) {
+            JsfUtil.addErrorMessage("OTP has expired. Please request a new OTP.");
+            otp = null;
+            enteredOtp = null;
+            otpSentTime = null;
+            otpSendSuccess = false;
+            return;
+        }
+
+        if (enteredOtp == null || enteredOtp.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Enter the authentication code.");
+            return;
+        }
+        if (!enteredOtp.equalsIgnoreCase(lastSms.getOtp())) {
+            JsfUtil.addErrorMessage("Enter correct authentication code.");
+            enteredOtp = null;
+            return;
+        }
+
+        otpVerified = true;
+    }
+
+    public void resetPassword() {
+        clearMessages();
+        if (!otpVerified || selectedAccount == null) {
+            JsfUtil.addErrorMessage("Error in Development.");
+            return;
+        }
+        if (newPassword == null || newPassword.length() < 6) {
+            JsfUtil.addErrorMessage("Password must be at least 6 characters.");
+            return;
+        }
+        if (!newPassword.equals(newPasswordConfirm)) {
+            JsfUtil.addErrorMessage("Password and confirmation do not match.");
+            return;
+        }
+        selectedAccount.setPasswordHash(securityController.hashAndCheck(newPassword));
+        clientAccountFacade.edit(selectedAccount);
+        resetComplete = true;
+    }
+
+    public int getOtpLength() {
+        Long configured = configOptionApplicationController.getLongValueByKey("Client Portal - OTP Length", 6L);
+        if (configured == null || configured < 4L || configured > 12L) {
+            return 6;
+        }
+        return configured.intValue();
+    }
+
+    public int getOtpTimeoutMinutes() {
+        return configOptionApplicationController.getIntegerValueByKey("Client Portal - OTP Timeout Minutes", 2);
+    }
+
+    public long getOtpExpiryEpochMs() {
+        if (otpSentTime == null) {
+            return 0;
+        }
+        return otpSentTime.getTime() + ((long) getOtpTimeoutMinutes() * 60 * 1000L);
+    }
+
+    public boolean isMultipleMatch() {
+        return matchedAccounts != null && matchedAccounts.size() > 1 && selectedAccount == null;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public List<ClientAccount> getMatchedAccounts() {
+        if (matchedAccounts == null) {
+            return new ArrayList<>();
+        }
+        return matchedAccounts;
+    }
+
+    public void setMatchedAccounts(List<ClientAccount> matchedAccounts) {
+        this.matchedAccounts = matchedAccounts;
+    }
+
+    public ClientAccount getSelectedAccount() {
+        return selectedAccount;
+    }
+
+    public void setSelectedAccount(ClientAccount selectedAccount) {
+        this.selectedAccount = selectedAccount;
+    }
+
+    public boolean isNoAccountFound() {
+        return noAccountFound;
+    }
+
+    public void setNoAccountFound(boolean noAccountFound) {
+        this.noAccountFound = noAccountFound;
+    }
+
+    public boolean isEmailResetUnsupported() {
+        return emailResetUnsupported;
+    }
+
+    public void setEmailResetUnsupported(boolean emailResetUnsupported) {
+        this.emailResetUnsupported = emailResetUnsupported;
+    }
+
+    public String getEnteredOtp() {
+        return enteredOtp;
+    }
+
+    public void setEnteredOtp(String enteredOtp) {
+        this.enteredOtp = enteredOtp;
+    }
+
+    public boolean isOtpSendSuccess() {
+        return otpSendSuccess;
+    }
+
+    public void setOtpSendSuccess(boolean otpSendSuccess) {
+        this.otpSendSuccess = otpSendSuccess;
+    }
+
+    public boolean isOtpVerified() {
+        return otpVerified;
+    }
+
+    public void setOtpVerified(boolean otpVerified) {
+        this.otpVerified = otpVerified;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getNewPasswordConfirm() {
+        return newPasswordConfirm;
+    }
+
+    public void setNewPasswordConfirm(String newPasswordConfirm) {
+        this.newPasswordConfirm = newPasswordConfirm;
+    }
+
+    public boolean isResetComplete() {
+        return resetComplete;
+    }
+
+    public void setResetComplete(boolean resetComplete) {
+        this.resetComplete = resetComplete;
+    }
+}

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalSessionController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalSessionController.java
@@ -1,0 +1,35 @@
+package com.divudi.bean.clientportal;
+
+import com.divudi.core.entity.ClientAccount;
+import java.io.Serializable;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class ClientPortalSessionController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private ClientAccount loggedInAccount;
+
+    public void login(ClientAccount account) {
+        this.loggedInAccount = account;
+    }
+
+    public void logout() {
+        this.loggedInAccount = null;
+    }
+
+    public boolean isLoggedIn() {
+        return loggedInAccount != null;
+    }
+
+    public ClientAccount getLoggedInAccount() {
+        return loggedInAccount;
+    }
+
+    public void setLoggedInAccount(ClientAccount loggedInAccount) {
+        this.loggedInAccount = loggedInAccount;
+    }
+}

--- a/src/main/java/com/divudi/core/data/MessageType.java
+++ b/src/main/java/com/divudi/core/data/MessageType.java
@@ -41,5 +41,6 @@ public enum MessageType {
     InpatientDocumentUpload,
     InpatientFilledForm,
     InpatientClinicalDocument,
-    ClientPortalRegistrationOTP
+    ClientPortalRegistrationOTP,
+    ClientPortalPasswordResetOTP
 }

--- a/src/main/java/com/divudi/core/facade/ClientAccountFacade.java
+++ b/src/main/java/com/divudi/core/facade/ClientAccountFacade.java
@@ -51,4 +51,17 @@ public class ClientAccountFacade extends AbstractFacade<ClientAccount> {
         create(newAccount);
         return newAccount;
     }
+
+    /**
+     * Returns all active ClientAccounts whose verifiedPhone or verifiedEmail
+     * exactly matches the given value. More than one account can match a
+     * shared household phone number; callers must disambiguate via password
+     * (login) or explicit selection (password reset).
+     */
+    public List<ClientAccount> findByVerifiedPhoneOrEmail(String phoneOrEmail) {
+        String jpql = "select c from ClientAccount c where c.retired=false and (c.verifiedPhone=:v or c.verifiedEmail=:v)";
+        Map<String, Object> params = new HashMap<>();
+        params.put("v", phoneOrEmail);
+        return findByJpql(jpql, params);
+    }
 }

--- a/src/main/webapp/client_portal/login.xhtml
+++ b/src/main/webapp/client_portal/login.xhtml
@@ -1,0 +1,774 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:a="http://xmlns.jcp.org/jsf/passthrough">
+    <h:head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+        <title>Client Portal Login</title>
+
+        <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as the Patient Portal precedent -->
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+        <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&amp;family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&amp;display=swap" rel="stylesheet"/>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"/>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+              integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"/>
+
+        <style>
+            /* ================================================
+               CLIENT PORTAL LOGIN  ·  Forest Health Aesthetic
+               Structural/CSS pattern copied from client_portal/register_phone.xhtml
+               Responsive: mobile-first, split layout on ≥992px
+               ================================================ */
+
+            :root {
+                --forest-mid:    #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')};
+                --forest-deep:   color-mix(in srgb, var(--forest-mid) 60%, #000);
+                --forest-bright: color-mix(in srgb, var(--forest-mid) 80%, #fff);
+                --emerald:       color-mix(in hsl, var(--forest-mid), white 55%);
+                --emerald-light: color-mix(in hsl, var(--forest-mid), white 65%);
+                --cream:         color-mix(in srgb, var(--forest-mid) 5%, #fff);
+                --white:         #ffffff;
+                --text-dark:     color-mix(in srgb, var(--forest-mid) 12%, #111);
+                --text-muted:    color-mix(in srgb, var(--forest-mid) 20%, #555);
+                --border:        color-mix(in srgb, var(--forest-mid) 12%, #fff);
+                --shadow-lg:     0 24px 64px color-mix(in srgb, var(--forest-mid) 20%, transparent);
+                --radius-sm:     10px;
+            }
+
+            *, *::before, *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            body, html {
+                font-family: 'DM Sans', sans-serif;
+                background: var(--cream);
+                min-height: 100vh;
+                color: var(--text-dark);
+            }
+
+            /* ── PAGE WRAPPER ────────────────────────────────────── */
+            .portal-wrapper {
+                min-height: 100vh;
+                display: flex;
+                align-items: stretch;
+            }
+
+            /* ── LEFT HERO PANEL  (visible ≥992px only) ──────────── */
+            .portal-hero {
+                display: none;
+                position: relative;
+                overflow: hidden;
+                flex-direction: column;
+                justify-content: space-between;
+                align-items: flex-start;
+                padding: 3rem 3.5rem;
+                --hero-color: var(--forest-mid);
+                background: linear-gradient(155deg,
+                    color-mix(in srgb, var(--hero-color) 55%, #000) 0%,
+                    var(--hero-color) 55%,
+                    color-mix(in srgb, var(--hero-color) 75%, #fff) 100%);
+            }
+
+            @media (min-width: 992px) {
+                .portal-hero {
+                    display: flex;
+                    width: 44%;
+                    min-width: 400px;
+                    max-width: 540px;
+                }
+            }
+
+            .hero-dots {
+                position: absolute;
+                inset: 0;
+                background-image: radial-gradient(circle, color-mix(in srgb, var(--emerald-light) 22%, transparent) 1px, transparent 1px);
+                background-size: 30px 30px;
+            }
+
+            .hero-ring {
+                position: absolute;
+                border-radius: 50%;
+                border: 1px solid color-mix(in srgb, var(--emerald) 13%, transparent);
+            }
+            .hero-ring-1 { width: 500px; height: 500px; top: -140px; right: -190px; }
+            .hero-ring-2 { width: 330px; height: 330px; top: -60px; right: -110px; border-color: color-mix(in srgb, var(--emerald) 20%, transparent); }
+            .hero-ring-3 { width: 620px; height: 620px; bottom: -220px; left: -220px; }
+            .hero-ring-4 {
+                width: 380px; height: 380px; bottom: -100px; left: -80px; border: none;
+                background: radial-gradient(circle, color-mix(in srgb, var(--emerald) 7%, transparent) 0%, transparent 70%);
+            }
+
+            .hero-cross { position: absolute; width: 26px; height: 26px; }
+            .hero-cross::before, .hero-cross::after { content: ''; position: absolute; background: var(--emerald-light); border-radius: 2px; }
+            .hero-cross::before { width: 4px; height: 26px; left: 11px; top: 0; }
+            .hero-cross::after  { width: 26px; height: 4px; top: 11px; left: 0; }
+
+            .hero-cross-lg { position: absolute; bottom: 2.5rem; right: 2.5rem; width: 72px; height: 72px; opacity: 0.07; }
+            .hero-cross-lg::before { content: ''; position: absolute; background: white; border-radius: 3px; width: 18px; height: 72px; left: 27px; top: 0; }
+            .hero-cross-lg::after  { content: ''; position: absolute; background: white; border-radius: 3px; width: 72px; height: 18px; top: 27px; left: 0; }
+
+            .hero-content { position: relative; z-index: 2; }
+
+            .hero-logo-wrap {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0.85rem 1.25rem;
+                margin-bottom: 2rem;
+                backdrop-filter: blur(4px);
+                width: 100%;
+            }
+            .hero-logo-img { width: 80%; height: 80%; object-fit: contain; object-position: left center; display: block; }
+
+            .mobile-logo-img { max-width: 220px; max-height: 120px; object-fit: contain; display: block; margin: 0 auto 0.75rem; }
+
+            .hero-badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                background: color-mix(in srgb, var(--emerald) 14%, transparent);
+                border: 1px solid color-mix(in srgb, var(--emerald) 28%, transparent);
+                border-radius: 100px;
+                padding: 0.32rem 1rem;
+                font-size: 0.7rem;
+                color: var(--emerald-light);
+                font-weight: 500;
+                letter-spacing: 0.07em;
+                text-transform: uppercase;
+                margin-bottom: 1.75rem;
+            }
+            .hero-badge-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--emerald); animation: blink 2s infinite; }
+
+            @keyframes blink {
+                0%, 100% { opacity: 1; transform: scale(1); }
+                50%      { opacity: 0.4; transform: scale(0.75); }
+            }
+
+            .hero-title {
+                font-family: 'Syne', sans-serif;
+                font-size: 3.25rem;
+                font-weight: 800;
+                color: var(--white);
+                line-height: 1.08;
+                letter-spacing: -0.025em;
+                margin-bottom: 1rem;
+            }
+            .hero-title .accent { color: var(--emerald-light); }
+
+            .hero-desc {
+                font-size: 0.95rem;
+                color: rgba(255,255,255,0.6);
+                line-height: 1.75;
+                margin-bottom: 2.25rem;
+                max-width: 320px;
+                font-weight: 300;
+            }
+
+            .hero-features { list-style: none; display: flex; flex-direction: column; gap: 0.85rem; }
+            .hero-features li { display: flex; align-items: center; gap: 0.75rem; color: rgba(255,255,255,0.78); font-size: 0.9rem; }
+            .feat-icon {
+                width: 32px; height: 32px;
+                background: color-mix(in srgb, var(--emerald) 18%, transparent);
+                border-radius: 8px;
+                display: flex; align-items: center; justify-content: center;
+                color: var(--emerald-light);
+                font-size: 0.82rem;
+                flex-shrink: 0;
+            }
+
+            /* ── RIGHT FORM PANEL ────────────────────────────────── */
+            .portal-form-panel {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 2.5rem 1.5rem;
+                background: var(--cream);
+            }
+
+            .form-container { width: 100%; max-width: 480px; }
+            @media (min-width: 992px) { .form-container { max-width: 560px; } }
+
+            .mobile-brand-header { text-align: center; margin-bottom: 2rem; }
+            @media (min-width: 992px) { .mobile-brand-header { display: none; } }
+            .mobile-icon {
+                width: 64px; height: 64px;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                border-radius: 18px;
+                display: inline-flex; align-items: center; justify-content: center;
+                font-size: 1.75rem; color: white; margin-bottom: 0.75rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 28%, transparent);
+            }
+            .mobile-inst-name { display: block; font-family: 'Syne', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--forest-mid); }
+            .mobile-portal-label { display: block; font-size: 0.78rem; color: var(--text-muted); margin-top: 0.15rem; letter-spacing: 0.05em; text-transform: uppercase; }
+
+            /* ── CARDS ────────────────────────────────────────────── */
+            .otp-card, .patient-select-card, .welcome-card {
+                background: var(--white);
+                border-radius: 22px;
+                padding: 2.25rem 2rem;
+                box-shadow: var(--shadow-lg);
+                border: 1px solid var(--border);
+                animation: fadeUp 0.45s ease forwards;
+                width: 100%;
+            }
+            .patient-select-card, .welcome-card { max-width: 480px; text-align: left; }
+            .welcome-card { text-align: center; padding: 2.5rem 2rem; }
+            @media (min-width: 992px) {
+                .patient-select-card, .welcome-card { max-width: 560px; }
+            }
+
+            @keyframes fadeUp {
+                from { opacity: 0; transform: translateY(22px); }
+                to   { opacity: 1; transform: translateY(0); }
+            }
+
+            .card-lead-icon {
+                width: 52px; height: 52px;
+                background: linear-gradient(135deg, color-mix(in srgb, var(--emerald) 20%, white), color-mix(in srgb, var(--emerald) 35%, white));
+                border-radius: 13px;
+                display: flex; align-items: center; justify-content: center;
+                font-size: 1.3rem; color: var(--forest-mid);
+                margin-bottom: 1.1rem;
+            }
+
+            .card-title { font-family: 'Syne', sans-serif; font-size: 1.5rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.35rem; line-height: 1.2; }
+            .card-subtitle { font-size: 0.87rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 1.75rem; font-weight: 400; }
+
+            /* ── STEP INDICATORS ─────────────────────────────────── */
+            .steps-bar { display: flex; align-items: center; margin-bottom: 1.75rem; }
+            .step-item { display: flex; align-items: center; gap: 0.45rem; }
+            .step-connector { flex: 1; height: 2px; background: var(--border); margin: 0 0.6rem; }
+            .step-dot {
+                width: 26px; height: 26px; border-radius: 50%;
+                background: var(--border);
+                display: flex; align-items: center; justify-content: center;
+                font-size: 0.72rem; font-weight: 700; color: var(--text-muted);
+                flex-shrink: 0; transition: all 0.3s;
+            }
+            .step-dot.active { background: var(--forest-mid); color: white; box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-mid) 15%, transparent); }
+            .step-label { font-size: 0.72rem; color: var(--text-muted); font-weight: 500; white-space: nowrap; }
+
+            /* ── FORM FIELDS ─────────────────────────────────────── */
+            .field-group { margin-bottom: 1.1rem; }
+            .field-label { display: block; font-size: 0.8rem; font-weight: 600; color: var(--text-dark); margin-bottom: 0.45rem; letter-spacing: 0.025em; }
+            .field-wrap { position: relative; }
+            .field-wrap .f-icon { position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%); color: var(--text-muted); font-size: 0.88rem; pointer-events: none; z-index: 1; }
+
+            .portal-form-panel .ui-inputtext {
+                width: 100% !important;
+                padding: 0.8rem 1rem 0.8rem 2.6rem !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'DM Sans', sans-serif !important;
+                font-size: 0.97rem !important;
+                color: var(--text-dark) !important;
+                background: color-mix(in srgb, var(--forest-mid) 5%, white) !important;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s !important;
+                box-shadow: none !important;
+                outline: none !important;
+                min-width: unset !important;
+            }
+            .portal-form-panel .ui-inputtext:hover { border-color: var(--emerald) !important; }
+            .portal-form-panel .ui-inputtext:focus {
+                border-color: var(--forest-bright) !important;
+                background: var(--white) !important;
+                box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent) !important;
+            }
+            /* p:password wraps the input in a span; strip padding-left icon offset when no icon present */
+            .field-wrap .ui-password { width: 100%; display: block; }
+
+            /* ── PRIMARY BUTTON ──────────────────────────────────── */
+            .btn-send .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid) 0%, var(--forest-bright) 100%) !important;
+                border: none !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: white !important;
+                cursor: pointer !important;
+                transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+                box-shadow: 0 4px 16px color-mix(in srgb, var(--forest-mid) 28%, transparent) !important;
+                letter-spacing: 0.01em !important;
+                min-width: unset !important;
+            }
+            .btn-send .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 7px 22px color-mix(in srgb, var(--forest-mid) 34%, transparent) !important; }
+            .btn-send .ui-button:active { transform: translateY(0) !important; }
+            .btn-send .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-send .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 6px !important; }
+
+            /* ── SECONDARY BUTTON ────────────────────────────────── */
+            .btn-verify .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: var(--cream) !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: var(--forest-mid) !important;
+                cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                min-width: unset !important;
+            }
+            .btn-verify .ui-button:hover { border-color: var(--emerald) !important; background: color-mix(in srgb, var(--emerald) 12%, white) !important; color: var(--forest-deep) !important; }
+            .btn-verify .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-verify .ui-button .ui-icon { color: var(--forest-mid) !important; margin-right: 6px !important; }
+
+            /* ── RESEND LINK ─────────────────────────────────────── */
+            .resend-wrap { text-align: center; font-size: 0.85rem; color: var(--text-muted); margin-top: 1.25rem; }
+            .resend-wrap .ui-commandlink { color: var(--forest-bright) !important; font-weight: 600 !important; text-decoration: none !important; font-family: 'DM Sans', sans-serif !important; transition: color 0.2s !important; }
+            .resend-wrap .ui-commandlink:hover { color: var(--emerald) !important; text-decoration: underline !important; }
+            .resend-wrap a { color: var(--forest-bright); font-weight: 600; text-decoration: none; font-family: 'DM Sans', sans-serif; transition: color 0.2s; }
+            .resend-wrap a:hover { color: var(--emerald); text-decoration: underline; }
+
+            /* ── GLOBAL TOP MESSAGES ─────────────────────────────── */
+            .global-messages-wrap { margin-bottom: 1.25rem; }
+            .portal-error-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fff5f5; color: #c0392b; border: 1px solid #f5c6cb; border-left: 4px solid #e74c3c;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; text-align: left; box-shadow: 0 2px 8px rgba(192,57,43,0.08);
+            }
+            .portal-error-msg::before { content: '\f071'; font-family: 'Font Awesome 6 Free'; font-weight: 900; font-size: 0.82rem; flex-shrink: 0; }
+            .portal-info-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #f0f7ff; color: #1a6fb3; border: 1px solid #bee3f8; border-left: 4px solid #3498db;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(52,152,219,0.08);
+            }
+            .portal-warn-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fffbf0; color: #b45309; border: 1px solid #fcd34d; border-left: 4px solid #f59e0b;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(245,158,11,0.08);
+            }
+
+            /* ── OTP COUNTDOWN ───────────────────────────────────── */
+            .otp-countdown-wrap { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin-bottom: 1.25rem; }
+            .otp-countdown-label { font-size: 0.82rem; color: var(--text-muted); }
+            .otp-countdown-timer {
+                font-family: 'Syne', sans-serif; font-size: 1.1rem; font-weight: 700; color: var(--forest-mid);
+                background: color-mix(in srgb, var(--emerald) 10%, white);
+                border: 1.5px solid var(--border); border-radius: 8px;
+                padding: 0.2rem 0.7rem; min-width: 3.5rem; text-align: center;
+                transition: color 0.3s, background 0.3s, border-color 0.3s;
+            }
+            .otp-countdown-timer.warning { color: #b45309; background: #fef3c7; border-color: #fcd34d; }
+            .otp-countdown-timer.expired { color: #dc2626; background: #fee2e2; border-color: #fca5a5; }
+
+            /* ── FOOTER NOTE ─────────────────────────────────────── */
+            .portal-footer-note { display: flex; align-items: center; justify-content: center; gap: 0.4rem; font-size: 0.73rem; color: var(--text-muted); margin-top: 1.5rem; }
+            .portal-footer-note i { color: var(--emerald); }
+
+            /* ── OTP DIGIT BOXES ─────────────────────────────────── */
+            .otp-boxes-wrap { display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.4rem; margin-bottom: 1rem; }
+            .otp-box {
+                width: 2.8rem; height: 3.2rem; text-align: center; font-size: 1.35rem; font-weight: 700;
+                font-family: 'Syne', sans-serif; border: 2px solid var(--border); border-radius: 10px;
+                background: var(--white); color: var(--forest-deep); outline: none;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+                caret-color: var(--forest-bright); -webkit-appearance: none; -moz-appearance: textfield;
+            }
+            .otp-box::-webkit-inner-spin-button, .otp-box::-webkit-outer-spin-button { -webkit-appearance: none; }
+            .otp-box:focus { border-color: var(--forest-bright); box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent); }
+            .otp-box.filled { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 6%, white); }
+
+            /* ── RESPONSIVE TWEAKS ───────────────────────────────── */
+            @media (max-width: 480px) {
+                .otp-card, .patient-select-card, .welcome-card { padding: 1.75rem 1.25rem; border-radius: 18px; }
+                .otp-box { width: 2.3rem; height: 2.8rem; font-size: 1.1rem; border-radius: 8px; gap: 0.35rem; }
+                .card-title { font-size: 1.3rem; }
+                .step-label { display: none; }
+                .patient-row { padding: 0.7rem 0.75rem; gap: 0.6rem; }
+                .patient-avatar { width: 34px; height: 34px; font-size: 0.85rem; }
+                .patient-name { font-size: 0.85rem; }
+                .patient-meta-pill { font-size: 0.65rem; padding: 0.1rem 0.4rem; }
+            }
+            @media (max-width: 360px) { .portal-form-panel { padding: 1.5rem 0.85rem; } }
+
+            /* ── MATCHED PATIENTS LIST ────────────────────────────── */
+            .patient-select-title { font-family: 'Syne', sans-serif; font-size: 1.4rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.3rem; }
+            .patient-select-subtitle { font-size: 0.87rem; color: var(--text-muted); margin-bottom: 1.5rem; line-height: 1.6; }
+
+            /* strip default PrimeFaces dataTable chrome so it reads as a plain card list
+               (selectors kept broad/generic since exact DOM class names can vary by PF version) */
+            .matched-patients-table.ui-datatable,
+            .matched-patients-table.ui-datatable .ui-widget-content,
+            .matched-patients-table.ui-datatable table,
+            .matched-patients-table.ui-datatable table tr,
+            .matched-patients-table.ui-datatable table td {
+                border: none !important;
+                background: transparent !important;
+            }
+            .matched-patients-table.ui-datatable table td {
+                padding: 0 0 0.75rem 0 !important;
+            }
+            .matched-patients-table.ui-datatable table tr:last-child td {
+                padding-bottom: 0 !important;
+            }
+
+            .patient-row {
+                display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+                padding: 0.9rem 1rem; border: 2px solid var(--border); border-radius: var(--radius-sm);
+                background: color-mix(in srgb, var(--forest-mid) 4%, white);
+                transition: all 0.2s ease;
+            }
+            .patient-row:hover { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 10%, white); }
+
+            .patient-avatar {
+                width: 42px; height: 42px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; color: white; font-size: 1rem; flex-shrink: 0;
+            }
+            .patient-info { flex: 1; min-width: 0; }
+            .patient-name { font-family: 'Syne', sans-serif; font-weight: 600; font-size: 0.95rem; color: var(--forest-deep); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+            .patient-meta { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.25rem; }
+            .patient-meta-pill {
+                display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--text-muted);
+                background: var(--cream); border: 1px solid var(--border); border-radius: 100px; padding: 0.15rem 0.55rem; font-weight: 500;
+            }
+            .patient-meta-pill i { font-size: 0.65rem; color: var(--emerald); }
+
+            .btn-select-patient .ui-button {
+                padding: 0.45rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid), var(--forest-bright)) !important;
+                border: none !important; border-radius: 8px !important;
+                font-family: 'Syne', sans-serif !important; font-weight: 600 !important; font-size: 0.82rem !important;
+                color: white !important; white-space: nowrap !important; cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                box-shadow: 0 2px 8px color-mix(in srgb, var(--forest-mid) 22%, transparent) !important;
+                min-width: unset !important;
+            }
+            .btn-select-patient .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 4px 12px color-mix(in srgb, var(--forest-mid) 30%, transparent) !important; }
+            .btn-select-patient .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-select-patient .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 4px !important; }
+
+            /* ── MESSAGE CARD (no-match / duplicate-blocked) ──────── */
+            .message-card-wrap { text-align: center; padding: 1rem 0 0.25rem; }
+            .message-card-wrap i.big-icon { font-size: 2.75rem; color: var(--emerald); margin-bottom: 1rem; display: block; }
+            .message-card-wrap p { font-size: 0.92rem; color: var(--text-muted); line-height: 1.7; }
+            .message-card-wrap p strong { color: var(--text-dark); }
+
+            /* ── WELCOME / COMPLETE CARD ──────────────────────────── */
+            .welcome-avatar {
+                width: 72px; height: 72px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; font-size: 1.8rem; color: white;
+                margin: 0 auto 1.25rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 25%, transparent);
+            }
+            .welcome-greeting { font-size: 0.82rem; font-weight: 600; color: var(--emerald); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.35rem; }
+            .welcome-name { font-family: 'Syne', sans-serif; font-size: 1.6rem; font-weight: 800; color: var(--forest-deep); margin-bottom: 0.75rem; }
+            .welcome-subtitle { font-size: 0.88rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 0.5rem; }
+        </style>
+        <script type="text/javascript">
+            //<![CDATA[
+            function otpBoxInput(el, index, total) {
+                el.value = el.value.replace(/\D/g, '').slice(0, 1);
+                if (el.value.length === 1) {
+                    el.classList.add('filled');
+                    if (index < total - 1) {
+                        var next = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                        if (next) { next.focus(); next.select(); }
+                    }
+                } else {
+                    el.classList.remove('filled');
+                }
+                assembleOtp(total);
+            }
+
+            function otpBoxKeydown(el, index, event, total) {
+                if (event.key === 'Backspace') {
+                    if (el.value === '' && index > 0) {
+                        var prev = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                        if (prev) { prev.value = ''; prev.classList.remove('filled'); prev.focus(); prev.select(); }
+                        assembleOtp(total);
+                    }
+                } else if (event.key === 'ArrowLeft' && index > 0) {
+                    var prevBox = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                    if (prevBox) prevBox.focus();
+                } else if (event.key === 'ArrowRight' && index < total - 1) {
+                    var nextBox = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                    if (nextBox) nextBox.focus();
+                }
+            }
+
+            function otpBoxPaste(event, total) {
+                event.preventDefault();
+                var text = (event.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '');
+                var boxes = document.querySelectorAll('.otp-box');
+                for (var i = 0; i < boxes.length && i < text.length; i++) {
+                    boxes[i].value = text[i];
+                    boxes[i].classList.add('filled');
+                }
+                assembleOtp(total);
+                var lastIdx = Math.min(text.length, total) - 1;
+                if (lastIdx >= 0) {
+                    var lastBox = document.querySelector('.otp-box[data-index="' + lastIdx + '"]');
+                    if (lastBox) lastBox.focus();
+                }
+            }
+
+            function assembleOtp(total) {
+                var otp = '';
+                for (var i = 0; i < total; i++) {
+                    var box = document.querySelector('.otp-box[data-index="' + i + '"]');
+                    otp += (box && box.value) ? box.value : '';
+                }
+                var hidden = document.getElementById('form:otpHiddenInput');
+                if (hidden) hidden.value = otp;
+            }
+
+            function initOtpBoxes(total) {
+                var container = document.getElementById('otpBoxesContainer');
+                if (!container) return;
+                container.innerHTML = '';
+                for (var i = 0; i < total; i++) {
+                    var inp = document.createElement('input');
+                    inp.type = 'text';
+                    inp.className = 'otp-box';
+                    inp.maxLength = 1;
+                    inp.setAttribute('inputmode', 'numeric');
+                    inp.setAttribute('pattern', '[0-9]*');
+                    inp.autocomplete = 'off';
+                    inp.setAttribute('data-index', i);
+                    (function(idx) {
+                        inp.oninput    = function()  { otpBoxInput(this, idx, total); };
+                        inp.onkeydown  = function(e) { otpBoxKeydown(this, idx, e, total); };
+                        inp.onpaste    = function(e) { otpBoxPaste(e, total); };
+                        inp.onfocus    = function()  { this.select(); };
+                    })(i);
+                    container.appendChild(inp);
+                }
+            }
+
+            var otpCountdownInterval = null;
+
+            function startOtpCountdown(expiryEpochMs) {
+                clearInterval(otpCountdownInterval);
+                var el = document.getElementById('otpCountdownTimer');
+                if (!el)
+                    return;
+                function tick() {
+                    var remaining = expiryEpochMs - Date.now();
+                    if (remaining <= 0) {
+                        clearInterval(otpCountdownInterval);
+                        el.textContent = 'OTP Expired';
+                        el.className = 'otp-countdown-timer expired';
+                        var label = document.querySelector('.otp-countdown-label');
+                        if (label)
+                            label.style.display = 'none';
+                        return;
+                    }
+                    var mins = Math.floor(remaining / 60000);
+                    var secs = Math.floor((remaining % 60000) / 1000);
+                    el.textContent = mins + ':' + (secs < 10 ? '0' : '') + secs;
+                    el.className = 'otp-countdown-timer' + (remaining < 30000 ? ' warning' : '');
+                }
+                tick();
+                otpCountdownInterval = setInterval(tick, 1000);
+            }
+            //]]>
+        </script>
+    </h:head>
+
+    <h:body style="margin:0; padding:0;">
+        <h:form id="form">
+
+            <!-- ═══════════════════════════════════════════
+                 MAIN WRAPPER  (hero left + form right)
+                 ═══════════════════════════════════════════ -->
+            <div class="portal-wrapper">
+
+                <!-- ── LEFT HERO PANEL (desktop ≥992px only) ── -->
+                <div class="portal-hero" style="--hero-color: #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')}">
+                    <div class="hero-dots"/>
+                    <div class="hero-ring hero-ring-1"/>
+                    <div class="hero-ring hero-ring-2"/>
+                    <div class="hero-ring hero-ring-3"/>
+                    <div class="hero-ring hero-ring-4"/>
+                    <div class="hero-cross-lg"/>
+                    <div class="hero-cross" style="top:16%; right:22%; opacity:0.22;"/>
+                    <div class="hero-cross" style="bottom:28%; right:14%; opacity:0.14;"/>
+                    <div class="hero-cross" style="top:52%; left:8%;  opacity:0.12;"/>
+
+                    <div class="hero-content">
+                        <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}" layout="block" styleClass="hero-logo-wrap">
+                            <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                 alt="Hospital Logo"
+                                 class="hero-logo-img"/>
+                        </h:panelGroup>
+
+                        <div class="hero-badge">
+                            <div class="hero-badge-dot"/>
+                            Client Self-Service
+                        </div>
+
+                        <div class="hero-title">
+                            Welcome<br/>
+                            <span class="accent">Back.</span>
+                        </div>
+
+                        <p class="hero-desc">
+                            Access your Client Portal account to manage your
+                            details and stay connected with our services.
+                        </p>
+
+                        <ul class="hero-features">
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-lock"/></span>
+                                Secure Password Login
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-user-gear"/></span>
+                                Manage Your Account
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-hourglass-half"/></span>
+                                Coming Soon: Bills &amp; Appointments
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <!-- END HERO PANEL -->
+
+                <!-- ── RIGHT FORM PANEL ───────────────────── -->
+                <div class="portal-form-panel">
+                    <div class="form-container">
+
+                        <!-- Mobile brand header (hidden on desktop) -->
+                        <div class="mobile-brand-header">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                     alt="Hospital Logo"
+                                     class="mobile-logo-img"/>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <div class="mobile-icon"><i class="fas fa-user-shield"/></div>
+                            </h:panelGroup>
+                            <span class="mobile-portal-label">Client Portal Login</span>
+                        </div>
+
+                        <!-- Global messages (middle-top, all steps) -->
+                        <h:panelGroup id="globalMessages" layout="block" styleClass="global-messages-wrap">
+                            <h:messages
+                                layout="list"
+                                showDetail="true"
+                                showSummary="false"
+                                errorClass="portal-error-msg"
+                                warnClass="portal-warn-msg"
+                                infoClass="portal-info-msg"/>
+                        </h:panelGroup>
+
+                        <!-- Main switchable content panel -->
+                        <h:panelGroup id="portalContentPanel" layout="block">
+
+                            <!-- LOGGED-OUT STATE: identifier + password form -->
+                            <h:panelGroup rendered="#{!clientPortalLoginController.isLoggedIn()}" layout="block">
+                                <div class="otp-card">
+                                    <div class="card-lead-icon"><i class="fas fa-right-to-bracket"/></div>
+                                    <div class="card-title">Log In to Client Portal</div>
+
+                                    <div class="card-subtitle">
+                                        Enter your registered phone number or email
+                                        and your password to access your account.
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:identifierInput">Phone Number or Email</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-id-badge f-icon"/>
+                                            <h:inputText id="identifierInput"
+                                                         value="#{clientPortalLoginController.identifier}"
+                                                         onfocus="this.select()"
+                                                         a:placeholder="Phone number or email"
+                                                         a:autocomplete="username"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:passwordInput">Password</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-lock f-icon"/>
+                                            <p:password id="passwordInput"
+                                                        value="#{clientPortalLoginController.password}"
+                                                        feedback="false"
+                                                        toggleMask="true"
+                                                        a:placeholder="Your password"
+                                                        a:autocomplete="current-password"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="btn-send">
+                                        <p:commandButton id="loginButton"
+                                                          value="Log In"
+                                                          icon="fas fa-right-to-bracket"
+                                                          action="#{clientPortalLoginController.login}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Log in to Client Portal"/>
+                                    </div>
+
+                                    <div class="resend-wrap">
+                                        <h:link outcome="/client_portal/reset_password" value="Forgot your password?" title="Reset your Client Portal password"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- LOGGED-IN STATE: welcome-back card -->
+                            <h:panelGroup rendered="#{clientPortalLoginController.isLoggedIn()}" layout="block">
+                                <div class="welcome-card">
+                                    <div class="welcome-avatar"><i class="fas fa-circle-check"/></div>
+                                    <div class="welcome-greeting">Welcome Back</div>
+                                    <div class="welcome-name">#{clientPortalLoginController.loggedInAccount.person.nameWithTitle}</div>
+                                    <p class="welcome-subtitle">
+                                        You are logged in to your Client Portal account.
+                                        Bills, appointments and reports are coming soon
+                                        to this portal — stay tuned for updates.
+                                    </p>
+
+                                    <div class="btn-verify" style="margin-top:1.5rem;">
+                                        <p:commandButton id="logoutButton"
+                                                          value="Log Out"
+                                                          icon="fas fa-right-from-bracket"
+                                                          action="#{clientPortalLoginController.logout}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Log out of Client Portal"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                        </h:panelGroup>
+                        <!-- END portalContentPanel -->
+
+                        <!-- Footer note -->
+                        <div class="portal-footer-note">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}"
+                                     alt="CareCode"
+                                     style="height:28px; vertical-align:middle; margin-right:6px;"/>
+                            </h:panelGroup>
+                            Powered by CareCode (Pvt) Ltd.
+                        </div>
+
+                    </div>
+                </div>
+                <!-- END FORM PANEL -->
+
+            </div>
+            <!-- END PORTAL WRAPPER -->
+
+        </h:form>
+    </h:body>
+</html>

--- a/src/main/webapp/client_portal/login.xhtml
+++ b/src/main/webapp/client_portal/login.xhtml
@@ -7,7 +7,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:a="http://xmlns.jcp.org/jsf/passthrough">
     <h:head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <title>Client Portal Login</title>
 
         <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as the Patient Portal precedent -->

--- a/src/main/webapp/client_portal/reset_password.xhtml
+++ b/src/main/webapp/client_portal/reset_password.xhtml
@@ -1,0 +1,936 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:a="http://xmlns.jcp.org/jsf/passthrough">
+    <h:head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+        <title>Client Portal — Reset Password</title>
+
+        <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as the Patient Portal precedent -->
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+        <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&amp;family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&amp;display=swap" rel="stylesheet"/>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"/>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+              integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous"/>
+
+        <style>
+            /* ================================================
+               CLIENT PORTAL PASSWORD RESET  ·  Forest Health Aesthetic
+               Structural/CSS pattern copied from client_portal/register_phone.xhtml
+               Responsive: mobile-first, split layout on ≥992px
+               ================================================ */
+
+            :root {
+                --forest-mid:    #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')};
+                --forest-deep:   color-mix(in srgb, var(--forest-mid) 60%, #000);
+                --forest-bright: color-mix(in srgb, var(--forest-mid) 80%, #fff);
+                --emerald:       color-mix(in hsl, var(--forest-mid), white 55%);
+                --emerald-light: color-mix(in hsl, var(--forest-mid), white 65%);
+                --cream:         color-mix(in srgb, var(--forest-mid) 5%, #fff);
+                --white:         #ffffff;
+                --text-dark:     color-mix(in srgb, var(--forest-mid) 12%, #111);
+                --text-muted:    color-mix(in srgb, var(--forest-mid) 20%, #555);
+                --border:        color-mix(in srgb, var(--forest-mid) 12%, #fff);
+                --shadow-lg:     0 24px 64px color-mix(in srgb, var(--forest-mid) 20%, transparent);
+                --radius-sm:     10px;
+            }
+
+            *, *::before, *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            body, html {
+                font-family: 'DM Sans', sans-serif;
+                background: var(--cream);
+                min-height: 100vh;
+                color: var(--text-dark);
+            }
+
+            /* ── PAGE WRAPPER ────────────────────────────────────── */
+            .portal-wrapper {
+                min-height: 100vh;
+                display: flex;
+                align-items: stretch;
+            }
+
+            /* ── LEFT HERO PANEL  (visible ≥992px only) ──────────── */
+            .portal-hero {
+                display: none;
+                position: relative;
+                overflow: hidden;
+                flex-direction: column;
+                justify-content: space-between;
+                align-items: flex-start;
+                padding: 3rem 3.5rem;
+                --hero-color: var(--forest-mid);
+                background: linear-gradient(155deg,
+                    color-mix(in srgb, var(--hero-color) 55%, #000) 0%,
+                    var(--hero-color) 55%,
+                    color-mix(in srgb, var(--hero-color) 75%, #fff) 100%);
+            }
+
+            @media (min-width: 992px) {
+                .portal-hero {
+                    display: flex;
+                    width: 44%;
+                    min-width: 400px;
+                    max-width: 540px;
+                }
+            }
+
+            .hero-dots {
+                position: absolute;
+                inset: 0;
+                background-image: radial-gradient(circle, color-mix(in srgb, var(--emerald-light) 22%, transparent) 1px, transparent 1px);
+                background-size: 30px 30px;
+            }
+
+            .hero-ring {
+                position: absolute;
+                border-radius: 50%;
+                border: 1px solid color-mix(in srgb, var(--emerald) 13%, transparent);
+            }
+            .hero-ring-1 { width: 500px; height: 500px; top: -140px; right: -190px; }
+            .hero-ring-2 { width: 330px; height: 330px; top: -60px; right: -110px; border-color: color-mix(in srgb, var(--emerald) 20%, transparent); }
+            .hero-ring-3 { width: 620px; height: 620px; bottom: -220px; left: -220px; }
+            .hero-ring-4 {
+                width: 380px; height: 380px; bottom: -100px; left: -80px; border: none;
+                background: radial-gradient(circle, color-mix(in srgb, var(--emerald) 7%, transparent) 0%, transparent 70%);
+            }
+
+            .hero-cross { position: absolute; width: 26px; height: 26px; }
+            .hero-cross::before, .hero-cross::after { content: ''; position: absolute; background: var(--emerald-light); border-radius: 2px; }
+            .hero-cross::before { width: 4px; height: 26px; left: 11px; top: 0; }
+            .hero-cross::after  { width: 26px; height: 4px; top: 11px; left: 0; }
+
+            .hero-cross-lg { position: absolute; bottom: 2.5rem; right: 2.5rem; width: 72px; height: 72px; opacity: 0.07; }
+            .hero-cross-lg::before { content: ''; position: absolute; background: white; border-radius: 3px; width: 18px; height: 72px; left: 27px; top: 0; }
+            .hero-cross-lg::after  { content: ''; position: absolute; background: white; border-radius: 3px; width: 72px; height: 18px; top: 27px; left: 0; }
+
+            .hero-content { position: relative; z-index: 2; }
+
+            .hero-logo-wrap {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0.85rem 1.25rem;
+                margin-bottom: 2rem;
+                backdrop-filter: blur(4px);
+                width: 100%;
+            }
+            .hero-logo-img { width: 80%; height: 80%; object-fit: contain; object-position: left center; display: block; }
+
+            .mobile-logo-img { max-width: 220px; max-height: 120px; object-fit: contain; display: block; margin: 0 auto 0.75rem; }
+
+            .hero-badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                background: color-mix(in srgb, var(--emerald) 14%, transparent);
+                border: 1px solid color-mix(in srgb, var(--emerald) 28%, transparent);
+                border-radius: 100px;
+                padding: 0.32rem 1rem;
+                font-size: 0.7rem;
+                color: var(--emerald-light);
+                font-weight: 500;
+                letter-spacing: 0.07em;
+                text-transform: uppercase;
+                margin-bottom: 1.75rem;
+            }
+            .hero-badge-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--emerald); animation: blink 2s infinite; }
+
+            @keyframes blink {
+                0%, 100% { opacity: 1; transform: scale(1); }
+                50%      { opacity: 0.4; transform: scale(0.75); }
+            }
+
+            .hero-title {
+                font-family: 'Syne', sans-serif;
+                font-size: 3.25rem;
+                font-weight: 800;
+                color: var(--white);
+                line-height: 1.08;
+                letter-spacing: -0.025em;
+                margin-bottom: 1rem;
+            }
+            .hero-title .accent { color: var(--emerald-light); }
+
+            .hero-desc {
+                font-size: 0.95rem;
+                color: rgba(255,255,255,0.6);
+                line-height: 1.75;
+                margin-bottom: 2.25rem;
+                max-width: 320px;
+                font-weight: 300;
+            }
+
+            .hero-features { list-style: none; display: flex; flex-direction: column; gap: 0.85rem; }
+            .hero-features li { display: flex; align-items: center; gap: 0.75rem; color: rgba(255,255,255,0.78); font-size: 0.9rem; }
+            .feat-icon {
+                width: 32px; height: 32px;
+                background: color-mix(in srgb, var(--emerald) 18%, transparent);
+                border-radius: 8px;
+                display: flex; align-items: center; justify-content: center;
+                color: var(--emerald-light);
+                font-size: 0.82rem;
+                flex-shrink: 0;
+            }
+
+            /* ── RIGHT FORM PANEL ────────────────────────────────── */
+            .portal-form-panel {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 2.5rem 1.5rem;
+                background: var(--cream);
+            }
+
+            .form-container { width: 100%; max-width: 480px; }
+            @media (min-width: 992px) { .form-container { max-width: 560px; } }
+
+            .mobile-brand-header { text-align: center; margin-bottom: 2rem; }
+            @media (min-width: 992px) { .mobile-brand-header { display: none; } }
+            .mobile-icon {
+                width: 64px; height: 64px;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                border-radius: 18px;
+                display: inline-flex; align-items: center; justify-content: center;
+                font-size: 1.75rem; color: white; margin-bottom: 0.75rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 28%, transparent);
+            }
+            .mobile-inst-name { display: block; font-family: 'Syne', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--forest-mid); }
+            .mobile-portal-label { display: block; font-size: 0.78rem; color: var(--text-muted); margin-top: 0.15rem; letter-spacing: 0.05em; text-transform: uppercase; }
+
+            /* ── CARDS ────────────────────────────────────────────── */
+            .otp-card, .patient-select-card, .welcome-card {
+                background: var(--white);
+                border-radius: 22px;
+                padding: 2.25rem 2rem;
+                box-shadow: var(--shadow-lg);
+                border: 1px solid var(--border);
+                animation: fadeUp 0.45s ease forwards;
+                width: 100%;
+            }
+            .patient-select-card, .welcome-card { max-width: 480px; text-align: left; }
+            .welcome-card { text-align: center; padding: 2.5rem 2rem; }
+            @media (min-width: 992px) {
+                .patient-select-card, .welcome-card { max-width: 560px; }
+            }
+
+            @keyframes fadeUp {
+                from { opacity: 0; transform: translateY(22px); }
+                to   { opacity: 1; transform: translateY(0); }
+            }
+
+            .card-lead-icon {
+                width: 52px; height: 52px;
+                background: linear-gradient(135deg, color-mix(in srgb, var(--emerald) 20%, white), color-mix(in srgb, var(--emerald) 35%, white));
+                border-radius: 13px;
+                display: flex; align-items: center; justify-content: center;
+                font-size: 1.3rem; color: var(--forest-mid);
+                margin-bottom: 1.1rem;
+            }
+
+            .card-title { font-family: 'Syne', sans-serif; font-size: 1.5rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.35rem; line-height: 1.2; }
+            .card-subtitle { font-size: 0.87rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 1.75rem; font-weight: 400; }
+
+            /* ── STEP INDICATORS ─────────────────────────────────── */
+            .steps-bar { display: flex; align-items: center; margin-bottom: 1.75rem; }
+            .step-item { display: flex; align-items: center; gap: 0.45rem; }
+            .step-connector { flex: 1; height: 2px; background: var(--border); margin: 0 0.6rem; }
+            .step-dot {
+                width: 26px; height: 26px; border-radius: 50%;
+                background: var(--border);
+                display: flex; align-items: center; justify-content: center;
+                font-size: 0.72rem; font-weight: 700; color: var(--text-muted);
+                flex-shrink: 0; transition: all 0.3s;
+            }
+            .step-dot.active { background: var(--forest-mid); color: white; box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-mid) 15%, transparent); }
+            .step-label { font-size: 0.72rem; color: var(--text-muted); font-weight: 500; white-space: nowrap; }
+
+            /* ── FORM FIELDS ─────────────────────────────────────── */
+            .field-group { margin-bottom: 1.1rem; }
+            .field-label { display: block; font-size: 0.8rem; font-weight: 600; color: var(--text-dark); margin-bottom: 0.45rem; letter-spacing: 0.025em; }
+            .field-wrap { position: relative; }
+            .field-wrap .f-icon { position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%); color: var(--text-muted); font-size: 0.88rem; pointer-events: none; z-index: 1; }
+
+            .portal-form-panel .ui-inputtext {
+                width: 100% !important;
+                padding: 0.8rem 1rem 0.8rem 2.6rem !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'DM Sans', sans-serif !important;
+                font-size: 0.97rem !important;
+                color: var(--text-dark) !important;
+                background: color-mix(in srgb, var(--forest-mid) 5%, white) !important;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s !important;
+                box-shadow: none !important;
+                outline: none !important;
+                min-width: unset !important;
+            }
+            .portal-form-panel .ui-inputtext:hover { border-color: var(--emerald) !important; }
+            .portal-form-panel .ui-inputtext:focus {
+                border-color: var(--forest-bright) !important;
+                background: var(--white) !important;
+                box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent) !important;
+            }
+            /* p:password wraps the input in a span; strip padding-left icon offset when no icon present */
+            .field-wrap .ui-password { width: 100%; display: block; }
+
+            /* ── PRIMARY BUTTON ──────────────────────────────────── */
+            .btn-send .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid) 0%, var(--forest-bright) 100%) !important;
+                border: none !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: white !important;
+                cursor: pointer !important;
+                transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+                box-shadow: 0 4px 16px color-mix(in srgb, var(--forest-mid) 28%, transparent) !important;
+                letter-spacing: 0.01em !important;
+                min-width: unset !important;
+            }
+            .btn-send .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 7px 22px color-mix(in srgb, var(--forest-mid) 34%, transparent) !important; }
+            .btn-send .ui-button:active { transform: translateY(0) !important; }
+            .btn-send .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-send .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 6px !important; }
+
+            /* ── SECONDARY BUTTON ────────────────────────────────── */
+            .btn-verify .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: var(--cream) !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: var(--forest-mid) !important;
+                cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                min-width: unset !important;
+            }
+            .btn-verify .ui-button:hover { border-color: var(--emerald) !important; background: color-mix(in srgb, var(--emerald) 12%, white) !important; color: var(--forest-deep) !important; }
+            .btn-verify .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-verify .ui-button .ui-icon { color: var(--forest-mid) !important; margin-right: 6px !important; }
+
+            /* ── RESEND LINK ─────────────────────────────────────── */
+            .resend-wrap { text-align: center; font-size: 0.85rem; color: var(--text-muted); margin-top: 1.25rem; }
+            .resend-wrap .ui-commandlink { color: var(--forest-bright) !important; font-weight: 600 !important; text-decoration: none !important; font-family: 'DM Sans', sans-serif !important; transition: color 0.2s !important; }
+            .resend-wrap .ui-commandlink:hover { color: var(--emerald) !important; text-decoration: underline !important; }
+            .resend-wrap a { color: var(--forest-bright); font-weight: 600; text-decoration: none; font-family: 'DM Sans', sans-serif; transition: color 0.2s; }
+            .resend-wrap a:hover { color: var(--emerald); text-decoration: underline; }
+
+            /* ── GLOBAL TOP MESSAGES ─────────────────────────────── */
+            .global-messages-wrap { margin-bottom: 1.25rem; }
+            .portal-error-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fff5f5; color: #c0392b; border: 1px solid #f5c6cb; border-left: 4px solid #e74c3c;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; text-align: left; box-shadow: 0 2px 8px rgba(192,57,43,0.08);
+            }
+            .portal-error-msg::before { content: '\f071'; font-family: 'Font Awesome 6 Free'; font-weight: 900; font-size: 0.82rem; flex-shrink: 0; }
+            .portal-info-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #f0f7ff; color: #1a6fb3; border: 1px solid #bee3f8; border-left: 4px solid #3498db;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(52,152,219,0.08);
+            }
+            .portal-warn-msg {
+                display: flex; align-items: center; gap: 0.6rem;
+                background: #fffbf0; color: #b45309; border: 1px solid #fcd34d; border-left: 4px solid #f59e0b;
+                padding: 0.75rem 1rem; border-radius: 8px; font-size: 0.88rem; margin-bottom: 0.5rem;
+                font-family: inherit; box-shadow: 0 2px 8px rgba(245,158,11,0.08);
+            }
+
+            /* ── OTP COUNTDOWN ───────────────────────────────────── */
+            .otp-countdown-wrap { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin-bottom: 1.25rem; }
+            .otp-countdown-label { font-size: 0.82rem; color: var(--text-muted); }
+            .otp-countdown-timer {
+                font-family: 'Syne', sans-serif; font-size: 1.1rem; font-weight: 700; color: var(--forest-mid);
+                background: color-mix(in srgb, var(--emerald) 10%, white);
+                border: 1.5px solid var(--border); border-radius: 8px;
+                padding: 0.2rem 0.7rem; min-width: 3.5rem; text-align: center;
+                transition: color 0.3s, background 0.3s, border-color 0.3s;
+            }
+            .otp-countdown-timer.warning { color: #b45309; background: #fef3c7; border-color: #fcd34d; }
+            .otp-countdown-timer.expired { color: #dc2626; background: #fee2e2; border-color: #fca5a5; }
+
+            /* ── FOOTER NOTE ─────────────────────────────────────── */
+            .portal-footer-note { display: flex; align-items: center; justify-content: center; gap: 0.4rem; font-size: 0.73rem; color: var(--text-muted); margin-top: 1.5rem; }
+            .portal-footer-note i { color: var(--emerald); }
+
+            /* ── OTP DIGIT BOXES ─────────────────────────────────── */
+            .otp-boxes-wrap { display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.4rem; margin-bottom: 1rem; }
+            .otp-box {
+                width: 2.8rem; height: 3.2rem; text-align: center; font-size: 1.35rem; font-weight: 700;
+                font-family: 'Syne', sans-serif; border: 2px solid var(--border); border-radius: 10px;
+                background: var(--white); color: var(--forest-deep); outline: none;
+                transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+                caret-color: var(--forest-bright); -webkit-appearance: none; -moz-appearance: textfield;
+            }
+            .otp-box::-webkit-inner-spin-button, .otp-box::-webkit-outer-spin-button { -webkit-appearance: none; }
+            .otp-box:focus { border-color: var(--forest-bright); box-shadow: 0 0 0 3px color-mix(in srgb, var(--forest-bright) 11%, transparent); }
+            .otp-box.filled { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 6%, white); }
+
+            /* ── RESPONSIVE TWEAKS ───────────────────────────────── */
+            @media (max-width: 480px) {
+                .otp-card, .patient-select-card, .welcome-card { padding: 1.75rem 1.25rem; border-radius: 18px; }
+                .otp-box { width: 2.3rem; height: 2.8rem; font-size: 1.1rem; border-radius: 8px; gap: 0.35rem; }
+                .card-title { font-size: 1.3rem; }
+                .step-label { display: none; }
+                .patient-row { padding: 0.7rem 0.75rem; gap: 0.6rem; }
+                .patient-avatar { width: 34px; height: 34px; font-size: 0.85rem; }
+                .patient-name { font-size: 0.85rem; }
+                .patient-meta-pill { font-size: 0.65rem; padding: 0.1rem 0.4rem; }
+            }
+            @media (max-width: 360px) { .portal-form-panel { padding: 1.5rem 0.85rem; } }
+
+            /* ── MATCHED ACCOUNTS LIST ────────────────────────────── */
+            .patient-select-title { font-family: 'Syne', sans-serif; font-size: 1.4rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.3rem; }
+            .patient-select-subtitle { font-size: 0.87rem; color: var(--text-muted); margin-bottom: 1.5rem; line-height: 1.6; }
+
+            /* strip default PrimeFaces dataTable chrome so it reads as a plain card list
+               (selectors kept broad/generic since exact DOM class names can vary by PF version) */
+            .matched-patients-table.ui-datatable,
+            .matched-patients-table.ui-datatable .ui-widget-content,
+            .matched-patients-table.ui-datatable table,
+            .matched-patients-table.ui-datatable table tr,
+            .matched-patients-table.ui-datatable table td {
+                border: none !important;
+                background: transparent !important;
+            }
+            .matched-patients-table.ui-datatable table td {
+                padding: 0 0 0.75rem 0 !important;
+            }
+            .matched-patients-table.ui-datatable table tr:last-child td {
+                padding-bottom: 0 !important;
+            }
+
+            .patient-row {
+                display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+                padding: 0.9rem 1rem; border: 2px solid var(--border); border-radius: var(--radius-sm);
+                background: color-mix(in srgb, var(--forest-mid) 4%, white);
+                transition: all 0.2s ease;
+            }
+            .patient-row:hover { border-color: var(--emerald); background: color-mix(in srgb, var(--emerald) 10%, white); }
+
+            .patient-avatar {
+                width: 42px; height: 42px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; color: white; font-size: 1rem; flex-shrink: 0;
+            }
+            .patient-info { flex: 1; min-width: 0; }
+            .patient-name { font-family: 'Syne', sans-serif; font-weight: 600; font-size: 0.95rem; color: var(--forest-deep); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+            .patient-meta { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.25rem; }
+            .patient-meta-pill {
+                display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; color: var(--text-muted);
+                background: var(--cream); border: 1px solid var(--border); border-radius: 100px; padding: 0.15rem 0.55rem; font-weight: 500;
+            }
+            .patient-meta-pill i { font-size: 0.65rem; color: var(--emerald); }
+
+            .btn-select-patient .ui-button {
+                padding: 0.45rem 1.5rem !important;
+                background: linear-gradient(135deg, var(--forest-mid), var(--forest-bright)) !important;
+                border: none !important; border-radius: 8px !important;
+                font-family: 'Syne', sans-serif !important; font-weight: 600 !important; font-size: 0.82rem !important;
+                color: white !important; white-space: nowrap !important; cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                box-shadow: 0 2px 8px color-mix(in srgb, var(--forest-mid) 22%, transparent) !important;
+                min-width: unset !important;
+            }
+            .btn-select-patient .ui-button:hover { transform: translateY(-1px) !important; box-shadow: 0 4px 12px color-mix(in srgb, var(--forest-mid) 30%, transparent) !important; }
+            .btn-select-patient .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-select-patient .ui-button .ui-icon { color: rgba(255,255,255,0.85) !important; margin-right: 4px !important; }
+
+            /* ── MESSAGE CARD (no-account / email-unsupported) ────── */
+            .message-card-wrap { text-align: center; padding: 1rem 0 0.25rem; }
+            .message-card-wrap i.big-icon { font-size: 2.75rem; color: var(--emerald); margin-bottom: 1rem; display: block; }
+            .message-card-wrap p { font-size: 0.92rem; color: var(--text-muted); line-height: 1.7; }
+            .message-card-wrap p strong { color: var(--text-dark); }
+
+            /* ── WELCOME / COMPLETE CARD ──────────────────────────── */
+            .welcome-avatar {
+                width: 72px; height: 72px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; font-size: 1.8rem; color: white;
+                margin: 0 auto 1.25rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 25%, transparent);
+            }
+            .welcome-greeting { font-size: 0.82rem; font-weight: 600; color: var(--emerald); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.35rem; }
+            .welcome-name { font-family: 'Syne', sans-serif; font-size: 1.6rem; font-weight: 800; color: var(--forest-deep); margin-bottom: 0.75rem; }
+            .welcome-subtitle { font-size: 0.88rem; color: var(--text-muted); line-height: 1.65; margin-bottom: 0.5rem; }
+        </style>
+        <script type="text/javascript">
+            //<![CDATA[
+            function otpBoxInput(el, index, total) {
+                el.value = el.value.replace(/\D/g, '').slice(0, 1);
+                if (el.value.length === 1) {
+                    el.classList.add('filled');
+                    if (index < total - 1) {
+                        var next = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                        if (next) { next.focus(); next.select(); }
+                    }
+                } else {
+                    el.classList.remove('filled');
+                }
+                assembleOtp(total);
+            }
+
+            function otpBoxKeydown(el, index, event, total) {
+                if (event.key === 'Backspace') {
+                    if (el.value === '' && index > 0) {
+                        var prev = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                        if (prev) { prev.value = ''; prev.classList.remove('filled'); prev.focus(); prev.select(); }
+                        assembleOtp(total);
+                    }
+                } else if (event.key === 'ArrowLeft' && index > 0) {
+                    var prevBox = document.querySelector('.otp-box[data-index="' + (index - 1) + '"]');
+                    if (prevBox) prevBox.focus();
+                } else if (event.key === 'ArrowRight' && index < total - 1) {
+                    var nextBox = document.querySelector('.otp-box[data-index="' + (index + 1) + '"]');
+                    if (nextBox) nextBox.focus();
+                }
+            }
+
+            function otpBoxPaste(event, total) {
+                event.preventDefault();
+                var text = (event.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '');
+                var boxes = document.querySelectorAll('.otp-box');
+                for (var i = 0; i < boxes.length && i < text.length; i++) {
+                    boxes[i].value = text[i];
+                    boxes[i].classList.add('filled');
+                }
+                assembleOtp(total);
+                var lastIdx = Math.min(text.length, total) - 1;
+                if (lastIdx >= 0) {
+                    var lastBox = document.querySelector('.otp-box[data-index="' + lastIdx + '"]');
+                    if (lastBox) lastBox.focus();
+                }
+            }
+
+            function assembleOtp(total) {
+                var otp = '';
+                for (var i = 0; i < total; i++) {
+                    var box = document.querySelector('.otp-box[data-index="' + i + '"]');
+                    otp += (box && box.value) ? box.value : '';
+                }
+                var hidden = document.getElementById('form:otpHiddenInput');
+                if (hidden) hidden.value = otp;
+            }
+
+            function initOtpBoxes(total) {
+                var container = document.getElementById('otpBoxesContainer');
+                if (!container) return;
+                container.innerHTML = '';
+                for (var i = 0; i < total; i++) {
+                    var inp = document.createElement('input');
+                    inp.type = 'text';
+                    inp.className = 'otp-box';
+                    inp.maxLength = 1;
+                    inp.setAttribute('inputmode', 'numeric');
+                    inp.setAttribute('pattern', '[0-9]*');
+                    inp.autocomplete = 'off';
+                    inp.setAttribute('data-index', i);
+                    (function(idx) {
+                        inp.oninput    = function()  { otpBoxInput(this, idx, total); };
+                        inp.onkeydown  = function(e) { otpBoxKeydown(this, idx, e, total); };
+                        inp.onpaste    = function(e) { otpBoxPaste(e, total); };
+                        inp.onfocus    = function()  { this.select(); };
+                    })(i);
+                    container.appendChild(inp);
+                }
+            }
+
+            var otpCountdownInterval = null;
+
+            function startOtpCountdown(expiryEpochMs) {
+                clearInterval(otpCountdownInterval);
+                var el = document.getElementById('otpCountdownTimer');
+                if (!el)
+                    return;
+                function tick() {
+                    var remaining = expiryEpochMs - Date.now();
+                    if (remaining <= 0) {
+                        clearInterval(otpCountdownInterval);
+                        el.textContent = 'OTP Expired';
+                        el.className = 'otp-countdown-timer expired';
+                        var label = document.querySelector('.otp-countdown-label');
+                        if (label)
+                            label.style.display = 'none';
+                        return;
+                    }
+                    var mins = Math.floor(remaining / 60000);
+                    var secs = Math.floor((remaining % 60000) / 1000);
+                    el.textContent = mins + ':' + (secs < 10 ? '0' : '') + secs;
+                    el.className = 'otp-countdown-timer' + (remaining < 30000 ? ' warning' : '');
+                }
+                tick();
+                otpCountdownInterval = setInterval(tick, 1000);
+            }
+            //]]>
+        </script>
+    </h:head>
+
+    <h:body style="margin:0; padding:0;">
+        <h:form id="form">
+
+            <!-- ═══════════════════════════════════════════
+                 MAIN WRAPPER  (hero left + form right)
+                 ═══════════════════════════════════════════ -->
+            <div class="portal-wrapper">
+
+                <!-- ── LEFT HERO PANEL (desktop ≥992px only) ── -->
+                <div class="portal-hero" style="--hero-color: #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')}">
+                    <div class="hero-dots"/>
+                    <div class="hero-ring hero-ring-1"/>
+                    <div class="hero-ring hero-ring-2"/>
+                    <div class="hero-ring hero-ring-3"/>
+                    <div class="hero-ring hero-ring-4"/>
+                    <div class="hero-cross-lg"/>
+                    <div class="hero-cross" style="top:16%; right:22%; opacity:0.22;"/>
+                    <div class="hero-cross" style="bottom:28%; right:14%; opacity:0.14;"/>
+                    <div class="hero-cross" style="top:52%; left:8%;  opacity:0.12;"/>
+
+                    <div class="hero-content">
+                        <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}" layout="block" styleClass="hero-logo-wrap">
+                            <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                 alt="Hospital Logo"
+                                 class="hero-logo-img"/>
+                        </h:panelGroup>
+
+                        <div class="hero-badge">
+                            <div class="hero-badge-dot"/>
+                            Client Self-Service
+                        </div>
+
+                        <div class="hero-title">
+                            Reset Your<br/>
+                            <span class="accent">Password.</span>
+                        </div>
+
+                        <p class="hero-desc">
+                            Verify your identity and set a new password to
+                            regain access to your Client Portal account.
+                        </p>
+
+                        <ul class="hero-features">
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-magnifying-glass"/></span>
+                                Find Your Account
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-shield-halved"/></span>
+                                Secure OTP Mobile Verification
+                            </li>
+                            <li>
+                                <span class="feat-icon"><i class="fas fa-lock"/></span>
+                                Set a New Password
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <!-- END HERO PANEL -->
+
+                <!-- ── RIGHT FORM PANEL ───────────────────── -->
+                <div class="portal-form-panel">
+                    <div class="form-container">
+
+                        <!-- Mobile brand header (hidden on desktop) -->
+                        <div class="mobile-brand-header">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}"
+                                     alt="Hospital Logo"
+                                     class="mobile-logo-img"/>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{empty configOptionApplicationController.getLongTextValueByKey('Client Portal - Logo URL')}">
+                                <div class="mobile-icon"><i class="fas fa-user-shield"/></div>
+                            </h:panelGroup>
+                            <span class="mobile-portal-label">Client Portal Password Reset</span>
+                        </div>
+
+                        <!-- Global messages (middle-top, all steps) -->
+                        <h:panelGroup id="globalMessages" layout="block" styleClass="global-messages-wrap">
+                            <h:messages
+                                layout="list"
+                                showDetail="true"
+                                showSummary="false"
+                                errorClass="portal-error-msg"
+                                warnClass="portal-warn-msg"
+                                infoClass="portal-info-msg"/>
+                        </h:panelGroup>
+
+                        <!-- Main switchable content panel -->
+                        <h:panelGroup id="portalContentPanel" layout="block">
+
+                            <!-- STEP 1: Identifier entry -->
+                            <h:panelGroup rendered="#{empty clientPortalPasswordResetController.matchedAccounts and !clientPortalPasswordResetController.noAccountFound and !clientPortalPasswordResetController.emailResetUnsupported and !clientPortalPasswordResetController.otpSendSuccess and !clientPortalPasswordResetController.resetComplete}" layout="block">
+                                <div class="otp-card">
+                                    <div class="card-lead-icon"><i class="fas fa-magnifying-glass"/></div>
+                                    <div class="card-title">Reset Your Password</div>
+
+                                    <div class="card-subtitle">
+                                        Enter your registered phone number or email
+                                        so we can find your account.
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:identifierInput">Phone Number or Email</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-id-badge f-icon"/>
+                                            <h:inputText id="identifierInput"
+                                                         value="#{clientPortalPasswordResetController.identifier}"
+                                                         onfocus="this.select()"
+                                                         a:placeholder="Phone number or email"
+                                                         a:autocomplete="username"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="btn-send">
+                                        <p:commandButton id="findAccountButton"
+                                                          value="Find My Account"
+                                                          icon="fas fa-magnifying-glass"
+                                                          action="#{clientPortalPasswordResetController.findAccount}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Find my Client Portal account"/>
+                                    </div>
+
+                                    <div class="resend-wrap">
+                                        <h:link outcome="/client_portal/login" value="Back to log in" title="Back to Client Portal login"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 2: No account found -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.noAccountFound}" layout="block">
+                                <div class="otp-card">
+                                    <div class="message-card-wrap">
+                                        <i class="fas fa-user-slash big-icon"/>
+                                        <h:panelGroup layout="block" styleClass="card-title">No Matching Account</h:panelGroup>
+                                        <p>
+                                            We could not find a Client Portal account for
+                                            <strong>#{clientPortalPasswordResetController.identifier}</strong>.
+                                            If you have not registered yet, you can create
+                                            a new account instead.
+                                        </p>
+                                        <p style="margin-top:1.25rem;">
+                                            <h:link outcome="/client_portal/register_phone" value="Register for Client Portal" title="Register for Client Portal"/>
+                                        </p>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 3: Multi-match picker -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.multipleMatch}" layout="block">
+                                <div class="patient-select-card">
+                                    <div class="card-lead-icon"><i class="fas fa-users"/></div>
+                                    <div class="patient-select-title">Select Your Account</div>
+                                    <div class="patient-select-subtitle">
+                                        We found multiple accounts matching
+                                        <strong>#{clientPortalPasswordResetController.identifier}</strong>.
+                                        Select the account that is yours.
+                                    </div>
+
+                                    <p:dataTable id="matchedAccountsTable"
+                                                 widgetVar="matchedAccountsTableWidget"
+                                                 value="#{clientPortalPasswordResetController.matchedAccounts}"
+                                                 var="acc"
+                                                 rowKey="#{acc.id}"
+                                                 styleClass="matched-patients-table">
+                                        <p:column>
+                                            <div class="patient-row" title="Account #{acc.person.nameWithTitle}">
+                                                <div class="patient-avatar"><i class="fas fa-user"/></div>
+                                                <div class="patient-info">
+                                                    <div class="patient-name">#{acc.person.nameWithTitle}</div>
+                                                </div>
+                                                <div class="btn-select-patient">
+                                                    <p:commandButton value="This is me"
+                                                                      icon="fas fa-arrow-right"
+                                                                      action="#{clientPortalPasswordResetController.selectAccount(acc)}"
+                                                                      update=":form:globalMessages :form:portalContentPanel"
+                                                                      title="Select account #{acc.person.nameWithTitle}"/>
+                                                </div>
+                                            </div>
+                                        </p:column>
+                                    </p:dataTable>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 4: Email reset unsupported -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.emailResetUnsupported}" layout="block">
+                                <div class="otp-card">
+                                    <div class="message-card-wrap">
+                                        <i class="fas fa-envelope-circle-check big-icon"/>
+                                        <h:panelGroup layout="block" styleClass="card-title">Email Reset Not Yet Available</h:panelGroup>
+                                        <p>
+                                            Password reset via email is not available yet.
+                                            If your account has a verified mobile number,
+                                            please try again using your phone number, or
+                                            contact our support team for assistance.
+                                        </p>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 5: OTP entry -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.otpSendSuccess and !clientPortalPasswordResetController.otpVerified}" layout="block">
+                                <div class="otp-card">
+                                    <script type="text/javascript">
+                                        //<![CDATA[
+                                        startOtpCountdown(#{clientPortalPasswordResetController.otpExpiryEpochMs});
+                                        //]]>
+                                    </script>
+
+                                    <div class="card-lead-icon"><i class="fas fa-shield-halved"/></div>
+                                    <div class="card-title">Verify Your Identity</div>
+
+                                    <div class="card-subtitle">
+                                        OTP sent to <strong>#{clientPortalPasswordResetController.selectedAccount.verifiedPhone}</strong>.
+                                        Enter it below to continue.
+                                    </div>
+
+                                    <div class="otp-countdown-wrap">
+                                        <span class="otp-countdown-label">OTP expires in</span>
+                                        <span id="otpCountdownTimer" class="otp-countdown-timer">
+                                            #{clientPortalPasswordResetController.otpTimeoutMinutes}:00
+                                        </span>
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="otpBoxesContainer">One-Time Password</label>
+                                        <div class="otp-boxes-wrap" id="otpBoxesContainer"/>
+                                        <script type="text/javascript">
+                                            //<![CDATA[
+                                            initOtpBoxes(#{clientPortalPasswordResetController.otpLength});
+                                            //]]>
+                                        </script>
+                                        <h:inputHidden id="otpHiddenInput" value="#{clientPortalPasswordResetController.enteredOtp}"/>
+                                    </div>
+
+                                    <div class="btn-verify">
+                                        <p:commandButton id="verifyOtpButton"
+                                                          value="Verify OTP"
+                                                          icon="fas fa-circle-check"
+                                                          action="#{clientPortalPasswordResetController.verifyOtp}"
+                                                          update="globalMessages portalContentPanel"
+                                                          onclick="assembleOtp(#{clientPortalPasswordResetController.otpLength})"
+                                                          title="Verify entered OTP"/>
+                                    </div>
+
+                                    <div class="resend-wrap">
+                                        Didn't receive it?&#160;
+                                        <p:commandLink id="resendOtpLink"
+                                                        value="Resend OTP"
+                                                        action="#{clientPortalPasswordResetController.sendOtp}"
+                                                        update="globalMessages portalContentPanel"
+                                                        title="Resend OTP"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 6: New password entry -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.otpVerified and !clientPortalPasswordResetController.resetComplete}" layout="block">
+                                <div class="otp-card">
+                                    <div class="card-lead-icon"><i class="fas fa-lock"/></div>
+                                    <div class="card-title">Set a New Password</div>
+
+                                    <div class="card-subtitle">
+                                        Create a new password for
+                                        <strong>#{clientPortalPasswordResetController.selectedAccount.person.nameWithTitle}</strong>.
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:newPasswordInput">New Password</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-lock f-icon"/>
+                                            <p:password id="newPasswordInput"
+                                                        value="#{clientPortalPasswordResetController.newPassword}"
+                                                        feedback="false"
+                                                        toggleMask="true"
+                                                        a:placeholder="At least 6 characters"
+                                                        a:autocomplete="new-password"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="field-group">
+                                        <label class="field-label" for="form:newPasswordConfirmInput">Confirm New Password</label>
+                                        <div class="field-wrap">
+                                            <i class="fas fa-lock f-icon"/>
+                                            <p:password id="newPasswordConfirmInput"
+                                                        value="#{clientPortalPasswordResetController.newPasswordConfirm}"
+                                                        feedback="false"
+                                                        toggleMask="true"
+                                                        a:placeholder="Re-enter new password"
+                                                        a:autocomplete="new-password"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="btn-send">
+                                        <p:commandButton id="resetPasswordButton"
+                                                          value="Reset Password"
+                                                          icon="fas fa-key"
+                                                          action="#{clientPortalPasswordResetController.resetPassword}"
+                                                          update="globalMessages portalContentPanel"
+                                                          title="Reset Client Portal password"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <!-- STEP 7: Reset complete -->
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.resetComplete}" layout="block">
+                                <div class="welcome-card">
+                                    <div class="welcome-avatar"><i class="fas fa-circle-check"/></div>
+                                    <div class="welcome-greeting">Password Reset Complete</div>
+                                    <h:panelGroup rendered="#{clientPortalPasswordResetController.selectedAccount ne null}" layout="block" styleClass="welcome-name">
+                                        All Set, #{clientPortalPasswordResetController.selectedAccount.person.nameWithTitle}!
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{clientPortalPasswordResetController.selectedAccount eq null}" layout="block" styleClass="welcome-name">
+                                        All Set!
+                                    </h:panelGroup>
+                                    <p class="welcome-subtitle">
+                                        Your password has been reset successfully.
+                                        You can now log in to your Client Portal
+                                        account using your new password.
+                                    </p>
+
+                                    <div class="resend-wrap" style="margin-top:1.5rem;">
+                                        <h:link outcome="/client_portal/login" value="Log In Now" title="Log in to Client Portal"/>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                        </h:panelGroup>
+                        <!-- END portalContentPanel -->
+
+                        <!-- Footer note -->
+                        <div class="portal-footer-note">
+                            <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}">
+                                <img src="#{configOptionApplicationController.getLongTextValueByKey('Client Portal - CareCode Logo URL','https://i.ibb.co/V0bCPdZZ/fcare.png')}"
+                                     alt="CareCode"
+                                     style="height:28px; vertical-align:middle; margin-right:6px;"/>
+                            </h:panelGroup>
+                            Powered by CareCode (Pvt) Ltd.
+                        </div>
+
+                    </div>
+                </div>
+                <!-- END FORM PANEL -->
+
+            </div>
+            <!-- END PORTAL WRAPPER -->
+
+        </h:form>
+    </h:body>
+</html>

--- a/src/main/webapp/client_portal/reset_password.xhtml
+++ b/src/main/webapp/client_portal/reset_password.xhtml
@@ -7,7 +7,7 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:a="http://xmlns.jcp.org/jsf/passthrough">
     <h:head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <title>Client Portal — Reset Password</title>
 
         <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as the Patient Portal precedent -->
@@ -797,7 +797,7 @@
                                     <div class="card-title">Verify Your Identity</div>
 
                                     <div class="card-subtitle">
-                                        OTP sent to <strong>#{clientPortalPasswordResetController.selectedAccount.verifiedPhone}</strong>.
+                                        OTP sent to <strong>#{clientPortalPasswordResetController.identifier}</strong>.
                                         Enter it below to continue.
                                     </div>
 
@@ -841,7 +841,7 @@
                             </h:panelGroup>
 
                             <!-- STEP 6: New password entry -->
-                            <h:panelGroup rendered="#{clientPortalPasswordResetController.otpVerified and !clientPortalPasswordResetController.resetComplete}" layout="block">
+                            <h:panelGroup rendered="#{clientPortalPasswordResetController.otpVerified and clientPortalPasswordResetController.selectedAccount ne null and !clientPortalPasswordResetController.resetComplete}" layout="block">
                                 <div class="otp-card">
                                     <div class="card-lead-icon"><i class="fas fa-lock"/></div>
                                     <div class="card-title">Set a New Password</div>


### PR DESCRIPTION
## Summary

Third piece of the Client Portal Registration feature (master issue #22359). Adds a `ClientAccount`-scoped login path and phone-OTP password reset — fully separate from staff `WebUser`/`SessionController` auth per the [design spec](docs/superpowers/specs/2026-07-23-client-portal-registration-design.md).

- **`ClientPortalSessionController`** — session-scoped holder for the logged-in `ClientAccount`.
- **`ClientPortalLoginController`** — phone-or-email + password login. Matches candidates via a new `ClientAccountFacade.findByVerifiedPhoneOrEmail(...)` and disambiguates via `SecurityController.matchPassword(...)` rather than a picker UI, since a shared household phone can map to multiple accounts but only the correct holder knows their own password.
- **`ClientPortalPasswordResetController`** — re-verifies identity via SMS OTP (new `MessageType.ClientPortalPasswordResetOTP`, kept distinct from the registration OTP type so SMS rows for the same phone number don't cross-match), then re-hashes the password via `SecurityController.hashAndCheck(...)`.
- **`login.xhtml` / `reset_password.xhtml`** — standalone public pages following the `register_phone.xhtml` pattern (own head/body, no admin template, same Forest Health theme, reused OTP-digit-box widget).

### Scope decision: phone/SMS reset only, not email

No `ClientAccount` can currently have a verified email on file — the self-service email-OTP registration channel (#22368) hasn't landed, so there's no email-OTP sending infrastructure in the codebase yet (no `Email` entity analogous to `Sms`). Building email-OTP reset now would be speculative work for accounts that can't exist, and would encroach on #22368's scope. If `findByVerifiedPhoneOrEmail` ever matches an account only via `verifiedEmail` (not `verifiedPhone`), the reset flow shows a clear "not available yet" message instead of silently failing or crashing. Flagging this prominently for review — happy to revisit if a different sequencing is preferred.

## Test plan

Verified end-to-end locally with Playwright + direct DB checks (screenshots have patient name/phone redacted via DOM text replacement before capture, per this repo's screenshot-evidence convention):

- [x] Registered a fresh `ClientAccount` via the existing merged phone-OTP flow (`register_phone.xhtml`) to get a known test password.
- [x] **Login**: correct phone + password → welcome-back card with correct person name; logout works.
- [x] **Login**: wrong password → "Incorrect phone/email or password." error, no session created.
- [x] **Password reset**: enter phone → single match found → OTP sent → confirmed a new `Sms` row with `SMSTYPE='ClientPortalPasswordResetOTP'` (distinct from `ClientPortalRegistrationOTP`) → entered OTP from DB → set new password → success card.
- [x] **Login with new password** succeeds; **login with old password** now correctly fails (`PASSWORDHASH` confirmed changed in DB).
- [x] No new `SEVERE` entries in `server.log` attributable to this code (one unrelated pre-existing `VOUCHERNO` schema-drift error from an unrelated background job, not touched by this PR).

## Bug found and fixed during this session

The initial XHTML draft (from an automated pass copying the OTP-digit-box `<script>` block from `register_phone.xhtml`) had `&&` mistakenly written as `&amp;&amp;` inside the `<![CDATA[...]]>` script blocks. This is syntactically valid XML (passes well-formedness checks) but throws a JS `SyntaxError` in the browser since `<script>` is an HTML5 "raw text" element that doesn't decode entities — this silently voided every function in the script block, breaking the OTP digit-box widget. Fixed and documented as a new gotcha in `developer_docs/testing/playwright-e2e-workflow.md` (§45) so it's easy to recognize next time.

## Not in scope (follow-up issues)

- Email-OTP password reset (blocked on #22368).
- Any landing/dashboard page beyond the inline "logged in" confirmation card — that's #22371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Client Portal login using phone number or email with password.
  - Added persistent session support with logout and logged-in welcome.
  - Added “Reset Password” flow with SMS OTP verification, OTP countdown, resend, and secure password update.
  - Added account picker for cases where multiple accounts match the same contact.
  - Added SMS OTP messaging support for password reset.
- **Documentation**
  - Added troubleshooting guidance for invalid JavaScript caused by XHTML entity encoding in deployed pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->