### PR TITLE
feat(patient): warn on possible duplicate patients (NIC, name+DOB) during registration

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -3526,11 +3526,11 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
         List<String> orConditions = new ArrayList<>();
         if (hasNic) {
-            orConditions.add("p.person.nic = :nic");
+            orConditions.add("UPPER(p.person.nic) = UPPER(:nic)");
             params.put("nic", nic.trim());
         }
         if (hasNameDob) {
-            orConditions.add("(p.person.name = :name and p.person.dob = :dob)");
+            orConditions.add("(UPPER(p.person.name) = UPPER(:name) and p.person.dob = :dob)");
             params.put("name", name.trim());
             params.put("dob", dob);
         }

--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -343,6 +343,14 @@ public class PatientController implements Serializable, ControllerWithPatient {
     private Map<String, Patient> PatientMap;
 
     /**
+     * Possible duplicate patients found by matching NIC/Passport, or
+     * name+DOB, against existing (non-retired) patients. Populated by
+     * {@link #checkForPossibleDuplicatePatients()} before saving a new
+     * patient, so the UI can warn the user before proceeding.
+     */
+    private List<Patient> possibleDuplicatePatients = new ArrayList<>();
+
+    /**
      *
      *
      *
@@ -3166,6 +3174,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     public String navigateToAddNewPatientForOpd() {
         current = null;
         getCurrent();
+        possibleDuplicatePatients = new ArrayList<>();
 
         reGenerateePhn = true;
         return "/opd/patient_edit?faces-redirect=true";
@@ -3174,12 +3183,14 @@ public class PatientController implements Serializable, ControllerWithPatient {
     public String navigateToAddNewPatientForOptician() {
         current = null;
         getCurrent();
+        possibleDuplicatePatients = new ArrayList<>();
         return "/optician/patient_edit?faces-redirect=true";
     }
 
     public String navigateToAddNewPatientForOpd(String name, String nic, String phone) {
         current = null;
         getCurrent();
+        possibleDuplicatePatients = new ArrayList<>();
         getCurrent().getPerson().setName(name);
         getCurrent().getPerson().setNic(nic);
         getCurrent().getPerson().setPhone(phone);
@@ -3190,6 +3201,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     public String navigateToAddNewPatientForOptician(String name, String nic, String phone) {
         current = null;
         getCurrent();
+        possibleDuplicatePatients = new ArrayList<>();
         getCurrent().getPerson().setName(name);
         getCurrent().getPerson().setNic(nic);
         getCurrent().getPerson().setPhone(phone);
@@ -3200,6 +3212,7 @@ public class PatientController implements Serializable, ControllerWithPatient {
     public String navigateToAddNewPatientForOpd(String phone) {
         current = null;
         getCurrent();
+        possibleDuplicatePatients = new ArrayList<>();
         getCurrent().getPerson().setPhone(phone);
         getCurrent().getPerson().setMobile(phone);
         return "/opd/patient_edit?faces-redirect=true";
@@ -3478,10 +3491,82 @@ public class PatientController implements Serializable, ControllerWithPatient {
         return "/membership/add_family?faces-redirect=true";
     }
 
+    /**
+     * Checks for other non-retired patients that possibly duplicate the
+     * current one, matching on NIC/Passport (Person.nic) or on name+DOB
+     * together. Populates {@link #possibleDuplicatePatients} (capped at 10
+     * results) so the UI can warn the user before saving a new patient.
+     * When editing an existing patient, that patient itself is excluded
+     * from the match.
+     */
+    public void checkForPossibleDuplicatePatients() {
+        possibleDuplicatePatients = new ArrayList<>();
+        if (current == null || current.getPerson() == null) {
+            return;
+        }
+        String nic = current.getPerson().getNic();
+        String name = current.getPerson().getName();
+        Date dob = current.getPerson().getDob();
+
+        boolean hasNic = nic != null && !nic.trim().isEmpty();
+        boolean hasNameDob = name != null && !name.trim().isEmpty() && dob != null;
+
+        if (!hasNic && !hasNameDob) {
+            return;
+        }
+
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("select p from Patient p where p.retired = false ");
+        Map<String, Object> params = new HashMap<>();
+
+        if (current.getId() != null) {
+            jpql.append("and p.id != :selfId ");
+            params.put("selfId", current.getId());
+        }
+
+        List<String> orConditions = new ArrayList<>();
+        if (hasNic) {
+            orConditions.add("p.person.nic = :nic");
+            params.put("nic", nic.trim());
+        }
+        if (hasNameDob) {
+            orConditions.add("(p.person.name = :name and p.person.dob = :dob)");
+            params.put("name", name.trim());
+            params.put("dob", dob);
+        }
+
+        jpql.append("and (").append(String.join(" or ", orConditions)).append(")");
+
+        possibleDuplicatePatients = getFacade().findByJpql(jpql.toString(), params, 10);
+    }
+
+    /**
+     * Navigates to the profile page of a possibly-duplicate patient
+     * surfaced by {@link #checkForPossibleDuplicatePatients()}, so the user
+     * can inspect it before deciding whether to proceed with a new
+     * registration.
+     */
+    public String viewDuplicatePatientProfile(Patient p) {
+        if (p == null) {
+            JsfUtil.addErrorMessage("No patient selected");
+            return "";
+        }
+        this.current = p;
+        navigatedFromAdmissionProfile = false;
+        return "/opd/patient?faces-redirect=true";
+    }
+
     public void checkBeforeSavePatient() {
         if (current != null && current.getId() != null && current.isBlacklisted()) {
             PrimeFaces.current().executeScript("PF('dlgBlacklistSaveWarning').show();");
             return;
+        }
+        if (current != null && current.getId() == null) {
+            checkForPossibleDuplicatePatients();
+            if (possibleDuplicatePatients != null && !possibleDuplicatePatients.isEmpty()) {
+                PrimeFaces.current().executeScript("PF('dlgDuplicatePatientSaveWarning').show();");
+                return;
+            }
         }
         boolean savedSuccessfully = saveSelected(current);
         if (!savedSuccessfully) {
@@ -3500,6 +3585,13 @@ public class PatientController implements Serializable, ControllerWithPatient {
         if (current != null && current.getId() != null && current.isBlacklisted()) {
             PrimeFaces.current().executeScript("PF('dlgBlacklistSaveAdmissionWarning').show();");
             return null;
+        }
+        if (current != null && current.getId() == null) {
+            checkForPossibleDuplicatePatients();
+            if (possibleDuplicatePatients != null && !possibleDuplicatePatients.isEmpty()) {
+                PrimeFaces.current().executeScript("PF('dlgDuplicatePatientAdmissionWarning').show();");
+                return null;
+            }
         }
         return saveAndNavigateToAdmissionProfile();
     }
@@ -4577,6 +4669,14 @@ public class PatientController implements Serializable, ControllerWithPatient {
 
     public void setNavigatedFromAdmissionProfile(boolean navigatedFromAdmissionProfile) {
         this.navigatedFromAdmissionProfile = navigatedFromAdmissionProfile;
+    }
+
+    public List<Patient> getPossibleDuplicatePatients() {
+        return possibleDuplicatePatients;
+    }
+
+    public void setPossibleDuplicatePatients(List<Patient> possibleDuplicatePatients) {
+        this.possibleDuplicatePatients = possibleDuplicatePatients;
     }
 
     public List<Patient> getSelectedItems() {

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -86,17 +86,18 @@
                                         </div>
                                         <div class="col-md-10">
                                             <p:outputLabel value="Name:" for="txtName" class="form-label" />
-                                            <p:inputText 
-                                                id="txtName" 
-                                                value="#{patientController.current.person.name}" 
-                                                class="w-100 form-control" 
-                                                required="true" 
+                                            <p:inputText
+                                                id="txtName"
+                                                value="#{patientController.current.person.name}"
+                                                class="w-100 form-control"
+                                                required="true"
                                                 validatorMessage="Please enter only letters and spaces."
-                                                requiredMessage="Please Enter a name" 
+                                                requiredMessage="Please Enter a name"
                                                 >
                                                 <c:if test="#{not empty sessionController.applicationPreference.nameRegex}">
                                                     <f:validateRegex pattern="#{sessionController.applicationPreference.nameRegex}"/>
                                                 </c:if>
+                                                <p:ajax event="blur" async="true" process="@this" update="panDuplicateWarningInline" listener="#{patientController.checkForPossibleDuplicatePatients()}" />
                                             </p:inputText>
                                         </div>
                                     </div>
@@ -152,9 +153,10 @@
                                         <div class="col-md-6">
                                             <p:outputLabel value="Date of Birth:"  class="form-label" />
                                             <p:calendar value="#{patientController.current.person.dob}" id="calNewPtDob" navigator="true"
-                                                        pattern="#{sessionController.applicationPreference.longDateFormat}" style="border: none; padding: 0px;" 
+                                                        pattern="#{sessionController.applicationPreference.longDateFormat}" style="border: none; padding: 0px;"
                                                         maxdate="#{sessionController.currentDate}" inputStyle="width:100%;" class="form-control" >
                                                 <p:ajax event="dateSelect" process="calNewPtDob" update="year month day" />
+                                                <p:ajax event="dateSelect" process="@this" update="panDuplicateWarningInline" listener="#{patientController.checkForPossibleDuplicatePatients()}" />
                                             </p:calendar>
                                         </div>
                                     </div>
@@ -196,10 +198,47 @@
                                         <div class="col-md-3">
                                             <h:outputLabel class="form-label" value="NIC / Passport No:" />
                                             <h:panelGroup>
-                                                <p:inputText autocomplete="off" id="txtNIC" value="#{patientController.current.person.nic}" class="form-control" />
+                                                <p:inputText autocomplete="off" id="txtNIC" value="#{patientController.current.person.nic}" class="form-control" >
+                                                    <p:ajax event="blur" async="true" process="@this" update="panDuplicateWarningInline" listener="#{patientController.checkForPossibleDuplicatePatients()}" />
+                                                </p:inputText>
                                             </h:panelGroup>
                                         </div>
                                     </div>
+
+                                    <div class="row form-group mb-1">
+                                        <div class="col-md-12">
+                                            <p:outputPanel id="panDuplicateWarningInline" layout="block">
+                                                <h:panelGroup rendered="#{not empty patientController.possibleDuplicatePatients}">
+                                                    <p style="color:#b71c1c; font-weight:bold;">
+                                                        &#9888; Possible duplicate patient(s) found:
+                                                    </p>
+                                                    <p:dataTable value="#{patientController.possibleDuplicatePatients}" var="dup" rows="10">
+                                                        <p:column headerText="Name">
+                                                            <h:outputText value="#{dup.person.name}" />
+                                                        </p:column>
+                                                        <p:column headerText="NIC / Passport">
+                                                            <h:outputText value="#{dup.person.nic}" />
+                                                        </p:column>
+                                                        <p:column headerText="PHN">
+                                                            <h:outputText value="#{dup.phn}" />
+                                                        </p:column>
+                                                        <p:column headerText="MRN">
+                                                            <h:outputText value="#{dup.code}" />
+                                                        </p:column>
+                                                        <p:column headerText="Date of Birth">
+                                                            <h:outputText value="#{dup.person.dob}">
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" />
+                                                            </h:outputText>
+                                                        </p:column>
+                                                        <p:column headerText="">
+                                                            <p:commandLink value="View" action="#{patientController.viewDuplicatePatientProfile(dup)}" ajax="false" styleClass="ui-button ui-button-info" />
+                                                        </p:column>
+                                                    </p:dataTable>
+                                                </h:panelGroup>
+                                            </p:outputPanel>
+                                        </div>
+                                    </div>
+
                                     <div class="row form-group mb-1">
                                         <div class="col-md-8">
                                             <p:outputLabel value="Address:"  class="form-label" />
@@ -419,6 +458,70 @@
                                             action="#{patientController.saveAndNavigateToAdmissionProfile()}"
                                             ajax="false"
                                             onclick="PF('dlgBlacklistSaveAdmissionWarning').hide();" />
+                                    </div>
+                                </div>
+                            </p:dialog>
+
+                            <!-- Duplicate Patient Warning Dialog — Save and go to Patient Profile -->
+                            <p:dialog id="dlgDuplicatePatientSaveWarning"
+                                      widgetVar="dlgDuplicatePatientSaveWarning"
+                                      header="&#9888; Possible Duplicate Patient"
+                                      modal="true"
+                                      resizable="false"
+                                      closable="true"
+                                      style="width:500px">
+                                <div style="padding:12px">
+                                    <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
+                                        &#9888; Possible duplicate patient(s) already exist matching this NIC/Passport or Name + Date of Birth (see the list above).
+                                    </p>
+                                    <p style="font-weight:bold;">
+                                        Are you sure you want to create a new patient record?
+                                    </p>
+                                    <div class="d-flex justify-content-end gap-2 mt-3">
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('dlgDuplicatePatientSaveWarning').hide(); return false;" />
+                                        <p:commandButton
+                                            value="Yes, Create New Patient"
+                                            icon="fa fa-exclamation-triangle"
+                                            class="ui-button-danger"
+                                            action="#{patientController.saveAndNavigateToOpdPatientProfile()}"
+                                            ajax="false"
+                                            onclick="PF('dlgDuplicatePatientSaveWarning').hide();" />
+                                    </div>
+                                </div>
+                            </p:dialog>
+
+                            <!-- Duplicate Patient Warning Dialog — Save and go to Inpatient Dashboard -->
+                            <p:dialog id="dlgDuplicatePatientAdmissionWarning"
+                                      widgetVar="dlgDuplicatePatientAdmissionWarning"
+                                      header="&#9888; Possible Duplicate Patient"
+                                      modal="true"
+                                      resizable="false"
+                                      closable="true"
+                                      style="width:500px">
+                                <div style="padding:12px">
+                                    <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
+                                        &#9888; Possible duplicate patient(s) already exist matching this NIC/Passport or Name + Date of Birth (see the list above).
+                                    </p>
+                                    <p style="font-weight:bold;">
+                                        Are you sure you want to create a new patient record?
+                                    </p>
+                                    <div class="d-flex justify-content-end gap-2 mt-3">
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fa fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('dlgDuplicatePatientAdmissionWarning').hide(); return false;" />
+                                        <p:commandButton
+                                            value="Yes, Create New Patient"
+                                            icon="fa fa-exclamation-triangle"
+                                            class="ui-button-danger"
+                                            action="#{patientController.saveAndNavigateToAdmissionProfile()}"
+                                            ajax="false"
+                                            onclick="PF('dlgDuplicatePatientAdmissionWarning').hide();" />
                                     </div>
                                 </div>
                             </p:dialog>

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -231,7 +231,7 @@
                                                             </h:outputText>
                                                         </p:column>
                                                         <p:column headerText="">
-                                                            <p:commandLink value="View" action="#{patientController.viewDuplicatePatientProfile(dup)}" ajax="false" styleClass="ui-button ui-button-info" />
+                                                            <p:commandLink value="View" action="#{patientController.viewDuplicatePatientProfile(dup)}" ajax="false" immediate="true" styleClass="ui-button ui-button-info" />
                                                         </p:column>
                                                     </p:dataTable>
                                                 </h:panelGroup>


### PR DESCRIPTION
## Summary
- Adds a live AJAX duplicate check on new-patient registration (`opd/patient_edit.xhtml`): blurring the NIC/Passport field, blurring the Name field, or selecting a Date of Birth each re-run `PatientController.checkForPossibleDuplicatePatients()`, which matches on exact NIC/Passport OR Name+DOB against existing non-retired patients (JPQL only, capped at 10 results).
- Matches are shown in an inline "⚠ Possible duplicate patient(s) found" panel (Name / NIC / PHN / MRN / DOB / **View** link to jump to that patient's profile).
- Saving a **new** patient when duplicates are present shows a confirmation dialog ("Are you sure you want to create a new patient record?") — Cancel aborts, "Yes, Create New Patient" proceeds. This mirrors the existing blacklist-warning dialog pattern already on this page. The check is advisory only — never a hard block.
- Fixed a stale-state bug: navigating to a fresh "New Patient" form now clears any leftover match list from a previous patient in the same session.
- The "standalone admin tool for finding existing duplicates" acceptance criterion is already satisfied by the existing `PatientMergeController` / Data Administration → Patient Data Management tool (deterministic NIC/PHN/MRN scans + probabilistic name/DOB/phone similarity scan) — no new tool was added to avoid duplicating that functionality.

## Context
Issue #20765 had been closed by mistake — PR #20796 actually implemented issue #20764's blacklist-dialog scope but its description said `Closes #20765` instead of `Closes #20764`. Reopened and implemented the actual duplicate-detection feature described here.

## Test plan
Verified end-to-end with Playwright against a local Payara/MySQL deployment (see screenshots in [issue #20765](https://github.com/hmislk/hmis/issues/20765#issuecomment-5082792158)):
- [x] Typing an existing NIC and blurring shows the matching patient in the inline panel
- [x] Typing a matching Name + selecting the matching DOB (no NIC) shows the warning via the name+DOB path
- [x] Changing to a unique Name/NIC/DOB clears the panel
- [x] Clicking Save with a duplicate present shows the confirmation dialog
- [x] Cancel aborts the save (confirmed no DB row created)
- [x] "Yes, Create New Patient" proceeds and saves despite the warning (confirmed new patient row created in DB with the same NIC as the existing match)
- [x] Save with no duplicate proceeds directly with no dialog (confirmed DB row created)
- [x] `mvn clean package` — 185 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duplicate-patient detection during patient registration using NIC/passport plus name and date of birth.
  * Shows an inline warning with matching patient records while editing (triggered by field blur and date selection).
  * Provides a “View” option to open a potential duplicate’s profile for confirmation.
* **Bug Fixes**
  * Blocks saving and prevents proceeding to admission when potential duplicates are found, with dedicated warning dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->