### PR TITLE
feat(pharmacy): add header and footer to stock report print/excel/pdf exports

### DIFF
--- a/developer_docs/feature/excel-export-html-table.md
+++ b/developer_docs/feature/excel-export-html-table.md
@@ -141,6 +141,54 @@ Use `#,##0.00` data format for all monetary cells.
 
 ---
 
+## Pattern: header/footer on top of `<p:dataExporter>` via `postProcessor`
+
+### When to use
+- The report already renders as a `<p:dataTable>` and exports fine with `<p:dataExporter>`
+- You just need to add a report title, active filters, and/or a "Printed by / Printed at" line to the exported file — not restructure the export itself
+
+`<p:dataExporter>` only serializes the table's column headers and row data; it ignores any `<f:facet name="header">`/`name="footer">` set directly on `<p:dataTable>`. To inject extra rows, use the exporter's `postProcessor` attribute, which hands your controller the already-populated POI `Workbook` before it's streamed to the response.
+
+### Shared utility (`ExcelController`)
+Two reusable methods added for issue #17615 do the row-shifting/writing so individual reports don't reimplement it:
+- `insertExcelReportHeader(Sheet sheet, String reportTitle, List<String[]> filterPairs, int mergeCol)` — shifts existing rows down and writes a title row + one row per `{label, value}` filter pair above the table. Always pass every filter the report supports, with an "All"/"No" fallback for unset ones.
+- `appendExcelPrintedByFooter(Sheet sheet, int mergeCol)` — appends a "Printed by: X" / "Printed at: Y" row after the last row.
+
+`mergeCol` is the last exported column's 0-based index (column count − 1). **Both methods guard `mergeCol == 0`/`1` before calling `addMergedRegion`** — POI throws `IllegalStateException: Merged region ... must contain 2 or more cells` if you try to merge a single cell, which happens for narrow reports (2-3 columns) or reports that export zero data rows. Any new caller passing a dynamically-computed `mergeCol` (e.g. `sheet.getRow(0).getLastCellNum() - 1`) should rely on these guards rather than assuming a fixed column count.
+
+### Controller method
+```java
+public void postProcessXLS<ReportName>(Object document) {
+    if (!(document instanceof Workbook)) {
+        return;
+    }
+    Sheet sheet = ((Workbook) document).getSheetAt(0);
+    List<String[]> filterPairs = new ArrayList<>();
+    filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+    // ... one entry per filter this report exposes ...
+    excelController.insertExcelReportHeader(sheet, "<Report Title>", filterPairs, mergeCol);
+    excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+}
+```
+
+### XHTML wiring
+```xml
+<p:dataExporter type="xlsx" target="tbl" fileName="..." postProcessor="#{bean.postProcessXLS<ReportName>}"/>
+```
+For the on-screen/print rendering (not the Excel file), add matching facets directly to `<p:dataTable>` — these two are independent of the exporter:
+```xml
+<f:facet name="header">...report title + filter summary...</f:facet>
+<f:facet name="footer"><common:report_print_footer/></f:facet>
+```
+`report_print_footer` (`resources/ezcomp/common/report_print_footer.xhtml`) is a no-arg composite that prints "Printed By: `#{sessionController.loggedUser.webUserPerson.name}`" / "Printed At: `#{sessionController.currentDate}`" — reuse it instead of duplicating the markup per report.
+
+PrimeFaces also supports the same `preProcessor`/`postProcessor` attributes on `<p:dataExporter type="pdf">`, receiving a `com.lowagie.text.Document` (OpenPDF) — see `ReportsStock.preProcessPdfDepartmentViceStock`/`postProcessPdfDepartmentViceStock` for a working example. Fully-qualify `com.lowagie.text.*` types if the same controller also has iText5 (`com.itextpdf.text.*`) imports for an unrelated export method, since the two libraries share class names.
+
+### Reference implementation
+`ReportsStock.postProcessXLSStockReportByItem` + `pharmacy_report_department_stock_by_item_DTO.xhtml`.
+
+---
+
 ## Reference implementations
 
 | Report | Controller | XHTML |

--- a/src/main/java/com/divudi/bean/common/ExcelController.java
+++ b/src/main/java/com/divudi/bean/common/ExcelController.java
@@ -37,6 +37,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CreationHelper;
 import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.WorkbookUtil;
@@ -5236,5 +5237,107 @@ public class ExcelController {
                 .build();
 
         return excelSc;
+    }
+
+    /**
+     * Inserts a report title row followed by one row per filter (label/value
+     * pair) above whatever the PrimeFaces {@code p:dataExporter} has already
+     * written to row 0, by shifting the existing rows down. Intended to be
+     * called from a report controller's {@code postProcessor} method
+     * (issue #17615).
+     *
+     * @param sheet the sheet the dataExporter already wrote the table into
+     * @param reportTitle the report name to show as the header title
+     * @param filterPairs ordered {label, value} pairs, e.g. {"Institution",
+     * "All Institutions"}; always pass every filter the report supports,
+     * using "All" / "No" for unset ones so the printed header is complete
+     * @param mergeCol the last column index (0-based) the header rows should
+     * span, e.g. the report's number of exported columns minus one
+     */
+    public void insertExcelReportHeader(Sheet sheet, String reportTitle, List<String[]> filterPairs, int mergeCol) {
+        if (sheet == null) {
+            return;
+        }
+        org.apache.poi.ss.usermodel.Workbook wb = sheet.getWorkbook();
+
+        org.apache.poi.ss.usermodel.Font titleFont = wb.createFont();
+        titleFont.setBold(true);
+        titleFont.setFontHeightInPoints((short) 14);
+        CellStyle titleStyle = wb.createCellStyle();
+        titleStyle.setFont(titleFont);
+        titleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+        org.apache.poi.ss.usermodel.Font labelFont = wb.createFont();
+        labelFont.setBold(true);
+        CellStyle labelStyle = wb.createCellStyle();
+        labelStyle.setFont(labelFont);
+
+        CellStyle valueStyle = wb.createCellStyle();
+
+        int headerRows = 1 + (filterPairs != null ? filterPairs.size() : 0);
+        if (sheet.getLastRowNum() >= 0) {
+            sheet.shiftRows(0, sheet.getLastRowNum(), headerRows);
+        }
+
+        int rowIndex = 0;
+        Row titleRow = sheet.createRow(rowIndex++);
+        Cell titleCell = titleRow.createCell(0);
+        titleCell.setCellValue(reportTitle != null ? reportTitle : "");
+        titleCell.setCellStyle(titleStyle);
+        if (mergeCol > 0) {
+            sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, mergeCol));
+        }
+
+        if (filterPairs != null) {
+            for (String[] pair : filterPairs) {
+                Row row = sheet.createRow(rowIndex);
+                Cell labelCell = row.createCell(0);
+                labelCell.setCellValue((pair[0] != null ? pair[0] : "") + ":");
+                labelCell.setCellStyle(labelStyle);
+                Cell valueCell = row.createCell(1);
+                valueCell.setCellValue(pair.length > 1 && pair[1] != null ? pair[1] : "All");
+                valueCell.setCellStyle(valueStyle);
+                if (mergeCol > 1) {
+                    sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex, 1, mergeCol));
+                }
+                rowIndex++;
+            }
+        }
+    }
+
+    /**
+     * Appends a "Printed by ... / Printed at ..." row after the last row
+     * currently on the sheet. Call this after {@link
+     * #insertExcelReportHeader} (or standalone) from a report controller's
+     * {@code postProcessor} method (issue #17615).
+     *
+     * @param sheet the sheet to append the footer row to
+     * @param mergeCol the last column index (0-based) the footer row may use;
+     * the "Printed at" cell is placed at column {@code min(4, mergeCol)}
+     */
+    public void appendExcelPrintedByFooter(Sheet sheet, int mergeCol) {
+        if (sheet == null) {
+            return;
+        }
+        org.apache.poi.ss.usermodel.Workbook wb = sheet.getWorkbook();
+        CellStyle footerStyle = wb.createCellStyle();
+        org.apache.poi.ss.usermodel.Font footerFont = wb.createFont();
+        footerFont.setFontHeightInPoints((short) 9);
+        footerStyle.setFont(footerFont);
+
+        String userName = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getName() : "";
+        String printedTime = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat()).format(new Date());
+
+        int rowIndex = sheet.getLastRowNum() + 2;
+        Row footerRow = sheet.createRow(rowIndex);
+
+        Cell printedByCell = footerRow.createCell(0);
+        printedByCell.setCellValue("Printed by: " + userName);
+        printedByCell.setCellStyle(footerStyle);
+
+        int printedAtCol = Math.min(4, mergeCol);
+        Cell printedAtCell = footerRow.createCell(printedAtCol);
+        printedAtCell.setCellValue("Printed at: " + printedTime);
+        printedAtCell.setCellStyle(footerStyle);
     }
 }

