### PR TITLE
Add focused single-admission patient accept view (#22420)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -66,6 +66,10 @@ public class PatientTransferController implements Serializable {
     private Date acceptedAt;
     private PatientTransferRequest lastInitiatedRequest;
 
+    // PENDING requests scoped to a single admission — used by the focused
+    // accept view launched from the Inpatient Dashboard (#22420)
+    private List<PatientTransferRequest> pendingRequestsForAdmission;
+
     // All transfer requests for the currently selected patient
     private List<PatientTransferRequest> currentAdmissionRequests;
 
@@ -121,6 +125,21 @@ public class PatientTransferController implements Serializable {
         loadPendingForDepartment();
         loadPendingReturnsForWard();
         return "/inward/inward_patient_accept?faces-redirect=true";
+    }
+
+    /**
+     * Focused single-admission accept flow launched from the Inpatient
+     * Dashboard's Room Management panel — scoped to just this admission's
+     * PENDING request(s), instead of the ward-wide worklist (#22420).
+     */
+    public String navigateToPatientAcceptForAdmission(Admission admission) {
+        if (admission == null) {
+            JsfUtil.addErrorMessage("No patient selected.");
+            return "";
+        }
+        current = admission;
+        loadPendingForAdmission(admission);
+        return "/inward/inward_patient_accept_single?faces-redirect=true";
     }
 
     /**
@@ -388,6 +407,28 @@ public class PatientTransferController implements Serializable {
     }
 
     /**
+     * Accept from the single-admission focused view (#22420) — delegates to
+     * acceptTransfer() then refreshes the admission-scoped list instead of
+     * the department-wide one.
+     */
+    public void acceptTransferForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        acceptTransfer(req);
+        loadPendingForAdmission(admission);
+    }
+
+    /**
+     * Cancel from the single-admission focused view (#22420) — delegates to
+     * cancelTransfer() then refreshes the admission-scoped list instead of
+     * the department-wide one.
+     */
+    public void cancelTransferForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        cancelTransfer(req);
+        loadPendingForAdmission(admission);
+    }
+
+    /**
      * True if there are any PENDING transfer requests targeting the logged-in
      * user's department. Used to enable/disable the Accept Patients button.
      */
