### PR TITLE
Show specific overlapping rooms in conflict warnings

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1692,6 +1692,9 @@ public class BhtSummeryController implements Serializable {
         if (patientRoom == null || patientRoom.getAdmittedAt() == null || patientRoom.getPatientEncounter() == null) {
             return new ArrayList<>();
         }
+        if (patientRoom.getDischargedAt() != null && patientRoom.getDischargedAt().before(patientRoom.getAdmittedAt())) {
+            return new ArrayList<>();
+        }
         if (patientRoom instanceof GuardianRoom || patientRoom instanceof TheatreRoom) {
             return new ArrayList<>();
         }
@@ -1750,7 +1753,8 @@ public class BhtSummeryController implements Serializable {
             if (i > 0) {
                 sb.append(", ");
             }
-            String roomName = pr2.getRoomFacilityCharge() != null ? pr2.getRoomFacilityCharge().getName() : "an unnamed room";
+            String roomName = pr2.getRoomFacilityCharge() != null && pr2.getRoomFacilityCharge().getName() != null
+                    ? pr2.getRoomFacilityCharge().getName() : "an unnamed room";
             sb.append(roomName).append(pr2.getDischargedAt() == null ? " (Active)" : " (Left)");
         }
         return sb.toString();

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1677,21 +1677,26 @@ public class BhtSummeryController implements Serializable {
         return pendingOverlapRoom;
     }
 
+    public String getPendingOverlapDescription() {
+        return getOverlapDescription(pendingOverlapRoom);
+    }
+
     /**
-     * True when this room's admitted/discharged time range overlaps another
-     * non-Guardian/Theatre room period for the same patient encounter or the
-     * same bed (RoomFacilityCharge). Used both to gate the save confirmation
-     * and to render a persistent warning on the room row.
+     * The other non-Guardian/Theatre room stay(s) for the same patient
+     * encounter or same bed (RoomFacilityCharge) whose admitted/discharged
+     * time range overlaps this room's. Returned (rather than just a count)
+     * so callers can report exactly which room(s) are the conflict instead
+     * of a generic "overlap detected" message.
      */
-    public boolean hasOverlap(PatientRoom patientRoom) {
+    public List<PatientRoom> getOverlappingRooms(PatientRoom patientRoom) {
         if (patientRoom == null || patientRoom.getAdmittedAt() == null || patientRoom.getPatientEncounter() == null) {
-            return false;
+            return new ArrayList<>();
         }
         if (patientRoom instanceof GuardianRoom || patientRoom instanceof TheatreRoom) {
-            return false;
+            return new ArrayList<>();
         }
         StringBuilder jpql = new StringBuilder();
-        jpql.append("SELECT COUNT(pr2) FROM PatientRoom pr2 WHERE pr2.retired = false ");
+        jpql.append("SELECT pr2 FROM PatientRoom pr2 WHERE pr2.retired = false ");
         jpql.append("AND TYPE(pr2) != :guardianClass AND TYPE(pr2) != :theatreClass ");
         Map<String, Object> params = new HashMap<>();
         params.put("guardianClass", GuardianRoom.class);
@@ -1713,8 +1718,42 @@ public class BhtSummeryController implements Serializable {
         }
         jpql.append("AND (pr2.dischargedAt IS NULL OR pr2.dischargedAt > :from)");
         params.put("from", patientRoom.getAdmittedAt());
-        long count = getPatientRoomFacade().findLongByJpql(jpql.toString(), params);
-        return count > 0;
+        List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params);
+        return overlaps != null ? overlaps : new ArrayList<>();
+    }
+
+    /**
+     * True when this room's admitted/discharged time range overlaps another
+     * non-Guardian/Theatre room period for the same patient encounter or the
+     * same bed (RoomFacilityCharge). Used both to gate the save confirmation
+     * and to render a persistent warning on the room row.
+     */
+    public boolean hasOverlap(PatientRoom patientRoom) {
+        return !getOverlappingRooms(patientRoom).isEmpty();
+    }
+
+    /**
+     * Human-readable summary of which specific room(s) this room's time
+     * range conflicts with, e.g. "Room 412 (Active)". Used by the row-level
+     * "Overlap" tag and the save confirmation dialog so a conflict can be
+     * identified and resolved instead of showing a generic warning that
+     * stays stuck when there are 3+ open (non-discharged) room stays.
+     */
+    public String getOverlapDescription(PatientRoom patientRoom) {
+        List<PatientRoom> overlaps = getOverlappingRooms(patientRoom);
+        if (overlaps.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("Overlaps with ");
+        for (int i = 0; i < overlaps.size(); i++) {
+            PatientRoom pr2 = overlaps.get(i);
+            if (i > 0) {
+                sb.append(", ");
+            }
+            String roomName = pr2.getRoomFacilityCharge() != null ? pr2.getRoomFacilityCharge().getName() : "an unnamed room";
+            sb.append(roomName).append(pr2.getDischargedAt() == null ? " (Active)" : " (Left)");
+        }
+        return sb.toString();
     }
 
     public boolean isAnyRoomOverlapping() {

--- a/src/main/webapp/inward/inward_patient_room_details.xhtml
+++ b/src/main/webapp/inward/inward_patient_room_details.xhtml
@@ -43,6 +43,9 @@
                             <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
                                 &#9888; WARNING: This room's time range overlaps another room period for this patient or bed.
                             </p>
+                            <p style="color:#b71c1c;">
+                                <h:outputText value="#{bhtSummeryController.pendingOverlapDescription}"/>
+                            </p>
                             <p>Are you sure you want to save this room with the overlapping time range?</p>
                             <div class="d-flex justify-content-end gap-2 mt-3">
                                 <p:commandButton value="Cancel" icon="fa fa-times" class="ui-button-secondary"
@@ -157,7 +160,8 @@
                                                     <p:badge value="Active" severity="warning"/>
                                                 </h:panelGroup>
                                                 <h:panelGroup rendered="#{bhtSummeryController.hasOverlap(rm)}">
-                                                    <p:tag value="Overlap" icon="fa fa-exclamation-triangle" severity="danger"/>
+                                                    <p:tag value="Overlap" icon="fa fa-exclamation-triangle" severity="danger"
+                                                           title="#{bhtSummeryController.getOverlapDescription(rm)}"/>
                                                 </h:panelGroup>
                                             </div>
                                         </p:column>


### PR DESCRIPTION
## Summary
Refactor room overlap detection to return the actual conflicting rooms instead of just a boolean count, enabling the UI to display specific room details in warnings and dialogs.

## Key Changes
- **Refactored `hasOverlap()`**: Now delegates to `getOverlappingRooms()` which returns a `List<PatientRoom>` instead of querying for a count
  - Changed JPQL from `SELECT COUNT(pr2)` to `SELECT pr2` to retrieve actual room entities
  - Returns empty list instead of false for null/invalid inputs and excluded room types
  
- **Added `getOverlapDescription()`**: New method that generates human-readable conflict summaries
  - Formats as "Overlaps with Room 412 (Active), Room 415 (Left)" 
  - Includes room name from `RoomFacilityCharge` and discharge status
  - Returns empty string when no overlaps exist

- **Added `getPendingOverlapDescription()`**: Convenience getter for the pending overlap room's description

- **Updated UI warnings**:
  - Save confirmation dialog now displays the specific overlapping room(s) via `pendingOverlapDescription`
  - Room row "Overlap" tag now shows room details on hover via `title` attribute

## Implementation Details
- Maintains backward compatibility: `hasOverlap()` still returns boolean by checking if the list is empty
- Avoids N+1 queries by fetching all overlapping rooms in a single query
- Handles edge cases: null room names default to "an unnamed room", distinguishes active vs. discharged rooms

https://claude.ai/code/session_01G4K82fvswagkgBAdsjnY6L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the room-timeline conflict dialog to show a dynamic, human-readable overlap message for the pending stay.
  * Overlap indicators in the room history now include tooltips describing each conflicting room and whether it is active or left.
* **Bug Fixes**
  * Improved overlap detection by retrieving the specific conflicting room stays (for the same encounter/bed and overlapping time range) rather than only reporting a count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->