### PR TITLE
feat(patient): add configurable MRN auto-generation strategy

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -32,6 +32,7 @@ import com.divudi.core.data.dataStructure.YearMonthDay;
 import com.divudi.core.data.hr.ReportKeyWord;
 import com.divudi.core.data.inward.PatientEncounterType;
 import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.MrnGenerator;
 
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
@@ -139,6 +140,8 @@ public class PatientController implements Serializable, ControllerWithPatient {
     BillNumberGenerator billNumberBean;
     @EJB
     private BillNumberGenerator billNumberGenerator;
+    @EJB
+    private MrnGenerator mrnGenerator;
 
     @EJB
     BillFacade billFacade;
@@ -3597,6 +3600,12 @@ public class PatientController implements Serializable, ControllerWithPatient {
         // Generate PHN upfront if needed
         if (p.getPhn() == null || p.getPhn().trim().equals("")) {
             p.setPhn(applicationController.createNewPersonalHealthNumber(getSessionController().getInstitution()));
+        }
+
+        if (p.getCode() == null || p.getCode().trim().isEmpty()) {
+            if (mrnGenerator.isMrnAutoGenerationEnabled()) {
+                p.setCode(mrnGenerator.generateMrn(getSessionController().getInstitution()));
+            }
         }
 
         // Add TextCase Format

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3603,7 +3603,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
         }
 
         if (p.getCode() == null || p.getCode().trim().isEmpty()) {
-            if (mrnGenerator.isMrnAutoGenerationEnabled()) {
+            if (isMrnAutoGenerationEnabled()) {
                 p.setCode(mrnGenerator.generateMrn(getSessionController().getInstitution()));
             }
         }
@@ -5031,6 +5031,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public void setReGenerateePhn(boolean reGenerateePhn) {
         this.reGenerateePhn = reGenerateePhn;
+    }
+
+    public boolean isMrnAutoGenerationEnabled() {
+        return mrnGenerator.isMrnAutoGenerationEnabled();
     }
 
     @Override

--- a/src/main/java/com/divudi/core/entity/MrnNumber.java
+++ b/src/main/java/com/divudi/core/entity/MrnNumber.java
@@ -1,0 +1,86 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * Internal counter entity used by MrnGenerator to track the last-issued
+ * Medical Record Number (Patient.code) serial. Mirrors the BillNumber
+ * counter-entity pattern.
+ *
+ * A null {@code year} represents the global, non-year-scoped counter used by
+ * the SERIAL and INSTITUTION_SERIAL strategies. A non-null {@code year}
+ * represents the yearly counter used by the YEAR_SERIAL and
+ * YEAR_INSTITUTION_SERIAL strategies.
+ */
+@Entity
+public class MrnNumber implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer year;
+
+    private Long lastMrnNumber;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    public Long getLastMrnNumber() {
+        return lastMrnNumber;
+    }
+
+    public void setLastMrnNumber(Long lastMrnNumber) {
+        this.lastMrnNumber = lastMrnNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        // TODO: Warning - this method won't work in the case the id fields are not set
+        if (!(object instanceof MrnNumber)) {
+            return false;
+        }
+        MrnNumber other = (MrnNumber) object;
+        if ((this.id == null && other.id != null) || (this.id != null && !this.id.equals(other.id))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.MrnNumber[ id=" + id + " ]";
+    }
+
+}

--- a/src/main/java/com/divudi/core/facade/MrnNumberFacade.java
+++ b/src/main/java/com/divudi/core/facade/MrnNumberFacade.java
@@ -1,0 +1,32 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.MrnNumber;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ *
+ * @author Dr. M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Stateless
+public class MrnNumberFacade extends AbstractFacade<MrnNumber> {
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public MrnNumberFacade() {
+        super(MrnNumber.class);
+    }
+
+}

--- a/src/main/java/com/divudi/ejb/MrnGenerator.java
+++ b/src/main/java/com/divudi/ejb/MrnGenerator.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.ejb.EJB;
-import javax.ejb.Stateless;
+import javax.ejb.Singleton;
 import javax.inject.Inject;
 
 /**
@@ -21,7 +21,7 @@ import javax.inject.Inject;
  *
  * @author Dr. M H B Ariyaratne <buddhika.ari at gmail.com>
  */
-@Stateless
+@Singleton
 public class MrnGenerator {
 
     // MRN generation strategies
@@ -120,9 +120,9 @@ public class MrnGenerator {
             String countJpql;
             Map<String, Object> countParams = new HashMap<>();
             if (year == null) {
-                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL AND p.retired = false";
+                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL";
             } else {
-                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL AND p.retired = false "
+                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL "
                         + "AND p.createdAt BETWEEN :startOfYear AND :endOfYear";
 
                 Calendar startOfYear = Calendar.getInstance();

--- a/src/main/java/com/divudi/ejb/MrnGenerator.java
+++ b/src/main/java/com/divudi/ejb/MrnGenerator.java
@@ -1,0 +1,219 @@
+package com.divudi.ejb;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.MrnNumber;
+import com.divudi.core.facade.MrnNumberFacade;
+import com.divudi.core.facade.PatientFacade;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+/**
+ * Generates the Medical Record Number (MRN, stored as {@code Patient.code})
+ * according to a configurable strategy. Mirrors the locking, counter-entity,
+ * and config-option patterns used by {@link BillNumberGenerator}.
+ *
+ * @author Dr. M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Stateless
+public class MrnGenerator {
+
+    // MRN generation strategies
+    public static final String MRN_STRATEGY_MANUAL = "MANUAL";
+    public static final String MRN_STRATEGY_SERIAL = "SERIAL";
+    public static final String MRN_STRATEGY_YEAR_SERIAL = "YEAR_SERIAL";
+    public static final String MRN_STRATEGY_INSTITUTION_SERIAL = "INSTITUTION_SERIAL";
+    public static final String MRN_STRATEGY_YEAR_INSTITUTION_SERIAL = "YEAR_INSTITUTION_SERIAL";
+
+    // Config option keys
+    public static final String CONFIG_KEY_MRN_STRATEGY = "MRN Generation Strategy";
+    public static final String CONFIG_KEY_MRN_SERIAL_DIGIT_COUNT = "MRN Serial Digit Count";
+    public static final String CONFIG_KEY_MRN_DELIMITER = "MRN Number Delimiter";
+
+    private static final int MAX_SERIAL_DIGITS = 12;
+
+    @EJB
+    private MrnNumberFacade mrnNumberFacade;
+
+    @EJB
+    private PatientFacade patientFacade;
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    private final ConcurrentHashMap<String, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+
+    private String getMrnStrategy() {
+        String strategy = configOptionApplicationController.getLongTextValueByKey(CONFIG_KEY_MRN_STRATEGY, MRN_STRATEGY_MANUAL);
+        if (strategy == null) {
+            return MRN_STRATEGY_MANUAL;
+        }
+        strategy = strategy.trim().toUpperCase();
+        if (strategy.isEmpty()) {
+            return MRN_STRATEGY_MANUAL;
+        }
+        switch (strategy) {
+            case MRN_STRATEGY_MANUAL:
+            case MRN_STRATEGY_SERIAL:
+            case MRN_STRATEGY_YEAR_SERIAL:
+            case MRN_STRATEGY_INSTITUTION_SERIAL:
+            case MRN_STRATEGY_YEAR_INSTITUTION_SERIAL:
+                return strategy;
+            default:
+                return MRN_STRATEGY_MANUAL;
+        }
+    }
+
+    public boolean isMrnAutoGenerationEnabled() {
+        return !MRN_STRATEGY_MANUAL.equals(getMrnStrategy());
+    }
+
+    private String formatSerialNumber(Long serialNumber) {
+        Integer digits = configOptionApplicationController.getIntegerValueByKey(CONFIG_KEY_MRN_SERIAL_DIGIT_COUNT, 6);
+        if (digits == null || digits < 1) {
+            digits = 6;
+        }
+        digits = Math.min(digits, MAX_SERIAL_DIGITS);
+        return String.format("%0" + digits + "d", serialNumber);
+    }
+
+    private String getMrnDelimiter() {
+        String delimiter = configOptionApplicationController.getShortTextValueByKey(CONFIG_KEY_MRN_DELIMITER, "/");
+        if (delimiter == null) {
+            return "/";
+        }
+        delimiter = delimiter.trim();
+        if (delimiter.isEmpty()) {
+            return "/";
+        }
+        return delimiter;
+    }
+
+    /**
+     * Fetches (creating and seeding if necessary) the MrnNumber counter row for
+     * the given year, or the global (non-year-scoped) counter when year is
+     * null. Does not increment — the caller increments under the per-key lock
+     * in {@link #generateMrn(Institution)}.
+     */
+    private MrnNumber fetchLastMrnNumberSynchronized(Integer year) {
+        String jpql;
+        Map<String, Object> hm = new HashMap<>();
+        if (year == null) {
+            jpql = "SELECT m FROM MrnNumber m WHERE m.year IS NULL";
+        } else {
+            jpql = "SELECT m FROM MrnNumber m WHERE m.year = :yr";
+            hm.put("yr", year);
+        }
+
+        MrnNumber mrnNumber = mrnNumberFacade.findFreshByJpql(jpql, hm);
+
+        if (mrnNumber == null) {
+            mrnNumber = new MrnNumber();
+            mrnNumber.setYear(year);
+
+            String countJpql;
+            Map<String, Object> countParams = new HashMap<>();
+            if (year == null) {
+                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL AND p.retired = false";
+            } else {
+                countJpql = "SELECT count(p) FROM Patient p WHERE p.code IS NOT NULL AND p.retired = false "
+                        + "AND p.createdAt BETWEEN :startOfYear AND :endOfYear";
+
+                Calendar startOfYear = Calendar.getInstance();
+                startOfYear.set(Calendar.YEAR, year);
+                startOfYear.set(Calendar.DAY_OF_YEAR, 1);
+                startOfYear.set(Calendar.HOUR_OF_DAY, 0);
+                startOfYear.set(Calendar.MINUTE, 0);
+                startOfYear.set(Calendar.SECOND, 0);
+                startOfYear.set(Calendar.MILLISECOND, 0);
+
+                Calendar endOfYear = Calendar.getInstance();
+                endOfYear.set(Calendar.YEAR, year);
+                endOfYear.set(Calendar.MONTH, Calendar.DECEMBER);
+                endOfYear.set(Calendar.DAY_OF_MONTH, 31);
+                endOfYear.set(Calendar.HOUR_OF_DAY, 23);
+                endOfYear.set(Calendar.MINUTE, 59);
+                endOfYear.set(Calendar.SECOND, 59);
+                endOfYear.set(Calendar.MILLISECOND, 999);
+
+                countParams.put("startOfYear", startOfYear.getTime());
+                countParams.put("endOfYear", endOfYear.getTime());
+            }
+
+            long seed = patientFacade.findLongByJpql(countJpql, countParams);
+            mrnNumber.setLastMrnNumber(seed);
+            mrnNumberFacade.createAndFlush(mrnNumber);
+        }
+
+        return mrnNumber;
+    }
+
+    private String getLockKey(boolean yearScoped) {
+        return yearScoped ? "YEAR" : "GLOBAL";
+    }
+
+    /**
+     * Generates the next MRN according to the configured strategy. Uses a
+     * per-key (year-scoped vs global) {@link ReentrantLock} rather than a
+     * blanket {@code synchronized} on the whole method so unrelated
+     * concurrent callers are not serialized against each other.
+     */
+    public String generateMrn(Institution institution) {
+        String strategy = getMrnStrategy();
+        boolean yearScoped = MRN_STRATEGY_YEAR_SERIAL.equals(strategy) || MRN_STRATEGY_YEAR_INSTITUTION_SERIAL.equals(strategy);
+
+        String lockKey = getLockKey(yearScoped);
+        ReentrantLock lock = lockMap.computeIfAbsent(lockKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            Integer year = yearScoped ? Calendar.getInstance().get(Calendar.YEAR) : null;
+            MrnNumber mrnNumber = fetchLastMrnNumberSynchronized(year);
+
+            Long lastMrnNumber = mrnNumber.getLastMrnNumber();
+            if (lastMrnNumber == null) {
+                lastMrnNumber = 0L;
+            }
+            Long next = lastMrnNumber + 1;
+            mrnNumber.setLastMrnNumber(next);
+            mrnNumberFacade.edit(mrnNumber);
+
+            return buildMrn(strategy, institution, next);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private String buildMrn(String strategy, Institution institution, Long next) {
+        String delimiter = getMrnDelimiter();
+        String serial = formatSerialNumber(next);
+        String twoDigitYear = String.format("%02d", Calendar.getInstance().get(Calendar.YEAR) % 100);
+        String institutionCode = institution != null ? institution.getInstitutionCode() : null;
+        boolean hasInstitutionCode = institutionCode != null && !institutionCode.trim().isEmpty();
+
+        switch (strategy) {
+            case MRN_STRATEGY_YEAR_SERIAL:
+                return twoDigitYear + delimiter + serial;
+            case MRN_STRATEGY_INSTITUTION_SERIAL:
+                if (hasInstitutionCode) {
+                    return institutionCode + delimiter + serial;
+                }
+                return serial;
+            case MRN_STRATEGY_YEAR_INSTITUTION_SERIAL:
+                if (hasInstitutionCode) {
+                    return institutionCode + delimiter + twoDigitYear + delimiter + serial;
+                }
+                return twoDigitYear + delimiter + serial;
+            case MRN_STRATEGY_MANUAL:
+            case MRN_STRATEGY_SERIAL:
+            default:
+                return serial;
+        }
+    }
+
+}

--- a/src/main/java/com/divudi/service/fhir/PatientFhirService.java
+++ b/src/main/java/com/divudi/service/fhir/PatientFhirService.java
@@ -13,6 +13,7 @@ import com.divudi.core.entity.Person;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.PatientFacade;
 import com.divudi.core.facade.PersonFacade;
+import com.divudi.ejb.MrnGenerator;
 import com.divudi.service.PatientService;
 import java.util.ArrayList;
 import java.util.Date;
@@ -43,6 +44,9 @@ public class PatientFhirService {
 
     @EJB
     private PatientService patientService;
+
+    @EJB
+    private MrnGenerator mrnGenerator;
 
     // -------------------------------------------------------------------------
     // Read
@@ -123,7 +127,7 @@ public class PatientFhirService {
         // MRN from identifier or auto-generate
         String mrn = extractIdentifierValue(fhirPt, "urn:hmis:mrn");
         if (mrn == null || mrn.trim().isEmpty()) {
-            mrn = generatePatientCode();
+            mrn = mrnGenerator.generateMrn(creator != null ? creator.getInstitution() : null);
         }
         patient.setCode(mrn);
 
@@ -339,11 +343,6 @@ public class PatientFhirService {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
-
-    public String generatePatientCode() {
-        long count = patientFacade.countByJpql("select count(p) FROM Patient p where p.code is not null");
-        return String.valueOf(count + 1);
-    }
 
     private String extractIdentifierValue(org.hl7.fhir.r5.model.Patient fhirPt, String system) {
         for (Identifier id : fhirPt.getIdentifier()) {

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -274,7 +274,7 @@
                                         <div class="col-md-6">
                                             <h:outputLabel class="form-label" value="MRN No:"  />
                                             <h:panelGroup>
-                                                <p:inputText autocomplete="off" id="txtMrn" value="#{patientController.current.code}" class="form-control" />
+                                                <p:inputText autocomplete="off" id="txtMrn" value="#{patientController.current.code}" class="form-control" readonly="#{configOptionApplicationController.getLongTextValueByKey('MRN Generation Strategy', 'MANUAL') ne 'MANUAL'}" />
                                             </h:panelGroup>
                                         </div>
                                     </div>

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -274,7 +274,7 @@
                                         <div class="col-md-6">
                                             <h:outputLabel class="form-label" value="MRN No:"  />
                                             <h:panelGroup>
-                                                <p:inputText autocomplete="off" id="txtMrn" value="#{patientController.current.code}" class="form-control" readonly="#{configOptionApplicationController.getLongTextValueByKey('MRN Generation Strategy', 'MANUAL') ne 'MANUAL'}" />
+                                                <p:inputText autocomplete="off" id="txtMrn" value="#{patientController.current.code}" class="form-control" readonly="#{patientController.mrnAutoGenerationEnabled}" />
                                             </h:panelGroup>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- Adds a configurable **MRN Generation Strategy** config key so institutions can choose `MANUAL` (default, unchanged), `SERIAL`, `YEAR_SERIAL`, `INSTITUTION_SERIAL`, or `YEAR_INSTITUTION_SERIAL`, mirroring the existing Bill Number generation pattern (`developer_docs/configuration/bill-number-config-options.md`).
- New `MrnNumber` counter entity/facade + `MrnGenerator` EJB with per-key `ReentrantLock` concurrency, matching `BillNumberGenerator`'s approach. Counter is global across institutions (institution code is a display prefix only, not a partition key).
- `PatientController.saveSelected` auto-fills a blank MRN when a non-`MANUAL` strategy is active, same pattern as the existing PHN auto-generation.
- `patient_edit.xhtml`'s MRN field becomes read-only once an auto-generation strategy is active, preventing accidental overwrites of a generated number.
- `PatientFhirService`'s FHIR patient-creation path now uses the same generator instead of its prior race-condition-prone `generatePatientCode()` (naive COUNT+1, no locking).

Closes #1366

## Test plan
Verified end-to-end against local Payara (OPD department), all 5 strategies, via the actual `patient_edit.xhtml` UI:

- [x] `MANUAL` (default) — MRN field stays editable, no auto-fill on save
- [x] `SERIAL` — `000938` → `000939` on a second patient, confirming the counter increments without collision
- [x] `YEAR_SERIAL` — `26/000407`
- [x] `INSTITUTION_SERIAL` — `COOP/000940` (continues the same global counter as `SERIAL`, `939` → `940`, confirming institution doesn't partition the count)
- [x] `YEAR_INSTITUTION_SERIAL` — `COOP/26/000406`
- [x] MRN field confirmed `readonly="readonly"` in rendered HTML once a non-`MANUAL` strategy is active (Playwright refused to fill it, as expected)
- [x] Verified `MrnNumber` counter table state directly in MySQL after each save
- [x] New `MrnNumber` table DDL regenerated and published to the [Database Schema DDL Generation Guide](https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide)

Screenshots and full verification notes are in the [issue comment](https://github.com/hmislk/hmis/issues/1366#issuecomment-5079377192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic Medical Record Number (MRN) generation for newly registered patients.
  * MRNs can use serial, year-based, institution-based, or combined numbering formats.
  * Patients created through FHIR integrations also receive automatically generated MRNs when none is provided.

* **Improvements**
  * MRN fields become read-only when automatic generation is enabled, helping prevent numbering conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->