### PR TITLE
fix(inward): route room-not-required admissions past the Admit to Room gate

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1413,7 +1413,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             bhtSummeryController.setPatientEncounterHasProvisionalBill(isAddmissionHaveProvisionalBill((Admission) current));
             return bhtSummeryController.navigateToInpatientProfile();
         } else {
-            if (current.isRoomAdmitted() || current.isDischarged() || current.isPaymentFinalized()) {
+            if (current.isRoomAdmitted() || current.isDischarged() || current.isPaymentFinalized()
+                    || !current.getAdmissionType().isRoomChargesAllowed()) {
                 current.getPatient().setEditingMode(false);
                 bhtSummeryController.setPatientEncounter(current);
                 bhtSummeryController.setPatientEncounterHasProvisionalBill(isAddmissionHaveProvisionalBill((Admission) current));


### PR DESCRIPTION
## Summary
- Admission types with `roomChargesAllowed=false` (e.g. OPD Card, Emergency/Credit) never get a `PatientRoom` created, so `Admission.roomAdmitted` stays `false` forever.
- When the config option "Patient admission and room assignment are simultaneous processes." is off, `AdmissionController.navigateToAdmissionProfilePage()` kept routing these admissions to `/inward/admit_room` instead of the Inpatient Profile, because the gate only checked `roomAdmitted`/`discharged`/`paymentFinalized`.
- `admit_room.xhtml` then threw `javax.el.PropertyNotFoundException` (`roomChangeController.currentPatientRoom.admittedAt`) as soon as the form was submitted, since `currentPatientRoom` was null for these admissions.
- Fix: extend the gate condition to also bypass admit-room when `!admissionType.isRoomChargesAllowed()`, matching the existing unguarded usage of that same flag elsewhere in `AdmissionController`.

## Test plan
- [x] Reproduced the exact reported error locally against an "OPD Card" admission (`roomChargesAllowed=false`), with the config option set to `false` to match the QA environment where this was reported.
- [x] After the fix, **Search > Admissions > Inpatient Dashboard** for that admission lands directly on the Inpatient Profile with no error (Room Management panel correctly shows "Not admitted to any room").
- [x] Regression: a normal room-required admission not yet room-admitted still correctly routes to the Admit to Room page as before.
- [x] Checked `server.log` — no exceptions on either path.
- Screenshots and full verification notes: https://github.com/hmislk/hmis/issues/22381#issuecomment-5076750503

Closes #22381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission navigation for encounter types that do not allow room charges.
  * These cases now open the inpatient profile directly instead of showing the room-change screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->