### PR TITLE
Add ward-wide pharmacy requests list with filters (issue #22428)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -5,6 +5,7 @@
  */
 package com.divudi.bean.inward;
 
+import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
@@ -14,16 +15,19 @@ import com.divudi.core.data.dto.InpatientPharmacyBillItemDTO;
 import com.divudi.core.data.dto.InpatientPharmacyDepartmentSummaryDTO;
 import com.divudi.core.data.dto.InpatientPharmacyItemSummaryDTO;
 import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.Department;
 import com.divudi.core.entity.PreBill;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.util.CommonFunctions;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -68,6 +72,8 @@ public class InwardPharmacyEncounterReportController implements Serializable {
 
     @Inject
     AdmissionController admissionController;
+    @Inject
+    SessionController sessionController;
 
     private PatientEncounter patientEncounter;
 
@@ -76,6 +82,19 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     // entity-only concerns (not expressible as pure DTO projections).
     private List<Bill> pharmacyRequestBillsToPatientEncounter;
     private double pharmacyRequestBillsToPatientEncounterNetTotal;
+
+    // 1a) Ward-wide Pharmacy Requests list (issue #22428) - reached from the
+    // Nursing Dashboard, scoped to the logged-in nurse's own department
+    // (Bill.department, set from sessionController.getDepartment() at
+    // request-creation time - see PharmacyRequestForBhtController), across
+    // all patients/encounters in that ward, with filters.
+    private List<Bill> pharmacyRequestBillsToWard;
+    private double pharmacyRequestBillsToWardNetTotal;
+    private String wardPharmacyRequestStatusFilter;
+    private Department wardPharmacyRequestDepartmentFilter;
+    private String wardPharmacyRequestPatientFilter;
+    private Date wardPharmacyRequestFromDate;
+    private Date wardPharmacyRequestToDate;
 
     // 1b) Pharmacy Request Drafts list (InwardPharmacyRequest bills with
     // billTypeAtomic = REQUEST_MEDICINE_INWARD_PRE, i.e. not yet settled)
@@ -139,6 +158,97 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         params.put("pe", patientEncounter);
 
         List<Bill> result = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * Ward-wide Pharmacy Requests list (issue #22428), reached from the
+     * Nursing Dashboard. Unlike {@link #navigateToInpatientPharmacyRequestsList()}
+     * this is not scoped to one patientEncounter - it lists InwardPharmacyRequest
+     * bills for the logged-in nurse's own department (ward), across all patients
+     * currently admitted there, with filters (status, requested/target
+     * department, patient/BHT no, date range). Modeled on
+     * {@link PatientTransferController#loadPendingForDepartment()}.
+     */
+    public String navigateToWardPharmacyRequestsList() {
+        wardPharmacyRequestStatusFilter = null;
+        wardPharmacyRequestDepartmentFilter = null;
+        wardPharmacyRequestPatientFilter = null;
+        wardPharmacyRequestFromDate = null;
+        wardPharmacyRequestToDate = null;
+        filterWardPharmacyRequests();
+        return "/inward/reports/ward_pharmacy_requests_list?faces-redirect=true";
+    }
+
+    /**
+     * Re-runs the ward-wide Pharmacy Requests query using the current filter
+     * field values. Bound to the filter panel's "Apply Filters" button on
+     * ward_pharmacy_requests_list.xhtml (ajax).
+     */
+    public void filterWardPharmacyRequests() {
+        pharmacyRequestBillsToWard = new ArrayList<>();
+        pharmacyRequestBillsToWardNetTotal = 0.0;
+        try {
+            pharmacyRequestBillsToWard = fetchWardPharmacyRequestBills();
+            for (Bill b : pharmacyRequestBillsToWard) {
+                pharmacyRequestBillsToWardNetTotal += b.getNetTotal();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
+                    .log(Level.SEVERE, "Error loading ward pharmacy request bills", e);
+            JsfUtil.addErrorMessage("Error loading pharmacy request data");
+        }
+    }
+
+    private List<Bill> fetchWardPharmacyRequestBills() {
+        Department dept = sessionController.getDepartment();
+        StringBuilder jpql = new StringBuilder(
+                "SELECT b FROM Bill b "
+                + "WHERE b.billType = :billType "
+                + "AND b.billTypeAtomic = :bta "
+                + "AND b.retired = false "
+                + "AND b.department = :dept ");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.InwardPharmacyRequest);
+        params.put("bta", BillTypeAtomic.REQUEST_MEDICINE_INWARD);
+        params.put("dept", dept);
+
+        if (wardPharmacyRequestStatusFilter != null) {
+            switch (wardPharmacyRequestStatusFilter) {
+                case "Issued":
+                    jpql.append("AND b.cancelled = false AND b.fullyIssued = true ");
+                    break;
+                case "Not Issued":
+                    jpql.append("AND b.cancelled = false AND b.fullyIssued = false ");
+                    break;
+                case "Cancelled":
+                    jpql.append("AND b.cancelled = true ");
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (wardPharmacyRequestDepartmentFilter != null) {
+            jpql.append("AND b.toDepartment = :toDept ");
+            params.put("toDept", wardPharmacyRequestDepartmentFilter);
+        }
+        if (wardPharmacyRequestPatientFilter != null && !wardPharmacyRequestPatientFilter.trim().isEmpty()) {
+            jpql.append("AND (UPPER(b.patientEncounter.bhtNo) LIKE :patientTxt "
+                    + "OR UPPER(b.patientEncounter.patient.person.name) LIKE :patientTxt) ");
+            params.put("patientTxt", "%" + wardPharmacyRequestPatientFilter.trim().toUpperCase() + "%");
+        }
+        if (wardPharmacyRequestFromDate != null) {
+            jpql.append("AND b.createdAt >= :fromDate ");
+            params.put("fromDate", wardPharmacyRequestFromDate);
+        }
+        if (wardPharmacyRequestToDate != null) {
+            jpql.append("AND b.createdAt <= :toDate ");
+            params.put("toDate", CommonFunctions.getEndOfDay(wardPharmacyRequestToDate));
+        }
+        jpql.append("ORDER BY b.createdAt DESC");
+
+        List<Bill> result = billFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
         return result != null ? result : new ArrayList<>();
     }
 
@@ -571,6 +681,15 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         return result;
     }
 
+    /**
+     * Back-nav for the ward-wide Pharmacy Requests page (issue #22428) - there
+     * is no single admission to return to, so this goes back to the Nursing
+     * Dashboard instead of {@link #navigateToAdmissionProfile()}.
+     */
+    public String navigateToNursingDashboard() {
+        return "/nurse/index?faces-redirect=true";
+    }
+
     public String navigateToAdmissionProfile() {
         if (patientEncounter == null) {
             JsfUtil.addErrorMessage("No encounter selected");
@@ -604,6 +723,62 @@ public class InwardPharmacyEncounterReportController implements Serializable {
 
     public void setPharmacyRequestBillsToPatientEncounterNetTotal(double pharmacyRequestBillsToPatientEncounterNetTotal) {
         this.pharmacyRequestBillsToPatientEncounterNetTotal = pharmacyRequestBillsToPatientEncounterNetTotal;
+    }
+
+    public List<Bill> getPharmacyRequestBillsToWard() {
+        return pharmacyRequestBillsToWard;
+    }
+
+    public void setPharmacyRequestBillsToWard(List<Bill> pharmacyRequestBillsToWard) {
+        this.pharmacyRequestBillsToWard = pharmacyRequestBillsToWard;
+    }
+
+    public double getPharmacyRequestBillsToWardNetTotal() {
+        return pharmacyRequestBillsToWardNetTotal;
+    }
+
+    public void setPharmacyRequestBillsToWardNetTotal(double pharmacyRequestBillsToWardNetTotal) {
+        this.pharmacyRequestBillsToWardNetTotal = pharmacyRequestBillsToWardNetTotal;
+    }
+
+    public String getWardPharmacyRequestStatusFilter() {
+        return wardPharmacyRequestStatusFilter;
+    }
+
+    public void setWardPharmacyRequestStatusFilter(String wardPharmacyRequestStatusFilter) {
+        this.wardPharmacyRequestStatusFilter = wardPharmacyRequestStatusFilter;
+    }
+
+    public Department getWardPharmacyRequestDepartmentFilter() {
+        return wardPharmacyRequestDepartmentFilter;
+    }
+
+    public void setWardPharmacyRequestDepartmentFilter(Department wardPharmacyRequestDepartmentFilter) {
+        this.wardPharmacyRequestDepartmentFilter = wardPharmacyRequestDepartmentFilter;
+    }
+
+    public String getWardPharmacyRequestPatientFilter() {
+        return wardPharmacyRequestPatientFilter;
+    }
+
+    public void setWardPharmacyRequestPatientFilter(String wardPharmacyRequestPatientFilter) {
+        this.wardPharmacyRequestPatientFilter = wardPharmacyRequestPatientFilter;
+    }
+
+    public Date getWardPharmacyRequestFromDate() {
+        return wardPharmacyRequestFromDate;
+    }
+
+    public void setWardPharmacyRequestFromDate(Date wardPharmacyRequestFromDate) {
+        this.wardPharmacyRequestFromDate = wardPharmacyRequestFromDate;
+    }
+
+    public Date getWardPharmacyRequestToDate() {
+        return wardPharmacyRequestToDate;
+    }
+
+    public void setWardPharmacyRequestToDate(Date wardPharmacyRequestToDate) {
+        this.wardPharmacyRequestToDate = wardPharmacyRequestToDate;
     }
 
     public List<Bill> getPharmacyRequestDraftBillsToPatientEncounter() {

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_requests_list.xhtml
@@ -160,13 +160,17 @@
                                         <h:outputLabel value="Status" />
                                     </f:facet>
                                     <p:tag
+                                        value="Cancelled"
+                                        severity="danger"
+                                        rendered="#{b.cancelled}" />
+                                    <p:tag
                                         value="Issued"
                                         severity="success"
-                                        rendered="#{inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                                        rendered="#{not b.cancelled and inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
                                     <p:tag
                                         value="Not Issued"
                                         severity="warning"
-                                        rendered="#{not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                                        rendered="#{not b.cancelled and not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
                                 </p:column>
 
                                 <p:column width="10em" style="padding: 2px" exportable="false">
@@ -190,7 +194,7 @@
                                         class="ui-button-success m-1"
                                         ajax="false"
                                         icon="fa fa-prescription-bottle-alt"
-                                        rendered="#{not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id) and webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
+                                        rendered="#{not b.cancelled and not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id) and webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
                                         action="#{pharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()}">
                                         <f:setPropertyActionListener value="#{b}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
                                     </p:commandButton>

--- a/src/main/webapp/inward/reports/ward_pharmacy_requests_list.xhtml
+++ b/src/main/webapp/inward/reports/ward_pharmacy_requests_list.xhtml
@@ -1,0 +1,270 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="wardPharmacyRequestsGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fa fa-clipboard-list"></h:outputText>
+                            <p:outputLabel value="Pharmacy Requests - #{sessionController.department.name}"></p:outputLabel>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToNursingDashboard"
+                                value="Nursing Dashboard"
+                                action="#{inwardPharmacyEncounterReportController.navigateToNursingDashboard()}"
+                                ajax="false"
+                                icon="fa fa-arrow-circle-left"
+                                styleClass="ui-button-info ui-button-outlined">
+                            </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnDownload"
+                                value="Download"
+                                ajax="false"
+                                icon="fa fa-download"
+                                styleClass="ui-button-secondary">
+                                <p:dataExporter fileName="Ward Pharmacy Requests" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnPrint"
+                                value="Print"
+                                ajax="false"
+                                icon="fa fa-print"
+                                styleClass="ui-button-secondary">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <p:panel>
+                    <f:facet name="header">
+                        <p:outputLabel value="Filters" style="font-weight: bold"></p:outputLabel>
+                    </f:facet>
+                    <div class="row">
+                        <div class="col-md-2">
+                            <p:outputLabel value="Status" for="statusFilter" />
+                            <p:selectOneMenu id="statusFilter" class="w-100"
+                                             value="#{inwardPharmacyEncounterReportController.wardPharmacyRequestStatusFilter}">
+                                <f:selectItem itemLabel="All" itemValue="#{null}" />
+                                <f:selectItem itemLabel="Issued" itemValue="Issued" />
+                                <f:selectItem itemLabel="Not Issued" itemValue="Not Issued" />
+                                <f:selectItem itemLabel="Cancelled" itemValue="Cancelled" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel value="Requested Department" for="deptFilter" />
+                            <p:selectOneMenu id="deptFilter" class="w-100" filter="true"
+                                             value="#{inwardPharmacyEncounterReportController.wardPharmacyRequestDepartmentFilter}">
+                                <f:selectItem itemLabel="All Departments" itemValue="#{null}" />
+                                <f:selectItems value="#{departmentController.items}" var="d"
+                                               itemLabel="#{d.name}" itemValue="#{d}" />
+                            </p:selectOneMenu>
+                        </div>
+                        <div class="col-md-3">
+                            <p:outputLabel value="Patient / BHT No" for="patientFilter" />
+                            <p:inputText id="patientFilter" class="w-100"
+                                         value="#{inwardPharmacyEncounterReportController.wardPharmacyRequestPatientFilter}" />
+                        </div>
+                        <div class="col-md-2">
+                            <p:outputLabel value="From" for="fromDate" />
+                            <p:calendar id="fromDate" class="w-100" inputStyleClass="w-100"
+                                        value="#{inwardPharmacyEncounterReportController.wardPharmacyRequestFromDate}"
+                                        navigator="true" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </div>
+                        <div class="col-md-2">
+                            <p:outputLabel value="To" for="toDate" />
+                            <p:calendar id="toDate" class="w-100" inputStyleClass="w-100"
+                                        value="#{inwardPharmacyEncounterReportController.wardPharmacyRequestToDate}"
+                                        navigator="true" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                        </div>
+                    </div>
+                    <div class="row mt-2">
+                        <div class="col-12 d-flex justify-content-end">
+                            <p:commandButton
+                                id="btnApplyFilters"
+                                value="Apply Filters"
+                                icon="fa fa-filter"
+                                update="form"
+                                actionListener="#{inwardPharmacyEncounterReportController.filterWardPharmacyRequests()}"
+                                styleClass="ui-button-primary">
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </p:panel>
+
+                <p:panel>
+                    <f:facet name="header">
+                        <p:outputLabel value="Pharmacy Requests" style="font-weight: bold"></p:outputLabel>
+                    </f:facet>
+
+                    <p:dataTable
+                        id="tbl1"
+                        rowIndexVar="rowIndex"
+                        rowKey="#{b.id}"
+                        value="#{inwardPharmacyEncounterReportController.pharmacyRequestBillsToWard}"
+                        var="b">
+
+                        <p:column width="2em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="No" />
+                            </f:facet>
+                            <h:outputLabel value="#{rowIndex+1}" />
+                        </p:column>
+
+                        <p:column width="8em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Bill No" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.deptId}" />
+                        </p:column>
+
+                        <p:column width="8em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="BHT No" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.patientEncounter.bhtNo}" />
+                        </p:column>
+
+                        <p:column width="12em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Patient" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.patientEncounter.patient.person.nameWithTitle}" />
+                        </p:column>
+
+                        <p:column width="12em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Requested Department" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.toDepartment.name}" />
+                        </p:column>
+
+                        <p:column width="12em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Requested At" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.createdAt}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                            </h:outputLabel>
+                        </p:column>
+
+                        <p:column width="10em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Requested By" />
+                            </f:facet>
+                            <h:outputLabel value="#{b.creater.webUserPerson.name}" />
+                        </p:column>
+
+                        <p:column width="8em" style="padding: 2px">
+                            <f:facet name="header">
+                                <h:outputLabel value="Status" />
+                            </f:facet>
+                            <p:tag
+                                value="Cancelled"
+                                severity="danger"
+                                rendered="#{b.cancelled}" />
+                            <p:tag
+                                value="Issued"
+                                severity="success"
+                                rendered="#{not b.cancelled and inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                            <p:tag
+                                value="Not Issued"
+                                severity="warning"
+                                rendered="#{not b.cancelled and not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id)}" />
+                        </p:column>
+
+                        <p:column width="10em" style="padding: 2px" exportable="false">
+                            <f:facet name="header">
+                                <h:outputLabel value="Actions" />
+                            </f:facet>
+                            <p:commandButton
+                                id="btnViewRequest"
+                                title="View Request"
+                                class="ui-button-primary m-1"
+                                ajax="false"
+                                icon="fa fa-eye"
+                                action="/ward/ward_pharmacy_reprint_bht_issue_request?faces-redirect=true">
+                                <f:setPropertyActionListener value="#{b}" target="#{pharmacyBillSearch.bill}"/>
+                                <f:setPropertyActionListener value="/inward/reports/ward_pharmacy_requests_list?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                id="btnIssueMedicines"
+                                title="Issue Medicines"
+                                class="ui-button-success m-1"
+                                ajax="false"
+                                icon="fa fa-prescription-bottle-alt"
+                                rendered="#{not b.cancelled and not inwardPharmacyEncounterReportController.isRequestFullyIssued(b.id) and webUserController.hasPrivilege('PharmacyBHTIssueAccept')}"
+                                action="#{pharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()}">
+                                <f:setPropertyActionListener value="#{b}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
+                            </p:commandButton>
+                        </p:column>
+
+                        <p:column style="width: 3em" exportable="false">
+                            <p:rowToggler />
+                        </p:column>
+
+                        <p:rowExpansion>
+                            <p:dataTable var="ib" value="#{inwardPharmacyEncounterReportController.getIssuedBillsForRequest(b.id)}">
+                                <p:column headerText="Bill No" width="15%">
+                                    <h:outputLabel value="#{ib.deptId}"/>
+                                </p:column>
+                                <p:column headerText="Date" width="20%">
+                                    <h:outputLabel value="#{ib.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Issued By" width="20%">
+                                    <h:outputLabel value="#{ib.creater.webUserPerson.name}"/>
+                                </p:column>
+                                <p:column headerText="To Staff" width="20%">
+                                    <h:outputLabel value="#{ib.toStaff.person.nameWithTitle}"/>
+                                </p:column>
+                                <p:column headerText="Net Total" width="12%" style="text-align: right;">
+                                    <h:outputLabel value="#{ib.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:column headerText="Action" width="13%">
+                                    <p:commandButton ajax="false" value="View Bill" action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint?faces-redirect=true">
+                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{ib}"/>
+                                    </p:commandButton>
+                                </p:column>
+                            </p:dataTable>
+                        </p:rowExpansion>
+
+                    </p:dataTable>
+
+                    <div class="d-flex justify-content-end p-2">
+                        <h:outputLabel value="Total Net: " style="font-weight: bold;" />
+                        <h:outputLabel value="#{inwardPharmacyEncounterReportController.pharmacyRequestBillsToWardNetTotal}" style="font-weight: bold; margin-left: 6px;">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </div>
+
+                </p:panel>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -643,14 +643,11 @@
                                                                 <p:commandButton
                                                                     id="btnPharmacyRequestsHistoryNurse"
                                                                     value="Pharmacy Requests"
-                                                                    action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyRequestsList()}"
+                                                                    action="#{inwardPharmacyEncounterReportController.navigateToWardPharmacyRequestsList()}"
                                                                     rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
                                                                     icon="fa fa-clipboard-list"
                                                                     class="w-100"
                                                                     ajax="false">
-                                                                    <f:setPropertyActionListener
-                                                                        value="#{admissionController.current}"
-                                                                        target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
                                                                 </p:commandButton>
                                                             </div>
                                                             <div class="col-6">


### PR DESCRIPTION
## Summary
Adds a new ward-wide pharmacy requests report page accessible from the Nursing Dashboard, allowing nurses to view and manage all InwardPharmacyRequest bills for their department across all admitted patients, with filtering capabilities.

## Changes

### New Page
- **`ward_pharmacy_requests_list.xhtml`**: New report page displaying pharmacy requests for the logged-in nurse's department with:
  - Filter panel (status, requested department, patient/BHT no, date range)
  - Data table showing request details (bill no, patient, requested department, status, requested by/at)
  - Row expansion showing issued bills for each request
  - Download (XLSX) and print functionality
  - Action buttons to view requests and issue medicines
  - Total net amount summary

### Controller Updates (`InwardPharmacyEncounterReportController`)
- Added `navigateToWardPharmacyRequestsList()` method to initialize the ward-wide view with cleared filters
- Added `filterWardPharmacyRequests()` method to apply filters and recalculate totals (bound to "Apply Filters" button)
- Added `fetchWardPharmacyRequestBills()` private method implementing JPQL query that:
  - Filters by logged-in user's department (`sessionController.getDepartment()`)
  - Supports status filtering (Issued, Not Issued, Cancelled)
  - Supports requested department filtering
  - Supports patient/BHT no search (case-insensitive)
  - Supports date range filtering (from/to dates with end-of-day handling)
  - Orders results by creation date (newest first)
- Added `navigateToNursingDashboard()` method for back-navigation (returns to `/nurse/index` instead of admission profile)
- Added properties and getters/setters for filter state and results:
  - `pharmacyRequestBillsToWard` (list)
  - `pharmacyRequestBillsToWardNetTotal` (double)
  - `wardPharmacyRequestStatusFilter` (String)
  - `wardPharmacyRequestDepartmentFilter` (Department)
  - `wardPharmacyRequestPatientFilter` (String)
  - `wardPharmacyRequestFromDate` (Date)
  - `wardPharmacyRequestToDate` (Date)
- Added `SessionController` injection for accessing logged-in user's department

### UI Updates
- **`nurse/index.xhtml`**: Updated "Pharmacy Requests" button to navigate to new ward-wide list instead of patient-encounter-specific list
- **`inpatient_pharmacy_requests_list.xhtml`**: Enhanced status tag display to show "Cancelled" status (with danger severity) and only show "Issued"/"Not Issued" for non-cancelled requests

## Implementation Details
- Scoped to the logged-in nurse's own department (set at request-creation time via `sessionController.getDepartment()`)
- Covers all patients/encounters in that ward, unlike the existing patient-encounter-specific pharmacy requests list
- Uses JPQL with parameterized queries for all filters
- Handles date range filtering with `CommonFunctions.getEndOfDay()` for inclusive end-date matching
- Integrates with existing `isRequestFullyIssued()` and `getIssuedBillsForRequest()` methods for status determination
- Supports direct navigation to issue medicines or view request details

https://claude.ai/code/session_012LznhJK5847aWBaTD9k1P2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ward-wide Pharmacy Requests report for nursing staff.
  * Added filters for status, department, patient/BHT number, and date range.
  * Added request details, issued medicine information, status indicators, totals, printing, and downloads.
  * Added navigation between the report and Nursing Dashboard.

* **Bug Fixes**
  * Cancelled requests are now clearly labeled and cannot be issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->