### PR TITLE
Add TTL-based caching for unified Gantt bars

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -300,9 +300,12 @@ public class BhtSummeryController implements Serializable {
      * Theatre bars are amber (active) or grey (completed).
      */
     private transient List<RoomGanttBar> cachedUnifiedGanttBars;
+    private transient long cachedUnifiedGanttBarsComputedAtMillis;
+    private static final long UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS = 5000;
 
     public List<RoomGanttBar> getUnifiedGanttBars() {
-        if (cachedUnifiedGanttBars != null) {
+        if (cachedUnifiedGanttBars != null
+                && (System.currentTimeMillis() - cachedUnifiedGanttBarsComputedAtMillis) < UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS) {
             return cachedUnifiedGanttBars;
         }
         List<PatientRoom> rooms = getPatientRooms();
@@ -346,6 +349,7 @@ public class BhtSummeryController implements Serializable {
 
         if (spanStart == null || spanEnd == null || !spanEnd.after(spanStart)) {
             cachedUnifiedGanttBars = getRoomGanttBars();
+            cachedUnifiedGanttBarsComputedAtMillis = System.currentTimeMillis();
             return cachedUnifiedGanttBars;
         }
 
@@ -403,6 +407,7 @@ public class BhtSummeryController implements Serializable {
         }
 
         cachedUnifiedGanttBars = bars;
+        cachedUnifiedGanttBarsComputedAtMillis = System.currentTimeMillis();
         return cachedUnifiedGanttBars;
     }
 
@@ -3710,6 +3715,7 @@ public class BhtSummeryController implements Serializable {
 //        makeNull();
         this.patientEncounter = patientEncounter;
         cachedUnifiedGanttBars = null;
+        cachedUnifiedGanttBarsComputedAtMillis = 0;
     }
 
     public SessionController getSessionController() {


### PR DESCRIPTION
## Summary
Implements time-to-live (TTL) based caching for the unified Gantt bars in the BHT summary controller to improve performance while ensuring data freshness.

## Key Changes
- Added `cachedUnifiedGanttBarsComputedAtMillis` field to track when the cache was last computed
- Added `UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS` constant set to 5 seconds (5000ms)
- Modified `getUnifiedGanttBars()` cache validation to check both cache existence and TTL expiration
- Updated all cache assignment points to record the computation timestamp
- Reset cache timestamp when patient encounter is changed to invalidate stale data

## Implementation Details
The cache now expires after 5 seconds of inactivity, ensuring that:
- Frequently accessed Gantt bars benefit from caching without serving stale data
- Cache is automatically invalidated when the patient encounter changes
- Timestamp is recorded at both cache assignment points (early return and final return paths)

https://claude.ai/code/session_01VQz1LrsskoCh1nGCCJWoLK