### PR TITLE
feat(ai-chat): register investigation-authoring tools in AnthropicApiService

### DIFF
--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -4196,6 +4196,7 @@ public class AnthropicApiService implements Serializable {
             } else {
                 return "Error: Unsupported method for manage_investigation_components: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
             }
+            rb.timeout(Duration.ofSeconds(15));
             if (!key.isEmpty()) rb.header("Finance", key);
             HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
             return "HTTP " + resp.statusCode() + "\n" + resp.body();
@@ -4245,6 +4246,7 @@ public class AnthropicApiService implements Serializable {
             } else {
                 return "Error: Unsupported method for manage_investigation_pricing: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
             }
+            rb.timeout(Duration.ofSeconds(15));
             if (!key.isEmpty()) rb.header("Finance", key);
             HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
             return "HTTP " + resp.statusCode() + "\n" + resp.body();
@@ -4281,6 +4283,7 @@ public class AnthropicApiService implements Serializable {
             } else {
                 return "Error: Unsupported method for manage_investigation_validators: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
             }
+            rb.timeout(Duration.ofSeconds(15));
             if (!key.isEmpty()) rb.header("Finance", key);
             HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
             return "HTTP " + resp.statusCode() + "\n" + resp.body();
@@ -4294,7 +4297,8 @@ public class AnthropicApiService implements Serializable {
             if (investigationId == null || investigationId.isEmpty()) return "Error: investigation_id is required.";
             String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
             HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
-            HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(root + "/api/investigations/" + investigationId + "/full")).GET();
+            HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(root + "/api/investigations/" + investigationId + "/full")).GET()
+                    .timeout(Duration.ofSeconds(15));
             if (!key.isEmpty()) rb.header("Finance", key);
             HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
             return "HTTP " + resp.statusCode() + "\n" + resp.body();

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -883,7 +883,31 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "'true' to charge VAT on this investigation, 'false' to exempt it. Optional."))
                                 .add("vatPercentage", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "VAT percentage applied when vatable is true (e.g. '18'). Optional.")))
+                                        .add("description", "VAT percentage applied when vatable is true (e.g. '18'). Optional."))
+                                .add("categoryId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation category ID (e.g. Haematology, Biochemistry). Must reference an existing category or an error is thrown. Optional for POST/PUT — alternative to categoryName."))
+                                .add("categoryName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation category name. Found-or-created by name if no matching category exists. Optional for POST/PUT — alternative to categoryId."))
+                                .add("sampleId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Sample type ID (e.g. Blood, Urine). Must reference an existing sample or an error is thrown. Optional for POST/PUT — alternative to sampleName."))
+                                .add("sampleName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Sample type name. Found-or-created by name if no matching sample exists. Optional for POST/PUT — alternative to sampleId."))
+                                .add("containerId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Collection container/tube ID (e.g. EDTA Tube, Citrate Tube). Must reference an existing container or an error is thrown. Optional for POST/PUT — alternative to containerName."))
+                                .add("containerName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Collection container/tube name. Found-or-created by name if no matching container exists. Optional for POST/PUT — alternative to containerId."))
+                                .add("analyzerId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Analyzer/machine ID (e.g. Sysmex XN-1000). Must reference an existing analyzer or an error is thrown. Optional for POST/PUT — alternative to analyzerName."))
+                                .add("analyzerName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Analyzer/machine name. Found-or-created by name if no matching analyzer exists. Optional for POST/PUT — alternative to analyzerId.")))
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
@@ -1083,6 +1107,136 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "FLAG: 'true' to display the normal message.")))
                         .add("required", Json.createArrayBuilder()
                                 .add("resource_type").add("method").add("investigation_id")))
