### PR TITLE
Fix false-positive room overlap from DATE-truncated timestamp binding

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -100,6 +100,7 @@ import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.persistence.TemporalType;
 import org.primefaces.PrimeFaces;
 import org.primefaces.event.ReorderEvent;
 import org.primefaces.event.RowEditEvent;
@@ -1726,7 +1727,11 @@ public class BhtSummeryController implements Serializable {
         }
         jpql.append("AND (pr2.dischargedAt IS NULL OR pr2.dischargedAt > :from)");
         params.put("from", patientRoom.getAdmittedAt());
-        List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params);
+        // TemporalType.TIMESTAMP is required: the 2-arg findByJpql overload binds
+        // every Date with TemporalType.DATE, truncating admittedAt/dischargedAt to
+        // midnight, so two stays merely sharing a calendar day were reported as
+        // overlapping even when the times did not actually conflict.
+        List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
         return overlaps != null ? overlaps : new ArrayList<>();
     }
 


### PR DESCRIPTION
## Summary

Fixes the false-positive "Overlap" badge on the Patient Room Details page.

`BhtSummeryController.getOverlappingRooms()` built its JPQL at full timestamp precision but executed it through the 2-argument `findByJpql(jpql, params)` overload. That overload binds **every** `Date` parameter with `TemporalType.DATE` (`AbstractFacade.java:882-884`), truncating the `:from`/`:to` bind values to midnight. As a result, any two room stays sharing a calendar day were flagged as overlapping even when their actual times did not conflict.

The fix switches the call to the existing 3-argument overload with `TemporalType.TIMESTAMP`, so the comparison runs at the precision the query text already assumed. No facade change and no JPQL change were needed.

```diff
-List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params);
+List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
```

## Root cause confirmed at the data layer

Running the exact predicate `getOverlappingRooms()` builds for BHT/53360, under both bindings:

| Binding | Overlaps found | Result |
|---|---|---|
| `DATE` (before) | 1 | false-positive badge |
| `TIMESTAMP` (after) | 0 | correct |

## Verification

Tested against local Payara + MySQL using the reproduction case from the issue — BHT/53360 (Room 503 discharged `2026-07-09 16:59`, Room 510 admitted `2026-07-09 17:00`, one minute apart):

- **No false positive:** the Room Stay History renders both rows (503 "Left", 510 "Active") with **zero** Overlap badges, and the "Room Time Overlap Detected" header banner is gone.
- **Save path unblocked:** clicking *Save Changes* on Room 510 now saves directly with a "Successfully" message; the overlap confirmation dialog is no longer triggered. Previously this save was blocked by the false-positive prompt.
- **No false negative:** temporarily setting Room 503's discharge to `17:30` (a genuine 30-minute conflict with Room 510's 17:00 admission) still produced **2** Overlap badges. The test data was restored to its original values afterwards.

![Room Details after fix - no overlap badge](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-22439-after-fix-no-overlap-badge.png)

## Audit of other call sites

The issue asked for a wider audit of the 2-arg `findByJpql` overload with `Date` parameters. Scoped to the timestamp-sensitive room queries in the inward package:

- `InwardBeanController.checkRoomDischarge()` — already passes `TemporalType.TIMESTAMP` ✅
- `InwardManagementReportController` (occupancy/admission metrics) — already passes `TemporalType.TIMESTAMP` ✅
- The other 2-arg `findByJpql` calls in `BhtSummeryController` (lines 426, 2277) pass **no** `Date` parameters, so they are unaffected ✅

This call site was the only genuine defect. The 2-arg overload's `TemporalType.DATE` default was deliberately left unchanged, since altering it would affect ~167 call sites across 43 files — well beyond this issue's scope.

## Secondary item from the issue

The reported cross-row refresh staleness did **not** reproduce after this fix. The `update="@form"` re-render reflects the new state correctly on save, supporting the issue author's hypothesis that the apparent staleness was this same false positive re-appearing after every save. No follow-up PrimeFaces partial-render work appears necessary.

Closes #22439

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room-stay conflict detection by comparing complete admission and discharge timestamps.
  * Prevented false overlap alerts for stays occurring on the same day but during separate time periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->