### PR TITLE
Refactor inward bill headers for consistent layout and UX

### DIFF
--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -30,35 +30,55 @@
             <h:form>
                 <p:panel rendered="#{!bhtSummeryController.printPreview}">
                     <f:facet name="header">
-                        <div class="d-flex align-items-center justify-content-between">
-                            <div>
+                        <div class="d-flex justify-content-between align-items-center w-100">
+
+                            <!-- LEFT: title -->
+                            <div class="d-flex align-items-center gap-2">
                                 <h:outputText styleClass="fas fa-file-invoice-dollar" />
-                                <h:outputLabel value="Inward Final Bill" class="mx-2"/>
+                                <h:outputLabel value="Inward Final Bill"/>
                             </div>
-                            <div>
-                                <p:commandButton 
-                                    update="dList tot @all settle saveProvisional" 
+
+                            <!-- CENTER: entity navigation -->
+                            <div class="d-flex gap-2">
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Inpatient Dashboard"
+                                        icon="fa fa-id-card"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}">
+                                        <f:setPropertyActionListener
+                                            target="#{admissionController.current}"
+                                            value="#{bhtSummeryController.patientEncounter}" />
+                                    </p:commandButton>
+                                </h:panelGroup>
+                            </div>
+
+                            <!-- RIGHT: actions — left=least important, right=primary -->
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:commandButton
+                                    update="dList tot @all settle saveProvisional"
                                     value="Process"
                                     actionListener="#{bhtSummeryController.processFinalBill()}"
                                     process="@this"
-                                    class="ui-button-warning mx-1" 
+                                    styleClass="ui-button-warning"
                                     icon="fas fa-cog"
                                     style="width: 150px; padding: 1px; margin: auto;"
                                     rendered="#{!configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
                                 </p:commandButton>
 
-                                <p:commandButton 
-                                    class="ui-button-warning mx-2"
+                                <p:commandButton
+                                    styleClass="ui-button-warning"
                                     icon="fas fa-cogs"
                                     value="Process Bill"
                                     process="@this"
                                     update="dList tot settle saveProvisional @all printTempBill"
-                                    action="#{bhtSummeryController.createTempBill()}" 
+                                    action="#{bhtSummeryController.createTempBill()}"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
                                 </p:commandButton>
 
-                                <p:commandButton 
-                                    class="ui-button-info"
+                                <p:commandButton
+                                    styleClass="ui-button-info"
                                     icon="fas fa-print"
                                     value="Check Final Bill"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false) and configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
@@ -71,7 +91,7 @@
                                     id="saveProvisional"
                                     ajax="false"
                                     disabled="#{bhtSummeryController.changed}"
-                                    class="ui-button-warning mx-1"
+                                    styleClass="ui-button-warning"
                                     icon="fa fa-save"
                                     style="width: 200px; padding: 1px; margin: auto;"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false) and webUserController.hasPrivilege('InwardSaveProvisionalFinalBill')}">
@@ -83,25 +103,13 @@
                                     id="settle"
                                     ajax="false"
                                     disabled="#{bhtSummeryController.changed}"
-                                    class="ui-button-success mx-1"
+                                    styleClass="ui-button-success"
                                     icon="fa fa-check"
                                     style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;"
                                     rendered="#{webUserController.hasPrivilege('InwardSettleFinalBill')}">
                                 </p:commandButton>
-
-                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
-                                    <p:commandButton
-                                        ajax="false"
-                                        value="Inpatient Profile"
-                                        icon="fa fa-id-card"
-                                        styleClass="ui-button-secondary mx-1"
-                                        action="#{bhtSummeryController.navigateToInpatientProfile()}">
-                                        <f:setPropertyActionListener
-                                            target="#{admissionController.current}"
-                                            value="#{bhtSummeryController.patientEncounter}" />
-                                    </p:commandButton>
-                                </h:panelGroup>
                             </div>
+
                         </div>
                     </f:facet>
 
@@ -940,11 +948,11 @@
                 <p:panel rendered="#{bhtSummeryController.printPreview}">
                     <p:panel>
                         <f:facet name="header">
-                            <div class="d-flex align-items-center justify-content-between">
-                                <div>
-                                    <h:outputLabel value="Final Bill" class="mt-2"/>
-                                </div>
-                                <div style="text-align: center!important;">
+                            <div class="d-flex justify-content-between align-items-center w-100">
+
+                                <!-- LEFT: title + claimable status -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <h:outputLabel value="Final Bill"/>
                                     <h:panelGroup
                                         rendered="#{bhtSummeryController.patientEncounter.admissionType.admissionTypeEnum eq 'DayCase' and sessionController.userPreference.applicationInstitution eq 'Ruhuna'}">
                                         <p:outputLabel value="CLAIMABLE"/>
