### PR TITLE
fix(inward): baby admission fixes — nested babies, room double-charge, cancel NPE

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -952,6 +952,30 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
     }
 
+    /**
+     * Copies address, area, and contact numbers from the mother's patient
+     * record onto the baby's own patient record. Bound to a button on the
+     * "Admit a Baby" page — babies usually share the mother's home address
+     * and contact numbers, so this saves re-typing them. (#9900)
+     */
+    public void copyPatientDetailsFromParent() {
+        if (parentAdmission == null || parentAdmission.getPatient() == null
+                || parentAdmission.getPatient().getPerson() == null) {
+            JsfUtil.addErrorMessage("No parent admission found to copy details from.");
+            return;
+        }
+        if (current == null || current.getPatient() == null || current.getPatient().getPerson() == null) {
+            return;
+        }
+        Person parentPerson = parentAdmission.getPatient().getPerson();
+        Person babyPerson = current.getPatient().getPerson();
+        babyPerson.setAddress(parentPerson.getAddress());
+        babyPerson.setArea(parentPerson.getArea());
+        babyPerson.setPhone(parentPerson.getPhone());
+        babyPerson.setMobile(parentPerson.getMobile());
+        JsfUtil.addSuccessMessage("Address and contact details copied from mother.");
+    }
+
     public String navigateCancelBabyAdmission() {
         if (parentAdmission != null) {
             current = parentAdmission;
@@ -2034,7 +2058,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         // MO-charge validation, but room occupancy is always enforced when a room
         // is voluntarily provided — an occupied room must never be double-assigned
         // regardless of admission type. (Issue #21183)
-        if (!isRapidTempAe()) {
+        // Baby admissions also skip the room requirement: the baby stays in the
+        // mother's room, so a separate PatientRoom would double-charge the room fee.
+        if (!isRapidTempAe() && !isBabyAdmission()) {
             if (getCurrent().getAdmissionType().isRoomChargesAllowed()) {
                 if (getPatientRoom().getRoomFacilityCharge() == null) {
                     JsfUtil.addErrorMessage("Select Room ");
@@ -2487,6 +2513,15 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private boolean isRapidTempAe() {
         return getCurrent() != null
                 && getCurrent().getEncounterRegistrationFlag() == EncounterRegistrationFlag.RAPID_TEMP_AE;
+    }
+
+    /**
+     * @return {@code true} when the current encounter is a baby admission
+     * (i.e. it has a parent encounter). Babies stay in the mother's room, so
+     * room selection is optional for them (#9900).
+     */
+    private boolean isBabyAdmission() {
+        return getCurrent() != null && getCurrent().getParentEncounter() != null;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -3128,7 +3128,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         bhtText = getInwardBean().getBhtTextPreview(getCurrent().getAdmissionType());
 
-        getPatientRoom().setRoomFacilityCharge(getCurrent().getAdmissionType().getRoomFacilityCharge());
+        // Baby admissions never get a room of their own — the baby stays in the
+        // mother's room. Skip applying the admission type's default/package room
+        // facility charge here, otherwise picking a package-priced admission type
+        // would silently create a PatientRoom and double-charge the room fee (#9900).
+        if (!isBabyAdmission()) {
+            getPatientRoom().setRoomFacilityCharge(getCurrent().getAdmissionType().getRoomFacilityCharge());
+        }
     }
 
     public String getBhtText() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -906,6 +906,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public String navigateToAddBabyAdmission() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("No Admission selected");
+            return "";
+        }
         if (current.getParentEncounter() != null) {
             // A baby admission's parentEncounter already points to the mother.
             // Do not allow a baby to have its own baby admission (e.g. grandmother
@@ -920,6 +924,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         setCurrent(ad);
         current.setParentEncounter(parentAdmission);
+        // This @SessionScoped bean may still hold a room selection left over from
+        // whatever admission was being edited before. Baby admissions never get
+        // their own room (see bhtNumberCalculation()/errorCheck()), so start the
+        // baby flow with a clean patientRoom to avoid carrying a stale selection
+        // through to saveSelected() and double-charging the room fee. (#9900)
+        patientRoom = new PatientRoom();
         patient = null;
         yearMonthDay = null;
         getPatient();

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -906,6 +906,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public String navigateToAddBabyAdmission() {
+        if (current.getParentEncounter() != null) {
+            // A baby admission's parentEncounter already points to the mother.
+            // Do not allow a baby to have its own baby admission (e.g. grandmother
+            // admits mother, mother admits daughter is not a realistic scenario).
+            JsfUtil.addErrorMessage("A baby admission cannot have its own baby admission.");
+            return "";
+        }
         parentAdmission = current;
         Admission ad = new Admission();
         if (ad.getDateOfAdmission() == null) {

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -730,6 +730,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             return "";
         }
         comment = null;
+        createPatientRoom();
         return "/inward/inward_cancel_admission?faces-redirect=true";
     }
 

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -269,10 +269,11 @@
                                         class="w-100 ui-button-secondary">
                                     </p:commandButton>
                                 </h:panelGroup>
-                                <h:panelGroup rendered="#{admissionController.current.parentEncounter == null and webUserController.hasPrivilege('InwardAdmissionsAdmission')}" layout="block" styleClass="col-6">
+                                <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardAdmissionsAdmission')}" layout="block" styleClass="col-6">
                                     <p:commandButton
                                         value="Add Baby Admission"
-                                        disabled="#{admissionController.current.discharged eq true}"
+                                        disabled="#{admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
+                                        title="#{admissionController.current.parentEncounter != null ? 'A baby admission cannot have its own baby admission' : (admissionController.current.discharged eq true ? 'Patient is discharged' : '')}"
                                         action="#{admissionController.navigateToAddBabyAdmission}"
                                         icon="fa fa-baby"
                                         ajax="false"

--- a/src/main/webapp/inward/inward_admission_child.xhtml
+++ b/src/main/webapp/inward/inward_admission_child.xhtml
@@ -110,21 +110,23 @@ xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
                                 class="m-1 w-100 form-control" />
                         </div>
                         <div class="col-md-3 p-2">
-                            <p:outputLabel 
+                            <p:outputLabel
                                 class="m-1 form-label"
-                                value="Room No* :" />
-                            <p:autoComplete 
+                                value="Room No (optional) :"
+                                title="Leave blank if the baby will stay in the mother's room — assigning a separate room here would charge the room fee twice" />
+                            <p:autoComplete
                                 forceSelection="true"
                                 id="cmbDoc"
                                 inputStyleClass="w-100"
                                 class="m-1 w-100"
+                                placeholder="Leave blank to stay in mother's room"
                                 disabled="#{admissionController.current.admissionType eq null or admissionController.current.admissionType.roomFacilityCharge ne null}"
-                                value="#{admissionController.patientRoom.roomFacilityCharge}" 
+                                value="#{admissionController.patientRoom.roomFacilityCharge}"
                                 completeMethod="#{roomFacilityChargeController.completeRoom}"
                                 var="rf"
                                 itemLabel="#{rf.name}"
                                 itemValue="#{rf}"
-                                size="30" >                                
+                                size="30" >
                             </p:autoComplete>
                         </div>
                         <div class="col-md-3 p-2">
@@ -144,7 +146,17 @@ xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
                             <div class="row my-2">
                                 <p:panel>
                                     <f:facet name="header">
-                                        <h:outputLabel value="Parent Details" />
+                                        <div class="d-flex justify-content-between align-items-center w-100">
+                                            <h:outputLabel value="Parent Details" />
+                                            <p:commandButton
+                                                value="Copy Address &amp; Phone to Baby"
+                                                icon="fa fa-copy"
+                                                styleClass="ui-button-info ui-button-outlined"
+                                                title="Copy the mother's address and phone/mobile numbers onto the baby's own patient details"
+                                                process="@this"
+                                                update="@form"
+                                                action="#{admissionController.copyPatientDetailsFromParent()}" />
+                                        </div>
                                     </f:facet>
                                     <common:patient patient="#{admissionController.parentAdmission.patient}" class="w-100"/>
                                 </p:panel>

--- a/src/main/webapp/inward/inward_admission_child.xhtml
+++ b/src/main/webapp/inward/inward_admission_child.xhtml
@@ -110,7 +110,7 @@ xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
                                 class="m-1 w-100 form-control" />
                         </div>
                         <div class="col-md-3 p-2">
-                            <p:outputLabel
+                            <h:outputText
                                 class="m-1 form-label"
                                 value="Room No (optional) :"
                                 title="Leave blank if the baby will stay in the mother's room — assigning a separate room here would charge the room fee twice" />

--- a/src/main/webapp/inward/inward_admission_child.xhtml
+++ b/src/main/webapp/inward/inward_admission_child.xhtml
@@ -14,46 +14,71 @@ xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
             <h:panelGroup rendered="#{!admissionController.printPreview}" >
                 <p:panel>
                     <f:facet name="header">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <h:outputText styleClass="fa fa-hospital"></h:outputText>
-                                <h:outputText class="mx-4" value="Admit a Baby"/>
+                        <!--
+                            Three-zone panel header layout (see UI guidelines § Panel Header Three-Zone Layout):
+                            LEFT  : panel title
+                            CENTER: entity-level navigation buttons (Inpatient Dashboard, Patient Lookup, Patient Profile)
+                            RIGHT : page actions ordered left→right by ascending importance; primary action rightmost
+                        -->
+                        <div class="d-flex justify-content-between align-items-center w-100">
+
+                            <!-- LEFT: title -->
+                            <div class="d-flex align-items-center gap-2">
+                                <h:outputText styleClass="fa fa-hospital" />
+                                <h:outputText value="Admit a Baby"/>
                             </div>
-                            <div>
+
+                            <!-- CENTER: navigation (page-to-page, entity-related) -->
+                            <div class="d-flex gap-2">
                                 <p:commandButton
                                     ajax="false"
                                     immediate="true"
                                     value="Inpatient Dashboard"
                                     icon="fa fa-id-card"
-                                    class="ui-button-secondary mx-1"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    title="Cancel this baby admission draft and return to the mother's Inpatient Dashboard"
                                     rendered="#{admissionController.parentAdmission ne null and admissionController.parentAdmission.id ne null}"
                                     action="#{admissionController.navigateCancelBabyAdmission()}">
                                 </p:commandButton>
                                 <p:commandButton
-                                    id="admt"
-                                    action="#{admissionController.saveSelected}"
                                     ajax="false"
-                                    class="ui-button-success mx-1"
-                                    value="Admit"  />
-                                <p:commandButton ajax="false" value="Clear" actionListener="#{admissionController.makeNull}" />
-                                <p:commandButton 
-                                    ajax="false" 
                                     immediate="true"
-                                    value="Patient Lookup" 
-                                    class="ui-button-warning mx-1" 
-                                    action="#{patientController.navigateToSearchPatients()}" 
-                                    icon="fa fa-search" /> <!-- Font Awesome icon for search -->
-
-                                <p:commandButton 
-                                    ajax="false" 
+                                    value="Patient Lookup"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    title="Search for an existing patient"
+                                    action="#{patientController.navigateToSearchPatients()}"
+                                    icon="fa fa-search" />
+                                <p:commandButton
+                                    ajax="false"
                                     immediate="true"
-                                    class="ui-button-warning mx-1" 
-                                    value="Patient Profile" 
-                                    action="#{patientController.navigateToOpdPatientProfile()}" 
-                                    icon="fa fa-user" > <!-- Font Awesome icon for user -->
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    value="Patient Profile"
+                                    title="View this patient's profile"
+                                    action="#{patientController.navigateToOpdPatientProfile()}"
+                                    icon="fa fa-user">
                                     <f:setPropertyActionListener value="#{admissionController.current.patient}" target="#{patientController.current}" ></f:setPropertyActionListener>
                                 </p:commandButton>
                             </div>
+
+                            <!-- RIGHT: actions — left=least important, right=primary -->
+                            <div class="d-flex gap-2 align-items-center">
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Clear"
+                                    icon="fas fa-eraser"
+                                    title="Clear the form and start over"
+                                    styleClass="ui-button-secondary"
+                                    actionListener="#{admissionController.makeNull}" />
+                                <p:commandButton
+                                    id="admt"
+                                    action="#{admissionController.saveSelected}"
+                                    ajax="false"
+                                    icon="pi pi-check-circle"
+                                    style="min-width:120px"
+                                    styleClass="ui-button-success"
+                                    value="Admit"  />
+                            </div>
+
                         </div>
                     </f:facet>
                     


### PR DESCRIPTION
## Summary
- Disable "Add Baby Admission" (UI + server-side guard) when the current admission is itself a baby admission, preventing unrealistic multi-generation chains (grandmother → mother → daughter).
- Restyle the "Admit a Baby" page header to the documented three-zone panel layout, matching `inward_admission.xhtml`.
- Fix a `NullPointerException` on Cancel Admission: `navigateToCancelAdmission()` never populated the session-scoped `patientRoom` list before rendering the confirmation page, so a prior cancel/delete in the same session (which resets it to `null`) crashed the next cancellation attempt.
- Add a "Copy Address & Phone to Baby" button on the Admit a Baby page to copy the mother's address/area/phone/mobile onto the baby's own patient record.
- Make room selection optional for baby admissions: babies normally stay in the mother's room, so a separate `PatientRoom` would double-charge the room fee. The existing "Select Room" validation now also skips for any admission with a `parentEncounter`, matching how `saveSelected()` already only creates a `PatientRoom` when a facility charge is actually chosen.

## Test plan
- [x] Verified "Add Baby Admission" is enabled on a mother's admission and disabled (with explanatory tooltip) on the baby's own admission profile.
- [x] Verified the server-side guard rejects `navigateToAddBabyAdmission()` when called on a baby admission.
- [x] Verified Cancel Admission completes successfully end-to-end (confirmed `RETIRED=1` in DB) after the NPE fix.
- [x] Verified "Copy Address & Phone to Baby" populates the baby's Mobile/Phone/Address fields from the mother's admission.
- [x] Admitted a baby with Room No left blank — admission succeeded, and confirmed no `PATIENTROOM` row was created for that encounter (no double charge).
- [x] Confirmed the copied address/phone persisted to the baby's `PERSON` record after admission.

Refs #9900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Copy Address & Phone to Baby” action to transfer parent contact details.
* **Bug Fixes**
  * Prevented starting a baby admission when the current admission already has a parent encounter.
  * Removed room requirement for baby admissions to avoid unnecessary room/fee handling when staying with the mother.
  * Improved cancellation flow by ensuring room information is refreshed before returning.
* **Usability Improvements**
  * Updated baby admission controls: clearer icons/tooltips, improved disabled states (discharged or existing parent encounter), and made “Room No” optional with guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->