### PR TITLE
Fix stale Gantt bars when room edit lands in the same save (#22447)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -304,6 +304,18 @@ public class BhtSummeryController implements Serializable {
     private transient long cachedUnifiedGanttBarsComputedAtMillis;
     private static final long UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS = 5000;
 
+    /**
+     * Clears the Gantt bar cache immediately. The 5s TTL above is a safety
+     * net for the wall-clock "Now" marker, which has no explicit save event
+     * to hook into - but any action that actually persists a room's
+     * admitted/discharged/retired state must call this so the same AJAX
+     * response reflects the change instead of waiting out the TTL.
+     */
+    public void invalidateUnifiedGanttBarsCache() {
+        cachedUnifiedGanttBars = null;
+        cachedUnifiedGanttBarsComputedAtMillis = 0;
+    }
+
     public List<RoomGanttBar> getUnifiedGanttBars() {
         if (cachedUnifiedGanttBars != null
                 && (System.currentTimeMillis() - cachedUnifiedGanttBarsComputedAtMillis) < UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS) {
@@ -1810,6 +1822,8 @@ public class BhtSummeryController implements Serializable {
         } else {
             getPatientRoomFacade().create(patientRoom);
         }
+
+        invalidateUnifiedGanttBarsCache();
 
         // Refresh the tables or any other necessary actions after saving
         createTables();
@@ -3719,8 +3733,7 @@ public class BhtSummeryController implements Serializable {
     public void setPatientEncounter(PatientEncounter patientEncounter) {
 //        makeNull();
         this.patientEncounter = patientEncounter;
-        cachedUnifiedGanttBars = null;
-        cachedUnifiedGanttBarsComputedAtMillis = 0;
+        invalidateUnifiedGanttBarsCache();
     }
 
     public SessionController getSessionController() {

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -370,6 +370,7 @@ public class RoomChangeController implements Serializable {
 
         // Record audit event
         recordRoomAuditEvent(pR, "Room Discharged", beforeState);
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
 
         JsfUtil.addSuccessMessage("Successfully Discharged from Room");
     }
@@ -389,6 +390,7 @@ public class RoomChangeController implements Serializable {
         // Record audit event
         recordRoomAuditEvent(pR, "Room Discharge Cancelled", beforeState);
         notificationController.createNotification(pR, "CancelDischarge");
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
 
         JsfUtil.addSuccessMessage("Room Discharge Cancelled");
     }
@@ -450,6 +452,7 @@ public class RoomChangeController implements Serializable {
         pR.setRetirer(sessionController.getWebUser());
         getPatientRoomFacade().edit(pR);
         bhtSummeryController.setPatientRooms(null);
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
         recordRoomAuditEvent(pR, "Room Removed", beforeState);
     }
 

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -306,6 +306,7 @@ public class RoomChangeController implements Serializable {
         }
 
         recordRoomAuditEvent(pR, "Room Removed", beforeState);
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
     }
 
     public void discharge(PatientRoom pR) {
@@ -330,6 +331,7 @@ public class RoomChangeController implements Serializable {
         }
 
         recordRoomAuditEvent(pR, "Room Discharged", beforeState);
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
     }
 
     public void dischargeWithCurrentTime(PatientRoom pR) {
@@ -477,6 +479,7 @@ public class RoomChangeController implements Serializable {
         }
 
         recordRoomAuditEvent(pR, "Guardian Room Removed", beforeState);
+        bhtSummeryController.invalidateUnifiedGanttBarsCache();
     }
 
     public void recreate() {


### PR DESCRIPTION
## Summary

- `BhtSummeryController.getUnifiedGanttBars()` caches its result for 5s to stop the "Now" marker from recomputing on every request, but nothing invalidated that cache when a room's admitted/discharged/retired state actually changed. Editing a room's time on the Room Stay History table and clicking **Save Changes** updated that table live in the same AJAX response, but the **Patient Room & Theatre Timeline** Gantt chart below it kept serving pre-edit bars until the 5s TTL lapsed.
- Added `BhtSummeryController.invalidateUnifiedGanttBarsCache()`, extracting the reset already used in `setPatientEncounter()`, and call it from every action on `inward_patient_room_details.xhtml` that persists a room's admitted/discharged/retired state:
  - `BhtSummeryController.updatePatientRoom()` — "Save Changes" (also covers `confirmUpdatePatientRoomWithOverlap()`, which delegates to it)
  - `RoomChangeController.dischargeWithCurrentTime()` — "Discharge from Room"
  - `RoomChangeController.dischargeCancel()` — "Cancel Room Discharge"
  - `RoomChangeController.removeRoom()` — "Remove Room"
- Out of scope: `updateChargesForRoom()` and the `changeDiscountListenerPatientRoom*` methods only touch money fields, never admitted/discharged/retired, so they can't affect Gantt bar geometry.

## Test plan

Verified live against BHT/53360 (Mrs. Kushari) on local Payara, reproducing the issue's exact scenario (Room 503 discharged 07 Jul 16:56→16:59, Room 510 active from 17:00):

- [x] Edited Room 503's Discharged At from `16:59` to `18:30` (creating an overlap) and clicked **Save Changes** with **Yes, Save Anyway** on the overlap confirm — Room Stay History showed the new time and Overlap tag as before, and this time the Gantt bar geometry for Room 503 (`left`/`width` style) also changed in the same rendered response instead of staying byte-identical to the pre-edit values.
- [x] To make the geometry change visually unambiguous, repeated with a larger jump (16:59 → 20 Jul 18:30): Room 503's bar width changed from `1.000%` to `67.972%` in the same response as the save, confirmed both via DOM inspection and a screenshot.
- [x] Verified `RoomChangeController.dischargeCancel()` ("Cancel Room Discharge") also invalidates the cache correctly — bar reverted to `100.000%` width (active/no discharge) immediately in the same response.
- [x] Verified the underlying DB rows (`PatientRoom.dischargedAt`/`discharged`) matched the UI state at each step via direct MySQL query against the local `coop` database.
- [x] Restored BHT/53360's room data back to its original baseline (Room 503: `16:56`→`16:59`, discharged=1; Room 510: `17:00`, active) afterward — confirmed DB values and Gantt bar geometry (`1.000%`/`99.986%`) match the pre-test state exactly.
- [x] `mvn clean package` — full build green, 185/185 tests passing.

Closes #22447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated room timelines immediately after creating or editing patient room assignments.
  * Ensured Gantt-bar displays refresh after room discharges, discharge cancellations, and room removals (including guardian room removals).
  * Improved consistency when switching patient encounters so displayed room information stays current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->