### PR TITLE
Isolate audit logging transaction to prevent stale audit-pool connections from rolling back business writes

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -982,7 +982,7 @@ test-fixture data, not a bug.
   silently toggle the wrong control if the page has more than one:
   `document.querySelector('[id$="chkApplicationWide"] .ui-chkbox-box')`.
 
-## 42. Local Payara can come up with a dead MySQL connection pool after any host sleep/restart — every page hangs, not just one touching a stale entity
+## 47. Local Payara can come up with a dead MySQL connection pool after any host sleep/restart — every page hangs, not just one touching a stale entity
 
 Unlike §38 (a pool holding connections from *before* an `ALTER TABLE`), this is
 the pool holding connections to a MySQL instance that was itself restarted or
@@ -994,9 +994,9 @@ because `ConfigOptionApplicationController.init()` runs on first
 request/session and hits the DB immediately. `server.log` shows
 `CJCommunicationsException: Communications link failure` /
 `SQLNonTransientConnectionException: No operations allowed after connection
-closed` from background EJB timers even while `mysql -h 127.0.0.1 ... SELECT
-1` succeeds fine from the shell — proving MySQL itself is up and it's
-specifically Payara's pool holding dead connections.
+closed` from background EJB timers even while `mysql -h <local-mysql-host>
+... SELECT 1` succeeds fine from the shell — proving MySQL itself is up and
+it's specifically Payara's pool holding dead connections.
 
 **Diagnose**: confirm MySQL responds directly first (rules out "DB is down"),
 then confirm Payara's admin port responds to `list-applications` (rules out
@@ -1016,7 +1016,7 @@ immediately after the flush. Verified while testing issue #22423 (itself a
 stale-audit-pool-connection bug), where the local dev machine's own audit
 pool had gone stale exactly the way the issue described.
 
-## 43. A leftover Playwright-MCP Chrome profile can lock out `browser_navigate` with no relation to the user's real browser windows
+## 48. A leftover Playwright-MCP Chrome profile can lock out `browser_navigate` with no relation to the user's real browser windows
 
 `mcp__playwright__browser_navigate`/`browser_snapshot` can fail with `Browser
 is already in use for <profile-dir>, use --isolated to run multiple instances

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -982,6 +982,63 @@ test-fixture data, not a bug.
   silently toggle the wrong control if the page has more than one:
   `document.querySelector('[id$="chkApplicationWide"] .ui-chkbox-box')`.
 