--- a/src/main/java/com/divudi/bean/common/ExcelController.java
+++ b/src/main/java/com/divudi/bean/common/ExcelController.java
@@ -5332,10 +5332,15 @@ public class ExcelController {
         Row footerRow = sheet.createRow(rowIndex);
 
         Cell printedByCell = footerRow.createCell(0);
-        printedByCell.setCellValue("Printed by: " + userName);
         printedByCell.setCellStyle(footerStyle);
 
         int printedAtCol = Math.min(4, mergeCol);
+        if (printedAtCol == 0) {
+            printedByCell.setCellValue("Printed by: " + userName + "     Printed at: " + printedTime);
+            return;
+        }
+
+        printedByCell.setCellValue("Printed by: " + userName);
         Cell printedAtCell = footerRow.createCell(printedAtCol);
         printedAtCell.setCellValue("Printed at: " + printedTime);
         printedAtCell.setCellStyle(footerStyle);

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -144,6 +144,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.primefaces.model.file.UploadedFile;
@@ -23856,6 +23858,30 @@ public class SearchController implements Serializable {
 
     public void setPharmacyAdjustmentRows(List<PharmacyAdjustmentRow> pharmacyAdjustmentRows) {
         this.pharmacyAdjustmentRows = pharmacyAdjustmentRows;
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Taking Report(New)"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockTakingNew(Object document) {
+        if (!(document instanceof Workbook)) {
+            return;
+        }
+        Sheet sheet = ((Workbook) document).getSheetAt(0);
+        int mergeCol = 0;
+        if (sheet.getRow(0) != null) {
+            mergeCol = Math.max(0, sheet.getRow(0).getLastCellNum() - 1);
+        }
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"From Date", fromDate != null ? new SimpleDateFormat("dd MMMM yyyy").format(fromDate) : "All"});
+        filterPairs.add(new String[]{"To Date", toDate != null ? new SimpleDateFormat("dd MMMM yyyy").format(toDate) : "All"});
+        filterPairs.add(new String[]{"Department", getReportKeyWord().getDepartment() != null ? getReportKeyWord().getDepartment().getName() : "All"});
+        filterPairs.add(new String[]{"Category", getReportKeyWord().getCategory() != null ? getReportKeyWord().getCategory().getName() : "All"});
+        filterPairs.add(new String[]{"Only Adjustments", getReportKeyWord().isAdditionalDetails() ? "Yes" : "No"});
+        excelController.insertExcelReportHeader(sheet, "Stock Taking Report (New)", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     private StreamedContent fileBillsAndBillItemsForDownload;

--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -175,6 +175,8 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
     SessionController sessionController;
     @Inject
     ItemController itemController;
+    @Inject
+    com.divudi.bean.common.ExcelController excelController;
     /**
      * EJBs
      */
@@ -283,6 +285,25 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
                     .sum();
             Date afterCal = new Date();
         }, PharmacyReports.STOCK_REPORT_BY_BATCH, sessionController.getLoggedUser());
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report by Batch"
+     * (Developers) page - adds the report title, active filters, and a
+     * Printed By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockByBatchDevelopers(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Institution", institution != null ? institution.getName() : "All"});
+        filterPairs.add(new String[]{"Site", site != null ? site.getName() : "All"});
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 12;
+        excelController.insertExcelReportHeader(sheet, "Stock Report by Batch", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     public void fillDepartmentStockDtos() {
@@ -543,6 +564,18 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             totalSale.setCellValue(stockSaleValue);
             totalSale.setCellStyle(formatStyle);
 
+            // =========================
+            // Printed By / Printed At
+            // =========================
+            rowIndex++;
+            Row printedRow = sheet.createRow(rowIndex++);
+            String userName = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getName() : "";
+            SimpleDateFormat printedSdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+            Cell printedByCell = printedRow.createCell(0);
+            printedByCell.setCellValue("Printed by: " + userName);
+            Cell printedAtCell = printedRow.createCell(4);
+            printedAtCell.setCellValue("Printed at: " + printedSdf.format(new Date()));
+
             // Auto size
             for (int i = 0; i < totalColumns; i++) {
                 sheet.autoSizeColumn(i);
@@ -717,6 +750,25 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             table.addCell(retailValueTotalCell);
 
             document.add(table);
+
+            // =========================
+            // Printed By / Printed At
+            // =========================
+            document.add(new Paragraph(" "));
+            String userName = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getName() : "";
+            SimpleDateFormat printedSdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+            PdfPTable printedTable = new PdfPTable(2);
+            printedTable.setWidthPercentage(100);
+            PdfPCell printedByCell = new PdfPCell(new Phrase("Printed by: " + userName, filterFont));
+            printedByCell.setBorder(Rectangle.NO_BORDER);
+            printedByCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+            printedTable.addCell(printedByCell);
+            PdfPCell printedAtCell = new PdfPCell(new Phrase("Printed at: " + printedSdf.format(new Date()), filterFont));
+            printedAtCell.setBorder(Rectangle.NO_BORDER);
+            printedAtCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            printedTable.addCell(printedAtCell);
+            document.add(printedTable);
+
             document.close();
             context.responseComplete();
 
@@ -760,6 +812,24 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             stocks = getStockFacade().findByJpql(jpql.toString(), parameters);
 
         }, PharmacyReports.STOCK_REPORT_BY_BATCH, sessionController.getLoggedUser());
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report by Batch
+     * for Export" page - adds the report title, active filters, and a
+     * Printed By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockByBatchForExport(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Include Zero Stocks", includeZeroStock ? "Yes" : "No"});
+        int mergeCol = 18;
+        excelController.insertExcelReportHeader(sheet, "Stock Report by Batch for Export", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     public void fillDepartmentStocksOfMedicines() {
@@ -1135,6 +1205,220 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         this.stockReportByItemDTOS = stockReportByItemDTOS;
     }
 
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report by Item"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockReportByItem(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Institution", institution != null ? institution.getName() : "All"});
+        filterPairs.add(new String[]{"Site", site != null ? site.getName() : "All"});
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Category", category != null ? category.getName() : "All"});
+        filterPairs.add(new String[]{"Dosage Form", dosageForm != null ? dosageForm.getName() : "All"});
+        filterPairs.add(new String[]{"Department Types", getSelectedDepartmentTypesPrintDisplay()});
+        filterPairs.add(new String[]{"Include Zero Stock", includeZeroStock ? "Yes" : "No"});
+        int mergeCol = 4;
+        excelController.insertExcelReportHeader(sheet, "Stock Report by Item", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * Human-readable label for the "Filter Type" radio selection on the
+     * Before Stock Taking Report (issue #17615).
+     */
+    public String getReportKeyWordFilterTypeLabel() {
+        String code = getReportKeyWord().getString();
+        if (code == null) {
+            return "All Batch";
+        }
+        switch (code) {
+            case "1":
+                return "Only Item";
+            case "2":
+                return "Item By Sale Rate";
+            case "3":
+                return "Extra Medicine";
+            case "4":
+                return "Extra Note";
+            default:
+                return "All Batch";
+        }
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Before Stock Taking
+     * Report" page - adds the report title, active filters, and a Printed
+     * By/At footer around the exported table (issue #17615). The column
+     * count on this report varies with the selected filter type, so the
+     * merge column is derived from the exported header row instead of a
+     * fixed constant.
+     */
+    public void postProcessXLSBeforeStockTaking(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        int mergeCol = 0;
+        if (sheet.getRow(0) != null) {
+            mergeCol = Math.max(0, sheet.getRow(0).getLastCellNum() - 1);
+        }
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Category", category != null ? category.getName() : "All"});
+        filterPairs.add(new String[]{"Filter Type", getReportKeyWordFilterTypeLabel()});
+        excelController.insertExcelReportHeader(sheet, "Before Stock Taking Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "After Stock Taking
+     * Report" page - adds the report title, active filters, and a Printed
+     * By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSAfterStockTaking(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        int mergeCol = 0;
+        if (sheet.getRow(0) != null) {
+            mergeCol = Math.max(0, sheet.getRow(0).getLastCellNum() - 1);
+        }
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Category", category != null ? category.getName() : "All"});
+        excelController.insertExcelReportHeader(sheet, "After Stock Taking Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Category Stock Report"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSCategoryStockByBatch(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Category", category != null ? category.getName() : "All"});
+        int mergeCol = 8;
+        excelController.insertExcelReportHeader(sheet, "Category Stock Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Category Stock Summary"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSCategoryStockByCategory(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 1;
+        excelController.insertExcelReportHeader(sheet, "Category Stock Summary", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report by Product"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockReportByProduct(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 4;
+        excelController.insertExcelReportHeader(sheet, "Stock Report by Product", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report of Single
+     * Product" page - adds the report title, active filters, and a Printed
+     * By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockReportOfSingleProduct(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Product", vmp != null ? vmp.getName() : "All"});
+        int mergeCol = 9;
+        excelController.insertExcelReportHeader(sheet, "Stock Report of Single Product", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report by Item -
+     * Order by VMP" page - adds the report title, active filters, and a
+     * Printed By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockReportByItemOrderByVmp(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 6;
+        excelController.insertExcelReportHeader(sheet, "Stock Report by Item - Order by VMP", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Supplier Stock Report"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSSupplierStockByBatch(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Supplier", institution != null ? institution.getName() : "All"});
+        int mergeCol = 8;
+        excelController.insertExcelReportHeader(sheet, "Supplier Stock Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Suppliers Stock Summary"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSAllSupplierStock(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 4;
+        excelController.insertExcelReportHeader(sheet, "Suppliers Stock Summary", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
     // Department Vice Stock Report fields
     private List<DepartmentViceStockDTO> departmentViceStockDtos;
     private double totalDepartmentViceStockQuantity;
@@ -1220,6 +1504,25 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         }, PharmacyReports.STOCK_REPORT_BY_ITEM, sessionController.getLoggedUser());
     }
 
+    /**
+     * {@code p:dataExporter} postProcessor for the "Zero Stock Item Report"
+     * page - adds the report title, active filters, and a Printed By/At
+     * footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSZeroStockItem(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Institution", institution != null ? institution.getName() : "All"});
+        filterPairs.add(new String[]{"Site", site != null ? site.getName() : "All"});
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 2;
+        excelController.insertExcelReportHeader(sheet, "Zero Stock Item Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
     public void fillDepartmentStockByItemOrderByVmp() {
         if (department == null) {
             JsfUtil.addErrorMessage("Please select a department");
@@ -1295,6 +1598,63 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
 
             departmentViceStockDtos = dtos;
         }, PharmacyReports.DEPARTMENT_VICE_STOCK_REPORT, sessionController.getLoggedUser());
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Department Vice Stock
+     * Report" xlsx export - adds the report title and a Printed By/At footer
+     * around the exported table (issue #17615). This report has no
+     * institution/site/department filter UI (it always aggregates across all
+     * departments), so no filter row is added.
+     */
+    public void postProcessXLSDepartmentViceStock(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        int mergeCol = 8;
+        excelController.insertExcelReportHeader(sheet, "Department Vice Stock Report", new ArrayList<>(), mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
+    /**
+     * {@code p:dataExporter} preProcessor for the "Department Vice Stock
+     * Report" pdf export - opens the PDF document and adds a centered report
+     * title before the table is written (issue #17615).
+     *
+     * Note: the PrimeFaces PDF exporter (14.x) uses the OpenPDF
+     * ({@code com.lowagie.text}) library, which is a different class
+     * hierarchy from the iText5 ({@code com.itextpdf.text}) classes already
+     * wildcard-imported in this file (see {@link #exportCurrentStockByBatchToPDF()}).
+     * Fully-qualified names are used throughout to avoid binding to the
+     * wrong "Document"/"Font"/etc type.
+     */
+    public void preProcessPdfDepartmentViceStock(Object document) throws com.lowagie.text.DocumentException {
+        com.lowagie.text.Document pdf = (com.lowagie.text.Document) document;
+        pdf.setPageSize(com.lowagie.text.PageSize.A4.rotate());
+        pdf.setMargins(20f, 20f, 20f, 20f);
+        pdf.open();
+
+        com.lowagie.text.Font titleFont = com.lowagie.text.FontFactory.getFont(com.lowagie.text.FontFactory.HELVETICA_BOLD, 16);
+        com.lowagie.text.Paragraph titlePara = new com.lowagie.text.Paragraph("Department Vice Stock Report", titleFont);
+        titlePara.setAlignment(com.lowagie.text.Element.ALIGN_CENTER);
+        titlePara.setSpacingAfter(12f);
+        pdf.add(titlePara);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Department Vice Stock
+     * Report" pdf export - appends a Printed By/At footer line after the
+     * table, before the document is closed (issue #17615).
+     */
+    public void postProcessPdfDepartmentViceStock(Object document) throws com.lowagie.text.DocumentException {
+        com.lowagie.text.Document pdf = (com.lowagie.text.Document) document;
+        com.lowagie.text.Font footerFont = com.lowagie.text.FontFactory.getFont(com.lowagie.text.FontFactory.HELVETICA, 9);
+        String userName = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getName() : "";
+        String printedTime = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat()).format(new Date());
+        com.lowagie.text.Paragraph footerPara = new com.lowagie.text.Paragraph("Printed by: " + userName + "     Printed at: " + printedTime, footerFont);
+        footerPara.setSpacingBefore(10f);
+        pdf.add(footerPara);
     }
 
     public void fillDepartmentInventryStocks() {
@@ -1827,6 +2187,27 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         }
     }
 
+    /**
+     * {@code p:dataExporter} postProcessor for the "Staff Stock" report -
+     * adds the report title, active filters, and a Printed By/At footer
+     * around the exported table (issue #17615).
+     */
+    public void postProcessXLSStaffStock(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        int mergeCol = 0;
+        if (sheet.getRow(0) != null) {
+            mergeCol = Math.max(0, sheet.getRow(0).getLastCellNum() - 1);
+        }
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Staff", staff != null ? staff.getPerson().getName() : "All"});
+        filterPairs.add(new String[]{"Item", item != null ? item.getName() : "All"});
+        excelController.insertExcelReportHeader(sheet, "Staff Stock Inventory Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
+    }
+
     public void clearFilters() {
         staff = null;
         itemController.setCurrent(null);
@@ -1957,6 +2338,24 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
         }
 
         return "/pharmacy/pharmacy_report_stock_report_with_supplier?faces-redirect=true";
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Report (with
+     * Suppliers)" page - adds the report title, active filters, and a
+     * Printed By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockReportWithSupplier(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Supplier", institution != null ? institution.getName() : "All"});
+        int mergeCol = 9;
+        excelController.insertExcelReportHeader(sheet, "Stock Report (with Suppliers)", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     public void fillCategoryStocks() {
@@ -2221,6 +2620,23 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
             }
         }
 
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock Summary (with
+     * Suppliers)" page - adds the report title, active filters, and a
+     * Printed By/At footer around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockSummaryWithSupplier(Object document) {
+        if (!(document instanceof org.apache.poi.ss.usermodel.Workbook)) {
+            return;
+        }
+        Sheet sheet = ((org.apache.poi.ss.usermodel.Workbook) document).getSheetAt(0);
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        int mergeCol = 4;
+        excelController.insertExcelReportHeader(sheet, "Stock Summary (with Suppliers)", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockHistoryController.java
@@ -35,6 +35,9 @@ import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.TemporalType;
+import java.text.SimpleDateFormat;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 
 /**
  *
@@ -56,6 +59,8 @@ public class StockHistoryController implements Serializable {
 
     @Inject
     SessionController sessionController;
+    @Inject
+    com.divudi.bean.common.ExcelController excelController;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
     private StockHistory current;
@@ -299,6 +304,29 @@ public class StockHistoryController implements Serializable {
 
     public void fillStockHistoriesWithOutZero() {
         fillStockHistories(true);
+    }
+
+    /**
+     * {@code p:dataExporter} postProcessor for the "Stock History" page -
+     * adds the report title, active filters, and a Printed By/At footer
+     * around the exported table (issue #17615).
+     */
+    public void postProcessXLSStockHistory(Object document) {
+        if (!(document instanceof Workbook)) {
+            return;
+        }
+        Sheet sheet = ((Workbook) document).getSheetAt(0);
+        int mergeCol = 0;
+        if (sheet.getRow(0) != null) {
+            mergeCol = Math.max(0, sheet.getRow(0).getLastCellNum() - 1);
+        }
+        List<String[]> filterPairs = new ArrayList<>();
+        filterPairs.add(new String[]{"Department", department != null ? department.getName() : "All"});
+        filterPairs.add(new String[]{"Department Type", departmentType != null ? departmentType.getLabel() : "All"});
+        filterPairs.add(new String[]{"History Date", historyDate != null ? new SimpleDateFormat("dd MMMM yyyy hh:mm a").format(historyDate) : "All"});
+        filterPairs.add(new String[]{"Include Archived", includeArchived ? "Yes" : "No"});
+        excelController.insertExcelReportHeader(sheet, "Pharmacy Stock History Report", filterPairs, mergeCol);
+        excelController.appendExcelPrintedByFooter(sheet, mergeCol);
     }
 
     public void recordHistory() {

--- a/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
@@ -115,12 +115,14 @@
                                         <h:outputText value="Pharmacy Stock History Report"/>
                                         <br/>
                                         <p:outputLabel value="#{stockHistoryController.department.name}" rendered="#{stockHistoryController.department ne null}" />
-                                        <p:outputLabel value="All Departents Stock" rendered="#{stockHistoryController.department eq null}" /><br></br>
-                                        <p:outputLabel value="#{stockHistoryController.historyDate}" >
-                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                        </p:outputLabel>
+                                        <p:outputLabel value="All Departments Stock" rendered="#{stockHistoryController.department eq null}" /><br></br>
                                         <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
-                                            <h:outputText value="Department Type: #{not empty stockHistoryController.departmentType ? stockHistoryController.departmentType.label : 'All'}   |   "/>
+                                            <h:outputText value="History Date: "/>
+                                            <h:outputText value="#{stockHistoryController.historyDate}" rendered="#{stockHistoryController.historyDate ne null}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
+                                            </h:outputText>
+                                            <h:outputText value="All" rendered="#{stockHistoryController.historyDate eq null}"/>
+                                            <h:outputText value="   |   Department Type: #{not empty stockHistoryController.departmentType ? stockHistoryController.departmentType.label : 'All'}   |   "/>
                                             <h:outputText value="Include Archived: #{stockHistoryController.includeArchived ? 'Yes' : 'No'}"/>
                                         </h:panelGroup>
                                     </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_department_stock_history.xhtml
@@ -5,6 +5,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:p="http://primefaces.org/ui"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -95,7 +96,7 @@
                                     <p:printer target="panelPrint" />
                                 </p:commandButton>
                                 <p:commandButton ajax="false" value="Excel" action="#" class="ui-button-success" icon="fas fa-file-excel" >
-                                    <p:dataExporter type="xlsx" target="tblHistories" fileName="Pharmacy_Stock_Report"   />
+                                    <p:dataExporter type="xlsx" target="tblHistories" fileName="Pharmacy_Stock_Report" postProcessor="#{stockHistoryController.postProcessXLSStockHistory}"  />
                                 </p:commandButton>
                             </h:panelGrid>
                         </div>
@@ -110,11 +111,22 @@
                                          rowIndexVar="ii"
                                          var="item">
                                 <f:facet name="header" >
-                                    <p:outputLabel value="#{stockHistoryController.department.name}" rendered="#{stockHistoryController.department ne null}" />
-                                    <p:outputLabel value="All Departents Stock" rendered="#{stockHistoryController.department eq null}" /><br></br>
-                                    <p:outputLabel value="#{stockHistoryController.historyDate}" >
-                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
-                                    </p:outputLabel>
+                                    <h:panelGroup layout="block">
+                                        <h:outputText value="Pharmacy Stock History Report"/>
+                                        <br/>
+                                        <p:outputLabel value="#{stockHistoryController.department.name}" rendered="#{stockHistoryController.department ne null}" />
+                                        <p:outputLabel value="All Departents Stock" rendered="#{stockHistoryController.department eq null}" /><br></br>
+                                        <p:outputLabel value="#{stockHistoryController.historyDate}" >
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  ></f:convertDateTime>
+                                        </p:outputLabel>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department Type: #{not empty stockHistoryController.departmentType ? stockHistoryController.departmentType.label : 'All'}   |   "/>
+                                            <h:outputText value="Include Archived: #{stockHistoryController.includeArchived ? 'Yes' : 'No'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
                                 <p:column style="width: 40px;" >
                                     <f:facet name="header" >

--- a/src/main/webapp/pharmacy/pharmacy_department_stock_report_by_batch_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_department_stock_report_by_batch_print.xhtml
@@ -215,6 +215,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_adjustment_bill_for_stock_taking.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_adjustment_bill_for_stock_taking.xhtml
@@ -5,7 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
-
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       xmlns:au="http://xmlns.jcp.org/jsf/composite/autocomplete">
 
     <h:body>
@@ -57,12 +57,12 @@
                                 icon="fas fa-search"
                                 class="ui-button-warning"
                                 action="#{searchController.createPharmacyAdjustmentBillItemTableForStockTaking()}"/>
-                            <p:commandButton 
-                                value="Excel" 
-                                ajax="false" 
+                            <p:commandButton
+                                value="Excel"
+                                ajax="false"
                                 icon="fas fa-file-excel"
                                 class="ui-button-success mx-2">
-                                <p:dataExporter type="xlsx" target="tblBills" fileName="Stock_Taking_New_Report"/>
+                                <p:dataExporter type="xlsx" target="tblBills" fileName="Stock_Taking_New_Report" postProcessor="#{searchController.postProcessXLSStockTakingNew}"/>
                             </p:commandButton>
                             <p:commandButton 
                                 ajax="false" 
@@ -82,11 +82,16 @@
                             <p:dataTable rowIndexVar="i" id="tblBills" 
                                          value="#{searchController.pharmacyAdjustmentRows}" var="r" >
                                 <f:facet name="header" >
+                                    <p:outputLabel value="Stock Taking Report(New)" style="font-weight: bold;"/><br></br>
                                     <p:outputLabel value="From Date - #{searchController.fromDate}"></p:outputLabel><br></br>
                                     <p:outputLabel value="To Date - #{searchController.toDate}"></p:outputLabel><br></br>
-                                    <p:outputLabel value="Department - #{searchController.reportKeyWord.department.name}" rendered="#{searchController.reportKeyWord.department ne null}" /><br></br>
-                                    <p:outputLabel value="Category - #{searchController.reportKeyWord.category.name}" rendered="#{searchController.reportKeyWord.category ne null}" />
+                                    <p:outputLabel value="Department - #{not empty searchController.reportKeyWord.department ? searchController.reportKeyWord.department.name : 'All'}" /><br></br>
+                                    <p:outputLabel value="Category - #{not empty searchController.reportKeyWord.category ? searchController.reportKeyWord.category.name : 'All'}" /><br></br>
+                                    <p:outputLabel value="Only Adjustments - #{searchController.reportKeyWord.additionalDetails ? 'Yes' : 'No'}" />
 
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
                                 <p:column styleClass="alignTop" >
                                     <f:facet name="header" >

--- a/src/main/webapp/pharmacy/pharmacy_report_adjustment_bill_for_stock_taking.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_adjustment_bill_for_stock_taking.xhtml
@@ -83,8 +83,16 @@
                                          value="#{searchController.pharmacyAdjustmentRows}" var="r" >
                                 <f:facet name="header" >
                                     <p:outputLabel value="Stock Taking Report(New)" style="font-weight: bold;"/><br></br>
-                                    <p:outputLabel value="From Date - #{searchController.fromDate}"></p:outputLabel><br></br>
-                                    <p:outputLabel value="To Date - #{searchController.toDate}"></p:outputLabel><br></br>
+                                    <h:outputLabel value="From Date - "/>
+                                    <h:outputText value="#{searchController.fromDate}" rendered="#{searchController.fromDate ne null}">
+                                        <f:convertDateTime pattern="dd MMMM yyyy"/>
+                                    </h:outputText>
+                                    <h:outputText value="All" rendered="#{searchController.fromDate eq null}"/><br></br>
+                                    <h:outputLabel value="To Date - "/>
+                                    <h:outputText value="#{searchController.toDate}" rendered="#{searchController.toDate ne null}">
+                                        <f:convertDateTime pattern="dd MMMM yyyy"/>
+                                    </h:outputText>
+                                    <h:outputText value="All" rendered="#{searchController.toDate eq null}"/><br></br>
                                     <p:outputLabel value="Department - #{not empty searchController.reportKeyWord.department ? searchController.reportKeyWord.department.name : 'All'}" /><br></br>
                                     <p:outputLabel value="Category - #{not empty searchController.reportKeyWord.category ? searchController.reportKeyWord.category.name : 'All'}" /><br></br>
                                     <p:outputLabel value="Only Adjustments - #{searchController.reportKeyWord.additionalDetails ? 'Yes' : 'No'}" />

--- a/src/main/webapp/pharmacy/pharmacy_report_after_stock_taking.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_after_stock_taking.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -35,13 +36,13 @@
                                 class="ui-button-warning"
                                 actionListener="#{reportsStock.fillCategoryStocks()}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
-                                value="Excel" 
+                            <p:commandButton
+                                ajax="false"
+                                value="Excel"
                                 icon="fas fa-file-excel"
                                 class="ui-button-success mx-2">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
-                            </p:commandButton> 
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report" postProcessor="#{reportsStock.postProcessXLSAfterStockTaking}"  />
+                            </p:commandButton>
                             <p:commandButton 
                                 value="Print" 
                                 icon="fas fa-print"
@@ -58,10 +59,17 @@
                                         
                                         >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock in #{reportsStock.department.name} "/>   <br/>                                 
-                                    <h:outputLabel value="for #{reportsStock.category.name}"/> <br/><br/>
-                                    <h:outputLabel value="Date : "><p:clock pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  /></h:outputLabel>                                   
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="After Stock Taking Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Category: #{not empty reportsStock.category ? reportsStock.category.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
                                 
                                 <p:column headerText="Item"
                                           sortBy="#{i.itemBatch.item.name}"

--- a/src/main/webapp/pharmacy/pharmacy_report_all_supplier_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_all_supplier_stock.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
     <h:body>
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
@@ -23,7 +24,7 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
                             <p:commandButton class="ui-button-success " icon="fas fa-file-excel"  ajax="false" value="Excel" styleClass="noPrintButton" >
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report" postProcessor="#{reportsStock.postProcessXLSAllSupplierStock}" />
                             </p:commandButton>
                         </h:panelGrid>
                        
@@ -38,7 +39,15 @@
                                          rowsPerPageTemplate="20, 50, 100" 
                                          >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Supplier Stock Summary - #{reportsStock.department.name}"/>  
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Suppliers Stock Summary"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
                                 <p:column headerText="No." style="width: 40px;">
 
@@ -123,16 +132,6 @@
                                             <f:facet name="footer" >
                                                 <h:outputLabel value="#{reportsStock.stockSaleValue}" >
                                                     <f:convertNumber parent="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                    <p:row>
-                                        <p:column colspan="5" >
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="Printed At " ></h:outputLabel>
-                                                <h:outputLabel value="#{sessionController.currentDate}" >
-                                                    <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
                                                 </h:outputLabel>
                                             </f:facet>
                                         </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_report_before_stock_taking.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_before_stock_taking.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -44,13 +45,13 @@
                                 class="ui-button-warning"
                                 actionListener="#{reportsStock.fillCategoryStocksNew()}" >
                             </p:commandButton>
-                            <p:commandButton 
-                                ajax="false" 
+                            <p:commandButton
+                                ajax="false"
                                 value="Excel"
                                 icon="fas fa-file-excel"
                                 class="ui-button-success mx-2">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
-                            </p:commandButton> 
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report" postProcessor="#{reportsStock.postProcessXLSBeforeStockTaking}"  />
+                            </p:commandButton>
                             <p:commandButton 
                                 value="Print" 
                                 icon="fas fa-print"
@@ -65,10 +66,18 @@
                             <p:dataTable id="tbl" rowStyleClass="#{i.stock eq 0 ?'noDisplayRow' : ''}" 
                                          value="#{reportsStock.stocks}" var="i" rowIndexVar="a">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock in #{reportsStock.department.name} "/>   <br/>                                 
-                                    <h:outputLabel value="for #{reportsStock.category.name}"/> <br/><br/>
-                                    <h:outputLabel value="Date : "><p:clock pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  /></h:outputLabel>
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Before Stock Taking Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Category: #{not empty reportsStock.category ? reportsStock.category.name : 'All'}   |   "/>
+                                            <h:outputText value="Filter Type: #{reportsStock.reportKeyWordFilterTypeLabel}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column headerText="No" rendered="#{reportsStock.reportKeyWord.string ne '4'}">
                                     <f:facet name="header">

--- a/src/main/webapp/pharmacy/pharmacy_report_category_stock_by_batch.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_category_stock_by_batch.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -31,8 +32,8 @@
                                 <p:printer target="gpBillPreview" />
                             </p:commandButton>
                             <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel"  ajax="false" value="Excel" style="float: right;" >
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
-                            </p:commandButton> 
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report" postProcessor="#{reportsStock.postProcessXLSCategoryStockByBatch}" />
+                            </p:commandButton>
                             
                         </h:panelGrid>
                        
@@ -46,10 +47,17 @@
                                          paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                          rowsPerPageTemplate="10, 20, 50">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Category Stock Report" style="font-weight: bold;"/>   <br/>
-                                    <h:outputLabel value="Department - #{reportsStock.department.name} "/>   <br/>                                 
-                                    <h:outputLabel value="Category - #{reportsStock.category.name}"/>                                    
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Category Stock Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Category: #{not empty reportsStock.category ? reportsStock.category.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">
                                     <h:outputLabel value="#{ii+1}" />
@@ -158,12 +166,6 @@
                                 </p:column>
                             </p:dataTable>
                         </h:panelGroup>
-                        <p:panel>
-                            <h:outputLabel value="Printed At " />
-                            <h:outputLabel value="#{sessionController.currentDate}" >
-                                <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
-                            </h:outputLabel>
-                        </p:panel>
                     </p:panel>
                 </h:form>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_category_stock_by_category.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_category_stock_by_category.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
     <h:body>
 
@@ -26,15 +27,23 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
                             </p:commandButton>
                             <p:commandButton class="ui-button-success" icon="fas fa-file-excel"  ajax="false" value="Excel"  >
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report"  />
-                            </p:commandButton>  
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Category_report" postProcessor="#{reportsStock.postProcessXLSCategoryStockByCategory}" />
+                            </p:commandButton>
                         </h:panelGrid>
 
                         <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder">
                             <p:dataTable id="tbl"  value="#{reportsStock.stockRecords}" var="i" style="width: 500px;" >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Category Stock Summary - #{reportsStock.department.name} "/>   <br/>                                 
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Category Stock Summary"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column headerText="Category"
                                           sortBy="#{i.category.name}"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch.xhtml
@@ -42,7 +42,7 @@
                                 class="ui-button-success"
                                 value="Excel"
                                 ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="stock_by_batch" />
+                                <p:dataExporter type="xlsx" target="tbl" fileName="stock_by_batch" postProcessor="#{reportsStock.postProcessXLSStockByBatchDevelopers}" />
                             </p:commandButton>
 
 
@@ -75,8 +75,18 @@
                                          rowsPerPageTemplate="20, 50, 100" 
                                          >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Batch Stock Report - #{reportsStock.department.name}"/>                                     
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report by Batch"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Institution: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}   |   "/>
+                                            <h:outputText value="Site: #{not empty reportsStock.site ? reportsStock.site.name : 'All'}   |   "/>
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
 
                                 <p:column 
@@ -268,16 +278,6 @@
                                             <f:facet name="footer" >
                                                 <h:outputLabel value="#{reportsStock.stockSaleValue}" >
                                                     <f:convertNumber pattern="#,##0.00" />
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row>
-                                    <p:row>
-                                        <p:column colspan="11" >
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="Printed At " ></h:outputLabel>
-                                                <h:outputLabel value="#{sessionController.currentDate}" >
-                                                    <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
                                                 </h:outputLabel>
                                             </f:facet>
                                         </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto_print.xhtml
@@ -331,6 +331,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_expiary_print.xhtml
@@ -353,6 +353,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_for_export.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_for_export.xhtml
@@ -4,7 +4,8 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
     <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
         <ui:define name="subcontent">
             <h:form id="frm">
@@ -42,7 +43,8 @@
                                      class="ui-button-success m-1">
                         <p:dataExporter type="xlsx"
                                         target="tbl"
-                                        fileName="stock_by_batch_#{reportsStock.department.name}" />
+                                        fileName="stock_by_batch_#{reportsStock.department.name}"
+                                        postProcessor="#{reportsStock.postProcessXLSStockByBatchForExport}" />
                     </p:commandButton>
 
 
@@ -56,6 +58,18 @@
                                  paginatorPosition="top"
                                  paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}">
 
+                        <f:facet name="header">
+                            <h:panelGroup layout="block">
+                                <h:outputLabel value="Stock Report by Batch for Export"/>
+                                <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                    <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                    <h:outputText value="Include Zero Stocks: #{reportsStock.includeZeroStock ? 'Yes' : 'No'}"/>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </f:facet>
+                        <f:facet name="footer">
+                            <common:report_print_footer/>
+                        </f:facet>
 
                         <p:column headerText="Serial No">
                             <h:outputText value="#{idx + 1}" />

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -105,7 +105,7 @@
                                     <p:commandButton ajax="false" value="Process" icon="fas fa-cogs" styleClass="ui-button-warning mx-1"
                                                      actionListener="#{reportsStock.fillDepartmentNonEmptyItemStocks()}" />
                                     <p:commandButton styleClass="ui-button-success mx-1" icon="fas fa-file-excel" value="Excel" ajax="false">
-                                        <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Report_By_Item"/>
+                                        <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Report_By_Item" postProcessor="#{reportsStock.postProcessXLSStockReportByItem}"/>
                                     </p:commandButton>
                                     <p:commandButton styleClass="ui-button-info mx-1" icon="fas fa-print" value="Print"
                                                      actionListener="#{reportsStock.prepareForPrint()}"
@@ -131,8 +131,22 @@
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="20, 50, 100">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock Report by Item - #{reportsStock.department.name}"/>                                     
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report by Item"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Institution: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}   |   "/>
+                                            <h:outputText value="Site: #{not empty reportsStock.site ? reportsStock.site.name : 'All'}   |   "/>
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Category: #{not empty reportsStock.category ? reportsStock.category.name : 'All'}   |   "/>
+                                            <h:outputText value="Dosage Form: #{not empty reportsStock.dosageForm ? reportsStock.dosageForm.name : 'All'}   |   "/>
+                                            <h:outputText value="Department Types: #{reportsStock.selectedDepartmentTypesPrintDisplay}   |   "/>
+                                            <h:outputText value="Include Zero Stock: #{reportsStock.includeZeroStock ? 'Yes' : 'No'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column width="20px;" headerText="No" sortBy="#{ii}"
                                           style="width: 20px;">

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_order_by_vmp.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_order_by_vmp.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -33,7 +34,7 @@
                                 icon="fas fa-file-excel" 
                                 value="Excel" 
                                 ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Item_Stock_order_by_VMP"/>
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Item_Stock_order_by_VMP" postProcessor="#{reportsStock.postProcessXLSStockReportByItemOrderByVmp}"/>
                             </p:commandButton>
                             <p:commandButton 
                                 class="ui-button-info" 
@@ -59,8 +60,16 @@
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="20, 50, 100">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock Report by Item Order by VMP - #{reportsStock.department.name}"/>                                     
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report by Item - Order by VMP"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column 
                                     width="3em" 

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_product.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_product.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -26,7 +27,7 @@
                             </p:commandButton>
                             <p:commandButton class="ui-button-success" icon="fas fa-file-excel" value="Excel" ajax="false">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Total_Stock"
-                                              
+                                                postProcessor="#{reportsStock.postProcessXLSStockReportByProduct}"
                                               />
                             </p:commandButton>
                         </h:panelGrid>
@@ -42,8 +43,16 @@
                                          paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                          rowsPerPageTemplate="20, 50, 100">
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock Report by Product - #{reportsStock.department.name}"/>                                     
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report by Product"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">
                                     <h:outputLabel value="#{ii+1}" />

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_single_product.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_single_product.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -28,8 +29,7 @@
                             </p:commandButton>
                             <p:commandButton class="ui-button-success" icon="fas fa-file-excel" value="Excel" ajax="false">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Total_Stock"
-                                               
-                                                   
+                                                postProcessor="#{reportsStock.postProcessXLSStockReportOfSingleProduct}"
                                               />
                             </p:commandButton>
                         </h:panelGrid>
@@ -49,8 +49,17 @@
                                          rows="10"
                                          >
                                 <f:facet name="header">
-                                    <h:outputLabel value="Stock Report of Single Product - #{reportsStock.department.name} - #{reportsStock.vmp.name}"/>                                     
-                                </f:facet> 
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report of Single Product"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Product: #{not empty reportsStock.vmp ? reportsStock.vmp.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">
                                     <h:outputLabel value="#{ii+1}" />

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item.xhtml
@@ -26,7 +26,7 @@
                             <p:commandButton class="ui-button-warning" icon="fas fa-cogs" ajax="false" value="Generate Report"
                                              actionListener="#{reportsStock.fillDepartmentZeroItemStocks()}" />
                             <p:commandButton class="ui-button-success mx-2" icon="fas fa-file-excel" value="Download Excel" ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="zero_stock_items" />
+                                <p:dataExporter type="xlsx" target="tbl" fileName="zero_stock_items" postProcessor="#{reportsStock.postProcessXLSZeroStockItem}"/>
                             </p:commandButton>
                             <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" ajax="false"
                                              action="pharmacy_report_department_stock_by_zero_item_print?faces-redirect=true"/>
@@ -44,7 +44,17 @@
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                 rowsPerPageTemplate="20, 50, 100">
                                 <f:facet name="header">
-                                <h:outputLabel value="Zero Stock Item Report - #{reportsStock.department.name}"/>
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Zero Stock Item Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Institution: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}   |   "/>
+                                            <h:outputText value="Site: #{not empty reportsStock.site ? reportsStock.site.name : 'All'}   |   "/>
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
 
                                 <p:column width="20px;" headerText="No" sortBy="#{ii}"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_zero_item_print.xhtml
@@ -105,6 +105,10 @@
                                         <h:outputText value="Zero Stock Item Report"/>
                                     </div>
                                     <div class="d-flex justify-content-center" style="font-weight: 600; font-size: 15px; margin-bottom: 5px;">
+                                        <h:outputLabel value="#{reportsStock.site.name}" rendered="#{reportsStock.site ne null}"/>
+                                        <h:outputLabel value="All Sites" rendered="#{reportsStock.site eq null}"/>
+                                    </div>
+                                    <div class="d-flex justify-content-center" style="font-weight: 600; font-size: 15px; margin-bottom: 5px;">
                                         <h:outputLabel value="#{reportsStock.department.name}" rendered="#{reportsStock.department ne null}"/>
                                         <h:outputLabel value="All Departments" rendered="#{reportsStock.department eq null}"/>
                                     </div>
@@ -146,6 +150,20 @@
                                         </tfoot>
                                     </table>
                                 </div>
+
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_vice_stock.xhtml
@@ -28,11 +28,13 @@
                                         actionListener="#{reportsStock.fillDepartmentViceStockDtos()}" />
 
                                     <p:commandButton styleClass="ui-button-danger mx-1" icon="fas fa-file-pdf" value="PDF" ajax="false">
-                                        <p:dataExporter type="pdf" target="tbl" fileName="department_vice_stock_report" />
+                                        <p:dataExporter type="pdf" target="tbl" fileName="department_vice_stock_report"
+                                                         preProcessor="#{reportsStock.preProcessPdfDepartmentViceStock}"
+                                                         postProcessor="#{reportsStock.postProcessPdfDepartmentViceStock}"/>
                                     </p:commandButton>
 
                                     <p:commandButton icon="fas fa-file-excel" styleClass="ui-button-success mx-1" value="Excel" ajax="false">
-                                        <p:dataExporter type="xlsx" target="tbl" fileName="department_vice_stock_report" />
+                                        <p:dataExporter type="xlsx" target="tbl" fileName="department_vice_stock_report" postProcessor="#{reportsStock.postProcessXLSDepartmentViceStock}"/>
                                     </p:commandButton>
                                     <p:commandButton
                                         value="Print" icon="fas fa-print"
@@ -59,6 +61,9 @@
 
                                 <f:facet name="header">
                                     <h:outputLabel value="Department Vice Stock Report" />
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
 
                                 <p:column headerText="Serial No" style="text-align: right;" styleClass="averageNumericColumn"

--- a/src/main/webapp/pharmacy/pharmacy_report_short_expiry_by_amp_period_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_short_expiry_by_amp_period_print.xhtml
@@ -337,6 +337,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -65,7 +66,7 @@
                                     icon="pi pi-download"
                                     value="Download"
                                     ajax="false">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Report_with_Suppliers"/>
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Report_with_Suppliers" postProcessor="#{reportsStock.postProcessXLSStockReportWithSupplier}"/>
                             </p:commandButton>
 
                             <p:commandButton
@@ -94,8 +95,16 @@
                                 rowsPerPageTemplate="20,50,1000">
 
                                 <f:facet name="header">
-                                    <h:outputLabel value="Department - #{reportsStock.department.name} "/>   <br/>                                 
-                                    <h:outputLabel value="Supplier - #{reportsStock.institution.name}"/>                                    
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Report (with Suppliers)"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Supplier: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">

--- a/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_stock_report_with_supplier_print.xhtml
@@ -249,6 +249,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/pharmacy/pharmacy_report_supplier_expiary_stock_by_batch_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_supplier_expiary_stock_by_batch_print.xhtml
@@ -233,6 +233,9 @@
                                     </tr>
                                     <tr>
                                         <td colspan="9" style="text-align: right; font-weight: 700;">
+                                            <h:outputLabel value="Printed By "/>
+                                            <h:outputLabel value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                            <h:outputText value="   |   "/>
                                             <h:outputLabel value="Printed At "/>
                                             <h:outputLabel value="#{sessionController.currentDate}">
                                                 <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>

--- a/src/main/webapp/pharmacy/pharmacy_report_supplier_stock_by_batch.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_supplier_stock_by_batch.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
 
     <h:body>
@@ -40,8 +41,7 @@
                             </p:commandButton>
                             <p:commandButton class="ui-button-success" icon="fas fa-file-excel"  value="Excel" ajax="false">
                                 <p:dataExporter type="xlsx" target="tbl" fileName="Lab_Investigation_List"
-
-
+                                                postProcessor="#{reportsStock.postProcessXLSSupplierStockByBatch}"
                                                 />
                             </p:commandButton>
                         </h:panelGrid>
@@ -59,8 +59,16 @@
                                          rowsPerPageTemplate="10,20,50">
 
                                 <f:facet name="header">
-                                    <h:outputLabel value="Department - #{reportsStock.department.name} "/>   <br/>                                 
-                                    <h:outputLabel value="Supplier - #{reportsStock.institution.name}"/>                                    
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Supplier Stock Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Supplier: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">
@@ -191,17 +199,6 @@
                                             </f:facet>
                                         </p:column>
                                     </p:row>
-
-                                    <p:row>
-                                        <p:column colspan="9" >
-                                            <f:facet name="footer" >
-                                                <h:outputLabel value="Printed At " ></h:outputLabel>
-                                                <h:outputLabel value="#{sessionController.currentDate}" >
-                                                    <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a" ></f:convertDateTime>
-                                                </h:outputLabel>
-                                            </f:facet>
-                                        </p:column>
-                                    </p:row> 
                                 </p:columnGroup>
 
                             </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
       >
     <h:body>
         <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
@@ -44,7 +45,7 @@
                                     icon="pi pi-download"
                                     ajax="false"
                                     value="Download">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Summary_with_Suppliers"/>
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Summary_with_Suppliers" postProcessor="#{reportsStock.postProcessXLSStockSummaryWithSupplier}"/>
                             </p:commandButton>
 
                             <p:commandButton
@@ -70,7 +71,15 @@
                                 rowsPerPageTemplate="20, 50, 100" 
                                 >
                                 <f:facet name="header">
-                                    <h:outputText value="Supplier Stock Summary - #{reportsStock.department.name}"/>  
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="Stock Summary (with Suppliers)"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
                                 </f:facet>
 
                                 <p:column headerText="No." style="width: 40px;">

--- a/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier_print.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_summary_with_supplier_print.xhtml
@@ -207,6 +207,19 @@
 
                                 </div>
 
+                                <div class="d-flex justify-content-between" style="font-weight:400; font-size: 10px; margin-top: 3mm;">
+                                    <span>
+                                        Printed By:
+                                        <h:outputText value="#{sessionController.loggedUser.webUserPerson.name}" />
+                                    </span>
+                                    <span>
+                                        Printed At:
+                                        <h:outputText value="#{sessionController.currentDate}">
+                                            <f:convertDateTime pattern="dd MMMM yyyy - hh:mm a"/>
+                                        </h:outputText>
+                                    </span>
+                                </div>
+
                             </div>
                         </h:panelGroup>
 

--- a/src/main/webapp/resources/ezcomp/common/report_print_footer.xhtml
+++ b/src/main/webapp/resources/ezcomp/common/report_print_footer.xhtml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <cc:interface>
+    </cc:interface>
+
+    <cc:implementation>
+        <h:panelGroup layout="block" styleClass="d-flex justify-content-between" style="font-size: 11px; font-weight: 400;">
+            <h:outputLabel value="Printed By: #{sessionController.loggedUser.webUserPerson.name}" />
+            <h:panelGroup layout="block">
+                <h:outputLabel value="Printed At: " />
+                <h:outputLabel value="#{sessionController.currentDate}">
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                </h:outputLabel>
+            </h:panelGroup>
+        </h:panelGroup>
+    </cc:implementation>
+
+</html>

--- a/src/main/webapp/resources/ezcomp/pharmacy/staff_stock.xhtml
+++ b/src/main/webapp/resources/ezcomp/pharmacy/staff_stock.xhtml
@@ -256,9 +256,7 @@
 
                         <f:facet name="footer">
                             <div class="p-2 text-muted">
-                                <small>
-                                    <common:report_print_footer/>
-                                </small>
+                                <common:report_print_footer/>
                             </div>
                         </f:facet>
 

--- a/src/main/webapp/resources/ezcomp/pharmacy/staff_stock.xhtml
+++ b/src/main/webapp/resources/ezcomp/pharmacy/staff_stock.xhtml
@@ -4,7 +4,8 @@
       xmlns:cc="http://xmlns.jcp.org/jsf/composite"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
 
     <!-- INTERFACE -->
     <cc:interface>
@@ -89,7 +90,7 @@
                                              value="Excel"
                                              ajax="false"
                                              title="Export to Excel">
-                                <p:dataExporter type="xlsx" target="tbl" fileName="Staff_Stock_Report"/>
+                                <p:dataExporter type="xlsx" target="tbl" fileName="Staff_Stock_Report" postProcessor="#{reportsStock.postProcessXLSStaffStock}"/>
                             </p:commandButton>
                         </div>
                     </div>
@@ -114,6 +115,10 @@
                         <f:facet name="header">
                             <div class="text-center p-2">
                                 <h:outputText value="Staff Stock Inventory Report" styleClass="fw-bold fs-5"/>
+                                <div style="font-size: 11px; font-weight: 400;">
+                                    <h:outputText value="Staff: #{not empty reportsStock.staff ? reportsStock.staff.person.name : 'All'}   |   "/>
+                                    <h:outputText value="Item: #{not empty reportsStock.item ? reportsStock.item.name : 'All'}"/>
+                                </div>
                             </div>
                         </f:facet>
 
@@ -250,12 +255,9 @@
                         </p:column>
 
                         <f:facet name="footer">
-                            <div class="text-center p-2 text-muted">
+                            <div class="p-2 text-muted">
                                 <small>
-                                    <h:outputText value="Report generated on "/>
-                                    <h:outputText value="#{sessionController.currentDate}">
-                                        <f:convertDateTime pattern="dd MMMM yyyy 'at' hh:mm a"/>
-                                    </h:outputText>
+                                    <common:report_print_footer/>
                                 </small>
                             </div>
                         </f:facet>


### PR DESCRIPTION
## Summary

Closes #17615. Pharmacy Analytics > Stock Reports pages now show a **header** (report name + every active filter) and a **footer** ("Printed By" / "Printed At") consistently across the on-screen view, print output, Excel export, and PDF export (where applicable).

- Added `ExcelController.insertExcelReportHeader()` / `appendExcelPrintedByFooter()` — a shared Apache POI utility invoked via PrimeFaces `p:dataExporter`'s `postProcessor` hook, so reports built on `p:dataTable` + `p:dataExporter` don't each reimplement header/footer injection.
- Added a `report_print_footer` composite component (`resources/ezcomp/common/report_print_footer.xhtml`) for the on-screen/print footer, reused across all touched pages.
- Applied the pattern across ~26 Stock Reports pages: Stock Report by Item/Category/Product/Batch/Supplier, Zero Stock Item, Department Vice Stock, Stock History, Before/After Stock Taking, Stock Taking (New), Staff Stock, Stock Report/Summary (with Suppliers), and their dedicated print pages.
- Documented the new pattern in `developer_docs/feature/excel-export-html-table.md` for future reports.

## Notable implementation details

- Department Vice Stock's PDF export uses `preProcessor`/`postProcessor` on `p:dataExporter type="pdf"`, which hands the controller a `com.lowagie.text.Document` (OpenPDF) — fully-qualified to avoid colliding with the same controller's existing iText5 (`com.itextpdf.text.*`) import used by another export method.
- `SearchController` (Stock Taking Report(New)) and `StockHistoryController` (Stock History) each got their own `ExcelController` injection, reusing the shared utility rather than duplicating it.
- One report (`pharmacy_report_item_stock_sale.xhtml`, "Stock With Movement" in the menu) was intentionally skipped — its actual page content is unrelated to stock reporting (a pre-existing menu-label/file mismatch), so applying the pattern there would have been incorrect.

## Bug found and fixed during testing

Testing surfaced a real crash: Apache POI throws `IllegalStateException: Merged region ... must contain 2 or more cells` when a report exports very few columns or zero data rows (e.g. Stock History with no recorded history for the selected range, Zero Stock Item Report with 2 columns). Fixed by guarding the merge-region calls in the shared utility — verified fixed via Playwright against the exact failing case.

## Verification (Playwright, local Payara, Main Pharmacy department)

- On-screen header/footer confirmed rendering correctly across report types.
- Excel exports inspected directly (unzipped `.xlsx`, checked `sharedStrings.xml`) — header/filter rows and "Printed by/at" footer row present and correctly positioned relative to data, including on empty-result exports (post-fix).
- PDF export (Department Vice Stock) verified via `pdftotext`.
- Print pages verified to include the same header/footer in their DOM.

![Stock Report by Item — header and footer](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/17615-stock-report-header-footer.png)

Issue comment with the same evidence: hmislk/hmis#17615 (comment)

## Test plan

- [x] `mvn clean package` succeeds
- [x] Local Payara redeploy succeeds with no new startup errors
- [x] On-screen header/footer verified across multiple report types (all 3 pre-existing UI patterns: custom POI/iText export, `p:dataExporter`, dedicated print pages)
- [x] Excel export content verified (header + footer rows present, correctly merged/positioned)
- [x] PDF export content verified (Department Vice Stock)
- [x] Print page DOM verified to include header/footer
- [x] Empty-result-set edge case verified fixed (previously crashed with HTTP 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pharmacy report Excel exports with richer headers (report title + selected filter details) and standardized **“Printed By”** / **“Printed At”** footers across multiple reports.
  * Updated print views to show consistent print metadata and to reuse a shared footer component.
* **Bug Fixes**
  * Added safeguards to avoid Excel merged-cell issues for narrow or empty exports.
* **Documentation**
  * Expanded guidance for Excel/PDF export configuration using post-processing (including header/footer handling and filter row behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->