### PR TITLE
Add Custom Bills tab with Custom2 A4 format to Inward Final Bill Reprint

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1113,6 +1113,36 @@ rendered and the browser console showed `initOtpBoxes is not defined` and
 `startOtpCountdown is not defined` — errors that look like a missing/renamed
 JS function, not a stray HTML entity three screens away in the same script tag.
 
+## 46. A fixed-position status banner (e.g. "Database Migration Pending") can silently swallow every click on the page below it
+
+When a global banner is rendered with fixed/sticky positioning and no
+`pointer-events: none`, Playwright's actionability check reports the target
+element as "visible, enabled and stable" and still fails the click with
+`<div class="nonPrintBlock">…</div> intercepts pointer events` — this can hit
+*any* element on the page, not just ones physically near the banner, if the
+banner's box overlaps them in the stacking order. Real symptoms seen while
+verifying issue #22415 (Custom Bills tab): clicking a `p:tabView` tab header
+and a `p:commandButton` both timed out this way, even though the elements
+themselves were correctly rendered and enabled.
+
+Standard fixes (Escape, clicking a neutral area first, waiting) don't help
+because the banner isn't a transient overlay (like a datepicker popup) — it's
+a permanent part of the page layout. The reliable workaround is to bypass
+Playwright's actionability gate entirely and dispatch the click straight to
+the element via `browser_evaluate`:
+
+```js
+() => { document.getElementById('theActualElementId').click(); return 'clicked'; }
+```
+
+Get the id from the failed click's error output (it echoes the resolved
+locator's outer HTML, e.g. `id="j_idt524:j_idt867:j_idt3539_header"`). This
+is a real accessibility gap worth fixing in the banner itself (add
+`pointer-events: none` unless the banner has its own interactive controls,
+or `z-index`/positioning that keeps it from overlapping page content) — but
+until that's fixed, `browser_evaluate` + `.click()` is the dependable way to
+drive the page underneath it.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -11,6 +11,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.BillController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SessionController;
@@ -93,6 +94,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
@@ -161,6 +163,8 @@ public class BhtSummeryController implements Serializable {
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
+    ConfigOptionController configOptionController;
+    @Inject
     AdmissionController admissionController;
     @Inject
     InwardPaymentController inwardPaymentController;
@@ -206,6 +210,13 @@ public class BhtSummeryController implements Serializable {
     Date toDate;
     private Date date;
     private boolean printPreview;
+    //////////////////////////
+    // Custom2 (Custom Bills tab) print-format settings
+    private boolean custom2ShowAddress;
+    private boolean custom2ShowNic;
+    private boolean custom2ShowPhone;
+    private boolean custom2ShowGuardian;
+    private boolean custom2ShowCorporateSponsor;
     @Inject
     private InwardMemberShipDiscount inwardMemberShipDiscount;
     @Inject
@@ -428,6 +439,93 @@ public class BhtSummeryController implements Serializable {
             surgeryBill = surgeryBills.get(0);
         }
     }
+
+    // <editor-fold defaultstate="collapsed" desc="Custom Bills tab - Custom2 print format">
+    public void loadCustom2Config() {
+        custom2ShowAddress = configOptionController.getBooleanValueByKey("Inward Final Bill Custom2 - Show Patient Address", false);
+        custom2ShowNic = configOptionController.getBooleanValueByKey("Inward Final Bill Custom2 - Show Patient NIC", false);
+        custom2ShowPhone = configOptionController.getBooleanValueByKey("Inward Final Bill Custom2 - Show Patient Phone", false);
+        custom2ShowGuardian = configOptionController.getBooleanValueByKey("Inward Final Bill Custom2 - Show Guardian", true);
+        custom2ShowCorporateSponsor = configOptionController.getBooleanValueByKey("Inward Final Bill Custom2 - Show Corporate Sponsor", true);
+    }
+
+    public void saveCustom2Config() {
+        try {
+            configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Patient Address", custom2ShowAddress);
+            configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Patient NIC", custom2ShowNic);
+            configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Patient Phone", custom2ShowPhone);
+            configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Guardian", custom2ShowGuardian);
+            configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Corporate Sponsor", custom2ShowCorporateSponsor);
+            JsfUtil.addSuccessMessage("Custom Bills configuration saved successfully");
+            loadCustom2Config();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Error saving Custom Bills configuration: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Charges grouped by inward charge type (excluding Professional Charge, which is
+     * printed separately on the Professional Bill section), alphabetical by display
+     * name, for the Custom2 "Final Bill" totals-only section.
+     */
+    public List<Map.Entry<String, Double>> getCustom2CategoryTotals(Bill bill) {
+        Map<String, Double> totals = new TreeMap<>();
+        if (bill == null || bill.getBillItems() == null) {
+            return new ArrayList<>(totals.entrySet());
+        }
+        for (BillItem bi : bill.getBillItems()) {
+            if (bi.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                continue;
+            }
+            if (bi.getAdjustedValue() == 0.0) {
+                continue;
+            }
+            String label = bi.getInwardChargeType().getName();
+            totals.merge(label, bi.getAdjustedValue(), Double::sum);
+        }
+        return new ArrayList<>(totals.entrySet());
+    }
+
+    public boolean isCustom2ShowAddress() {
+        return custom2ShowAddress;
+    }
+
+    public void setCustom2ShowAddress(boolean custom2ShowAddress) {
+        this.custom2ShowAddress = custom2ShowAddress;
+    }
+
+    public boolean isCustom2ShowNic() {
+        return custom2ShowNic;
+    }
+
+    public void setCustom2ShowNic(boolean custom2ShowNic) {
+        this.custom2ShowNic = custom2ShowNic;
+    }
+
+    public boolean isCustom2ShowPhone() {
+        return custom2ShowPhone;
+    }
+
+    public void setCustom2ShowPhone(boolean custom2ShowPhone) {
+        this.custom2ShowPhone = custom2ShowPhone;
+    }
+
+    public boolean isCustom2ShowGuardian() {
+        return custom2ShowGuardian;
+    }
+
+    public void setCustom2ShowGuardian(boolean custom2ShowGuardian) {
+        this.custom2ShowGuardian = custom2ShowGuardian;
+    }
+
+    public boolean isCustom2ShowCorporateSponsor() {
+        return custom2ShowCorporateSponsor;
+    }
+
+    public void setCustom2ShowCorporateSponsor(boolean custom2ShowCorporateSponsor) {
+        this.custom2ShowCorporateSponsor = custom2ShowCorporateSponsor;
+    }
+    // </editor-fold>
 
     public String navigateToAddServiceFromSurgeriesFromAdmissionProfile() {
         if (surgeryBills == null) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -450,6 +450,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     public void saveCustom2Config() {
+        if (!webUserController.hasPrivilege("ChangeReceiptPrintingPaperTypes")) {
+            JsfUtil.addErrorMessage("You do not have privilege to change Custom Bills configuration");
+            return;
+        }
         try {
             configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Patient Address", custom2ShowAddress);
             configOptionController.setBooleanValueByKey("Inward Final Bill Custom2 - Show Patient NIC", custom2ShowNic);
@@ -480,7 +484,7 @@ public class BhtSummeryController implements Serializable {
             if (bi.getAdjustedValue() == 0.0) {
                 continue;
             }
-            String label = bi.getInwardChargeType().getName();
+            String label = getChargeTypeLabel(bi.getInwardChargeType());
             totals.merge(label, bi.getAdjustedValue(), Double::sum);
         }
         return new ArrayList<>(totals.entrySet());

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -576,6 +576,119 @@
                                         </h:panelGroup>
                                     </p:panel>
                                 </p:tab>
+
+                                <p:tab title="Custom Bills">
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary mx-1"
+                                            type="button"
+                                            onclick="PF('custom2ConfigDialog').show();" />
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-lg-6">
+                                            <p:panel>
+                                                <f:facet name="header">
+                                                    <div class="d-flex justify-content-between">
+                                                        <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                        <div>
+                                                            <p:commandButton
+                                                                icon="fa fa-print"
+                                                                value="Custom Bill"
+                                                                class="ui-button-info"
+                                                                ajax="false">
+                                                                <p:printer target="originalCustom2BillPriview" ></p:printer>
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
+                                                </f:facet>
+
+                                                <h:panelGroup id="originalCustom2BillPriview">
+                                                    <bi:finalBillCustom2 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false"/>
+                                                </h:panelGroup>
+
+                                            </p:panel>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <p:panel>
+                                                <f:facet name="header">
+                                                    <div class="d-flex justify-content-between">
+                                                        <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                        <div>
+                                                            <p:commandButton
+                                                                icon="fa fa-print"
+                                                                value="Custom Bill"
+                                                                class="ui-button-info"
+                                                                ajax="false">
+                                                                <p:printer target="duplicateCustom2BillPriview" ></p:printer>
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
+                                                </f:facet>
+
+                                                <h:panelGroup id="duplicateCustom2BillPriview">
+                                                    <bi:finalBillCustom2 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true"/>
+                                                </h:panelGroup>
+
+                                            </p:panel>
+                                        </div>
+                                    </div>
+
+                                    <p:dialog id="custom2ConfigDialog"
+                                              header="Custom Bills Printer Configuration"
+                                              widgetVar="custom2ConfigDialog"
+                                              modal="true"
+                                              width="600"
+                                              resizable="true"
+                                              closeOnEscape="true">
+
+                                        <p:ajax event="open" listener="#{bhtSummeryController.loadCustom2Config}" update="custom2ConfigForm" />
+
+                                        <h:form id="custom2ConfigForm">
+                                            <div class="card-body">
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox id="custom2ShowAddress" value="#{bhtSummeryController.custom2ShowAddress}" />
+                                                    <h:outputLabel for="custom2ShowAddress" value="Show Patient Address" class="ms-2" />
+                                                </div>
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox id="custom2ShowNic" value="#{bhtSummeryController.custom2ShowNic}" />
+                                                    <h:outputLabel for="custom2ShowNic" value="Show Patient NIC" class="ms-2" />
+                                                </div>
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox id="custom2ShowPhone" value="#{bhtSummeryController.custom2ShowPhone}" />
+                                                    <h:outputLabel for="custom2ShowPhone" value="Show Patient Phone" class="ms-2" />
+                                                </div>
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox id="custom2ShowGuardian" value="#{bhtSummeryController.custom2ShowGuardian}" />
+                                                    <h:outputLabel for="custom2ShowGuardian" value="Show Guardian" class="ms-2" />
+                                                </div>
+                                                <div class="mb-3">
+                                                    <h:selectBooleanCheckbox id="custom2ShowCorporateSponsor" value="#{bhtSummeryController.custom2ShowCorporateSponsor}" />
+                                                    <h:outputLabel for="custom2ShowCorporateSponsor" value="Show Corporate Sponsor" class="ms-2" />
+                                                </div>
+
+                                                <p:messages id="custom2ConfigMessages" showDetail="true" closable="true" />
+
+                                                <div class="d-flex gap-2">
+                                                    <p:commandButton
+                                                        value="Apply &amp; Close"
+                                                        icon="fas fa-save"
+                                                        class="ui-button-success"
+                                                        ajax="false"
+                                                        action="#{bhtSummeryController.saveCustom2Config}" />
+                                                    <p:commandButton
+                                                        value="Cancel"
+                                                        icon="fas fa-times"
+                                                        class="ui-button-secondary"
+                                                        onclick="PF('custom2ConfigDialog').hide(); return false;"
+                                                        type="button" />
+                                                </div>
+                                            </div>
+                                        </h:form>
+                                    </p:dialog>
+                                </p:tab>
                             </p:tabView>
 
                         </p:panel>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -646,7 +646,7 @@
 
                                         <p:ajax event="open" listener="#{bhtSummeryController.loadCustom2Config}" update="custom2ConfigForm" />
 
-                                        <h:form id="custom2ConfigForm">
+                                        <h:form id="custom2ConfigForm" rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
                                             <div class="card-body">
                                                 <div class="mb-3">
                                                     <h:selectBooleanCheckbox id="custom2ShowAddress" value="#{bhtSummeryController.custom2ShowAddress}" />

--- a/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
@@ -1,0 +1,347 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputStylesheet library="css" name="printing.css"/>
+
+        <h:panelGroup id="gpCustom2BillPreview">
+
+            <!-- ===================== PAGE 1 of 3 : FINAL BILL ===================== -->
+            <div class="a4bill" style="padding: 10px 25px;">
+
+                <div class="d-flex justify-content-end">
+                    <p:barcode value="#{cc.attrs.bill.patientEncounter.patient.phn}" cache="false" type="code128" style="height: 40px;"/>
+                </div>
+
+                <div style="text-align: center; font-size: 20px; font-weight: bold;">FINAL BILL</div>
+                <div style="text-align: right; font-weight: bold; font-size: 12px;">
+                    <h:outputLabel value="Duplicate Copy" rendered="#{cc.attrs.duplicate eq true}"/>
+                    <h:outputLabel value="Original Copy" rendered="#{cc.attrs.duplicate ne true}"/>
+                </div>
+
+                <div class="row mt-2" style="font-size: 12px;">
+                    <div class="col-6">
+                        <div class="d-flex mb-1">
+                            <span style="width: 140px;">Patient Name</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"/></span>
+                        </div>
+                        <div class="d-flex mb-1">
+                            <span style="width: 140px;">Patient MRD No.</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.phn}"/></span>
+                        </div>
+                        <h:panelGroup layout="block" styleClass="d-flex mb-1" rendered="#{configOptionController.getBooleanValueByKey('Inward Final Bill Custom2 - Show Guardian', true)}">
+                            <span style="width: 140px;">Guardian Name</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.guardian.nameWithTitle}"/></span>
+                        </h:panelGroup>
+                        <div class="d-flex mb-1">
+                            <span style="width: 140px;">BHT NO</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}"/></span>
+                        </div>
+                        <h:panelGroup layout="block" styleClass="d-flex mb-1" rendered="#{configOptionController.getBooleanValueByKey('Inward Final Bill Custom2 - Show Patient Address', false)}">
+                            <span style="width: 140px;">Address</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.address}"/></span>
+                        </h:panelGroup>
+                        <h:panelGroup layout="block" styleClass="d-flex mb-1" rendered="#{configOptionController.getBooleanValueByKey('Inward Final Bill Custom2 - Show Patient NIC', false)}">
+                            <span style="width: 140px;">NIC No</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nic}"/></span>
+                        </h:panelGroup>
+                        <h:panelGroup layout="block" styleClass="d-flex mb-1" rendered="#{configOptionController.getBooleanValueByKey('Inward Final Bill Custom2 - Show Patient Phone', false)}">
+                            <span style="width: 140px;">Phone No</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.phone}"/></span>
+                        </h:panelGroup>
+                    </div>
+                    <div class="col-6">
+                        <h:panelGroup layout="block" styleClass="d-flex mb-1" rendered="#{configOptionController.getBooleanValueByKey('Inward Final Bill Custom2 - Show Corporate Sponsor', true) and cc.attrs.bill.creditCompany ne null}">
+                            <span style="width: 160px;">Corporate Sponsor</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.creditCompany.name}"/></span>
+                        </h:panelGroup>
+                        <div class="d-flex mb-1">
+                            <span style="width: 160px;">Ward/Bed</span><span>:</span>
+                            <span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.currentPatientRoom.roomFacilityCharge.name}"/></span>
+                        </div>
+                        <div class="d-flex mb-1">
+                            <span style="width: 160px;">Admission date</span><span>:</span>
+                            <span class="ps-2">
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.printingAdmissionTime ne null and !cc.attrs.bill.patientEncounter.printingAdmissionTime.equals('') ? cc.attrs.bill.patientEncounter.printingAdmissionTime : cc.attrs.bill.patientEncounter.dateOfAdmission}">
+                                    <f:convertDateTime pattern="dd/MM/yyyy" />
+                                </h:outputLabel>
+                            </span>
+                        </div>
+                        <div class="d-flex mb-1">
+                            <span style="width: 160px;">Discharge Date</span><span>:</span>
+                            <span class="ps-2">
+                                <h:outputLabel value="#{cc.attrs.bill.patientEncounter.printingDischargeTime ne null and !cc.attrs.bill.patientEncounter.printingDischargeTime.equals('') ? cc.attrs.bill.patientEncounter.printingDischargeTime : cc.attrs.bill.patientEncounter.dateOfDischarge}">
+                                    <f:convertDateTime pattern="dd/MM/yyyy" />
+                                </h:outputLabel>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mt-3" style="font-size: 12px;">
+                    <table class="w-100">
+                        <tr>
+                            <td style="font-weight: bold;">Description</td>
+                            <td style="text-align: right; font-weight: bold;">Total Amount (LKR)</td>
+                        </tr>
+                        <ui:repeat value="#{bhtSummeryController.getCustom2CategoryTotals(cc.attrs.bill)}" var="entry">
+                            <tr>
+                                <td><h:outputLabel value="#{entry.key}"/></td>
+                                <td style="text-align: right;">
+                                    <h:outputLabel value="#{entry.value}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                        <tr style="border-top: 1px solid #000;">
+                            <td style="font-weight: bold;">Total Amount</td>
+                            <td style="text-align: right; font-weight: bold;">
+                                <h:outputLabel value="#{cc.attrs.bill.hospitalFee}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="d-flex justify-content-between mt-5" style="font-size: 11px;">
+                    <div>
+                        <div><b>Prepared By</b>&#160; <h:outputLabel value="#{cc.attrs.bill.creater.name}"/></div>
+                        <div><b>Generated By</b>&#160; <h:outputLabel value="#{sessionController.loggedUser.name}"/></div>
+                    </div>
+                    <div style="text-align: right;">
+                        <div><b>Prepared On</b>&#160;
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                        <div><b>Generated On</b>&#160;
+                            <h:outputLabel value="#{sessionController.currentDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                    </div>
+                </div>
+                <div style="text-align: center; font-size: 11px;">Page 1 of 3</div>
+            </div>
+
+            <!-- ===================== PAGE 2 of 3 : PROFESSIONAL BILL ===================== -->
+            <div class="a4bill" style="padding: 10px 25px;">
+
+                <div class="d-flex justify-content-end">
+                    <p:barcode value="#{cc.attrs.bill.patientEncounter.patient.phn}" cache="false" type="code128" style="height: 40px;"/>
+                </div>
+
+                <div style="text-align: center; font-size: 20px; font-weight: bold;">Professional Bill</div>
+                <div style="text-align: right; font-weight: bold; font-size: 12px;">
+                    <h:outputLabel value="Duplicate Copy" rendered="#{cc.attrs.duplicate eq true}"/>
+                    <h:outputLabel value="Original Copy" rendered="#{cc.attrs.duplicate ne true}"/>
+                </div>
+
+                <div class="mt-2" style="font-size: 12px;">
+                    <div class="d-flex mb-1"><span style="width: 120px;">BHT NO</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">MRN</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.phn}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">Patient Name</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">Invoice No</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.deptId}"/></span></div>
+                </div>
+
+                <table class="w-100 mt-3" style="font-size: 12px;">
+                    <tr>
+                        <td style="font-weight: bold;">Consultant Name</td>
+                        <td style="text-align: right; font-weight: bold;">Amount</td>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge'}">
+                            <ui:repeat value="#{bip.proFees}" var="fe">
+                                <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                    <tr>
+                                        <td>
+                                            <h:outputLabel value="#{fe.staff.person.nameWithTitle}"/>
+                                            <h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/>
+                                        </td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{fe.feeAdjusted}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
+                            </ui:repeat>
+                        </h:panelGroup>
+                    </ui:repeat>
+                    <tr style="border-top: 1px solid #000;">
+                        <td style="font-weight: bold;">Total Amount</td>
+                        <td style="text-align: right; font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.bill.professionalFee}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+
+                <div class="d-flex justify-content-between mt-5" style="font-size: 11px;">
+                    <div>
+                        <div><b>Prepared By</b>&#160; <h:outputLabel value="#{cc.attrs.bill.creater.name}"/></div>
+                        <div><b>Generated By</b>&#160; <h:outputLabel value="#{sessionController.loggedUser.name}"/></div>
+                    </div>
+                    <div style="text-align: right;">
+                        <div><b>Prepared On</b>&#160;
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                        <div><b>Generated On</b>&#160;
+                            <h:outputLabel value="#{sessionController.currentDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                    </div>
+                </div>
+                <div style="text-align: center; font-size: 11px;">Page 2 of 3</div>
+            </div>
+
+            <!-- ===================== PAGE 3 of 3 : FINAL BILL SUMMARY ===================== -->
+            <div class="a4bill" style="padding: 10px 25px;">
+
+                <div class="d-flex justify-content-end">
+                    <p:barcode value="#{cc.attrs.bill.patientEncounter.patient.phn}" cache="false" type="code128" style="height: 40px;"/>
+                </div>
+
+                <div style="text-align: center; font-size: 20px; font-weight: bold;">Final Bill Summary</div>
+                <div style="text-align: right; font-weight: bold; font-size: 12px;">
+                    <h:outputLabel value="Duplicate Copy" rendered="#{cc.attrs.duplicate eq true}"/>
+                    <h:outputLabel value="Original Copy" rendered="#{cc.attrs.duplicate ne true}"/>
+                </div>
+
+                <div class="mt-2" style="font-size: 12px;">
+                    <div class="d-flex mb-1"><span style="width: 120px;">BHT NO</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">MRN</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.phn}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">Patient Name</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"/></span></div>
+                    <div class="d-flex mb-1"><span style="width: 120px;">Invoice No</span><span>:</span><span class="ps-2"><h:outputLabel value="#{cc.attrs.bill.deptId}"/></span></div>
+                </div>
+
+                <table class="w-100 mt-3" style="font-size: 12px;">
+                    <tr>
+                        <td>Hospital Bill Total</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.hospitalFee}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                    </tr>
+                    <tr>
+                        <td>Professional Bill Total</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.professionalFee}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                    </tr>
+                    <tr style="font-weight: bold; border-top: 1px solid #000;">
+                        <td>Net Total</td>
+                        <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.netTotal}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                    </tr>
+                </table>
+
+                <!-- No "sponsor discount" concept is modeled yet on Bill/PatientEncounter; shown as 0
+                     until such a field exists (see issue #22415 discussion) -->
+                <h:panelGroup rendered="#{cc.attrs.bill.creditCompany ne null}">
+                    <table class="w-100 mt-3" style="font-size: 12px;">
+                        <tr>
+                            <td>Total Sponsor Amount</td>
+                            <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.creditLimit}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                        </tr>
+                        <tr>
+                            <td>Sponsor Discount Amount</td>
+                            <td style="text-align: right;"><h:outputLabel value="0.00"/></td>
+                        </tr>
+                        <tr style="font-weight: bold; border-top: 1px solid #000;">
+                            <td>Sponsor Amount</td>
+                            <td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.patientEncounter.creditLimit}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                        </tr>
+                    </table>
+                </h:panelGroup>
+
+                <div class="mt-3" style="font-size: 12px;">
+                    <table class="w-100">
+                        <tr>
+                            <td style="font-weight: bold;">Receipt No</td>
+                            <td style="font-weight: bold;">Receipt Date</td>
+                            <td style="font-weight: bold;">Payment type</td>
+                            <td style="text-align: right; font-weight: bold;">Receipt Amount</td>
+                            <td style="text-align: right; font-weight: bold;">Adjusted Amount</td>
+                        </tr>
+                        <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
+                            <h:panelGroup rendered="#{(b.netTotal ne 0) and ((b.cancelled eq false and b.billClass eq 'class com.divudi.core.entity.BilledBill') or (b.cancelled eq false and b.refundedBill eq null and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}">
+                                <tr>
+                                    <td><h:outputLabel value="#{b.deptId}"/></td>
+                                    <td><h:outputLabel value="#{b.createdAt}"><f:convertDateTime pattern="dd/MM/yyyy HH:mm" /></h:outputLabel></td>
+                                    <td><h:outputLabel value="#{b.paymentMethod}"/></td>
+                                    <td style="text-align: right;"><h:outputLabel value="#{b.netTotal}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                                    <!-- Adjusted Amount: no distinct field exists on Bill, duplicated from Receipt Amount -->
+                                    <td style="text-align: right;"><h:outputLabel value="#{b.netTotal}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                                </tr>
+                            </h:panelGroup>
+                        </ui:repeat>
+                    </table>
+                </div>
+
+                <div class="mt-3" style="font-size: 12px;">
+                    <table class="w-100">
+                        <tr>
+                            <td style="font-weight: bold;">Receipt No</td>
+                            <td style="font-weight: bold;">Receipt Date</td>
+                            <td style="font-weight: bold;">Payment type</td>
+                            <td style="text-align: right; font-weight: bold;">Amount</td>
+                        </tr>
+                        <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
+                            <h:panelGroup rendered="#{(b.netTotal ne 0) and ((b.cancelled eq false and b.billClass eq 'class com.divudi.core.entity.BilledBill') or (b.cancelled eq false and b.refundedBill eq null and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}">
+                                <tr>
+                                    <td><h:outputLabel value="#{b.deptId}"/></td>
+                                    <td><h:outputLabel value="#{b.createdAt}"><f:convertDateTime pattern="dd/MM/yyyy HH:mm" /></h:outputLabel></td>
+                                    <td><h:outputLabel value="#{b.paymentMethod}"/></td>
+                                    <td style="text-align: right;"><h:outputLabel value="#{b.netTotal}"><f:convertNumber pattern="#,##0.00" /></h:outputLabel></td>
+                                </tr>
+                            </h:panelGroup>
+                        </ui:repeat>
+                    </table>
+                </div>
+
+                <div class="mt-3" style="font-size: 13px; font-weight: bold;">
+                    Balance To Pay
+                    <h:outputLabel value="#{cc.attrs.bill.netTotal-cc.attrs.bill.paidAmount}" style="float: right;">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputLabel>
+                </div>
+
+                <div class="d-flex justify-content-between mt-5" style="font-size: 11px;">
+                    <div>
+                        <div><b>Prepared By</b>&#160; <h:outputLabel value="#{cc.attrs.bill.creater.name}"/></div>
+                        <div><b>Generated By</b>&#160; <h:outputLabel value="#{sessionController.loggedUser.name}"/></div>
+                    </div>
+                    <div style="text-align: right;">
+                        <div><b>Prepared On</b>&#160;
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                        <div><b>Generated On</b>&#160;
+                            <h:outputLabel value="#{sessionController.currentDate}">
+                                <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
+                            </h:outputLabel>
+                        </div>
+                    </div>
+                </div>
+                <div style="text-align: center; font-size: 11px;">Page 3 of 3</div>
+            </div>
+
+        </h:panelGroup>
+
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- Adds a new always-visible **"Custom Bills"** tab to `inward_reprint_bill_final.xhtml`, hosting a combined A4 print format (**Custom2**) that matches a hospital-supplied sample: Final Bill (charges grouped by category, totals only), Professional Bill, and Final Bill Summary printed as one continuous document, for both Original and Duplicate copies.
- Adds a **Settings** gear button (gated by the existing `ChangeReceiptPrintingPaperTypes` privilege) opening a printer-configuration dialog with field-visibility toggles (address, NIC, phone, guardian, corporate sponsor), following the documented [Printer Configuration System](../developer_docs/configuration/printer-configuration-system.md) pattern.
- New composite: `src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml`.
- New backend config + category-totals helper in `BhtSummeryController.java`.
- Records a new Playwright testing gotcha found during verification (`developer_docs/testing/playwright-e2e-workflow.md` §46).

