### PR TITLE
feat(api): add bundled investigation full-definition export API

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationFullDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationFullDTO.java
@@ -1,0 +1,43 @@
+package com.divudi.core.data.dto.investigation;
+
+import com.divudi.core.data.dto.service.ItemFeeDTO;
+
+import java.util.List;
+
+public class InvestigationFullDTO {
+
+    private InvestigationResponseDTO investigation;
+    private List<InvestigationComponentDTO> components;
+    private List<InvestigationItemDTO> formatItems;
+    private List<InvestigationItemValueDTO> itemValues;
+    private List<IxCalDTO> calculations;
+    private List<TestFlagDTO> flags;
+    private List<DynamicLabelDTO> dynamicLabels;
+    private List<InvestigationValidatorDTO> validators;
+    private List<ItemFeeDTO> fees;
+    private String message;
+
+    public InvestigationFullDTO() {
+    }
+
+    public InvestigationResponseDTO getInvestigation() { return investigation; }
+    public void setInvestigation(InvestigationResponseDTO investigation) { this.investigation = investigation; }
+    public List<InvestigationComponentDTO> getComponents() { return components; }
+    public void setComponents(List<InvestigationComponentDTO> components) { this.components = components; }
+    public List<InvestigationItemDTO> getFormatItems() { return formatItems; }
+    public void setFormatItems(List<InvestigationItemDTO> formatItems) { this.formatItems = formatItems; }
+    public List<InvestigationItemValueDTO> getItemValues() { return itemValues; }
+    public void setItemValues(List<InvestigationItemValueDTO> itemValues) { this.itemValues = itemValues; }
+    public List<IxCalDTO> getCalculations() { return calculations; }
+    public void setCalculations(List<IxCalDTO> calculations) { this.calculations = calculations; }
+    public List<TestFlagDTO> getFlags() { return flags; }
+    public void setFlags(List<TestFlagDTO> flags) { this.flags = flags; }
+    public List<DynamicLabelDTO> getDynamicLabels() { return dynamicLabels; }
+    public void setDynamicLabels(List<DynamicLabelDTO> dynamicLabels) { this.dynamicLabels = dynamicLabels; }
+    public List<InvestigationValidatorDTO> getValidators() { return validators; }
+    public void setValidators(List<InvestigationValidatorDTO> validators) { this.validators = validators; }
+    public List<ItemFeeDTO> getFees() { return fees; }
+    public void setFees(List<ItemFeeDTO> fees) { this.fees = fees; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/service/investigation/InvestigationFullApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationFullApiService.java
@@ -1,0 +1,60 @@
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.dto.investigation.InvestigationFullDTO;
+import com.divudi.core.data.dto.investigation.InvestigationItemDTO;
+import com.divudi.core.data.dto.investigation.InvestigationItemValueDTO;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read-only aggregation of an investigation's complete definition tree —
+ * metadata, category/sample/container/analyzer linking, components, report
+ * format (items, item values, calculations, flags, dynamic labels),
+ * validators, and fees — into a single nested JSON document.
+ *
+ * Pure composition over the existing per-domain services built in
+ * #22360/#22361/#22362/#22364; no new entity mutation logic. See issue
+ * #22365 (supersedes #458).
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class InvestigationFullApiService implements Serializable {
+
+    @EJB
+    private InvestigationApiService investigationApiService;
+    @EJB
+    private InvestigationComponentApiService investigationComponentApiService;
+    @EJB
+    private InvestigationFormatApiService investigationFormatApiService;
+    @EJB
+    private InvestigationValidatorApiService investigationValidatorApiService;
+    @EJB
+    private InvestigationFeeApiService investigationFeeApiService;
+
+    public InvestigationFullDTO getFullDefinition(Long investigationId) throws Exception {
+        InvestigationFullDTO dto = new InvestigationFullDTO();
+        dto.setInvestigation(investigationApiService.findById(investigationId));
+        dto.setComponents(investigationComponentApiService.listComponents(investigationId));
+        dto.setValidators(investigationValidatorApiService.listValidators(investigationId));
+        dto.setFees(investigationFeeApiService.listFees(investigationId));
+
+        List<InvestigationItemDTO> items = investigationFormatApiService.listItems(investigationId);
+        dto.setFormatItems(items);
+        List<InvestigationItemValueDTO> allValues = new ArrayList<>();
+        for (InvestigationItemDTO item : items) {
+            allValues.addAll(investigationFormatApiService.listValues(investigationId, item.getId()));
+        }
+        dto.setItemValues(allValues);
+        dto.setCalculations(investigationFormatApiService.listCalculations(investigationId));
+        dto.setFlags(investigationFormatApiService.listFlags(investigationId));
+        dto.setDynamicLabels(investigationFormatApiService.listDynamicLabels(investigationId));
+
+        dto.setMessage("Full investigation definition retrieved successfully");
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -65,6 +65,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationComponentApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFeeApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
+        resources.add(com.divudi.ws.investigation.InvestigationFullApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationValidatorApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -436,6 +436,14 @@ public class CapabilityStatementResource {
                         + "code in the app today and is intentionally not exposed by this API.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Investigation Full Definition", "/api/investigations/{investigationId}/full",
+                        "Read-only aggregation of an investigation's complete definition into one nested JSON "
+                        + "document: metadata (incl. category/sample/container/analyzer), components, report "
+                        + "format (items, item values, calculations, flags, dynamic labels), validators, and fees. "
+                        + "Pure composition over the other investigation sub-resources — no new mutation logic. "
+                        + "Supersedes the old 'Export Investigation as JSON' idea (#458).",
+                        "API Key",
+                        "GET"))
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories. "
                         + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "

--- a/src/main/java/com/divudi/ws/investigation/InvestigationFullApi.java
+++ b/src/main/java/com/divudi/ws/investigation/InvestigationFullApi.java
@@ -1,0 +1,115 @@
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.InvestigationFullApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Path("investigations/{investigationId}/full")
+@RequestScoped
+public class InvestigationFullApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private InvestigationFullApiService investigationFullApiService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    /**
+     * GET /api/investigations/{investigationId}/full
+     * Returns the investigation's complete definition tree in one document.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getFullDefinition(@PathParam("investigationId") Long investigationId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(investigationFullApiService.getFullDefinition(investigationId));
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        return successData(data, 200);
+    }
+
+    private Map<String, Object> successData(Object data, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", statusCode);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
- Part of #464 (Full API + AI-Agent-Driven Investigation Authoring). Closes #22365. Supersedes #458 (Export Investigation as JSON) — closing that separately once this merges.
- New `GET /investigations/{investigationId}/full`, aggregating an investigation's complete definition into **one nested JSON document**: metadata (incl. category/sample/container/analyzer from #22360), components (#22361), report format — items, item values, calculations, flags, dynamic labels (existing `InvestigationFormatApi`) — validators (#22364), and fees (#22362).
- Pure read composition: `InvestigationFullApiService` only calls the existing per-domain services and assembles their DTOs into `InvestigationFullDTO`. No new entity mutation logic, per the issue's own scope note.
- Maps `"not found"` to HTTP 404 (matching the fee/validator sibling convention), since this is a GET-only aggregation endpoint — not the flat-500 style used by the mutation-heavy `InvestigationComponentApi`.
- This PR was rebased onto `development` after #22364 merged (PR #22397), so it has `InvestigationValidatorApiService` available for the validators section from the start.

## Files changed
- `InvestigationFullDTO.java` (new) — flat top-level DTO with one list/object per sub-domain (investigation, components, formatItems, itemValues, calculations, flags, dynamicLabels, validators, fees)
- `InvestigationFullApiService.java` (new) — calls `InvestigationApiService`, `InvestigationComponentApiService`, `InvestigationFormatApiService`, `InvestigationValidatorApiService`, `InvestigationFeeApiService`
- `InvestigationFullApi.java` (new) — REST resource, `Finance`-header auth, standard success/error envelope
- `ApplicationConfig.java` — registers the new JAX-RS resource
- `CapabilityStatementResource.java` — documents the new `/api/investigations/{investigationId}/full` resource

## Test plan
Verified end-to-end against the local Payara `rh` domain / `coop` database using investigation `A.P.T.T` (id 87589):
- [x] `GET /investigations/87589/full` — 200, returns nested document with correct counts: 16 format items, 2 flags, 3 fees (matching the pre-existing data used in #22362's own verification), validators (empty, none yet created), category/sample/container/analyzer all populated (Haematology / Blood / Citrate Tube / BioRadD10)
- [x] Nonexistent investigation id — 404 `"Investigation not found with ID: ..."`
- [x] Retired investigation (flipped `RETIRED=1` on test investigation 13839294 via SQL + redeploy per the EclipseLink L2 cache gotcha, then reverted) — 404
- [x] Missing `Finance` header — 401
- [x] `GET /api/capabilities` — confirms the new "Investigation Full Definition" resource entry is present
- [x] `mvn clean package -DskipTests` — builds clean, no compile errors

🤖 Generated with [Claude Code](https://claude.ai/code)