@@ -959,28 +967,29 @@
                                     </h:panelGroup>
                                 </div>
 
-                                <div>
+                                <!-- CENTER: entity navigation -->
+                                <div class="d-flex gap-2">
+                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
+                                        <p:commandButton
+                                            ajax="false"
+                                            value="Inpatient Dashboard"
+                                            icon="fa fa-id-card"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            action="#{bhtSummeryController.navigateToInpatientProfile()}">
+                                            <f:setPropertyActionListener
+                                                target="#{admissionController.current}"
+                                                value="#{bhtSummeryController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </h:panelGroup>
+                                </div>
+
+                                <!-- RIGHT: actions — left=least important, right=primary -->
+                                <div class="d-flex gap-2 align-items-center">
                                     <p:selectBooleanCheckbox value="#{bhtSummeryController.showOrginalBill}"
                                                              label="Show Original Bill" itemLabel="Show Original Bill"
                                                              class="mx-2">
                                         <p:ajax process="@this" update="@all"/>
                                     </p:selectBooleanCheckbox>
-
-                                    <!-- Collect payment button — routes to the right page based on payment method -->
-                                    <p:commandButton
-                                        value="Collect Patient Payment"
-                                        ajax="false"
-                                        icon="fas fa-money-bill-wave"
-                                        class="ui-button-success mx-1"
-                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit'}"
-                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
-                                    <p:commandButton
-                                        value="Collect Patient Co-payment"
-                                        ajax="false"
-                                        icon="fas fa-user-check"
-                                        class="ui-button-warning mx-1"
-                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'}"
-                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
 
                                     <p:commandButton value="Final Bill" ajax="false"
                                                      class="ui-button-info mx-1" icon="fas fa-print">
@@ -1058,6 +1067,21 @@
                                         </p:commandButton>
                                     </h:panelGroup>
 
+                                    <!-- Collect payment button — routes to the right page based on payment method; primary action, rightmost -->
+                                    <p:commandButton
+                                        value="Collect Patient Payment"
+                                        ajax="false"
+                                        icon="fas fa-money-bill-wave"
+                                        class="ui-button-success mx-1"
+                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod ne 'Credit'}"
+                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
+                                    <p:commandButton
+                                        value="Collect Patient Co-payment"
+                                        ajax="false"
+                                        icon="fas fa-user-check"
+                                        class="ui-button-success mx-1"
+                                        rendered="#{bhtSummeryController.patientEncounter.paymentMethod eq 'Credit'}"
+                                        action="#{bhtSummeryController.navigateToCollectPayment()}"/>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -191,60 +191,78 @@
 
                     <p:panel rendered="#{bhtSummeryController.patientEncounter ne null}">
                         <f:facet name="header">
-                            <h:outputText styleClass="fas fa-file-invoice-dollar" />
-                            <p:outputLabel value="Inward Payment Bill" class="mx-2"/>
-                            <div columns="12" class="m-0 d-flex justify-content-end align-items-center" style="float:right;">
-                                <p:commandButton
-                                    ajax="false"
-                                    value="Clear"
-                                    icon="fa-solid fa-eraser"
-                                    class="ui-button-warning"
-                                    action="#{bhtSummeryController.clear}"  />
+                            <div class="d-flex justify-content-between align-items-center w-100">
 
-                                <p:commandButton
-                                    ajax="false"
-                                    value="Settle Bill"
-                                    icon="fa fa-check"
-                                    class="ui-button-success mx-1"
-                                    onclick="PF('settleBillLoadingDlg').show();"
-                                    action="#{bhtSummeryController.toSettle()}"  />
+                                <!-- LEFT: title -->
+                                <div class="d-flex align-items-center gap-2">
+                                    <h:outputText styleClass="fas fa-file-invoice-dollar" />
+                                    <p:outputLabel value="Inward Payment Bill"/>
+                                </div>
 
-                                <p:commandButton
-                                    ajax="false"
-                                    value="Print Bill"
-                                    icon="fas fa-print"
-                                    class="ui-button-info"
-                                    action="#{bhtSummeryController.toPrintItrim()}"  />
+                                <!-- CENTER: entity navigation -->
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        ajax="false"
+                                        immediate="true"
+                                        icon="fa fa-search"
+                                        title="Patient Lookup"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="#{patientController.navigateToSearchPatients()}"
+                                        />
 
+                                    <p:commandButton
+                                        ajax="false"
+                                        immediate="true"
+                                        icon="fa fa-user"
+                                        title="Patient Profile"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="#{patientController.navigateToOpdPatientProfile()}" >
 
