### PR TITLE
fix(opd): guard against silent BillItem persistence failure in OPD batch bill settlement

### DIFF
--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2285,6 +2285,24 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return bi != null && bi.getId() != null;
     }
 
+    private void retirePartialBillOnSettlementFailure(Bill bill, List<BillItem> persistedItems) {
+        if (bill == null) {
+            return;
+        }
+        for (BillItem bi : persistedItems) {
+            if (isPersistedBillItem(bi) && !bi.isRetired()) {
+                bi.setRetired(true);
+                bi.setRetiredAt(new Date());
+                getBillItemFacade().edit(bi);
+            }
+        }
+        if (bill.getId() != null && !bill.isRetired()) {
+            bill.setRetired(true);
+            bill.setRetiredAt(new Date());
+            getBillFacade().edit(bill);
+        }
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2303,6 +2321,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
                     if (!isPersistedBillItem(bi)) {
+                        retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                         JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
                         return false;
                     }
@@ -2311,6 +2330,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 }
             }
             if (tmp.isEmpty()) {
+                retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                 JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
                 return false;
             }
@@ -2363,6 +2383,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
                         if (!isPersistedBillItem(bi)) {
+                            retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                             JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                             return false;
                         }
@@ -2371,6 +2392,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     }
                 }
                 if (tmp.isEmpty()) {
+                    retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                     JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                     return false;
                 }
@@ -2513,6 +2535,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             for (BillEntry billEntry : getLstBillEntries()) {
                 BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
                 if (!isPersistedBillItem(bi)) {
+                    retirePartialBillOnSettlementFailure(newSingleBill, list);
                     JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
                     return false;
                 }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2281,6 +2281,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return false; // Fallback case, should not reach here.
     }
 
+    static boolean isPersistedBillItem(BillItem bi) {
+        return bi != null && bi.getId() != null;
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2298,9 +2302,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 Department prformingDept = departmentResolver.resolvePerformingDepartment(sessionController.getDepartment(), e.getBillItem().getItem());
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
+                    if (!isPersistedBillItem(bi)) {
+                        JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
+                        return false;
+                    }
                     myBill.getBillItems().add(bi);
                     tmp.add(e);
                 }
+            }
+            if (tmp.isEmpty()) {
+                JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
+                return false;
             }
             if (getSessionController().getApplicationPreference().isPartialPaymentOfOpdBillsAllowed()) {
                 myBill.setCashPaid(cashPaid);
@@ -2350,9 +2362,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     if (Objects.equals(dept.getId(), d.getId())
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
+                        if (!isPersistedBillItem(bi)) {
+                            JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                            return false;
+                        }
                         newlyCreatedIndividualBill.getBillItems().add(bi);
                         tmp.add(billEntry);
                     }
+                }
+                if (tmp.isEmpty()) {
+                    JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                    return false;
                 }
 
                 Priority highestPriority = Optional
@@ -2491,7 +2511,12 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             }
             List<BillItem> list = new ArrayList<>();
             for (BillEntry billEntry : getLstBillEntries()) {
-                list.add(getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser()));
+                BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
+                if (!isPersistedBillItem(bi)) {
+                    JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
+                    return false;
+                }
+                list.add(bi);
             }
             newSingleBill.setBillItems(list);
 
@@ -2532,9 +2557,13 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             getBillBean().checkBillItemFeesInitiated(newSingleBill);
             getBills().add(newSingleBill);
         } else if (oneOpdBillForEachDepartmentAndCategoryCombination) {
-            processBillsByDepartmentAndCategory();
+            if (!processBillsByDepartmentAndCategory()) {
+                return false;
+            }
         } else if (oneOpdBillForEachDepartment) {
-            processBillsByDepartment();
+            if (!processBillsByDepartment()) {
+                return false;
+            }
         } else if (oneOpdBillForEachCategory) {
             JsfUtil.addErrorMessage("Still Under Development");
             return false;

--- a/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
+++ b/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
@@ -1,0 +1,27 @@
+package com.divudi.bean.opd;
+
+import com.divudi.core.entity.BillItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpdBillControllerTest {
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(null));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenIdIsNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(new BillItem()));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsTrue_whenIdIsSet() {
+        BillItem bi = new BillItem();
+        bi.setId(1L);
+        assertTrue(OpdBillController.isPersistedBillItem(bi));
+    }
+}


### PR DESCRIPTION
## Summary

At Ruhunu Hospital, an OPD batch-bill settle could produce a sub-bill with a correct `NETTOTAL` and a correct payment, but **zero `BillItem` rows** — because the sub-bill's total is computed from an in-memory list, completely independent of whether the item rows actually got persisted. This caused a Rs 2,420 gap between the Daily Return report (counts `BillItem`s) and the All Cashier Summary report (counts `Payment`s). Full investigation: #22399.

This PR adds a persisted-check (`isPersistedBillItem`) immediately after every per-item save in the three OPD settle-flow code paths in `OpdBillController` (`processBillsByDepartment`, `processBillsByDepartmentAndCategory`, and the default `oneOpdBillForAllDepartments` branch), aborting the settlement with a clear error message before any batch bill or payment is created — instead of letting a broken sub-bill silently reach that point. `executeSettleBillActions()` now also correctly checks the boolean these methods return (previously discarded).

## Changes

- `src/main/java/com/divudi/bean/opd/OpdBillController.java`:
  - New `static boolean isPersistedBillItem(BillItem bi)` helper.
  - Guard added after each `saveBillItemForOpdBill`/`saveBillItem` call in all three settle-flow branches, plus an empty-matched-entries guard.
  - `executeSettleBillActions()` now aborts (`return false`) if the delegate methods report failure, matching the existing pattern already used for the `newSingleBill == null` check.
- `src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java` (new): unit tests for `isPersistedBillItem`.

Root-cause internals (`BillBeanController.saveBillItemForOpdBill`/`saveBillItem`) are intentionally left untouched — they're shared with `OpdOrderController`, and the underlying stale-ID mechanism needs its own follow-up investigation (to be filed as a separate issue).

## Test plan

- `mvn clean package` — 185/185 tests pass (182 pre-existing + 3 new), clean build.
- Playwright end-to-end regression on local dev: logged in, selected OPD, settled a normal single-item OPD bill (Hospital Charges, Rs 300, with referral doctor set). Settle succeeded and navigated to `opd_batch_bill_print.xhtml` as expected.
- Verified in local MySQL: resulting bill has `NETTOTAL=300` and exactly **1** `BillItem` row, plus the batch bill with 1 payment row — confirming the new guard does not interfere with the normal happy path.
- Ran the identical flow against an unmodified `development` baseline first, to rule out interference from an unrelated pre-existing session-scoped bug (`billSettlingStarted` flag not reset after an exception) encountered mid-investigation — confirmed not caused by this change.

Closes #22399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OPD bill settlement reliability by detecting when bill items fail to save.
  * Settlement now stops with a clear error message when required items are not persisted.
  * Added validation to prevent completing department or category-based bills without saved items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->