### PR TITLE
Client Portal: landing page, default institution, deferred DDL regen

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1160,20 +1160,23 @@ like `"/client_portal/home?faces-redirect=true"` and `<h:link outcome="/client_p
 already resolve to the correct `/faces/`-prefixed URL automatically — this gotcha only
 bites when a human or a script types the URL by hand.)
 
-## 48. Raw SQL `UPDATE` on *any* EclipseLink-mapped entity (not just `ConfigOption`) can be invisible to the running app — the shared L2 cache is general, not `ConfigOption`-specific
+## 48. Raw SQL `UPDATE` on an already-cached EclipseLink-mapped entity (not just `ConfigOption`) can be invisible to the running app — the shared L2 cache is general, not `ConfigOption`-specific
 
 §26 documents this for `ConfigOption` specifically, but `eclipselink.cache.size.default`
 in `persistence.xml` applies to every entity class, so the same trap exists for `Institution`,
-`Patient`, or any other frequently-read entity. Hit while verifying issue #22371: a direct
-`UPDATE INSTITUTION SET DEFAULTINSTITUTION=1, POINTOFISSUENO='COOP' WHERE id=2` via the
-`mysql` CLI changed the DB row, but the next page load still showed the old (unset) values
-in the edit form and the PHN-generation code path still saw a blank POI — the already-cached
-`Institution` entity in the running Payara instance kept serving stale field values, with no
-error anywhere. Re-doing the exact same change through the admin UI form (Save button, which
-goes through `EntityManager.merge`/`edit`) fixed it immediately, confirming the raw SQL path
-was the problem. **Rule of thumb: never `UPDATE` an entity table via raw SQL mid-test if the
-running app might read that row again in the same session — use the corresponding admin
-UI/CRUD screen instead, and reserve raw SQL for read-only verification queries.**
+`Patient`, or any other frequently-read entity **once that row has already been loaded into
+the shared L2 cache during the current app run** — visibility depends on persistence-context/
+cache state, not a blanket guarantee that every raw SQL update is invisible. Hit while
+verifying issue #22371: a direct `UPDATE INSTITUTION SET DEFAULTINSTITUTION=1,
+POINTOFISSUENO='COOP' WHERE id=2` via the `mysql` CLI changed the DB row, but the next page
+load still showed the old (unset) values in the edit form and the PHN-generation code path
+still saw a blank POI — the already-cached `Institution` entity in the running Payara instance
+kept serving stale field values, with no error anywhere. Re-doing the exact same change through
+the admin UI form (Save button, which goes through `EntityManager.merge`/`edit`) fixed it
+immediately, confirming the raw SQL path was the problem. **Rule of thumb: if a row might
+already be cached (anything read earlier in the same test session), don't `UPDATE` it via raw
+SQL mid-test — use the corresponding admin UI/CRUD screen instead, so the cache gets properly
+refreshed, and reserve raw SQL for read-only verification queries.**
 
 ## Quick checklist
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1143,6 +1143,38 @@ or `z-index`/positioning that keeps it from overlapping page content) — but
 until that's fixed, `browser_evaluate` + `.click()` is the dependable way to
 drive the page underneath it.
 
+## 47. Any JSF page under a plain (non-`/faces/`) webapp path must still be loaded through `/faces/` — otherwise the raw `.xhtml` source is served unprocessed
+
+`FacesServlet` is mapped to `/faces/*` in `web.xml` (`<url-pattern>/faces/*</url-pattern>`).
+Requesting `http://localhost:8080/rh/client_portal/login.xhtml` directly (no `/faces/`
+segment) does **not** 404 — the container serves the file as a static resource, so the
+page loads with a real `<title>`, but every EL expression renders as literal text
+(`#{clientPortalLoginController.login}`, `#{bean.property}` etc.) and there are **zero**
+`<input>` elements in the DOM (Facelets never ran, so `p:inputText`/`h:commandButton`
+components were never compiled to HTML). This looks like a broken page at first glance —
+confirmed via issue #22371 verification, where `register_phone.xhtml` initially appeared
+to have no input fields at all. Always use `/rh/faces/<same-path>.xhtml` for any new page
+under `src/main/webapp/`, matching the pattern already used for `client_portal/login.xhtml`
+→ `/rh/faces/client_portal/login.xhtml`. (JSF's own `action`/`outcome` navigation strings
+like `"/client_portal/home?faces-redirect=true"` and `<h:link outcome="/client_portal/login"/>`
+already resolve to the correct `/faces/`-prefixed URL automatically — this gotcha only
+bites when a human or a script types the URL by hand.)
+
+## 48. Raw SQL `UPDATE` on *any* EclipseLink-mapped entity (not just `ConfigOption`) can be invisible to the running app — the shared L2 cache is general, not `ConfigOption`-specific
+
+§26 documents this for `ConfigOption` specifically, but `eclipselink.cache.size.default`
+in `persistence.xml` applies to every entity class, so the same trap exists for `Institution`,
+`Patient`, or any other frequently-read entity. Hit while verifying issue #22371: a direct
+`UPDATE INSTITUTION SET DEFAULTINSTITUTION=1, POINTOFISSUENO='COOP' WHERE id=2` via the
+`mysql` CLI changed the DB row, but the next page load still showed the old (unset) values
+in the edit form and the PHN-generation code path still saw a blank POI — the already-cached
+`Institution` entity in the running Payara instance kept serving stale field values, with no
+error anywhere. Re-doing the exact same change through the admin UI form (Save button, which
+goes through `EntityManager.merge`/`edit`) fixed it immediately, confirming the raw SQL path
+was the problem. **Rule of thumb: never `UPDATE` an entity table via raw SQL mid-test if the
+running app might read that row again in the same session — use the corresponding admin
+UI/CRUD screen instead, and reserve raw SQL for read-only verification queries.**
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalHomeController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalHomeController.java
@@ -1,0 +1,33 @@
+package com.divudi.bean.clientportal;
+
+import com.divudi.core.entity.Institution;
+import com.divudi.core.facade.InstitutionFacade;
+import java.io.Serializable;
+import javax.ejb.EJB;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ViewScoped
+public class ClientPortalHomeController implements Serializable {
+
+    @Inject
+    private ClientPortalSessionController clientPortalSessionController;
+    @EJB
+    private InstitutionFacade institutionFacade;
+
+    private Institution institution;
+
+    public Institution getInstitution() {
+        if (institution == null) {
+            institution = institutionFacade.findDefaultInstitution();
+        }
+        return institution;
+    }
+
+    public String logout() {
+        clientPortalSessionController.logout();
+        return "/client_portal/login?faces-redirect=true";
+    }
+}

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalKioskRegistrationController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalKioskRegistrationController.java
@@ -16,6 +16,7 @@ import com.divudi.core.entity.Person;
 import com.divudi.core.entity.Sms;
 import com.divudi.core.facade.ClientAccountFacade;
 import com.divudi.core.facade.EmailFacade;
+import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.PatientFacade;
 import com.divudi.core.facade.PersonFacade;
 import com.divudi.core.facade.SmsFacade;
@@ -71,6 +72,8 @@ public class ClientPortalKioskRegistrationController implements Serializable {
     private PersonFacade personFacade;
     @EJB
     private ClientAccountFacade clientAccountFacade;
+    @EJB
+    private InstitutionFacade institutionFacade;
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
@@ -471,7 +474,7 @@ public class ClientPortalKioskRegistrationController implements Serializable {
 
         newPatient.setRegistrationSource(PatientRegistrationSource.KIOSK);
         newPatient.setCreatedAt(new Date());
-        String phn = applicationController.createNewPersonalHealthNumber(sessionController.getInstitution());
+        String phn = applicationController.createNewPersonalHealthNumber(institutionFacade.findDefaultInstitution());
         if (phn != null) {
             newPatient.setPhn(phn);
         }

--- a/src/main/java/com/divudi/bean/clientportal/ClientPortalLoginController.java
+++ b/src/main/java/com/divudi/bean/clientportal/ClientPortalLoginController.java
@@ -32,15 +32,15 @@ public class ClientPortalLoginController implements Serializable {
         }
     }
 
-    public void login() {
+    public String login() {
         clearMessages();
         if (identifier == null || identifier.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Enter your phone number or email.");
-            return;
+            return null;
         }
         if (password == null || password.trim().isEmpty()) {
             JsfUtil.addErrorMessage("Enter your password.");
-            return;
+            return null;
         }
 
         List<ClientAccount> candidates = clientAccountFacade.findByVerifiedPhoneOrEmail(identifier.trim());
@@ -55,11 +55,12 @@ public class ClientPortalLoginController implements Serializable {
 
         if (matched == null) {
             JsfUtil.addErrorMessage("Incorrect phone/email or password.");
-            return;
+            return null;
         }
 
         clientPortalSessionController.login(matched);
         password = null;
+        return "/client_portal/home?faces-redirect=true";
     }
 
     public void logout() {

--- a/src/main/java/com/divudi/bean/common/InstitutionController.java
+++ b/src/main/java/com/divudi/bean/common/InstitutionController.java
@@ -196,6 +196,9 @@ public class InstitutionController implements Serializable {
         } else {
             getFacade().edit(current);
         }
+        if (current.isDefaultInstitution()) {
+            getFacade().clearDefaultInstitutionExceptFor(current.getId());
+        }
         return toListInstitutions();
     }
 

--- a/src/main/java/com/divudi/core/entity/Institution.java
+++ b/src/main/java/com/divudi/core/entity/Institution.java
@@ -172,6 +172,7 @@ public class Institution implements Serializable, IdentifiableWithNameOrCode {
 
     //Inactive Status
     private boolean inactive;
+    private boolean defaultInstitution;
     @ManyToOne
     private Institution parentInstitution;
 
@@ -654,6 +655,14 @@ public class Institution implements Serializable, IdentifiableWithNameOrCode {
 
     public void setInactive(boolean inactive) {
         this.inactive = inactive;
+    }
+
+    public boolean isDefaultInstitution() {
+        return defaultInstitution;
+    }
+
+    public void setDefaultInstitution(boolean defaultInstitution) {
+        this.defaultInstitution = defaultInstitution;
     }
 
     public String getTransAddress5() {

--- a/src/main/java/com/divudi/core/facade/InstitutionFacade.java
+++ b/src/main/java/com/divudi/core/facade/InstitutionFacade.java
@@ -5,6 +5,9 @@
 package com.divudi.core.facade;
 
 import com.divudi.core.entity.Institution;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -25,6 +28,27 @@ public class InstitutionFacade extends AbstractFacade<Institution> {
 
     public InstitutionFacade() {
         super(Institution.class);
+    }
+
+    public Institution findDefaultInstitution() {
+        Institution flagged = findFirstByJpql(
+            "select i from Institution i where i.defaultInstitution=true and i.retired=false order by i.id asc");
+        if (flagged != null) {
+            return flagged;
+        }
+        return findFirstByJpql(
+            "select i from Institution i where i.retired=false order by i.id asc");
+    }
+
+    public void clearDefaultInstitutionExceptFor(Long id) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", id);
+        List<Institution> others = findByJpql(
+            "select i from Institution i where i.defaultInstitution=true and i.id<>:id", params);
+        for (Institution other : others) {
+            other.setDefaultInstitution(false);
+            edit(other);
+        }
     }
 
 }

--- a/src/main/webapp/admin/institutions/institution.xhtml
+++ b/src/main/webapp/admin/institutions/institution.xhtml
@@ -42,10 +42,17 @@
                                     <p:inputText autocomplete="off"  value="#{institutionController.current.code}"  style="width: 650px">
                                     </p:inputText> 
 
-                                    <h:outputText value="Bill Prefix" >                                        
+                                    <h:outputText value="Bill Prefix" >
                                     </h:outputText>
                                     <p:inputText autocomplete="off"  value="#{institutionController.current.institutionCode}" style="width: 650px" >
-                                    </p:inputText> 
+                                    </p:inputText>
+
+                                    <h:outputText id="lblDefaultInstitution" value="Default Institution" ></h:outputText>
+                                    <h:panelGroup style="width: 650px">
+                                        <p:selectBooleanCheckbox id="chkDefaultInstitution" value="#{institutionController.current.defaultInstitution}">
+                                        </p:selectBooleanCheckbox>
+                                        <h:outputText value=" (shown on the Client Portal landing page)" style="color: #777; font-size: 0.85em; margin-left: 6px;"></h:outputText>
+                                    </h:panelGroup>
 
                                     <h:outputText id="lblParent" value="Parent" ></h:outputText>
                                     <p:autoComplete value="#{institutionController.current.parentInstitution}"

--- a/src/main/webapp/client_portal/home.xhtml
+++ b/src/main/webapp/client_portal/home.xhtml
@@ -1,0 +1,246 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+    <h:head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <title>Client Portal - Home</title>
+
+        <!-- Fonts: Syne (display) + DM Sans (body) — same pairing as client_portal/login.xhtml -->
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+        <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&amp;family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&amp;display=swap" rel="stylesheet"/>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"/>
+
+        <style>
+            /* ================================================
+               CLIENT PORTAL HOME  ·  Forest Health Aesthetic
+               Theme variables copied verbatim from client_portal/login.xhtml
+               Single centered column layout (not a split login layout)
+               ================================================ */
+
+            :root {
+                --forest-mid:    #{configOptionApplicationController.getColorValueByKey('Client Portal - Theme Color','#1b4332')};
+                --forest-deep:   color-mix(in srgb, var(--forest-mid) 60%, #000);
+                --forest-bright: color-mix(in srgb, var(--forest-mid) 80%, #fff);
+                --emerald:       color-mix(in hsl, var(--forest-mid), white 55%);
+                --emerald-light: color-mix(in hsl, var(--forest-mid), white 65%);
+                --cream:         color-mix(in srgb, var(--forest-mid) 5%, #fff);
+                --white:         #ffffff;
+                --text-dark:     color-mix(in srgb, var(--forest-mid) 12%, #111);
+                --text-muted:    color-mix(in srgb, var(--forest-mid) 20%, #555);
+                --border:        color-mix(in srgb, var(--forest-mid) 12%, #fff);
+                --shadow-lg:     0 24px 64px color-mix(in srgb, var(--forest-mid) 20%, transparent);
+                --radius-sm:     10px;
+            }
+
+            *, *::before, *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+
+            body, html {
+                font-family: 'DM Sans', sans-serif;
+                background: var(--cream);
+                min-height: 100vh;
+                color: var(--text-dark);
+            }
+
+            /* ── PAGE WRAPPER ────────────────────────────────────── */
+            .home-wrapper {
+                min-height: 100vh;
+                display: flex;
+                justify-content: center;
+                padding: 2.5rem 1.25rem;
+            }
+
+            .home-column {
+                width: 100%;
+                max-width: 640px;
+                display: flex;
+                flex-direction: column;
+                gap: 1.5rem;
+            }
+
+            /* ── CARDS ────────────────────────────────────────────── */
+            .home-card {
+                background: var(--white);
+                border-radius: 22px;
+                padding: 2.25rem 2rem;
+                box-shadow: var(--shadow-lg);
+                border: 1px solid var(--border);
+                animation: fadeUp 0.45s ease forwards;
+            }
+
+            @keyframes fadeUp {
+                from { opacity: 0; transform: translateY(22px); }
+                to   { opacity: 1; transform: translateY(0); }
+            }
+
+            /* ── WELCOME HEADER CARD ─────────────────────────────── */
+            .welcome-avatar {
+                width: 64px; height: 64px; border-radius: 50%;
+                background: linear-gradient(135deg, var(--forest-mid), var(--emerald));
+                display: flex; align-items: center; justify-content: center; font-size: 1.6rem; color: white;
+                margin: 0 auto 1.1rem;
+                box-shadow: 0 8px 24px color-mix(in srgb, var(--forest-mid) 25%, transparent);
+            }
+            .welcome-greeting { font-size: 0.8rem; font-weight: 600; color: var(--emerald); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 0.35rem; text-align: center; }
+            .welcome-name { font-family: 'Syne', sans-serif; font-size: 1.5rem; font-weight: 800; color: var(--forest-deep); margin-bottom: 0; text-align: center; }
+
+            /* ── INSTITUTION DETAILS CARD ────────────────────────── */
+            .card-lead-icon {
+                width: 48px; height: 48px;
+                background: linear-gradient(135deg, color-mix(in srgb, var(--emerald) 20%, white), color-mix(in srgb, var(--emerald) 35%, white));
+                border-radius: 12px;
+                display: flex; align-items: center; justify-content: center;
+                font-size: 1.2rem; color: var(--forest-mid);
+                margin-bottom: 1rem;
+            }
+            .card-title { font-family: 'Syne', sans-serif; font-size: 1.25rem; font-weight: 700; color: var(--forest-deep); margin-bottom: 0.9rem; line-height: 1.2; }
+
+            .inst-detail-row { display: flex; align-items: flex-start; gap: 0.65rem; font-size: 0.9rem; color: var(--text-dark); margin-bottom: 0.65rem; }
+            .inst-detail-row:last-child { margin-bottom: 0; }
+            .inst-detail-row i { width: 18px; text-align: center; color: var(--emerald); margin-top: 0.15rem; flex-shrink: 0; }
+
+            /* ── COMING SOON PLACEHOLDER CARDS ───────────────────── */
+            .coming-soon-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; }
+            .coming-soon-tile {
+                background: color-mix(in srgb, var(--forest-mid) 6%, white);
+                border: 2px solid var(--border);
+                border-radius: 16px;
+                padding: 1.5rem 1.1rem;
+                display: flex; flex-direction: column; align-items: center; text-align: center; gap: 0.6rem;
+            }
+            .coming-soon-tile i { font-size: 1.9rem; color: var(--forest-mid); }
+            .coming-soon-tile .tile-title { font-family: 'Syne', sans-serif; font-weight: 700; font-size: 0.95rem; color: var(--forest-deep); }
+            .coming-soon-tile .tile-subtext { font-size: 0.78rem; color: var(--text-muted); line-height: 1.5; }
+
+            /* ── LOGOUT BUTTON ────────────────────────────────────── */
+            .btn-verify .ui-button {
+                width: 100% !important;
+                padding: 0.85rem 1.5rem !important;
+                background: var(--cream) !important;
+                border: 2px solid var(--border) !important;
+                border-radius: var(--radius-sm) !important;
+                font-family: 'Syne', sans-serif !important;
+                font-weight: 600 !important;
+                font-size: 0.92rem !important;
+                color: var(--forest-mid) !important;
+                cursor: pointer !important;
+                transition: all 0.2s ease !important;
+                min-width: unset !important;
+            }
+            .btn-verify .ui-button:hover { border-color: var(--emerald) !important; background: color-mix(in srgb, var(--emerald) 12%, white) !important; color: var(--forest-deep) !important; }
+            .btn-verify .ui-button .ui-button-text { padding: 0 !important; }
+            .btn-verify .ui-button .ui-icon { color: var(--forest-mid) !important; margin-right: 6px !important; }
+
+            /* ── NOT LOGGED IN FALLBACK ──────────────────────────── */
+            .not-logged-in-card { text-align: center; }
+            .not-logged-in-card i.big-icon { font-size: 2.5rem; color: var(--emerald); margin-bottom: 1rem; display: block; }
+            .not-logged-in-card p { font-size: 0.92rem; color: var(--text-muted); line-height: 1.7; margin-bottom: 1.25rem; }
+            .not-logged-in-card a { color: var(--forest-bright); font-weight: 600; text-decoration: none; font-family: 'DM Sans', sans-serif; }
+            .not-logged-in-card a:hover { color: var(--emerald); text-decoration: underline; }
+
+            @media (max-width: 480px) {
+                .home-card { padding: 1.75rem 1.25rem; border-radius: 18px; }
+            }
+        </style>
+    </h:head>
+
+    <h:body style="margin:0; padding:0;">
+        <h:form id="form">
+        <div class="home-wrapper">
+            <div class="home-column">
+
+                <!-- ═══════════════════════════════════════════
+                     LOGGED-IN CONTENT
+                     ═══════════════════════════════════════════ -->
+                <h:panelGroup rendered="#{clientPortalSessionController.isLoggedIn()}" layout="block">
+
+                    <!-- Welcome header card -->
+                    <div class="home-card">
+                        <div class="welcome-avatar"><i class="fas fa-circle-check"/></div>
+                        <div class="welcome-greeting">Welcome</div>
+                        <div class="welcome-name">#{clientPortalSessionController.loggedInAccount.person.nameWithTitle}</div>
+                    </div>
+
+                    <!-- Institution details card -->
+                    <h:panelGroup rendered="#{clientPortalHomeController.institution != null}" layout="block" styleClass="home-card">
+                        <div class="card-lead-icon"><i class="fas fa-hospital"/></div>
+                        <div class="card-title">#{clientPortalHomeController.institution.name}</div>
+
+                        <h:panelGroup rendered="#{not empty clientPortalHomeController.institution.address}" layout="block" styleClass="inst-detail-row">
+                            <i class="fas fa-location-dot"/>
+                            <span>#{clientPortalHomeController.institution.address}</span>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{not empty clientPortalHomeController.institution.phone}" layout="block" styleClass="inst-detail-row">
+                            <i class="fas fa-phone"/>
+                            <span>#{clientPortalHomeController.institution.phone}</span>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{not empty clientPortalHomeController.institution.email}" layout="block" styleClass="inst-detail-row">
+                            <i class="fas fa-envelope"/>
+                            <span>#{clientPortalHomeController.institution.email}</span>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{not empty clientPortalHomeController.institution.web}" layout="block" styleClass="inst-detail-row">
+                            <i class="fas fa-globe"/>
+                            <span>#{clientPortalHomeController.institution.web}</span>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <!-- Coming soon placeholder cards -->
+                    <div class="home-card">
+                        <div class="card-title">What's Next</div>
+                        <div class="coming-soon-grid">
+                            <div class="coming-soon-tile">
+                                <i class="fas fa-file-invoice"/>
+                                <span class="tile-title">Bills</span>
+                                <span class="tile-subtext">Coming soon</span>
+                            </div>
+                            <div class="coming-soon-tile">
+                                <i class="fas fa-calendar-check"/>
+                                <span class="tile-title">Appointments</span>
+                                <span class="tile-subtext">Coming soon</span>
+                            </div>
+                            <div class="coming-soon-tile">
+                                <i class="fas fa-chart-line"/>
+                                <span class="tile-title">Reports</span>
+                                <span class="tile-subtext">Coming soon</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Log out -->
+                    <div class="home-card btn-verify">
+                        <p:commandButton value="Log Out"
+                                          icon="fas fa-right-from-bracket"
+                                          action="#{clientPortalHomeController.logout}"
+                                          ajax="false"
+                                          title="Log out of Client Portal"/>
+                    </div>
+
+                </h:panelGroup>
+
+                <!-- ═══════════════════════════════════════════
+                     NOT-LOGGED-IN FALLBACK
+                     ═══════════════════════════════════════════ -->
+                <h:panelGroup rendered="#{!clientPortalSessionController.isLoggedIn()}" layout="block">
+                    <div class="home-card not-logged-in-card">
+                        <i class="fas fa-lock big-icon"/>
+                        <p>You're not logged in. Please log in to access your Client Portal account.</p>
+                        <h:link outcome="/client_portal/login" value="Go to Login" title="Go to Client Portal login"/>
+                    </div>
+                </h:panelGroup>
+
+            </div>
+        </div>
+        </h:form>
+    </h:body>
+</html>

--- a/src/main/webapp/client_portal/login.xhtml
+++ b/src/main/webapp/client_portal/login.xhtml
@@ -716,7 +716,7 @@
                                                           value="Log In"
                                                           icon="fas fa-right-to-bracket"
                                                           action="#{clientPortalLoginController.login}"
-                                                          update="globalMessages portalContentPanel"
+                                                          ajax="false"
                                                           title="Log in to Client Portal"/>
                                     </div>
 


### PR DESCRIPTION
## Summary

This is the sixth and final child issue of the Client Portal Registration feature (master issue #22359). All four registration channels (staff-assisted, phone-OTP, email-OTP, kiosk) plus login/password-reset are already merged.

- **New `Institution.defaultInstitution` field** (boolean) — falls back to the lowest-ID institution if none is flagged. Added `InstitutionFacade.findDefaultInstitution()` / `clearDefaultInstitutionExceptFor(id)` (JPQL only). Exposed as a checkbox on the existing institution edit page (`admin/institutions/institution.xhtml`), with exclusivity enforced in `InstitutionController.saveSelectedInstitution()` — flagging one institution automatically un-flags any previously-flagged one.
- **New post-login landing page** — `client_portal/home.xhtml` + new `ClientPortalHomeController` (`@ViewScoped`). Shows the default institution's name/address/phone/email/web, a personalized welcome (`ClientPortalSessionController.loggedInAccount.person.nameWithTitle`), and "coming soon" placeholders for Bills/Appointments/Reports. `ClientPortalLoginController.login()` now returns a real `faces-redirect` navigation string instead of staying on the login page with an embedded panel.
- **Fixes a real bug**: new patients created via kiosk registration always got a `NULL` PHN, because `ClientPortalKioskRegistrationController.saveNewPatient()` passed `sessionController.getInstitution()` (always `null` for an anonymous kiosk session) into `ApplicationController.createNewPersonalHealthNumber(Institution)`, which short-circuits to `null` before even checking PHN strategy. Now passes `institutionFacade.findDefaultInstitution()` instead.
- **Deferred DDL regeneration** — ran the `generate-ddl` skill once, capturing this issue's `Institution.DEFAULTINSTITUTION` column together with the previously-deferred `CLIENTACCOUNT` table (#22358) and `AppEmail.OTP` column (#22368) in a single migration pass, per the Foundation PR's deferral plan. Wiki DDL guide + `files/createDDL.sql` updated and pushed.

## Test plan

All verified locally via Playwright + direct DB queries against the `coop` database:

- [x] Registered a fresh test account via phone self-service OTP flow, logged in, confirmed redirect to `/client_portal/home.xhtml` showing the default institution's name/address/phone/email/web and a personalized welcome message.
- [x] Clicked Log Out, confirmed redirect back to `/client_portal/login.xhtml`.
- [x] Navigated directly to `/client_portal/home.xhtml` while logged out, confirmed the "please log in" fallback panel renders.
- [x] Admin UI: checked "Default Institution" on one institution, saved, confirmed in DB that exactly one row has `DEFAULTINSTITUTION=1`; then checked it on a second institution and confirmed the first was automatically un-flagged (exclusivity works).
- [x] Kiosk PHN fix: ran the kiosk's email-OTP → no-match → new-patient-creation flow twice (once before setting a POI on the default institution to confirm the pre-existing null-POI config gap is unrelated to this fix, once after) — confirmed the newly created `Patient.PHN` is non-null (e.g. `COOPH5DV7TMYYP8`) when a POI is configured, proving the institution is now correctly resolved instead of `null`.
- [x] `mvn clean package` compiles cleanly; deployed to local Payara and exercised all flows above against the running app.
- [x] DDL regeneration verified: `createDDL.jdbc` contains `CREATE TABLE CLIENTACCOUNT`, `ALTER TABLE APPEMAIL ADD COLUMN OTP`, and `ALTER TABLE INSTITUTION ADD COLUMN DEFAULTINSTITUTION`; applied to the local DB via the app's "Add Missing Fields" screen and confirmed via `SHOW COLUMNS`.

Screenshots (institution/hospital contact info + a fake test-patient account, no real patient data): see wiki page update in a follow-up commit.

Closes #22371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Client Portal home page showing account and institution details, upcoming features, and logout access.
  - Successful Client Portal logins now navigate directly to the home page.
  - Added support for designating a default institution, with automatic enforcement of a single active default.
  - Kiosk registrations now use the configured default institution when generating PHNs.

- **Documentation**
  - Added guidance for accessing JSF pages and verifying database updates during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->