-                                <p:commandButton
-                                    ajax="false"
-                                    icon="fa fa-search"
-                                    class="ui-button-warning  mx-1"
-                                    action="#{patientController.navigateToSearchPatients()}"
-                                    />
+                                        <f:setPropertyActionListener
+                                            value="#{bhtSummeryController.patientEncounter.patient}"
+                                            target="#{patientController.current}" ></f:setPropertyActionListener>
+                                    </p:commandButton>
 
-                                <p:commandButton
-                                    ajax="false"
-                                    icon="fa fa-user"
-                                    class="ui-button-warning  mx-1"
-                                    action="#{patientController.navigateToOpdPatientProfile()}" >
+                                    <p:commandButton
+                                        ajax="false"
+                                        immediate="true"
+                                        value="Inpatient Dashboard"
+                                        icon="fas fa-id-card"
+                                        styleClass="ui-button-info ui-button-outlined"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                        >
+                                        <f:setPropertyActionListener
+                                            value="#{bhtSummeryController.patientEncounter}"
+                                            target="#{admissionController.current}" ></f:setPropertyActionListener>
+                                    </p:commandButton>
+                                </div>
 
-                                    <f:setPropertyActionListener
-                                        value="#{bhtSummeryController.patientEncounter.patient}"
-                                        target="#{patientController.current}" ></f:setPropertyActionListener>
-                                </p:commandButton>
-                                <p:commandButton
-                                    ajax="false"
-                                    value="Inpatient Dashboard"
-                                    icon="fas fa-id-card"
-                                    class="ui-button-secondary  mx-1"
-                                    action="#{bhtSummeryController.navigateToInpatientProfile()}"
-                                    >
-                                    <f:setPropertyActionListener
-                                        value="#{bhtSummeryController.patientEncounter}"
-                                        target="#{admissionController.current}" ></f:setPropertyActionListener>
-                                </p:commandButton>
+                                <!-- RIGHT: actions — left=least important, right=primary -->
+                                <div class="d-flex gap-2 align-items-center">
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Clear"
+                                        icon="fa-solid fa-eraser"
+                                        styleClass="ui-button-secondary"
+                                        action="#{bhtSummeryController.clear}"  />
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Print Interim Bill"
+                                        icon="fas fa-print"
+                                        styleClass="ui-button-info"
+                                        action="#{bhtSummeryController.toPrintItrim()}"  />
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        value="Create Final Bill"
+                                        icon="pi pi-check-circle"
+                                        style="min-width:120px"
+                                        styleClass="ui-button-success"
+                                        onclick="PF('settleBillLoadingDlg').show();"
+                                        action="#{bhtSummeryController.toSettle()}"  />
+                                </div>
+
                             </div>
 
                         </f:facet>


### PR DESCRIPTION
## Summary
Restructured the panel headers in inward billing pages (`inward_bill_intrim.xhtml` and `inward_bill_final.xhtml`) to use a consistent three-section layout pattern: title on the left, entity navigation in the center, and primary actions on the right. This improves visual hierarchy and usability across the billing workflow.

## Key Changes

### `inward_bill_intrim.xhtml`
- Reorganized header into three flex sections:
  - **Left**: Title with icon
  - **Center**: Patient lookup, profile, and inpatient dashboard navigation buttons (marked `immediate="true"`)
  - **Right**: Clear, Print Interim Bill, and Create Final Bill actions
- Updated button styling: replaced `ui-button-warning` and `ui-button-secondary` with `ui-button-info ui-button-outlined` for navigation buttons
- Renamed "Settle Bill" to "Create Final Bill" with updated icon (`pi pi-check-circle`)
- Renamed "Print Bill" to "Print Interim Bill" for clarity
- Added `title` attributes to icon-only buttons for accessibility
- Applied consistent `gap-2` spacing throughout

### `inward_bill_final.xhtml`
- Applied same three-section header layout pattern in both edit and print-preview panels
- Moved "Inpatient Dashboard" button to center navigation section
- Moved "Collect Patient Payment" / "Collect Patient Co-payment" buttons to the right section as primary actions (changed class from `ui-button-warning` to `ui-button-success`)
- Consolidated "Show Original Bill" checkbox into the right actions section
- Replaced inline `class` attributes with `styleClass` for consistency
- Removed redundant spacing classes (`mx-1`, `mx-2`) in favor of flex `gap-2`
- Maintained privilege checks (`InwardSearch`) on navigation buttons

## Implementation Details
- All changes are JSF/XHTML only—no Java logic modifications
- Flexbox layout uses `d-flex justify-content-between align-items-center w-100` for consistent alignment
- Navigation buttons use `ui-button-info ui-button-outlined` styling to distinguish them from primary actions
- Primary actions (rightmost) use `ui-button-success` for settlement/payment operations
- Maintains all existing functionality and privilege-based rendering

https://claude.ai/code/session_01FWQc29SDj6AjQR8BoVNg7P