### PR TITLE
Register free-item-without-quantity option in Direct Purchase config UI

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -2747,6 +2747,12 @@ public class PharmacyDirectPurchaseController implements Serializable {
                 OptionScope.APPLICATION
         ));
         metadata.addConfigOption(new ConfigOptionInfo(
+                "Allow Adding Direct Purchase Items When Normal Quantity Is Zero And Free Quantity Is Present",
+                "Allows adding a direct purchase item with zero normal quantity as long as free quantity is entered, "
+                + "for fully-free supplier items. When off, quantity must be greater than zero to add an item.",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
                 "Use Save Finalize Approve Workflow for Direct Purchase",
                 "Switches the page from single-step Settle to a Save Draft / Finalize / Approve workflow",
                 OptionScope.APPLICATION


### PR DESCRIPTION
## Summary

- Issue #13509 asks for an option to add fully-free items (Qty = 0, Free Qty > 0) in Direct Purchase, similar to what was reportedly built for GRN. Investigation showed the feature **already existed in code** — `PharmacyDirectPurchaseController` already gates the Qty-must-be-positive check behind the config key `Allow Adding Direct Purchase Items When Normal Quantity Is Zero And Free Quantity Is Present` — but the key was never registered in `registerPageMetadata()`, so it never appeared on the page's admin configuration screen. No admin could ever turn it on, matching the reporter's follow-up comment "Option isn't displayed."
- Fix: register the existing key alongside the page's other config options, so it now shows up under **Direct Purchase → Config → Manage Application Configuration**. No business logic changed.
- GRN was checked too — it has no equivalent restriction to begin with (PO-sourced GRN lines can already be edited to Qty 0 / Free Qty > 0 with no blocking validation), so no GRN change was needed.
- Added a wiki page documenting the option and how to enable it: [Adding Fully-Free Items in Direct Purchase](https://github.com/hmislk/hmis/wiki/Direct-Purchase-Free-Items-Without-Quantity), linked from the existing [Pharmacy Direct Purchase](https://github.com/hmislk/hmis/wiki/Pharmacy-DIrect-Purchase) wiki page.

## Test plan

Verified end-to-end locally (Playwright + DB), see the issue comment and linked wiki page for screenshots:
- [x] With the option at its default (disabled), adding an item with Qty=0 / Free Qty=5 is rejected with "Please enter quantity"
- [x] The option now appears (previously absent) under Direct Purchase's Page Configuration Management / Manage Application Configuration
- [x] With the option enabled, the same item is added successfully with Qty=0, Free Qty=5
- [x] Draft saves successfully; confirmed in MySQL that `BILLITEMFINANCEDETAILS.QUANTITY = 0.0000` and `FREEQUANTITY = 5.0000` persisted correctly
- [x] `mvn clean package -DskipTests` builds cleanly, no compile errors

Fixes #13509

🤖 Generated with [Claude Code](https://claude.ai/code)