### PR TITLE
fix(inward): include batch-bill fees in Professional Payments Report

### DIFF
--- a/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
+++ b/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
@@ -2,7 +2,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
-import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.facade.BillFeeFacade;
@@ -71,17 +71,21 @@ public class ProfessionalFeeHoldController implements Serializable {
         if (currentEncounter == null || currentEncounter.getId() == null) {
             return;
         }
+        List<BillTypeAtomic> btcs = new ArrayList<>();
+        btcs.add(BillTypeAtomic.INWARD_PROFESSIONAL_FEE_BILL);
+        btcs.add(BillTypeAtomic.INWARD_THEATRE_PROFESSIONAL_FEE_BILL);
+        btcs.add(BillTypeAtomic.INWARD_SERVICE_BILL);
+        btcs.add(BillTypeAtomic.INWARD_SERVICE_BATCH_BILL);
         String jpql = "select bf from BillFee bf where "
                 + " bf.retired=false "
                 + " and bf.bill.cancelled=false "
                 + " and bf.patienEncounter=:pe "
                 + " and bf.staff is not null "
-                + " and (bf.bill.billType=:btp or bf.bill.billType=:btp2) "
+                + " and bf.bill.billTypeAtomic in :btcs "
                 + " order by bf.staff.person.name, bf.createdAt";
         Map<String, Object> params = new HashMap<>();
         params.put("pe", currentEncounter);
-        params.put("btp", BillType.InwardBill);
-        params.put("btp2", BillType.InwardProfessional);
+        params.put("btcs", btcs);
         professionalFees = billFeeFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to #22398, found reviewing that PR after it merged.
- `ProfessionalFeeHoldController.loadProfessionalFees()` filtered on `bf.bill.billType in (InwardBill, InwardProfessional)`. No `BillTypeAtomic` ever sets `billType=InwardBill` (dead filter branch), and `InwardProfessional` only covers `INWARD_SERVICE_BILL`/`INWARD_PROFESSIONAL_FEE_BILL`/`INWARD_THEATRE_PROFESSIONAL_FEE_BILL` — so `INWARD_SERVICE_BATCH_BILL` fees (`billType=InwardProfessionalEstimates`) never showed up in the Professional Payments Report even though `InwardStaffPaymentBillController`'s own due-fees query already includes them and they are payable.
- Switched the report's JPQL to filter on `bf.bill.billTypeAtomic in (...)` using the same 4-item list the staff payment controller uses, so the report's coverage matches what can actually be paid/held.

## Test plan
- [x] Rebuilt and redeployed locally (JDK 11 / Maven / Payara).
- [x] Verified via Playwright against a real local admission with `INWARD_SERVICE_BILL` professional fees:
  - Professional Payments Report lists both fee rows correctly.
  - Hold Selected → row shows "On Hold since ... by buddhika" with notes tooltip; DB confirms `FEEPAYMENTONHOLD`/`FEEPAYMENTHOLDDATETIME`/`FEEPAYMENTHOLDBY_ID`/`FEEPAYMENTHOLDNOTES` set correctly.
  - Audit trail: `Professional Fee Payment Hold` / `... Released` events recorded in `hmisAuditPU` (`ruhunuaudit.auditevent`) against the admission.
  - Release Hold on Selected → fields cleared, audit event recorded.
  - End-to-end block confirmed: while held, the fee is **absent** (not tagged, just missing) from the Inward Professional Payment "Find Due Payments" search; after release, it appears with the correct Total Due.
- [x] No `BillTypeAtomic` maps to `BillType.InwardBill` anywhere in the codebase — confirmed via grep, so the removed branch was dead code, not a behavior change for existing rows.
- [x] Local dev DB was missing the `feePaymentOnHold`/`feePaymentHoldDateTime`/`feePaymentHoldBy`/`feePaymentHoldNotes` columns on `billfee` (added locally per the project's "missing_database_fields" pattern — not something this PR needs to migrate, per `developer_docs/database/migration-development-guide.md`).
- [x] Wiki documentation added/updated: new [Inpatient — Professional Payments Report](https://github.com/hmislk/hmis/wiki/Inpatient-Professional-Payments-Report) article, cross-linked from Hold Professional Payments, the Admission Profile dashboard article, and Inward Professional and Surgery Payments (documents that item-level holds are silently excluded from the due-fees search, unlike the whole-BHT "On Hold" tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)