+## 42. Local Payara can come up with a dead MySQL connection pool after any host sleep/restart — every page hangs, not just one touching a stale entity
+
+Unlike §38 (a pool holding connections from *before* an `ALTER TABLE`), this is
+the pool holding connections to a MySQL instance that was itself restarted or
+the host machine slept/resumed. Symptoms are more severe than §38's
+single-page hang: **the app root itself** (`GET /rh`, even the pre-login page)
+times out in both a direct `Invoke-WebRequest`/`curl` and
+`browser_navigate`/`browser_snapshot` (30-60s timeouts with no response) —
+because `ConfigOptionApplicationController.init()` runs on first
+request/session and hits the DB immediately. `server.log` shows
+`CJCommunicationsException: Communications link failure` /
+`SQLNonTransientConnectionException: No operations allowed after connection
+closed` from background EJB timers even while `mysql -h 127.0.0.1 ... SELECT
+1` succeeds fine from the shell — proving MySQL itself is up and it's
+specifically Payara's pool holding dead connections.
+
+**Diagnose**: confirm MySQL responds directly first (rules out "DB is down"),
+then confirm Payara's admin port responds to `list-applications` (rules out
+"domain is down") — if both succeed but the HTTP listener (9090) times out,
+suspect the connection pool.
+
+**Fix**: flush both the main and audit pools (find pool names via
+`grep -B2 'jndi-name="jdbc/coop"' domain.xml` /
+`grep -B2 'jndi-name="jdbc/ruhunuAudit"' domain.xml` — e.g. `poolCoop` and
+`poolRuhunuAuditLocal` locally):
+```powershell
+& asadmin.bat --port 5858 flush-connection-pool poolCoop
+& asadmin.bat --port 5858 flush-connection-pool poolRuhunuAuditLocal
+```
+No redeploy or domain restart needed — a plain HTTP request succeeds
+immediately after the flush. Verified while testing issue #22423 (itself a
+stale-audit-pool-connection bug), where the local dev machine's own audit
+pool had gone stale exactly the way the issue described.
+
+## 43. A leftover Playwright-MCP Chrome profile can lock out `browser_navigate` with no relation to the user's real browser windows
+
+`mcp__playwright__browser_navigate`/`browser_snapshot` can fail with `Browser
+is already in use for <profile-dir>, use --isolated to run multiple instances
+of the same browser` even when no Playwright session is visibly active. This
+comes from an orphaned Chrome process tree still holding that specific
+`--user-data-dir` (named `ms-playwright-mcp\mcp-chrome-<hash>` on Windows),
+left behind by a prior session that didn't shut down cleanly — it is **not**
+related to the user's everyday Chrome windows, which run under a different
+profile entirely. Confirm before touching anything:
+```powershell
+Get-CimInstance Win32_Process -Filter "Name = 'chrome.exe'" |
+  Where-Object { $_.CommandLine -like '*ms-playwright-mcp*' } |
+  Select-Object ProcessId, CommandLine
+```
+Every process whose `CommandLine` contains `ms-playwright-mcp` (main browser,
+crashpad handler, gpu-process, utility, renderer subprocesses) is safe to
+`Stop-Process -Force` — they all share that same isolated profile directory,
+distinct from the user's real Chrome profile. After clearing them,
+`browser_navigate` launches a fresh instance normally (the very first
+navigation after relaunch can still take up to 60s — a single retry is
+usually enough). Verified while testing issue #22423.
+
 Found while verifying issue #21538 (discharge notifications routing to the
 wrong patient) — the fix couldn't be end-to-end tested at all until this was
 discovered and worked around.

--- a/src/main/java/com/divudi/service/AuditService.java
+++ b/src/main/java/com/divudi/service/AuditService.java
@@ -3,15 +3,12 @@ package com.divudi.service;
 import com.divudi.core.entity.AuditEvent;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.WebUser;
-import com.divudi.core.facade.AuditEventFacade;
 import com.google.gson.Gson;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
 import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpServletRequest;
 
@@ -21,13 +18,12 @@ import javax.servlet.http.HttpServletRequest;
  *
  */
 @Stateless