Closes #22415

## Test plan

Verified locally with Playwright against `BHT/56211` (Inward department, Galle Co-Operative Hospital test DB) — full details posted as a comment on #22415 (screenshots omitted there since the test record shows real patient data and no redaction tooling was available):

- [x] Custom Bills tab renders with both Original and Duplicate panels, each showing all 3 sections.
- [x] Final Bill category totals sum correctly and match `bill.hospitalFee`.
- [x] Professional Bill Total matches the existing Final Bill tab's own Professional Charge subtotal.
- [x] Final Bill Summary's Net Total matches the page's Bill Details panel; Total Sponsor Amount matches the Credit Limit field; Balance To Pay = Net Total − Paid Amount.
- [x] Barcode component renders (verified via DOM: one `<svg>` per page × copy = 6 total).
- [x] Settings dialog: toggle → Apply & Close (full postback) → reload → field visibility change persisted and reflected correctly; toggled back to confirm both directions.
- [x] No new console errors.
- [x] Did not click the live print buttons (`p:printer` can hang a Playwright session per workflow doc §43) — page-break-per-section relies on the existing `.a4bill` CSS class already used in production by `finalBillGreenSheet.xhtml`, `finalProfessionalBill.xhtml`, and `staffBillCustom1.xhtml`.

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Custom Bills** tab with **Original** and **Duplicate** final bill print actions.
  - Introduced a **Custom Bills Printer Configuration** dialog to control whether to show address, NIC, phone, guardian, and corporate sponsor details.
  - Implemented a **three-page Custom2 “Final Bill”** print layout with category totals, professional charge breakdown, summaries, receipts, and balance-to-pay.
- **Documentation**
  - Added Playwright E2E workflow troubleshooting for click timeouts caused by overlapping fixed status banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->