### PR TITLE
docs(skills): fix generate-ddl redeploy app-name detection

### DIFF
--- a/.claude/skills/generate-ddl/SKILL.md
+++ b/.claude/skills/generate-ddl/SKILL.md
@@ -89,18 +89,24 @@ mvn -q package -DskipTests
 ```
 
 Find the built WAR and force-deploy it (this also triggers the singleton's
-`@PostConstruct`, which is what runs the column-enhancement step):
+`@PostConstruct`, which is what runs the column-enhancement step). First
+look up the **actual currently-deployed app name** — do not assume `rh`; on
+some machines the app is deployed as `rh-3.0.0` (derived from the WAR
+filename) instead:
 
 ```bash
 WAR=$(ls target/*.war | head -1)
-/home/buddhika/payara/bin/asadmin redeploy --name rh "$WAR"
+DEPLOYED_NAME=$(/home/buddhika/payara/bin/asadmin list-applications | awk 'NR==1{print $1}')
+DEPLOYED_NAME="${DEPLOYED_NAME:-rh}"
+/home/buddhika/payara/bin/asadmin redeploy --name "$DEPLOYED_NAME" "$WAR"
 ```
 
-Use the explicit app name `rh` — the same name `dev-issue` and
-`playwright-e2e` redeploy under. Omitting `--name` lets `asadmin` derive the
-app name from the WAR filename (e.g. `rh-3.0.0`) instead of redeploying the
-existing `rh` app, which can leave two separate apps competing for the same
-hardcoded `/rh` context root (`glassfish-web.xml`).
+Always pass the looked-up `--name`, matching whatever app name this
+particular machine actually has deployed — `dev-issue` and `playwright-e2e`
+default to `rh`, but that's only a convention, not a guarantee. Omitting
+`--name` lets `asadmin` derive the app name from the WAR filename instead of
+redeploying the existing app, which can leave two separate apps competing
+for the same hardcoded `/rh` context root (`glassfish-web.xml`).
 
 **If deploy fails with a JNDI lookup error for a datasource** (e.g.
 `jdbc/ruhunuAudit` not found): this is a pre-existing local-environment
@@ -109,6 +115,24 @@ this skill. Run `/home/buddhika/payara/bin/asadmin list-jdbc-resources` to
 see what's actually registered, report the mismatch to the user, and ask
 before changing `<jta-data-source>` (that line may already be a deliberate
 uncommitted local override).
+
+**If the `redeploy` command itself fails** (for the JNDI reason above or any
+other), re-run `list-applications` before retrying anything — a failed
+`redeploy` can leave the app fully undeployed rather than rolled back to the
+previous working version:
+
+```bash
+/home/buddhika/payara/bin/asadmin list-applications
+```
+
+If `$DEPLOYED_NAME` is no longer listed, do **not** retry `redeploy` (it will
+fail again with "Application ... is not deployed"). Fall back to a plain
+`deploy` instead, setting `--contextroot` explicitly since a fresh `deploy`
+doesn't infer it the way `redeploy` does:
+
+```bash
+/home/buddhika/payara/bin/asadmin deploy --name "$DEPLOYED_NAME" --contextroot rh "$WAR"
+```
 
 ### 5. Verify the output
 
@@ -136,9 +160,15 @@ pre-existing local-only change was already there before step 1 — never more.
 
 ### 7. Rebuild and redeploy again to restore the running app
 
+Re-check the deployed app name rather than assuming it's still the same —
+use the same `$DEPLOYED_NAME` lookup as step 4:
+
 ```bash
 mvn -q package -DskipTests
-/home/buddhika/payara/bin/asadmin redeploy --name rh "$(ls target/*.war | head -1)"
+WAR=$(ls target/*.war | head -1)
+DEPLOYED_NAME=$(/home/buddhika/payara/bin/asadmin list-applications | awk 'NR==1{print $1}')
+DEPLOYED_NAME="${DEPLOYED_NAME:-rh}"
+/home/buddhika/payara/bin/asadmin redeploy --name "$DEPLOYED_NAME" "$WAR"
 ```
 
 If this redeploy fails for the same pre-existing JNDI reason noted in step
@@ -146,6 +176,17 @@ If this redeploy fails for the same pre-existing JNDI reason noted in step
 known-good state when it isn't. The previous (DDL-generation-enabled)
 deployment will keep running in that case until the underlying datasource
 issue is fixed.
+
+If the failed `redeploy` left the app undeployed (check with
+`asadmin list-applications` — `$DEPLOYED_NAME` will be absent), fall back to:
+
+```bash
+/home/buddhika/payara/bin/asadmin deploy --name "$DEPLOYED_NAME" --contextroot rh "$WAR"
+```
+
+Report this fallback explicitly too — the app is restored, but via `deploy`
+rather than `redeploy`, which is worth flagging since it means the earlier
+`redeploy` genuinely failed rather than just being slow.
 
 ### 8. Publish the DDL to the wiki
 

--- a/.claude/skills/generate-ddl/SKILL.md
+++ b/.claude/skills/generate-ddl/SKILL.md
@@ -92,12 +92,20 @@ Find the built WAR and force-deploy it (this also triggers the singleton's
 `@PostConstruct`, which is what runs the column-enhancement step). First
 look up the **actual currently-deployed app name** — do not assume `rh`; on
 some machines the app is deployed as `rh-3.0.0` (derived from the WAR
-filename) instead:
+filename) instead. `list-applications` lists *every* deployed app (not just
+this one), so don't just grab the first line — filter for the `rh`/`rh-<version>`
+naming convention and require exactly one unambiguous match, failing loudly
+rather than silently defaulting to `rh` if that's not the case:
 
 ```bash
 WAR=$(ls target/*.war | head -1)
-DEPLOYED_NAME=$(/home/buddhika/payara/bin/asadmin list-applications | awk 'NR==1{print $1}')
-DEPLOYED_NAME="${DEPLOYED_NAME:-rh}"
+MATCHES=$(/home/buddhika/payara/bin/asadmin list-applications | awk '{print $1}' | grep -E '^rh(-[0-9][0-9.]*)?$' || true)
+MATCH_COUNT=$(printf '%s\n' "$MATCHES" | grep -c . || true)
+if [ "$MATCH_COUNT" -ne 1 ]; then
+  echo "ERROR: expected exactly one deployed app matching rh/rh-<version>, found $MATCH_COUNT: $MATCHES" >&2
+  exit 1
+fi
+DEPLOYED_NAME="$MATCHES"
 /home/buddhika/payara/bin/asadmin redeploy --name "$DEPLOYED_NAME" "$WAR"
 ```
 
@@ -106,7 +114,9 @@ particular machine actually has deployed — `dev-issue` and `playwright-e2e`
 default to `rh`, but that's only a convention, not a guarantee. Omitting
 `--name` lets `asadmin` derive the app name from the WAR filename instead of
 redeploying the existing app, which can leave two separate apps competing
-for the same hardcoded `/rh` context root (`glassfish-web.xml`).
+for the same hardcoded `/rh` context root (`glassfish-web.xml`). If the
+error above fires (zero or multiple matches), stop and ask the user rather
+than guessing which app to redeploy.
 
 **If deploy fails with a JNDI lookup error for a datasource** (e.g.
 `jdbc/ruhunuAudit` not found): this is a pre-existing local-environment
@@ -166,8 +176,13 @@ use the same `$DEPLOYED_NAME` lookup as step 4:
 ```bash
 mvn -q package -DskipTests
 WAR=$(ls target/*.war | head -1)
-DEPLOYED_NAME=$(/home/buddhika/payara/bin/asadmin list-applications | awk 'NR==1{print $1}')
-DEPLOYED_NAME="${DEPLOYED_NAME:-rh}"
+MATCHES=$(/home/buddhika/payara/bin/asadmin list-applications | awk '{print $1}' | grep -E '^rh(-[0-9][0-9.]*)?$' || true)
+MATCH_COUNT=$(printf '%s\n' "$MATCHES" | grep -c . || true)
+if [ "$MATCH_COUNT" -ne 1 ]; then
+  echo "ERROR: expected exactly one deployed app matching rh/rh-<version>, found $MATCH_COUNT: $MATCHES" >&2
+  exit 1
+fi
+DEPLOYED_NAME="$MATCHES"
 /home/buddhika/payara/bin/asadmin redeploy --name "$DEPLOYED_NAME" "$WAR"
 ```
 


### PR DESCRIPTION
## Summary
- `generate-ddl` SKILL.md steps 4 and 7 hardcoded `asadmin redeploy --name rh`, which fails (or risks creating a second competing app on the `/rh` context root) on machines where the app is actually deployed under a different name, e.g. `rh-3.0.0`.
- Both steps now look up the actual deployed app name via `asadmin list-applications` before redeploying, falling back to `rh` only if nothing is listed.
- Added an explicit fallback for the case where a failed `redeploy` leaves the app fully undeployed: re-check `list-applications`, and if the app is absent, fall back to `asadmin deploy --name <name> --contextroot rh <war>` instead of retrying `redeploy`.

## Test plan
- [x] Documentation-only change (`.claude/skills/generate-ddl/SKILL.md`) — no Java/JSF code touched, so no compile/deploy/Playwright verification needed per CLAUDE.md.
- [x] Re-read the edited steps for internal consistency (variable names, bash syntax) and confirmed no other skill files were affected.

Closes #22450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to automatically detect the currently deployed application name and redeploy using that exact name.
  * Improved redeploy failure recovery by verifying whether the application is still deployed and guiding a fresh deployment when it is not.
  * Applied consistent rebuild-and-redeploy guidance with the same automatic name detection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->