-@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class AuditService {
 
     private static final Logger LOGGER = Logger.getLogger(AuditService.class.getName());
 
     @EJB
-    AuditEventFacade auditEventFacade;
+    AuditEventService auditEventService;
 
     private final Gson gson = new Gson();
 
@@ -63,7 +59,7 @@ public class AuditService {
             audit.setEventStatus("Completed");
             audit.setIpAddress(getClientIpAddress());
 
-            auditEventFacade.create(audit);
+            auditEventService.saveAuditEvent(audit);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
@@ -84,7 +80,7 @@ public class AuditService {
             audit.setEventStatus("Completed");
             audit.setIpAddress(getClientIpAddress());
 
-            auditEventFacade.create(audit);
+            auditEventService.saveAuditEvent(audit);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
@@ -115,7 +111,7 @@ public class AuditService {
             audit.setEventStatus(eventStatus != null ? eventStatus : "Completed");
             audit.setIpAddress(getClientIpAddress());
 
-            auditEventFacade.create(audit);
+            auditEventService.saveAuditEvent(audit);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
@@ -165,7 +161,7 @@ public class AuditService {
             audit.setAfterJson(after != null ? gson.toJson(after) : null);
             audit.setEventStatus("Completed");
             audit.setIpAddress(getClientIpAddress());
-            auditEventFacade.create(audit);
+            auditEventService.saveAuditEvent(audit);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }

--- a/src/main/java/com/divudi/service/AuditService.java
+++ b/src/main/java/com/divudi/service/AuditService.java
@@ -6,8 +6,12 @@ import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.AuditEventFacade;
 import com.google.gson.Gson;
 import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpServletRequest;
 
@@ -17,7 +21,10 @@ import javax.servlet.http.HttpServletRequest;
  *
  */
 @Stateless
+@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class AuditService {
+
+    private static final Logger LOGGER = Logger.getLogger(AuditService.class.getName());
 
     @EJB
     AuditEventFacade auditEventFacade;
@@ -58,10 +65,10 @@ public class AuditService {
 
             auditEventFacade.create(audit);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
     }
-    
+
     public void logAudit(Object before, Object after, WebUser user, String entityType, String eventTrigger, Long objectId) {
         try {
             AuditEvent audit = new AuditEvent();
@@ -79,7 +86,7 @@ public class AuditService {
 
             auditEventFacade.create(audit);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
     }
 
@@ -110,7 +117,7 @@ public class AuditService {
 
             auditEventFacade.create(audit);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
     }
 
@@ -160,7 +167,7 @@ public class AuditService {
             audit.setIpAddress(getClientIpAddress());
             auditEventFacade.create(audit);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.WARNING, "Failed to record audit event: " + eventTrigger, e);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #22423 — accepting a patient transfer (and any other flow that calls `AuditService`/`AuditEventFacade`, ~55 call sites) could fail with a 500 if the audit-DB connection pool held a stale connection, because the audit write was implicitly enlisted in the **same JTA transaction** as the caller's real business writes (both `AuditService` and the business-logic facades default to `@TransactionAttribute(REQUIRED)`). A failed 2-phase commit on the audit datasource rolled back the already-succeeded business logic too.

- `AuditService` is now annotated `@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)` at the class level, so every audit write (`logAudit`/`logEncounterAudit`, all 4 overloads) always runs in its own isolated transaction against `hmisAuditPU`/`jdbc/ruhunuAudit`. A stale/failed audit connection can no longer roll back the caller's transaction.
- Replaced `e.printStackTrace()` in each catch block with `java.util.logging.Logger` (matching the convention used elsewhere in `com.divudi.service`), so audit-write failures are now visible in `server.log` instead of silently going to stdout.
- This mirrors the existing `@TransactionAttribute(REQUIRES_NEW)` pattern already used in `BillItemFacade` for the same kind of isolation need.
- The issue's other suggested mitigation (lowering `poolRuhunuAuditLocal`'s idle-timeout / enabling connection validation) is a Payara `domain.xml`/ops-side config change outside this repo's version control and is intentionally not part of this PR.

## Test plan

Verified end-to-end against a local Payara/MySQL instance (department: Inward, admission BHT/53358):

- [x] Initiated a transfer (Ward 95/II → Room 401) via `inward_transfer_initiate.xhtml`
- [x] Accepted the pending transfer via `inward_patient_accept_single.xhtml` (the exact page from this issue) — succeeded with no 500, pending list cleared
- [x] Confirmed in the DB that both the business rows (`patienttransferrequest.STATUS=ACCEPTED`, `patientencounter.CURRENTPATIENTROOM_ID` updated) **and** the audit rows (`Transfer Initiated` + `Transfer Accepted` in the audit DB's `auditevent` table) committed successfully — proving `REQUIRES_NEW` isolation doesn't silently drop legitimate audit writes
- [x] `mvn clean package` — all 185 existing tests pass
- [x] Full before/after screenshots and DB verification posted to [issue #22423](https://github.com/hmislk/hmis/issues/22423#issuecomment-5081039914)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit event handling so audit records are saved independently from the surrounding transaction.
  * Replaced console stack traces with structured warning logs when audit recording fails.

* **Documentation**
  * Added troubleshooting guidance for database connection pool failures after host sleep or restart.
  * Documented steps for resolving locked Playwright browser profiles that prevent navigation and page inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->