### PR TITLE
fix(inward): rebuild interim bill search with working filters and DTO backend

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -16110,56 +16110,6 @@ public class SearchController implements Serializable {
 
     }
 
-    public void createInwardIntrimBills() {
-        Date startTime = new Date();
-
-        String sql;
-        Map temMap = new HashMap();
-        sql = "select b from BilledBill b where"
-                + " b.billType = :billType and "
-                + " b.createdAt between :fromDate and :toDate "
-                + "and b.retired=false ";
-
-        if (getSearchKeyword().getPatientName() != null && !getSearchKeyword().getPatientName().trim().equals("")) {
-            sql += " and  ((b.patientEncounter.patient.person.name) like :patientName )";
-            temMap.put("patientName", "%" + getSearchKeyword().getPatientName().trim().toUpperCase() + "%");
-        }
-
-        if (getSearchKeyword().getNumber() != null && !getSearchKeyword().getNumber().trim().equals("")) {
-            sql += " and  (((b.patientEncounter.patient.code) =:number ) or ((b.patientEncounter.patient.phn) =:number )) ";
-            temMap.put("number", getSearchKeyword().getNumber().trim().toUpperCase());
-        }
-
-        if (getSearchKeyword().getPatientPhone() != null && !getSearchKeyword().getPatientPhone().trim().equals("")) {
-            sql += " and  ((b.patientEncounter.patient.person.phone) like :patientPhone )";
-            temMap.put("patientPhone", "%" + getSearchKeyword().getPatientPhone().trim().toUpperCase() + "%");
-        }
-
-        if (getSearchKeyword().getBhtNo() != null && !getSearchKeyword().getBhtNo().trim().equals("")) {
-            sql += " and  ((b.patientEncounter.bhtNo) like :bht )";
-            temMap.put("bht", "%" + getSearchKeyword().getBhtNo().trim().toUpperCase() + "%");
-        }
-
-        if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().equals("")) {
-            sql += " and  ((b.insId) like :billNo )";
-            temMap.put("billNo", "%" + getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
-        }
-
-        if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
-            sql += " and  ((b.netTotal) = :netTotal )";
-            temMap.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
-        }
-
-        sql += " order by b.insId desc  ";
-
-        temMap.put("billType", BillType.InwardIntrimBill);
-        temMap.put("toDate", toDate);
-        temMap.put("fromDate", fromDate);
-
-        bills = getBillFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP, 50);
-
-    }
-
     public void createInwardPaymentBills() {
         Date startTime = new Date();
 

--- a/src/main/java/com/divudi/bean/inward/InwardIntrimBillSearchController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardIntrimBillSearchController.java
@@ -45,6 +45,13 @@ import javax.persistence.TemporalType;
 @SessionScoped
 public class InwardIntrimBillSearchController implements Serializable {
 
+    /**
+     * Matches the row cap the previous entity-based
+     * SearchController#createInwardIntrimBills() used, to avoid pulling an
+     * unbounded result set into memory for a wide date range.
+     */
+    private static final int MAX_RESULTS = 50;
+
     @EJB
     private BillFacade billFacade;
     @EJB
@@ -107,17 +114,17 @@ public class InwardIntrimBillSearchController implements Serializable {
         params.put("toDate", toDate);
 
         if (billNo != null && !billNo.trim().isEmpty()) {
-            jpql += " AND b.deptId like :billNo ";
+            jpql += " AND UPPER(b.deptId) like :billNo ";
             params.put("billNo", "%" + billNo.trim().toUpperCase() + "%");
         }
 
         if (bhtNo != null && !bhtNo.trim().isEmpty()) {
-            jpql += " AND pe.bhtNo like :bhtNo ";
+            jpql += " AND UPPER(pe.bhtNo) like :bhtNo ";
             params.put("bhtNo", "%" + bhtNo.trim().toUpperCase() + "%");
         }
 
         if (patientName != null && !patientName.trim().isEmpty()) {
-            jpql += " AND per.name like :patientName ";
+            jpql += " AND UPPER(per.name) like :patientName ";
             params.put("patientName", "%" + patientName.trim().toUpperCase() + "%");
         }
 
@@ -127,13 +134,13 @@ public class InwardIntrimBillSearchController implements Serializable {
         }
 
         if (patientPhone != null && !patientPhone.trim().isEmpty()) {
-            jpql += " AND per.phone like :patientPhone ";
+            jpql += " AND UPPER(per.phone) like :patientPhone ";
             params.put("patientPhone", "%" + patientPhone.trim().toUpperCase() + "%");
         }
 
         if (patientIdentityNumber != null && !patientIdentityNumber.trim().isEmpty()) {
-            jpql += " AND per.nic = :nic ";
-            params.put("nic", patientIdentityNumber.trim());
+            jpql += " AND UPPER(per.nic) = :nic ";
+            params.put("nic", patientIdentityNumber.trim().toUpperCase());
         }
 
         if (referringDoctor != null) {
@@ -142,7 +149,7 @@ public class InwardIntrimBillSearchController implements Serializable {
         }
 
         if (occupation != null && !occupation.trim().isEmpty()) {
-            jpql += " AND occ.name like :occ ";
+            jpql += " AND UPPER(occ.name) like :occ ";
             params.put("occ", "%" + occupation.trim().toUpperCase() + "%");
         }
 
@@ -190,7 +197,7 @@ public class InwardIntrimBillSearchController implements Serializable {
 
         jpql += " order by b.createdAt desc ";
 
-        results = (List<InwardIntrimBillSearchDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+        results = (List<InwardIntrimBillSearchDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, MAX_RESULTS);
     }
 
     public String viewInterimBill() {
@@ -200,6 +207,10 @@ public class InwardIntrimBillSearchController implements Serializable {
         }
         Bill b = billService.reloadBill(billId);
         if (b == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        if (b.getBillType() != BillType.InwardIntrimBill) {
             JsfUtil.addErrorMessage("Bill not found");
             return null;
         }

--- a/src/main/java/com/divudi/bean/inward/InwardIntrimBillSearchController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardIntrimBillSearchController.java
@@ -1,0 +1,355 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.dto.InwardIntrimBillSearchDTO;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.BillService;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+
+/**
+ * Search + view controller for inward interim bills (BillType.InwardIntrimBill),
+ * DTO-driven (issue #1009). Replaces SearchController#createInwardIntrimBills(),
+ * whose "Total"/"Net Total" filters were broken (Total was never read; Net Total
+ * put a wildcarded String into a double-typed JPQL parameter) and which returned
+ * full entity graphs instead of a lightweight DTO.
+ *
+ * Every InwardIntrimBill is tied 1:1 to an Admission/PatientEncounter via
+ * {@code Bill.patientEncounter}, so the filters here mirror
+ * {@link AdmissionController#searchAdmissions()} / inward/inpatient_search.xhtml
+ * instead of reintroducing a Total/Net Total search on a running (in-progress)
+ * total that is not meaningful to exact-match.
+ *
+ * @author Buddhika
+ */
+@Named
+@SessionScoped
+public class InwardIntrimBillSearchController implements Serializable {
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillService billService;
+
+    @Inject
+    private InwardSearch inwardSearch;
+
+    // <editor-fold defaultstate="collapsed" desc="Search Filters">
+    private Date fromDate;
+    private Date toDate;
+    private String billNo;
+    private String bhtNo;
+    private String patientName;
+    private String mrnOrPhn;
+    private String patientPhone;
+    private String patientIdentityNumber;
+    private Staff referringDoctor;
+    private String occupation;
+    private Institution creditCompany;
+    private AdmissionStatus admissionStatus;
+    private AdmissionType admissionType;
+    private Institution institution;
+    private Department department;
+    /**
+     * UI-only narrowing for the Department dropdown (mirrors
+     * AdmissionController#site) - not used as a JPQL predicate here.
+     */
+    private Institution site;
+    // </editor-fold>
+
+    private List<InwardIntrimBillSearchDTO> results;
+    private Long billId;
+
+    public void search() {
+        if (fromDate == null || toDate == null) {
+            JsfUtil.addErrorMessage("Please select date");
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        String jpql = "SELECT NEW com.divudi.core.data.dto.InwardIntrimBillSearchDTO("
+                + "b.id, b.deptId, pe.bhtNo, b.createdAt, b.cancelled, cb.createdAt, cbcp.name, "
+                + "bcrp.name, per.name, b.paymentMethod, b.total, cb.comments, rb.comments) "
+                + "FROM BilledBill b "
+                + "LEFT JOIN b.patientEncounter pe "
+                + "LEFT JOIN pe.patient p "
+                + "LEFT JOIN p.person per "
+                + "LEFT JOIN per.occupation occ "
+                + "LEFT JOIN b.creater bcr "
+                + "LEFT JOIN bcr.webUserPerson bcrp "
+                + "LEFT JOIN b.cancelledBill cb "
+                + "LEFT JOIN cb.creater cbc "
+                + "LEFT JOIN cbc.webUserPerson cbcp "
+                + "LEFT JOIN b.refundedBill rb "
+                + "WHERE b.billType = :billType AND b.retired = false "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate ";
+        params.put("billType", BillType.InwardIntrimBill);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (billNo != null && !billNo.trim().isEmpty()) {
+            jpql += " AND b.deptId like :billNo ";
+            params.put("billNo", "%" + billNo.trim().toUpperCase() + "%");
+        }
+
+        if (bhtNo != null && !bhtNo.trim().isEmpty()) {
+            jpql += " AND pe.bhtNo like :bhtNo ";
+            params.put("bhtNo", "%" + bhtNo.trim().toUpperCase() + "%");
+        }
+
+        if (patientName != null && !patientName.trim().isEmpty()) {
+            jpql += " AND per.name like :patientName ";
+            params.put("patientName", "%" + patientName.trim().toUpperCase() + "%");
+        }
+
+        if (mrnOrPhn != null && !mrnOrPhn.trim().isEmpty()) {
+            jpql += " AND (p.code = :mrnOrPhn OR p.phn = :mrnOrPhn) ";
+            params.put("mrnOrPhn", mrnOrPhn.trim().toUpperCase());
+        }
+
+        if (patientPhone != null && !patientPhone.trim().isEmpty()) {
+            jpql += " AND per.phone like :patientPhone ";
+            params.put("patientPhone", "%" + patientPhone.trim().toUpperCase() + "%");
+        }
+
+        if (patientIdentityNumber != null && !patientIdentityNumber.trim().isEmpty()) {
+            jpql += " AND per.nic = :nic ";
+            params.put("nic", patientIdentityNumber.trim());
+        }
+
+        if (referringDoctor != null) {
+            jpql += " AND pe.referringDoctor = :refDoc ";
+            params.put("refDoc", referringDoctor);
+        }
+
+        if (occupation != null && !occupation.trim().isEmpty()) {
+            jpql += " AND occ.name like :occ ";
+            params.put("occ", "%" + occupation.trim().toUpperCase() + "%");
+        }
+
+        if (creditCompany != null) {
+            jpql += " AND pe.creditCompany = :cc ";
+            params.put("cc", creditCompany);
+        }
+
+        if (admissionStatus != null) {
+            switch (admissionStatus) {
+                case ADMITTED_BUT_NOT_DISCHARGED:
+                    jpql += " AND pe.discharged = :dis ";
+                    params.put("dis", false);
+                    break;
+                case DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED:
+                    jpql += " AND pe.discharged = :dis AND pe.paymentFinalized = :bf ";
+                    params.put("dis", true);
+                    params.put("bf", false);
+                    break;
+                case DISCHARGED_AND_FINAL_BILL_COMPLETED:
+                    jpql += " AND pe.discharged = :dis AND pe.paymentFinalized = :bf ";
+                    params.put("dis", true);
+                    params.put("bf", true);
+                    break;
+                case ANY_STATUS:
+                default:
+                    break;
+            }
+        }
+
+        if (institution != null) {
+            jpql += " AND pe.institution = :ins ";
+            params.put("ins", institution);
+        }
+
+        if (department != null) {
+            jpql += " AND pe.department = :dept ";
+            params.put("dept", department);
+        }
+
+        if (admissionType != null) {
+            jpql += " AND pe.admissionType = :at ";
+            params.put("at", admissionType);
+        }
+
+        jpql += " order by b.createdAt desc ";
+
+        results = (List<InwardIntrimBillSearchDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
+    public String viewInterimBill() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        Bill b = billService.reloadBill(billId);
+        if (b == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        inwardSearch.setBill(b);
+        return "/inward/inward_reprint_bill_intrim?faces-redirect=true";
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public String getBillNo() {
+        return billNo;
+    }
+
+    public void setBillNo(String billNo) {
+        this.billNo = billNo;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public void setBhtNo(String bhtNo) {
+        this.bhtNo = bhtNo;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getMrnOrPhn() {
+        return mrnOrPhn;
+    }
+
+    public void setMrnOrPhn(String mrnOrPhn) {
+        this.mrnOrPhn = mrnOrPhn;
+    }
+
+    public String getPatientPhone() {
+        return patientPhone;
+    }
+
+    public void setPatientPhone(String patientPhone) {
+        this.patientPhone = patientPhone;
+    }
+
+    public String getPatientIdentityNumber() {
+        return patientIdentityNumber;
+    }
+
+    public void setPatientIdentityNumber(String patientIdentityNumber) {
+        this.patientIdentityNumber = patientIdentityNumber;
+    }
+
+    public Staff getReferringDoctor() {
+        return referringDoctor;
+    }
+
+    public void setReferringDoctor(Staff referringDoctor) {
+        this.referringDoctor = referringDoctor;
+    }
+
+    public String getOccupation() {
+        return occupation;
+    }
+
+    public void setOccupation(String occupation) {
+        this.occupation = occupation;
+    }
+
+    public Institution getCreditCompany() {
+        return creditCompany;
+    }
+
+    public void setCreditCompany(Institution creditCompany) {
+        this.creditCompany = creditCompany;
+    }
+
+    public AdmissionStatus getAdmissionStatus() {
+        return admissionStatus;
+    }
+
+    public void setAdmissionStatus(AdmissionStatus admissionStatus) {
+        this.admissionStatus = admissionStatus;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    public Department getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    public Institution getSite() {
+        return site;
+    }
+
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    public List<InwardIntrimBillSearchDTO> getResults() {
+        return results;
+    }
+
+    public void setResults(List<InwardIntrimBillSearchDTO> results) {
+        this.results = results;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+    // </editor-fold>
+}

--- a/src/main/java/com/divudi/core/data/dto/InwardIntrimBillSearchDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardIntrimBillSearchDTO.java
@@ -1,0 +1,101 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.PaymentMethod;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for inward interim bill (BillType.InwardIntrimBill) search.
+ * Used by InwardIntrimBillSearchController / inward/inward_search_intrim.xhtml.
+ *
+ * Loaded directly via a SELECT NEW JPQL constructor query
+ * (InwardIntrimBillSearchController#search) - never build this from an
+ * entity-to-DTO conversion loop.
+ */
+public class InwardIntrimBillSearchDTO implements Serializable {
+
+    private Long id;
+    private String deptId;
+    private String bhtNo;
+    private Date createdAt;
+    private Boolean cancelled;
+    private Date cancelledAt;
+    private String cancelledByName;
+    private String createrName;
+    private String patientName;
+    private PaymentMethod paymentMethod;
+    private Double total;
+    private String cancelledComments;
+    private String refundedComments;
+
+    public InwardIntrimBillSearchDTO() {
+    }
+
+    public InwardIntrimBillSearchDTO(
+            Long id,
+            String deptId,
+            String bhtNo,
+            Date createdAt,
+            Boolean cancelled,
+            Date cancelledAt,
+            String cancelledByName,
+            String createrName,
+            String patientName,
+            PaymentMethod paymentMethod,
+            Double total,
+            String cancelledComments,
+            String refundedComments) {
+        this.id = id;
+        this.deptId = deptId;
+        this.bhtNo = bhtNo;
+        this.createdAt = createdAt;
+        this.cancelled = cancelled;
+        this.cancelledAt = cancelledAt;
+        this.cancelledByName = cancelledByName;
+        this.createrName = createrName;
+        this.patientName = patientName;
+        this.paymentMethod = paymentMethod;
+        this.total = total;
+        this.cancelledComments = cancelledComments;
+        this.refundedComments = refundedComments;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+
+    public String getBhtNo() { return bhtNo; }
+    public void setBhtNo(String bhtNo) { this.bhtNo = bhtNo; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public Boolean getCancelled() { return cancelled; }
+    public void setCancelled(Boolean cancelled) { this.cancelled = cancelled; }
+
+    public Date getCancelledAt() { return cancelledAt; }
+    public void setCancelledAt(Date cancelledAt) { this.cancelledAt = cancelledAt; }
+
+    public String getCancelledByName() { return cancelledByName; }
+    public void setCancelledByName(String cancelledByName) { this.cancelledByName = cancelledByName; }
+
+    public String getCreaterName() { return createrName; }
+    public void setCreaterName(String createrName) { this.createrName = createrName; }
+
+    public String getPatientName() { return patientName; }
+    public void setPatientName(String patientName) { this.patientName = patientName; }
+
+    public PaymentMethod getPaymentMethod() { return paymentMethod; }
+    public void setPaymentMethod(PaymentMethod paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public Double getTotal() { return total; }
+    public void setTotal(Double total) { this.total = total; }
+
+    public String getCancelledComments() { return cancelledComments; }
+    public void setCancelledComments(String cancelledComments) { this.cancelledComments = cancelledComments; }
+
+    public String getRefundedComments() { return refundedComments; }
+    public void setRefundedComments(String refundedComments) { this.refundedComments = refundedComments; }
+}

--- a/src/main/webapp/inward/inward_reprint_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_intrim.xhtml
@@ -37,7 +37,7 @@
                                         <h:outputText styleClass="fas fa-id-card-alt"></h:outputText>
                                         <h:outputLabel value="Patient Details" class="mx-2"></h:outputLabel>
                                     </f:facet>
-                                    <common:patient patient="#{billSearch.bill.patient}" class="w-100"/>
+                                    <common:patient patient="#{inwardSearch.bill.patientEncounter.patient}" class="w-100"/>
                                 </p:panel>
                             </div>
                             <div class="col-6">

--- a/src/main/webapp/inward/inward_search_intrim.xhtml
+++ b/src/main/webapp/inward/inward_search_intrim.xhtml
@@ -19,7 +19,7 @@
                             <div class="col-2">
                                 <h:outputLabel value="From Date"/>
                                 <p:datePicker
-                                    value="#{searchController.fromDate}"
+                                    value="#{inwardIntrimBillSearchController.fromDate}"
                                     class="w-100"
                                     showTime="true"
                                     showButtonBar="true"
@@ -31,7 +31,7 @@
 
                                 <h:outputLabel value="To Date"/>
                                 <p:datePicker
-                                    value="#{searchController.toDate}"
+                                    value="#{inwardIntrimBillSearchController.toDate}"
                                     class="w-100"
                                     showTime="true"
                                     showButtonBar="true"
@@ -45,31 +45,126 @@
                                     class="mt-2 w-100 mb-3 ui-button-warning"
                                     icon="fa-solid fa-search"
                                     ajax="false"
-                                    action="#{searchController.createInwardIntrimBills()}"
+                                    action="#{inwardIntrimBillSearchController.search()}"
                                     value="Search"  >
                                 </p:commandButton>
-                                
+
                                 <hr/>
 
                                 <h:outputLabel value="Bill No"/>
-                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" class="w-100" />
+                                <p:inputText autocomplete="off"  value="#{inwardIntrimBillSearchController.billNo}" class="w-100" />
                                 <h:outputLabel value="BHT No"/>
-                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.bhtNo}" class="w-100"/>
+                                <p:inputText autocomplete="off"  value="#{inwardIntrimBillSearchController.bhtNo}" class="w-100"/>
                                 <h:outputLabel value="Patient Name"/>
-                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.patientName}" class="w-100"/>
+                                <p:inputText autocomplete="off" value="#{inwardIntrimBillSearchController.patientName}" class="w-100"/>
                                 <h:outputLabel value="MRN / PHN No"/>
-                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.number}" class="w-100"/>
+                                <p:inputText autocomplete="off" value="#{inwardIntrimBillSearchController.mrnOrPhn}" class="w-100"/>
                                 <h:outputLabel value="Patient Phone"/>
-                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.patientPhone}" class="w-100"/>
-                                <h:outputLabel value="Total"/>
-                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.total}" class="w-100"/>
-                                <h:outputLabel value="Net Total"/>
-                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}" class="w-100"/>
+                                <p:inputText autocomplete="off"  value="#{inwardIntrimBillSearchController.patientPhone}" class="w-100"/>
+
+                                <h:outputLabel value="Patient NIC / Passport"/>
+                                <p:inputText autocomplete="off" value="#{inwardIntrimBillSearchController.patientIdentityNumber}" class="w-100"/>
+
+                                <h:outputLabel value="Referring Doctor"/>
+                                <p:autoComplete
+                                    forceSelection="true"
+                                    id="cmbDoc"
+                                    value="#{inwardIntrimBillSearchController.referringDoctor}"
+                                    completeMethod="#{doctorController.completeDoctor}"
+                                    var="ix"
+                                    class="w-100"
+                                    inputStyleClass="form-control">
+                                    <p:column headerText="Name">
+                                        <h:outputLabel value="#{ix.person.nameWithTitle}"></h:outputLabel>
+                                    </p:column>
+                                    <p:column headerText="Speciality">
+                                        <h:outputLabel value="#{ix.speciality.name}"></h:outputLabel>
+                                    </p:column>
+                                </p:autoComplete>
+
+                                <h:outputLabel value="Occupation"/>
+                                <p:inputText autocomplete="off" value="#{inwardIntrimBillSearchController.occupation}" class="w-100"/>
+
+                                <h:outputLabel value="Insurance Company"/>
+                                <p:selectOneMenu
+                                    class="w-100"
+                                    value="#{inwardIntrimBillSearchController.creditCompany}"
+                                    filter="true"
+                                    autoWidth="false"
+                                    >
+                                    <f:selectItem itemLabel="All"></f:selectItem>
+                                    <f:selectItems value="#{institutionController.creditCompanies}" var="cc" itemLabel="#{cc.name}" itemValue="#{cc}" />
+                                </p:selectOneMenu>
+
+                                <h:outputLabel value="Status"/>
+                                <p:selectOneMenu
+                                    class="w-100"
+                                    value="#{inwardIntrimBillSearchController.admissionStatus}" >
+                                    <f:selectItem itemLabel="Any Status"></f:selectItem>
+                                    <f:selectItems value="#{enumController.admissionStatuses}"
+                                                   var="status"
+                                                   itemValue="#{status}" itemLabel="#{status.label}" />
+                                </p:selectOneMenu>
+
+                                <h:outputLabel value="Admission Type"/>
+                                <p:selectOneMenu
+                                    class="w-100"
+                                    value="#{inwardIntrimBillSearchController.admissionType}" >
+                                    <f:selectItem itemLabel="All"></f:selectItem>
+                                    <f:selectItems value="#{admissionTypeController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" />
+                                </p:selectOneMenu>
+
+                                <h:outputLabel value="Institution"/>
+                                <p:selectOneMenu
+                                    class="w-100"
+                                    id="cmbInstitution"
+                                    value="#{inwardIntrimBillSearchController.institution}"
+                                    filter="true"
+                                    autoWidth="false"
+                                    >
+                                    <f:selectItem itemLabel="All"></f:selectItem>
+                                    <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                    <p:ajax process="@this"
+                                            update=":#{p:resolveFirstComponentWithId('cmbDepartment',view).clientId}" />
+                                </p:selectOneMenu>
+
+                                <h:panelGroup  rendered="#{webUserController.hasPrivilege('InwardSearchServiceBillUnrestrictedAccess') or !configOptionApplicationController.getBooleanValueByKey('Restirct Inward Admission Search to Logged Department of the User')}" >
+                                    <h:outputLabel value="Site"/>
+                                    <p:selectOneMenu
+                                        class="w-100"
+                                        id="cmbSite"
+                                        value="#{inwardIntrimBillSearchController.site}"
+                                        filter="true"
+                                        autoWidth="false"
+                                        >
+                                        <f:selectItem itemLabel="All"></f:selectItem>
+                                        <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
+                                        <p:ajax process="@this"
+                                                update=":#{p:resolveFirstComponentWithId('cmbDepartment',view).clientId}" />
+                                    </p:selectOneMenu>
+
+                                    <h:outputLabel value="Department"/>
+                                    <p:selectOneMenu
+                                        class="w-100"
+                                        id="cmbDepartment"
+                                        value="#{inwardIntrimBillSearchController.department}"
+                                        filter="true"
+                                        autoWidth="false"
+                                        >
+                                        <f:selectItem itemLabel="All"></f:selectItem>
+                                        <f:selectItems
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite(inwardIntrimBillSearchController.institution,inwardIntrimBillSearchController.site)}"
+                                            var="d"
+                                            itemLabel="#{d.name}"
+                                            itemValue="#{d}" />
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
+
                             </div>
                             <div class="col-10 ">
                                 <p:dataTable
                                     id="tblBills"
-                                    value="#{searchController.bills}"
+                                    value="#{inwardIntrimBillSearchController.results}"
                                     var="bb"
                                     rowKey="#{bb.id}"
                                     paginator="true"
@@ -87,7 +182,7 @@
                                     </p:column>
 
                                     <p:column headerText="BHT No" >
-                                        <h:outputLabel value="#{bb.patientEncounter.bhtNo}" ></h:outputLabel>
+                                        <h:outputLabel value="#{bb.bhtNo}" ></h:outputLabel>
                                     </p:column>
 
                                     <p:column headerText="Billed At" >
@@ -95,25 +190,25 @@
                                         <br/>
                                         <h:panelGroup rendered="#{bb.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled at " />
-                                            <h:outputLabel style="color: red;" rendered="#{bb.cancelled}" value="#{bb.cancelledBill.createdAt}" >
+                                            <h:outputLabel style="color: red;" rendered="#{bb.cancelled}" value="#{bb.cancelledAt}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </h:panelGroup>
                                     </p:column>
 
                                     <p:column headerText="Billed By">
-                                        <h:outputLabel value="#{bb.creater.webUserPerson.name}" >
+                                        <h:outputLabel value="#{bb.createrName}" >
                                         </h:outputLabel>
                                         <br/>
                                         <h:panelGroup rendered="#{bb.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled By " />
-                                            <h:outputLabel style="color: red;" rendered="#{bb.cancelled}" value="#{bb.cancelledBill.creater.webUserPerson.name}" >
+                                            <h:outputLabel style="color: red;" rendered="#{bb.cancelled}" value="#{bb.cancelledByName}" >
                                             </h:outputLabel>
                                         </h:panelGroup>
                                     </p:column>
 
                                     <p:column headerText="Client" >
-                                        <h:outputLabel value="#{bb.patientEncounter.patient.person.nameWithTitle}" ></h:outputLabel>
+                                        <h:outputLabel value="#{bb.patientName}" ></h:outputLabel>
                                     </p:column>
                                     <p:column headerText="Payment Method">
                                         <h:outputLabel value="#{bb.paymentMethod}" ></h:outputLabel>
@@ -124,14 +219,14 @@
                                         </h:outputLabel>
                                     </p:column>
                                     <p:column headerText="Comments" >
-                                        <h:outputLabel rendered="#{bb.refundedBill ne null}" value="#{bb.refundedBill.comments}" >
+                                        <h:outputLabel rendered="#{bb.refundedComments ne null}" value="#{bb.refundedComments}" >
                                         </h:outputLabel>
-                                        <h:outputLabel  rendered="#{bb.cancelledBill ne null}" value="#{bb.cancelledBill.comments}" >
+                                        <h:outputLabel  rendered="#{bb.cancelledComments ne null}" value="#{bb.cancelledComments}" >
                                         </h:outputLabel>
                                     </p:column>
                                     <p:column headerText="Action">
-                                        <p:commandButton ajax="false" value="View Bill" action="inward_reprint_bill_intrim"  >
-                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
+                                        <p:commandButton ajax="false" value="View Bill" action="#{inwardIntrimBillSearchController.viewInterimBill()}"  >
+                                            <f:setPropertyActionListener value="#{bb.id}" target="#{inwardIntrimBillSearchController.billId}"/>
                                         </p:commandButton>
                                     </p:column>
                                 </p:dataTable>


### PR DESCRIPTION
## Summary

- Fixes #1009 — "Interim bill search not working". Root cause: the **Total** filter was bound in the UI but never read by the query, and **Net Total** put a wildcarded string into a `double`-typed JPQL parameter (type mismatch), breaking the search whenever it was used.
- Since both fields are running totals on an in-progress admission (not meaningful to exact-match search), they're removed and replaced with the same filter set already proven on the Admissions search page (BHT No, Patient Name, MRN/PHN, Patient Phone, NIC/Passport, Referring Doctor, Occupation, Insurance Company, Admission Status, Admission Type, Institution, Department) — every interim bill is tied 1:1 to an admission via `Bill.patientEncounter`.
- Converted the page's backend from an entity-based query on the shared `SearchController` (`bills`/`getBills()` used by ~150 other pages, left untouched) to a new, isolated DTO-based controller (`InwardIntrimBillSearchController` + `InwardIntrimBillSearchDTO`), following the existing `PharmacyBillSearch` pattern in this codebase.
- Found and fixed a related bug while verifying: `inward_reprint_bill_intrim.xhtml` (opened by "View Bill") read its Patient Details panel from `billSearch.bill.patient` — an unrelated session bean never populated by this flow — and from `Bill.patient`, which is legitimately `NULL` for interim bills (only `Bill.patientEncounter.patient` is set when an interim bill is created). Now correctly reads `inwardSearch.bill.patientEncounter.patient`.

## Test plan

- [x] Rebuilt and redeployed locally (`mvn clean package` + `asadmin redeploy`)
- [x] Searched interim bills by date range only — confirmed the one seeded `InwardIntrimBill` record (`BHT/50545`) returns correctly via the new DTO query
- [x] Confirmed BHT No filter includes a matching value and excludes a non-matching one
- [x] Confirmed Admission Status filter correctly excludes the (discharged) test record when set to "Admitted but not discharged"
- [x] Confirmed the Total/Net Total inputs no longer appear on the page
- [x] Clicked "View Bill" and confirmed the reprint page now shows the correct patient in the Patient Details panel, plus correct bill items/totals
- [x] Checked `server.log` throughout — no JPQL/EL errors

![Interim bill search results](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-1009-interim-bill-search.png)

![View Bill — Patient Details now populated correctly](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-1009-interim-bill-reprint-patient-panel.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expanded inward interim bill search with filters for dates, patient details, admission information, referring doctor, insurance, institution, site, and department.
  * Added clearer, lightweight search results showing billing, patient, payment, cancellation, and refund information.
  * Added direct navigation from search results to the interim bill reprint view.

* **Bug Fixes**
  * Corrected patient details displayed on the interim bill reprint page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->