+                .build();
+
+        JsonObject manageInvestigationComponentsTool = Json.createObjectBuilder()
+                .add("name", "manage_investigation_components")
+                .add("description",
+                        "Manage InvestigationComponent groupings used to organize report items within an investigation's "
+                        + "format (e.g. grouping FBC items under a 'White Cell Differential' heading). "
+                        + "First use manage_investigations GET to find the investigation ID, then use this tool. "
+                        + "method: LIST | POST | PUT | DELETE. PUT and DELETE require component_id; POST and PUT require component_name. "
+                        + "DELETE permanently removes the component and is rejected if any report item still references it. "
+                        + "Always confirm with the user before POST, PUT, or DELETE.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "Operation to perform."))
+                                .add("investigation_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation ID. Required for all methods."))
+                                .add("component_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Component ID. Required for PUT and DELETE."))
+                                .add("component_name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Component name/label. Required for POST and PUT.")))
+                        .add("required", Json.createArrayBuilder().add("method").add("investigation_id")))
+                .build();
+
+        JsonObject manageInvestigationPricingTool = Json.createObjectBuilder()
+                .add("name", "manage_investigation_pricing")
+                .add("description",
+                        "Manage investigation pricing (ItemFee) — the fees charged when an investigation is billed. "
+                        + "First use manage_investigations GET to find the investigation ID, then use this tool. "
+                        + "method: LIST | POST | PUT | DELETE. PUT and DELETE require fee_id. POST requires name, feeType, and fee. "
+                        + "DELETE soft-deletes (retires) a fee. All mutations recalculate the investigation's total and are "
+                        + "rejected against a retired investigation. Always confirm with the user before POST, PUT, or DELETE "
+                        + "— these changes affect live billing.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "Operation to perform."))
+                                .add("investigation_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation ID. Required for all methods."))
+                                .add("fee_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee ID. Required for PUT and DELETE."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee name (e.g. 'Hospital Fee', 'Professional Fee'). Required for POST."))
+                                .add("feeType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "ItemFeeType enum value (e.g. OwnInstitution, Referral, Professional). Required for POST."))
+                                .add("fee", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Fee amount. Required for POST."))
+                                .add("ffee", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Foreigner fee amount. Optional; defaults to fee if omitted."))
+                                .add("discountAllowed", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "'true' or 'false' — whether discounts can be applied to this fee. Optional."))
+                                .add("institutionId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Institution ID this fee applies to. Optional."))
+                                .add("departmentId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Department ID this fee applies to. Optional."))
+                                .add("specialityId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Speciality ID this fee applies to. Optional."))
+                                .add("staffId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Staff ID this fee applies to (e.g. for Professional fees). Optional.")))
+                        .add("required", Json.createArrayBuilder().add("method").add("investigation_id")))
+                .build();
+
+        JsonObject manageInvestigationValidatorsTool = Json.createObjectBuilder()
+                .add("name", "manage_investigation_validators")
+                .add("description",
+                        "Manage InvestigationValidator result-range checks (min/max value validation) for an investigation. "
+                        + "First use manage_investigations GET to find the investigation ID, then use this tool. "
+                        + "method: LIST | POST | PUT | DELETE. PUT and DELETE require validator_id; POST requires name. "
+                        + "minimumValue and maximumValue are optional but minimumValue cannot exceed maximumValue. "
+                        + "DELETE soft-deletes (retires) a validator. Always confirm with the user before POST, PUT, or DELETE.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "Operation to perform."))
+                                .add("investigation_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation ID. Required for all methods."))
+                                .add("validator_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Validator ID. Required for PUT and DELETE."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Validator name. Required for POST."))
+                                .add("maximumValue", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Maximum acceptable result value. Optional."))
+                                .add("minimumValue", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Minimum acceptable result value. Optional.")))
+                        .add("required", Json.createArrayBuilder().add("method").add("investigation_id")))
+                .build();
+
+        JsonObject manageInvestigationExportTool = Json.createObjectBuilder()
+                .add("name", "manage_investigation_export")
+                .add("description",
+                        "Retrieve an investigation's complete definition as one nested document: metadata "
+                        + "(incl. category/sample/container/analyzer), components, report format (items, item values, "
+                        + "calculations, flags, dynamic labels), validators, and fees. Use this to review everything "
+                        + "configured for an investigation in a single call — e.g. to confirm a newly-built test is "
+                        + "complete, or as a reference when building a similar investigation. Read-only.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("investigation_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Investigation ID. Required.")))
+                        .add("required", Json.createArrayBuilder().add("investigation_id")))
                 .build();
 
         JsonObject manageFormsTool = Json.createObjectBuilder()
@@ -1792,6 +1946,10 @@ public class AnthropicApiService implements Serializable {
                 .add(manageInvestigationsTool)
                 .add(manageServicesTool)
                 .add(manageInvestigationFormatTool)
+                .add(manageInvestigationComponentsTool)
+                .add(manageInvestigationPricingTool)
+                .add(manageInvestigationValidatorsTool)
+                .add(manageInvestigationExportTool)
                 .add(manageFormsTool)
                 .add(manageSubscriptionsTool)
                 .add(manageStaffTool)
@@ -1969,7 +2127,52 @@ public class AnthropicApiService implements Serializable {
                     String bypass = toolInput.containsKey("bypassSampleWorkflow") ? toolInput.getString("bypassSampleWorkflow", "") : "";
                     String vatable = toolInput.containsKey("vatable") ? toolInput.getString("vatable", "") : "";
                     String vatPercentage = toolInput.containsKey("vatPercentage") ? toolInput.getString("vatPercentage", "") : "";
-                    return callInvestigationApi(method, id, query, inactive, limit, name, code, printName, reportType, bypass, vatable, vatPercentage, hmisBaseUrl, hmisApiKey);
+                    String categoryId = toolInput.containsKey("categoryId") ? toolInput.getString("categoryId", "") : "";
+                    String categoryName = toolInput.containsKey("categoryName") ? toolInput.getString("categoryName", "") : "";
+                    String sampleId = toolInput.containsKey("sampleId") ? toolInput.getString("sampleId", "") : "";
+                    String sampleName = toolInput.containsKey("sampleName") ? toolInput.getString("sampleName", "") : "";
+                    String containerId = toolInput.containsKey("containerId") ? toolInput.getString("containerId", "") : "";
+                    String containerName = toolInput.containsKey("containerName") ? toolInput.getString("containerName", "") : "";
+                    String analyzerId = toolInput.containsKey("analyzerId") ? toolInput.getString("analyzerId", "") : "";
+                    String analyzerName = toolInput.containsKey("analyzerName") ? toolInput.getString("analyzerName", "") : "";
+                    return callInvestigationApi(method, id, query, inactive, limit, name, code, printName, reportType, bypass, vatable, vatPercentage,
+                            categoryId, categoryName, sampleId, sampleName, containerId, containerName, analyzerId, analyzerName, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_investigation_components": {
+                    String method = toolInput.getString("method", "LIST");
+                    String investigationId = toolInput.getString("investigation_id", "");
+                    String componentId = toolInput.containsKey("component_id") ? toolInput.getString("component_id", "") : "";
+                    String componentName = toolInput.containsKey("component_name") ? toolInput.getString("component_name", "") : "";
+                    return callInvestigationComponentApi(method, investigationId, componentId, componentName, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_investigation_pricing": {
+                    String method = toolInput.getString("method", "LIST");
+                    String investigationId = toolInput.getString("investigation_id", "");
+                    String feeId = toolInput.containsKey("fee_id") ? toolInput.getString("fee_id", "") : "";
+                    String name = toolInput.containsKey("name") ? toolInput.getString("name", "") : "";
+                    String feeType = toolInput.containsKey("feeType") ? toolInput.getString("feeType", "") : "";
+                    String fee = toolInput.containsKey("fee") ? toolInput.getString("fee", "") : "";
+                    String ffee = toolInput.containsKey("ffee") ? toolInput.getString("ffee", "") : "";
+                    String discountAllowed = toolInput.containsKey("discountAllowed") ? toolInput.getString("discountAllowed", "") : "";
+                    String institutionId = toolInput.containsKey("institutionId") ? toolInput.getString("institutionId", "") : "";
+                    String departmentId = toolInput.containsKey("departmentId") ? toolInput.getString("departmentId", "") : "";
+                    String specialityId = toolInput.containsKey("specialityId") ? toolInput.getString("specialityId", "") : "";
+                    String staffId = toolInput.containsKey("staffId") ? toolInput.getString("staffId", "") : "";
+                    return callInvestigationPricingApi(method, investigationId, feeId, name, feeType, fee, ffee, discountAllowed,
+                            institutionId, departmentId, specialityId, staffId, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_investigation_validators": {
+                    String method = toolInput.getString("method", "LIST");
+                    String investigationId = toolInput.getString("investigation_id", "");
+                    String validatorId = toolInput.containsKey("validator_id") ? toolInput.getString("validator_id", "") : "";
+                    String name = toolInput.containsKey("name") ? toolInput.getString("name", "") : "";
+                    String maximumValue = toolInput.containsKey("maximumValue") ? toolInput.getString("maximumValue", "") : "";
+                    String minimumValue = toolInput.containsKey("minimumValue") ? toolInput.getString("minimumValue", "") : "";
+                    return callInvestigationValidatorApi(method, investigationId, validatorId, name, maximumValue, minimumValue, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_investigation_export": {
+                    String investigationId = toolInput.getString("investigation_id", "");
+                    return callInvestigationFullApi(investigationId, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_services": {
                     String method = toolInput.getString("method", "GET");
@@ -3925,7 +4128,9 @@ public class AnthropicApiService implements Serializable {
      * @param userHmisApiKey  The logged-in user's active HMIS API key value
      * @param githubBranch    The GitHub branch for documentation links (e.g. "development")
      */
-    private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String vatable, String vatPercentage, String hmisBaseUrl, String hmisApiKey) {
+    private String callInvestigationApi(String method, String id, String query, String inactive, String limit, String name, String code, String printName, String reportType, String bypassSampleWorkflow, String vatable, String vatPercentage,
+            String categoryId, String categoryName, String sampleId, String sampleName, String containerId, String containerName, String analyzerId, String analyzerName,
+            String hmisBaseUrl, String hmisApiKey) {
         try {
             String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
             if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
@@ -3942,6 +4147,14 @@ public class AnthropicApiService implements Serializable {
                 if(code!=null&&!code.isEmpty()) b.add("code", code); if(printName!=null&&!printName.isEmpty()) b.add("printName", printName); if(reportType!=null&&!reportType.isEmpty()) b.add("reportType", reportType); if(bypassSampleWorkflow!=null&&!bypassSampleWorkflow.isEmpty()) b.add("bypassSampleWorkflow", Boolean.parseBoolean(bypassSampleWorkflow));
                 if(vatable!=null&&!vatable.isEmpty()) b.add("vatable", Boolean.parseBoolean(vatable));
                 if(vatPercentage!=null&&!vatPercentage.isEmpty()) b.add("vatPercentage", Double.parseDouble(vatPercentage));
+                if(categoryId!=null&&!categoryId.isEmpty()) b.add("categoryId", Long.parseLong(categoryId));
+                if(categoryName!=null&&!categoryName.isEmpty()) b.add("categoryName", categoryName);
+                if(sampleId!=null&&!sampleId.isEmpty()) b.add("sampleId", Long.parseLong(sampleId));
+                if(sampleName!=null&&!sampleName.isEmpty()) b.add("sampleName", sampleName);
+                if(containerId!=null&&!containerId.isEmpty()) b.add("containerId", Long.parseLong(containerId));
+                if(containerName!=null&&!containerName.isEmpty()) b.add("containerName", containerName);
+                if(analyzerId!=null&&!analyzerId.isEmpty()) b.add("analyzerId", Long.parseLong(analyzerId));
+                if(analyzerName!=null&&!analyzerName.isEmpty()) b.add("analyzerName", analyzerName);
                 String u = "POST".equalsIgnoreCase(method) ? root+"/api/investigations" : root+"/api/investigations/"+id;
                 rb = HttpRequest.newBuilder().uri(URI.create(u)).method("POST".equalsIgnoreCase(method)?"POST":"PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
             } else if ("ACTIVATE".equalsIgnoreCase(method) || "DEACTIVATE".equalsIgnoreCase(method)) {
@@ -3955,6 +4168,137 @@ public class AnthropicApiService implements Serializable {
             }
             if(!key.isEmpty()) rb.header("Finance", key); HttpResponse<String> resp=client.send(rb.build(), HttpResponse.BodyHandlers.ofString()); return "HTTP "+resp.statusCode()+"\n"+resp.body();
         } catch (Exception e) { return "Investigation API error: "+e.getMessage(); }
+    }
+
+    private String callInvestigationComponentApi(String method, String investigationId, String componentId, String componentName, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            if (investigationId == null || investigationId.isEmpty()) return "Error: investigation_id is required.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            String basePath = root + "/api/investigations/" + investigationId + "/components";
+            HttpRequest.Builder rb;
+            if ("LIST".equalsIgnoreCase(method)) {
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).GET();
+            } else if ("POST".equalsIgnoreCase(method)) {
+                if (componentName == null || componentName.isEmpty()) return "Error: component_name is required for POST.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("componentName", componentName);
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).POST(HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("PUT".equalsIgnoreCase(method)) {
+                if (componentId == null || componentId.isEmpty()) return "Error: component_id is required for PUT.";
+                if (componentName == null || componentName.isEmpty()) return "Error: component_name is required for PUT.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("componentName", componentName);
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + componentId)).method("PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("DELETE".equalsIgnoreCase(method)) {
+                if (componentId == null || componentId.isEmpty()) return "Error: component_id is required for DELETE.";
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + componentId)).DELETE();
+            } else {
+                return "Error: Unsupported method for manage_investigation_components: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
+            }
+            if (!key.isEmpty()) rb.header("Finance", key);
+            HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + resp.statusCode() + "\n" + resp.body();
+        } catch (Exception e) { return "Investigation Components API error: " + e.getMessage(); }
+    }
+
+    private String callInvestigationPricingApi(String method, String investigationId, String feeId, String name, String feeType, String fee, String ffee,
+            String discountAllowed, String institutionId, String departmentId, String specialityId, String staffId, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            if (investigationId == null || investigationId.isEmpty()) return "Error: investigation_id is required.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            String basePath = root + "/api/investigations/" + investigationId + "/fees";
+            HttpRequest.Builder rb;
+            if ("LIST".equalsIgnoreCase(method)) {
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).GET();
+            } else if ("POST".equalsIgnoreCase(method)) {
+                if (name == null || name.isEmpty()) return "Error: name is required for POST.";
+                if (feeType == null || feeType.isEmpty()) return "Error: feeType is required for POST.";
+                if (fee == null || fee.isEmpty()) return "Error: fee is required for POST.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("name", name).add("feeType", feeType).add("fee", Double.parseDouble(fee));
+                if (ffee != null && !ffee.isEmpty()) b.add("ffee", Double.parseDouble(ffee));
+                if (discountAllowed != null && !discountAllowed.isEmpty()) b.add("discountAllowed", Boolean.parseBoolean(discountAllowed));
+                if (institutionId != null && !institutionId.isEmpty()) b.add("institutionId", Long.parseLong(institutionId));
+                if (departmentId != null && !departmentId.isEmpty()) b.add("departmentId", Long.parseLong(departmentId));
+                if (specialityId != null && !specialityId.isEmpty()) b.add("specialityId", Long.parseLong(specialityId));
+                if (staffId != null && !staffId.isEmpty()) b.add("staffId", Long.parseLong(staffId));
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).POST(HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("PUT".equalsIgnoreCase(method)) {
+                if (feeId == null || feeId.isEmpty()) return "Error: fee_id is required for PUT.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+                if (name != null && !name.isEmpty()) b.add("name", name);
+                if (feeType != null && !feeType.isEmpty()) b.add("feeType", feeType);
+                if (fee != null && !fee.isEmpty()) b.add("fee", Double.parseDouble(fee));
+                if (ffee != null && !ffee.isEmpty()) b.add("ffee", Double.parseDouble(ffee));
+                if (discountAllowed != null && !discountAllowed.isEmpty()) b.add("discountAllowed", Boolean.parseBoolean(discountAllowed));
+                if (institutionId != null && !institutionId.isEmpty()) b.add("institutionId", Long.parseLong(institutionId));
+                if (departmentId != null && !departmentId.isEmpty()) b.add("departmentId", Long.parseLong(departmentId));
+                if (specialityId != null && !specialityId.isEmpty()) b.add("specialityId", Long.parseLong(specialityId));
+                if (staffId != null && !staffId.isEmpty()) b.add("staffId", Long.parseLong(staffId));
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + feeId)).method("PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("DELETE".equalsIgnoreCase(method)) {
+                if (feeId == null || feeId.isEmpty()) return "Error: fee_id is required for DELETE.";
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + feeId)).DELETE();
+            } else {
+                return "Error: Unsupported method for manage_investigation_pricing: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
+            }
+            if (!key.isEmpty()) rb.header("Finance", key);
+            HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + resp.statusCode() + "\n" + resp.body();
+        } catch (Exception e) { return "Investigation Pricing API error: " + e.getMessage(); }
+    }
+
+    private String callInvestigationValidatorApi(String method, String investigationId, String validatorId, String name, String maximumValue, String minimumValue, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            if (investigationId == null || investigationId.isEmpty()) return "Error: investigation_id is required.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            String basePath = root + "/api/investigations/" + investigationId + "/validators";
+            HttpRequest.Builder rb;
+            if ("LIST".equalsIgnoreCase(method)) {
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).GET();
+            } else if ("POST".equalsIgnoreCase(method)) {
+                if (name == null || name.isEmpty()) return "Error: name is required for POST.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder().add("name", name);
+                if (maximumValue != null && !maximumValue.isEmpty()) b.add("maximumValue", Double.parseDouble(maximumValue));
+                if (minimumValue != null && !minimumValue.isEmpty()) b.add("minimumValue", Double.parseDouble(minimumValue));
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath)).POST(HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("PUT".equalsIgnoreCase(method)) {
+                if (validatorId == null || validatorId.isEmpty()) return "Error: validator_id is required for PUT.";
+                javax.json.JsonObjectBuilder b = Json.createObjectBuilder();
+                if (name != null && !name.isEmpty()) b.add("name", name);
+                if (maximumValue != null && !maximumValue.isEmpty()) b.add("maximumValue", Double.parseDouble(maximumValue));
+                if (minimumValue != null && !minimumValue.isEmpty()) b.add("minimumValue", Double.parseDouble(minimumValue));
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + validatorId)).method("PUT", HttpRequest.BodyPublishers.ofString(b.build().toString())).header("Content-Type", "application/json");
+            } else if ("DELETE".equalsIgnoreCase(method)) {
+                if (validatorId == null || validatorId.isEmpty()) return "Error: validator_id is required for DELETE.";
+                rb = HttpRequest.newBuilder().uri(URI.create(basePath + "/" + validatorId)).DELETE();
+            } else {
+                return "Error: Unsupported method for manage_investigation_validators: " + method + ". Allowed: LIST, POST, PUT, DELETE.";
+            }
+            if (!key.isEmpty()) rb.header("Finance", key);
+            HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + resp.statusCode() + "\n" + resp.body();
+        } catch (Exception e) { return "Investigation Validators API error: " + e.getMessage(); }
+    }
+
+    private String callInvestigationFullApi(String investigationId, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            if (investigationId == null || investigationId.isEmpty()) return "Error: investigation_id is required.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(root + "/api/investigations/" + investigationId + "/full")).GET();
+            if (!key.isEmpty()) rb.header("Finance", key);
+            HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + resp.statusCode() + "\n" + resp.body();
+        } catch (Exception e) { return "Investigation Export API error: " + e.getMessage(); }
     }
 
     private String callServiceApi(String method, String id, String query, String serviceType, String categoryId, String inactive, String limit, String name, String code, String printName, String fullName, String inwardChargeType, String vatable, String vatPercentage, String hmisBaseUrl, String hmisApiKey) {
@@ -5334,7 +5678,7 @@ public class AnthropicApiService implements Serializable {
         }
 
         sb.append("## Tools Available to You\n");
-        sb.append("You have thirteen tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records, investigation report formats, dynamic clinical form templates, notification subscriptions, and document templates:\n\n");
+        sb.append("You have many tools to ground your answers in the actual codebase, live configuration, clinical master data, collecting-centre fees, inward discount matrix entries, investigation master records (including category/sample/container/analyzer, components, pricing, validators, and a full-definition export), investigation report formats, dynamic clinical form templates, notification subscriptions, and document templates:\n\n");
         sb.append("### search_github_code\n");
         sb.append("Searches the hmislk/hmis repository source code for files matching keywords. ");
         sb.append("Use this first when a user asks about system behaviour, page logic, or wants to understand how something works.\n\n");
@@ -5380,6 +5724,12 @@ public class AnthropicApiService implements Serializable {
           .append("Use PUT to update name, code, printName, reportType, bypassSampleWorkflow, vatable, or vatPercentage. ")
           .append("Set vatable=true and vatPercentage (e.g. 18) to charge VAT automatically wherever this investigation is billed; ")
           .append("vatable=false or vatPercentage=0 means no VAT. ")
+          .append("For POST and PUT you can also set category (categoryId or categoryName), sample type (sampleId or sampleName), ")
+          .append("collection container (containerId or containerName), and analyzer/machine (analyzerId or analyzerName) — ")
+          .append("passing an *Id must reference an existing row or an error is thrown, while passing a *Name finds-or-creates ")
+          .append("a matching row by name. When building a new investigation conversationally, ask the user for these four ")
+          .append("(category, sample, container, analyzer) before or alongside the basic name/code so the investigation is ")
+          .append("fully identifiable from the start. ")
           .append("Always confirm with the user before POST or PUT — these changes affect live investigation billing.\n\n");
         sb.append("### manage_services\n");
         sb.append("Search, retrieve, create, update, activate, or deactivate service master records ")
@@ -5404,6 +5754,34 @@ public class AnthropicApiService implements Serializable {
           .append("For FLAG POST, investigation_item_of_value_type_id and investigation_item_of_flag_type_id are required. ")
           .append("Always LIST items first to get the item IDs before creating calculations, flags, or dynamic labels. ")
           .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
+        sb.append("### manage_investigation_components\n");
+        sb.append("Manage InvestigationComponent groupings that organize an investigation's report items under a heading ")
+          .append("(e.g. grouping FBC items under 'White Cell Differential'). ")
+          .append("First look up the investigation ID using manage_investigations GET, then use this tool. ")
+          .append("method: LIST, POST, PUT, DELETE. POST and PUT require component_name; PUT and DELETE require component_id. ")
+          .append("DELETE permanently removes the component and fails if any report item still references it — ")
+          .append("reassign or remove those items first via manage_investigation_format. ")
+          .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
+        sb.append("### manage_investigation_pricing\n");
+        sb.append("Manage investigation pricing (ItemFee) — the fees charged when an investigation is billed. ")
+          .append("First look up the investigation ID using manage_investigations GET, then use this tool. ")
+          .append("method: LIST, POST, PUT, DELETE. POST requires name, feeType, and fee; PUT and DELETE require fee_id. ")
+          .append("Optional fields: ffee (foreigner fee, defaults to fee), discountAllowed, institutionId, departmentId, specialityId, staffId. ")
+          .append("DELETE soft-deletes (retires) a fee. All mutations recalculate the investigation's total automatically. ")
+          .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live billing.\n\n");
+        sb.append("### manage_investigation_validators\n");
+        sb.append("Manage InvestigationValidator result-range checks (minimum/maximum acceptable result values) for an investigation. ")
+          .append("First look up the investigation ID using manage_investigations GET, then use this tool. ")
+          .append("method: LIST, POST, PUT, DELETE. POST requires name; PUT and DELETE require validator_id. ")
+          .append("maximumValue and minimumValue are optional but minimumValue cannot exceed maximumValue. ")
+          .append("DELETE soft-deletes (retires) a validator. ")
+          .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
+        sb.append("### manage_investigation_export\n");
+        sb.append("Retrieve an investigation's complete definition as one nested document: metadata (incl. category, sample, ")
+          .append("container, analyzer), components, report format (items, item values, calculations, flags, dynamic labels), ")
+          .append("validators, and fees. Requires investigation_id. Read-only — use this to review everything configured for ")
+          .append("an investigation in one call, e.g. to confirm a newly-built investigation is complete before telling the user ")
+          .append("it's ready, or as a reference when building a similar investigation.\n\n");
         sb.append("### manage_inward_rooms\n");
         sb.append("Manage inward room master data: room categories (/inward/room-categories), ")
           .append("rooms (/inward/rooms), and room facility charges — i.e. room fee configurations — (/inward/room-facility-charges). ")


### PR DESCRIPTION
## Summary
- Final sub-issue of #464 (Full API + AI-Agent-Driven Investigation Authoring). Closes #22366.
- Adds four new AI-chat tools and extends one existing tool in `AnthropicApiService`, so the chat agent can build a fully configured, billable investigation conversationally — matching #464's acceptance criterion directly.

| Tool | Status | Backs |
|---|---|---|
| `manage_investigations` | **extended** — added categoryId/categoryName, sampleId/sampleName, containerId/containerName, analyzerId/analyzerName | `/api/investigations` (#22360's fields were on the REST API but never wired into the AI-chat schema until now) |
| `manage_investigation_components` | **new** | `/api/investigations/{id}/components` (#22361) |
| `manage_investigation_pricing` | **new** | `/api/investigations/{id}/fees` (#22362) |
| `manage_investigation_validators` | **new** | `/api/investigations/{id}/validators` (#22364) |
| `manage_investigation_export` | **new**, GET-only | `/api/investigations/{id}/full` (#22365) |

All five follow the existing `manage_investigations`/`manage_investigation_format` pattern exactly: a JSON tool schema in `buildToolsArray()` (using `manage_forms`'s tighter `enum` style for `method` rather than free-text-only), a dispatch case in `executeToolCall()`, and a private `callXxxApi()` helper that makes an outbound HTTP call to this app's own REST layer with the `Finance` header — no new `@EJB` injection needed, since the REST resource classes already resolve `WebUser` internally from the API key. Also extended `buildSystemPrompt()` with one guidance paragraph per new tool (cross-referencing `manage_investigations` GET for ID lookup, same as `manage_investigation_format` does), and removed the stale hardcoded "thirteen tools" count sentence (36 tools are registered as of this PR).

## Files changed
- `AnthropicApiService.java` — tool schemas, dispatch, HTTP-call helpers, system prompt

## Test plan
This is the integration issue whose acceptance criterion is explicitly about the **chat experience**, so it was verified live through the actual AI Chat UI with Playwright, not just curl — per the master issue's own note that this needs conversational testing.

- [x] Logged into local Payara (`rh` domain / `coop` DB) via Playwright, selected Main Pharmacy department, opened `ai_chat.xhtml`
- [x] Sent one natural-language message: *"I want to create a new lab investigation called 'Claude Test CBC 22366'... Category: Haematology. Sample: Blood. Container: EDTA Tube. Analyzer: Sysmex XN-1000. Please create it, then add a report component called 'Differential Count', add a pricing fee named 'Test Fee'... add a result validator named 'WBC Range' with minimum 4 and maximum 11, and finally show me the full definition export..."*
- [x] The agent made 5 tool calls in one turn — create (with category/sample/container/analyzer), add component, add fee, add validator, full export — and rendered a correct formatted summary table back to the user
- [x] **Verified against the DB directly** (not just trusting the chat's own summary): `ITEM` row 13839298 has `CATEGORY_ID=65`, `SAMPLE_ID=69`, `INVESTIGATIONTUBE_ID=1544`, `MACHINE_ID=1719` — all matching what the agent reported; `INVESTIGATIONCOMPONENT` row (id 5, "Differential Count") linked to 13839298; `FEE` row (id 13523880, "Test Fee", OwnInstitution, 500/500) linked to 13839298; `INVESTIGATIONVALIDATOR` row (id 5, "WBC Range", min 4, max 11) linked to 13839298
- [x] `mvn clean package -DskipTests` — builds clean, no compile errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded investigation management to identify categories, samples, containers, and analyzers using either ID or name.
  * Added new investigation tools for managing components, pricing, and validators (including list/create/update/delete).
  * Added a full investigation export capability.
  * Updated AI guidance to reflect the new investigation actions and the ID-vs-name selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->