@@ -445,6 +486,43 @@ public class PatientTransferController implements Serializable {
         if (pendingRequests == null) {
             pendingRequests = new ArrayList<>();
         }
+    }
+
+    /**
+     * Loads only the PENDING request(s) for a single admission — for the
+     * focused accept view (#22420). Normally there is exactly one, but more
+     * than one is handled by listing them all.
+     */
+    private void loadPendingForAdmission(Admission admission) {
+        if (admission == null) {
+            pendingRequestsForAdmission = new ArrayList<>();
+            return;
+        }
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("status", TransferRequestStatus.PENDING);
+        params.put("admission", admission);
+        String jpql = "SELECT r FROM PatientTransferRequest r "
+                + "WHERE r.status = :status "
+                + "AND r.admission = :admission "
+                + "AND r.theatreTransferType IS NULL "
+                + "AND r.retired = false "
+                + "ORDER BY r.initiatedAt";
+        pendingRequestsForAdmission = patientTransferRequestFacade.findByJpql(jpql, params);
+        if (pendingRequestsForAdmission == null) {
+            pendingRequestsForAdmission = new ArrayList<>();
+        }
+        for (PatientTransferRequest req : pendingRequestsForAdmission) {
+            if (req.getAcceptedAt() == null) {
+                req.setAcceptedAt(new Date());
+            }
+        }
+    }
+
+    public List<PatientTransferRequest> getPendingRequestsForAdmission() {
+        if (pendingRequestsForAdmission == null) {
+            pendingRequestsForAdmission = new ArrayList<>();
+        }
+        return pendingRequestsForAdmission;
     }
 
     public Date getAcceptedAt() {

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -698,7 +698,7 @@
                                             value="Accept Patients"
                                             ajax="false"
                                             disabled="#{not patientTransferController.hasPendingRequestsForDepartment}"
-                                            action="#{patientTransferController.navigateToPatientAccept()}"
+                                            action="#{patientTransferController.navigateToPatientAcceptForAdmission(admissionController.current)}"
                                             icon="fa fa-check-circle"
                                             class="w-100 ui-button-success">
                                         </p:commandButton>

--- a/src/main/webapp/inward/inward_patient_accept_single.xhtml
+++ b/src/main/webapp/inward/inward_patient_accept_single.xhtml
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="content">
+        <h:form>
+            <p:panel class="my-3">
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between">
+                        <div>
+                            <h:outputText styleClass="fa fa-check-circle fa-lg"/>
+                            <p:outputLabel value="Accept Patient" class="m-2"/>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                value="Inpatient Dashboard"
+                                icon="fa fa-id-card"
+                                ajax="false"
+                                class="ui-button-secondary"
+                                rendered="#{admissionController.current ne null and admissionController.current.id ne null}"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"/>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <!-- Patient Identity Banner -->
+                <div class="d-flex flex-wrap gap-4 align-items-center p-3 mb-3 rounded" style="background:#f0f4f8; border-left:6px solid #0d6efd;">
+                    <div>
+                        <div class="text-muted small">Name</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.nameWithTitle}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Age</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.ageAsString}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Sex</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.sex}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">BHT No</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.bhtNo}"/></div>
+                    </div>
+                </div>
+
+                <p:dataTable
+                    value="#{patientTransferController.pendingRequestsForAdmission}"
+                    var="req"
+                    emptyMessage="No pending transfer/admission request for this patient.">
+
+                    <p:column headerText="Type">
+                        <h:outputText value="#{req.fromPatientRoom == null ? 'Admission' : 'Transfer'}"/>
+                    </p:column>
+
+                    <p:column headerText="From">
+                        <h:outputText value="#{req.fromPatientRoom != null ? req.fromPatientRoom.roomFacilityCharge.name : 'Admission Desk'}"/>
+                    </p:column>
+
+                    <p:column headerText="To Room">
+                        <h:outputText value="#{req.toRoomFacilityCharge.name}"/>
+                    </p:column>
+
+                    <p:column headerText="Initiated By">
+                        <h:outputText value="#{req.initiatedBy.webUserPerson.name}"/>
+                    </p:column>
+
+                    <p:column headerText="Initiated At">
+                        <h:outputText value="#{req.initiatedAt}">
+                            <f:convertDateTime pattern="dd MMM yyyy HH:mm"/>
+                        </h:outputText>
+                    </p:column>
+
+                    <p:column headerText="Accepted At">
+                        <p:datePicker
+                            value="#{req.acceptedAt}"
+                            showTime="true"
+                            timeInput="true"
+                            pattern="dd MMM yyyy HH:mm:ss"/>
+                    </p:column>
+
+                    <p:column headerText="Actions">
+                        <div class="d-flex gap-1">
+                            <p:commandButton
+                                value="Accept"
+                                icon="fa fa-check"
+                                ajax="false"
+                                class="ui-button-success"
+                                action="#{patientTransferController.acceptTransferForAdmission(req)}"
+                                onclick="if (!confirm('Accept this patient?')) return false;"/>
+                            <p:commandButton
+                                value="Cancel"
+                                icon="fa fa-times"
+                                ajax="false"
+                                class="ui-button-danger"
+                                action="#{patientTransferController.cancelTransferForAdmission(req)}"
+                                onclick="if (!confirm('Cancel this transfer request?')) return false;"/>
+                        </div>
+                    </p:column>
+
+                </p:dataTable>
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
## Summary
Adds a new focused patient acceptance workflow for the Inpatient Dashboard's Room Management panel. Instead of showing the department-wide transfer/admission worklist, this new view displays only the pending requests for a specific admission, enabling ward staff to quickly accept or cancel transfers without navigating away from the patient's profile.

## Changes

- **New XHTML view** (`inward_patient_accept_single.xhtml`):
  - Displays patient identity banner (name, age, sex, BHT number)
  - Shows only pending transfer/admission requests for the current admission
  - Provides Accept/Cancel actions with confirmation dialogs
  - Includes link back to Inpatient Dashboard

- **PatientTransferController enhancements**:
  - Added `pendingRequestsForAdmission` field to hold admission-scoped requests
  - New `navigateToPatientAcceptForAdmission(Admission)` method to launch the focused view
  - New `loadPendingForAdmission(Admission)` method to query only pending requests for a specific admission
  - New `acceptTransferForAdmission()` and `cancelTransferForAdmission()` wrapper methods that delegate to existing logic then refresh the admission-scoped list
  - Added getter `getPendingRequestsForAdmission()`

- **admission_profile.xhtml update**:
  - Modified "Accept Patients" button to call `navigateToPatientAcceptForAdmission()` instead of the department-wide `navigateToPatientAccept()`

## Implementation Details
- The new view reuses existing `acceptTransfer()` and `cancelTransfer()` business logic; the wrapper methods only differ in which list they refresh afterward
- Pending requests are pre-populated with current timestamp in `acceptedAt` field for user convenience
- JPQL query filters by `status = PENDING`, `admission = :admission`, excludes theatre transfers, and excludes retired records
- Maintains backward compatibility; the department-wide accept view remains unchanged

https://claude.ai/code/session_0155zh6L9NGX9Kbu5LgmYvC9