### PR TITLE
feat(pharmacy): native-SQL Sale for Cashier page

### DIFF
--- a/docs/superpowers/plans/2026-07-27-native-sale-for-cashier.md
+++ b/docs/superpowers/plans/2026-07-27-native-sale-for-cashier.md
@@ -123,9 +123,7 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
   `PaymentMethodData`, `PaymentScheme`.
 - Produces:
   ```java
-  public void settle(PreBill preBill, List<BillItemData> items,
-                     PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
-                     PaymentScheme paymentScheme)
+  public void settle(PreBill preBill, List<BillItemData> items)
 
   public Object[] loadViewDataByBillId(long billId)   // [PrintBillData, List<BillItemData>]
   ```
@@ -193,22 +191,22 @@ Replace:
 with:
 
 ```java
-    public void settle(PreBill preBill, List<BillItemData> items,
-                       PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
-                       PaymentScheme paymentScheme) {
+    public void settle(PreBill preBill, List<BillItemData> items) {
 ```
 
-`paymentMethod` / `paymentMethodData` / `paymentScheme` stay in the signature even though no
-Payment rows are written — they are retained so the method shape matches its sibling and so a
-future change (e.g. recording method on the bill inside the service) needs no call-site churn.
-Mark them so no reader thinks they were forgotten by adding, immediately after the guard clause:
+The three payment parameters are **dropped**, not retained: this bill type is `NO_PAYMENT`, so
+the service writes no `Payment` rows and has no use for them. The controller stamps payment
+details onto the bill's own columns via `billBean.setPaymentMethodData(...)` *before* calling
+`settle`. Record why, immediately after the guard clause:
 
 ```java
-        // paymentMethod / paymentMethodData / paymentScheme are intentionally unused here:
-        // PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER is a NO_PAYMENT bill type. The
-        // controller stamps them onto the bill's own columns via billBean.setPaymentMethodData
-        // before calling settle(). No Payment entity is created.
+        // No payment parameters: PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER is a
+        // NO_PAYMENT bill type, so no Payment entity is created here. The controller
+        // stamps payment details onto the bill's own columns before calling settle().
 ```
+
+Remove the `PaymentMethod`, `PaymentMethodData` and `PaymentScheme` imports if nothing else
+in the file uses them.
 
 - [ ] **Step 5: Delete the BilledBill persist and cross-link (Steps 1b and 1c)**
 
@@ -506,8 +504,7 @@ end of the `try` block with:
         }
 
         try {
-            nativeSqlService.settle(preBillEntity, billItemDataList,
-                    paymentMethod, getPaymentMethodData(), paymentScheme);
+            nativeSqlService.settle(preBillEntity, billItemDataList);
 
             settleTokenIfEnabled(preBillEntity);
 
@@ -1369,8 +1366,9 @@ and note that Phase 3 (production testing gate) is now the blocker for Phase 4.
   from the originals; the recipe plus the two `grep` gates is more reliable and is how the
   existing `*_native` composites were produced.
 
-**Type consistency:** `settle(...)` is `void` and 5-arg in Task 2's Produces block, Task 3's
-call site, and the spec. `buildPrintBill(Bill)` keeps its one-arg entity signature (Task 3
+**Type consistency:** `settle(...)` is `void` and 2-arg in Task 2's Produces block and Task 3's
+call site. (The spec's §5.2 sketch shows a 5-arg form; the three payment parameters were
+dropped during plan pre-flight as unused — this plan governs.) `buildPrintBill(Bill)` keeps its one-arg entity signature (Task 3
 Steps 6, 11). `recalculateRow(BillItemData)` is introduced in Task 3 Step 8 and used only
 there. `navigateToPharmacyBillForCashierNativeFromMenu()` is defined in Task 3 Step 10 and
 consumed in Task 7 Step 1 — names match.

--- a/docs/superpowers/plans/2026-07-27-native-sale-for-cashier.md
+++ b/docs/superpowers/plans/2026-07-27-native-sale-for-cashier.md
@@ -1,0 +1,1376 @@
+# Native-SQL Sale for Cashier — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the entity-based "Sale for Cashier" pharmacy page with a native-SQL
+implementation that avoids the EAGER `Stock → ItemBatch → Item` cascade load, at 100%
+functional parity.
+
+**Architecture:** Clone `RetailSaleNativeSqlController` / `RetailSaleNativeSqlService`, collapse
+the two-bill (PreBill + BilledBill + Payment) settle into the cashier's single-bill
+(`PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`, no Payment rows) settle, then re-apply the
+six cashier-specific deltas identified by the inventory diff in the spec.
+
+**Tech Stack:** Java EE (CDI `@SessionScoped`, EJB `@Stateless`), JPA/EclipseLink with native
+SQL via `EntityManager.createNativeQuery`, JSF 2.x + PrimeFaces, Maven, MySQL, Payara.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-native-sale-for-cashier-design.md`
+**Issue:** #20261 — **Master:** #22442 (Phase 2) — **Branch:** `20261-native-sale-for-cashier`
+
+## Global Constraints
+
+- **No unit-test harness exists for these controllers.** Verification per task is
+  `mvn -q compile` (must exit 0); functional verification is the DB-backed E2E in Task 9.
+  Do not invent test files — there is no test source tree for this layer.
+- **JPQL first, native SQL last** (CLAUDE.md). Native SQL here is pre-authorised: it is the
+  entire point of the migration and mirrors `RetailSaleNativeSqlService`.
+- **Never modify existing constructors.** DTO changes are additive fields + accessors only.
+- **Never rename or "fix" existing typos** (e.g. `descreption`, `purcahseRate`) — DB column
+  compatibility depends on them.
+- **Never use `ui:fragment`** — use `h:panelGroup rendered="..."`. `p:repeat` does not exist;
+  use `ui:repeat`.
+- **`persistence.xml` stays untouched.** It carries local JNDI (`jdbc/coop`,
+  `jdbc/ruhunuAudit`) as an unstaged modification. Never stage or commit it.
+- **Bill type:** `BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`,
+  `BillType.PharmacyPre`. Bill-number suffix `SCPB`.
+- Commit messages end with `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` and
+  reference `#20261`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/main/java/com/divudi/core/data/dto/PrintBillData.java` | **Modify.** Add `billIdStr`, `cancelled` — needed by token composites (barcode, cancelled marker). |
+| `src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java` | **Create.** Single-bill native settle: BillItem + fully-populated PBI, stock deduct, StockHistory, BFD/BIFD, totals. No BilledBill, no Payment. |
+| `src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java` | **Create.** `@Named @SessionScoped` page controller: cart, validation, token integration, qty helpers, print-data assembly. |
+| `src/main/webapp/resources/pharmacy/*_native.xhtml` (6) | **Create.** Native token + cashier bill print composites (`phi:` namespace). |
+| `src/main/webapp/resources/pharmacy/print/*_native.xhtml` (3) | **Create.** Native cashier custom bill formats (`pp:` namespace). |
+| `src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml` | **Create.** The page: cart entry, token panel, qty helpers, inline print panel, printer-config dialog. |
+| `src/main/webapp/resources/ezcomp/menu.xhtml` | **Modify.** Retarget "Sale for cashier"; add "Sale for cashier (Legacy)". |
+
+---
+
+## Task 1: Extend `PrintBillData` for token composites
+
+**Files:**
+- Modify: `src/main/java/com/divudi/core/data/dto/PrintBillData.java`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PrintBillData.getBillIdStr()` / `setBillIdStr(String)`,
+  `PrintBillData.isCancelled()` / `setCancelled(boolean)`. Tasks 2, 3, 4 rely on these.
+
+**Why:** `saleBillToken.xhtml:132` renders `<p:barcode value="#{cc.attrs.bill.idStr}">` and
+line 33 renders `**Cancelled**` on `#{cc.attrs.bill.cancelled}`. `PrintBillData` has neither,
+so the native token composites cannot be written without them.
+
+- [ ] **Step 1: Add the fields**
+
+In the "Bill identity" block (after `private String creatorName;`, currently line 25):
+
+```java
+    private String billIdStr;
+    private boolean cancelled;
+```
+
+- [ ] **Step 2: Add the accessors**
+
+After the `creatorName` accessors:
+
+```java
+    public String getBillIdStr() { return billIdStr; }
+    public void setBillIdStr(String billIdStr) { this.billIdStr = billIdStr; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+```
+
+Do **not** touch any existing constructor (CLAUDE.md rule) — `PrintBillData` uses the
+implicit no-arg constructor plus setters, so nothing else changes.
+
+- [ ] **Step 3: Compile**
+
+Run: `mvn -q compile`
+Expected: exit code 0, no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/data/dto/PrintBillData.java
+git commit -m "feat(pharmacy): add billIdStr and cancelled to PrintBillData
+
+Needed by the native Sale for Cashier token print composites, which render
+a Code128 barcode from bill.idStr and a Cancelled marker from bill.cancelled.
+Additive fields only; no constructor changed.
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `RetailSaleForCashierNativeSqlService`
+
+**Files:**
+- Create: `src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java`
+- Reference (do not modify): `src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java`
+
+**Interfaces:**
+- Consumes: `PrintBillData` (Task 1), `BillItemData`, `PreBill`, `PaymentMethod`,
+  `PaymentMethodData`, `PaymentScheme`.
+- Produces:
+  ```java
+  public void settle(PreBill preBill, List<BillItemData> items,
+                     PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
+                     PaymentScheme paymentScheme)
+
+  public Object[] loadViewDataByBillId(long billId)   // [PrintBillData, List<BillItemData>]
+  ```
+  Task 3 calls both.
+
+**Method:** copy `RetailSaleNativeSqlService.java` verbatim, then apply the deletions and
+edits below. Copying first preserves the table-name resolution helpers
+(`resolveTable`/`stockTable()`/…), `deductStock`, `fetchStockQty`, `computeAggregates`,
+`insertStockHistory`, `insertFinanceDetails` and `safeStr` — all of which carry
+production fixes and must not be retyped.
+
+- [ ] **Step 1: Copy the source file**
+
+```bash
+cp src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java \
+   src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+```
+
+- [ ] **Step 2: Rename the class and logger**
+
+```bash
+sed -i 's/\bRetailSaleNativeSqlService\b/RetailSaleForCashierNativeSqlService/g' \
+   src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+```
+
+This is safe to run unanchored here — the file contains no other numbered or
+similarly-prefixed identifier. (Contrast the page copies in Phase 4, which need the guarded
+replace from the multi-window guide.)
+
+- [ ] **Step 3: Replace the class javadoc**
+
+Replace the existing class-level comment with:
+
+```java
+/**
+ * Native-SQL settle path for the pharmacy "Sale for Cashier" page.
+ *
+ * Unlike RetailSaleNativeSqlService this writes a SINGLE bill — a PreBill of
+ * BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER. There is no BilledBill
+ * and there are no Payment rows: that atomic type is NO_PAYMENT / NO_FINANCE_TRANSACTIONS,
+ * and the cashier settles payment later via PharmacyPreSettleController.
+ *
+ * Stock is still deducted here, at pharmacy time, exactly as the legacy
+ * PharmacySaleForCashierController did.
+ *
+ * Deviation from legacy: BillFinanceDetails / BillItemFinanceDetails ARE written at settle.
+ * Legacy wrote none, which is why DataAdministrationController
+ * .backfillBfdForPreToSettleAtCashierBills() exists — without BFD the F15 report reads
+ * totalRetailSaleValue as 0. Bills created here never need that backfill.
+ *
+ * Issue: #20261
+ */
+```
+
+- [ ] **Step 4: Change the `settle` signature**
+
+Replace:
+
+```java
+    public List<Payment> settle(PreBill preBill, BilledBill saleBill, List<BillItemData> items,
+                          PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
+                          PaymentScheme paymentScheme) {
+```
+
+with:
+
+```java
+    public void settle(PreBill preBill, List<BillItemData> items,
+                       PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
+                       PaymentScheme paymentScheme) {
+```
+
+`paymentMethod` / `paymentMethodData` / `paymentScheme` stay in the signature even though no
+Payment rows are written — they are retained so the method shape matches its sibling and so a
+future change (e.g. recording method on the bill inside the service) needs no call-site churn.
+Mark them so no reader thinks they were forgotten by adding, immediately after the guard clause:
+
+```java
+        // paymentMethod / paymentMethodData / paymentScheme are intentionally unused here:
+        // PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER is a NO_PAYMENT bill type. The
+        // controller stamps them onto the bill's own columns via billBean.setPaymentMethodData
+        // before calling settle(). No Payment entity is created.
+```
+
+- [ ] **Step 5: Delete the BilledBill persist and cross-link (Steps 1b and 1c)**
+
+Delete this whole block:
+
+```java
+        // Step 1b: Persist BilledBill (payment will reference its ID).
+        saleBill.setBillItems(null);
+        saleBill.setReferenceBill(preBill);
+        em.persist(saleBill);
+        em.flush();
+        long billId = saleBill.getId();
+
+        // Step 1c: Cross-link PreBill → BilledBill via JPA so the L2 cache stays coherent.
+        preBill.setReferenceBill(saleBill);
+        em.merge(preBill);
+        em.flush();
+```
+
+Change the following log line to:
+
+```java
+        LOGGER.log(Level.INFO, "[CashierNativeSettle] PreBill id={0} ms={1}",
+                new Object[]{preBillId, System.currentTimeMillis() - t0});
+```
+
+- [ ] **Step 6: Make the single PBI fully populated (Step 2a)**
+
+In the Step 2a loop, the PreBill PBI insert currently zeroes the value columns. With no
+BilledBill to carry them, this single PBI is the only source of cost/retail/purchase values
+for costing and F15 — so it must be populated. Replace the Step 2a PBI insert with:
+
+```java
+            // Single-bill flow: this PBI is the ONLY one, so it carries the real
+            // cost/retail/purchase values. (The two-bill retail flow zeroes them here
+            // because its BilledBill PBI carries them instead.)
+            em.createNativeQuery(
+                "INSERT INTO " + pharmBillItemTable()
+                + " (billItem_ID, itemBatch_ID, stock_ID, qty, stringValue,"
+                + " costRate, purchaseRate, retailRate, wholesaleRate, doe, description)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+                .setParameter(1, biPreIds[i])
+                .setParameter(2, d.getItemBatchId())
+                .setParameter(3, d.getStockId())
+                .setParameter(4, d.getPbiQty())
+                .setParameter(5, d.getStringValue())
+                .setParameter(6, d.getCostRate())
+                .setParameter(7, d.getPurchaseRate())
+                .setParameter(8, d.getRetailRate())
+                .setParameter(9, d.getWholesaleRate())
+                .setParameter(10, d.getDoe() != null ? new Timestamp(d.getDoe().getTime()) : null)
+                .setParameter(11, d.getDescription())
+                .executeUpdate();
+            pbPreIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+```
+
+Also change the comment above the Step 2a `BillItem` insert from
+`// Step 2a: Native INSERT BillItem + bare PBI on PreBill ...` to
+`// Step 2: Native INSERT BillItem + fully-populated PBI on the single PreBill`.
+
+- [ ] **Step 7: Delete the duplicate BillItem/PBI insert (Step 2b)**
+
+Delete the entire `// Step 2b: ...` block — the `long[] biIds` / `long[] pbIds` declarations
+and the loop that inserts into `billItemTable()` and `pharmBillItemTable()` against `billId`.
+
+- [ ] **Step 8: Trim the L2 cache eviction**
+
+Delete the `cache.evict(BilledBill.class);` line. Keep the `StockHistory`, `Stock`,
+`BillItem`, `Bill` and `PreBill` evictions.
+
+- [ ] **Step 9: Point finance details at the PreBill (Step 4)**
+
+Replace:
+
+```java
+        double[] billTotals = insertFinanceDetails(billId, biIds, pbIds, items);
+```
+
+with:
+
+```java
+        // Deviation from legacy (which wrote no finance details for cashier bills):
+        // BFD/BIFD are written against the single PreBill so F15's totalRetailSaleValue
+        // is correct without backfillBfdForPreToSettleAtCashierBills. Issue #20261.
+        double[] billTotals = insertFinanceDetails(preBillId, biPreIds, pbPreIds, items);
+```
+
+- [ ] **Step 10: Update the totals statement (Step 5) for one bill**
+
+Replace:
+
+```java
+        em.createNativeQuery(
+                "UPDATE " + billTable() + " SET total=?, netTotal=?, DISCOUNT=? WHERE ID=? OR ID=?")
+                .setParameter(1, billTotals[0])
+                .setParameter(2, billTotals[1])
+                .setParameter(3, billTotals[2])
+                .setParameter(4, preBillId)
+                .setParameter(5, billId)
+                .executeUpdate();
+```
+
+with:
+
+```java
+        em.createNativeQuery(
+                "UPDATE " + billTable() + " SET total=?, netTotal=?, DISCOUNT=? WHERE ID=?")
+                .setParameter(1, billTotals[0])
+                .setParameter(2, billTotals[1])
+                .setParameter(3, billTotals[2])
+                .setParameter(4, preBillId)
+                .executeUpdate();
+```
+
+- [ ] **Step 11: Delete the Payment insert (Step 6) and its helpers**
+
+Delete the `// Step 6: ...` block and the `return payments;` statement. Replace the trailing
+log with:
+
+```java
+        LOGGER.log(Level.INFO, "[CashierNativeSettle] DONE items={0} ms={1}",
+                new Object[]{items.size(), System.currentTimeMillis() - t0});
+    }
+```
+
+Then delete the now-unreachable private methods `insertPayment(...)` and
+`insertMultiplePayments(...)`, and delete the `buildPrintPaymentLinesFromPersisted(Bill)`
+helper only if `loadViewDataByBillId` does not call it — check first:
+
+```bash
+grep -n "buildPrintPaymentLinesFromPersisted" \
+  src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+```
+
+If `loadViewDataByBillId` calls it, keep it: reprinting a persisted cashier bill still needs
+to show the payment breakdown stored on the bill's own columns.
+
+- [ ] **Step 12: Remove now-unused imports**
+
+Remove imports that no longer resolve to a use — at minimum `BilledBill` and, if Step 11
+removed every reference, `Payment`. Verify with:
+
+```bash
+grep -n "BilledBill\|Payment" \
+  src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+```
+
+- [ ] **Step 13: Compile**
+
+Run: `mvn -q compile`
+Expected: exit code 0. If it fails on an unused-variable or missing-symbol error, the most
+likely cause is a leftover `billId` / `biIds` / `pbIds` reference from an incompletely deleted
+Step 2b or Step 6 block.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+git commit -m "feat(pharmacy): native-SQL settle service for Sale for Cashier
+
+Single-bill settle: one PreBill of PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER,
+no BilledBill and no Payment rows (NO_PAYMENT bill type). Stock is still
+deducted at pharmacy time.
+
+- PBI fully populated: it is the only one, so it carries cost/retail/purchase
+- BFD/BIFD written at settle, removing the need for the F15 backfill
+- Payment insert and multiple-payment helpers dropped
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `RetailSaleForCashierNativeSqlController`
+
+**Files:**
+- Create: `src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java`
+- Reference: `src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java`,
+  `src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java`
+
+**Interfaces:**
+- Consumes: `RetailSaleForCashierNativeSqlService.settle(...)` (Task 2),
+  `PrintBillData.setBillIdStr/setCancelled` (Task 1).
+- Produces (EL-visible on bean name `retailSaleForCashierNativeSqlController`):
+  ```java
+  String navigateToPharmacyBillForCashierNativeFromMenu()
+  String settleBillWithPay()                 // returns null; renders inline print panel
+  void   addBillItem()
+  void   removeBillItem(BillItemData)
+  void   removeSelectedBillItems()
+  void   quantityInTableChangeEvent(RowEditEvent)
+  void   multiplyQuantityByTwo(BillItemData)
+  void   divideQuantityByHalf(BillItemData)
+  void   multiplyAllQuantitiesByTwo()
+  void   divideAllQuantitiesByHalf()
+  List<StockDTO> completeAvailableStockOptimizedDtoFilteredByDepartmentType(String)
+  void   resetAll()
+  PrintBillData getPrintBill()
+  List<BillItemData> getPrintBillItems()
+  Token  getCurrentToken()
+  ```
+  Task 7 (page) binds these.
+
+- [ ] **Step 1: Copy the source file**
+
+```bash
+cp src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java \
+   src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+sed -i 's/\bRetailSaleNativeSqlController\b/RetailSaleForCashierNativeSqlController/g; s/\bRetailSaleNativeSqlService\b/RetailSaleForCashierNativeSqlService/g' \
+   src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+```
+
+The bean name is derived from the class name (the class uses a bare `@Named`), giving
+`retailSaleForCashierNativeSqlController`. Do not add an explicit `@Named("...")` value —
+the sibling controllers rely on derivation and Phase 4's numbered copies depend on it.
+
+- [ ] **Step 2: Verify the bean name is unique**
+
+```bash
+grep -rn "retailSaleForCashierNativeSqlController" src/main/java/ src/main/webapp/
+```
+Expected at this point: only the class file (no EL references yet). No other Java class may
+declare the same derived name.
+
+- [ ] **Step 3: Switch the bill types**
+
+In `buildPreBill()`:
+
+```java
+        pb.setBillType(BillType.PharmacyPre);
+        pb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+```
+
+- [ ] **Step 4: Delete `buildSaleBill(PreBill)` entirely**
+
+It builds the `BilledBill` that no longer exists. Remove the whole method and the
+`BilledBill` import.
+
+- [ ] **Step 5: Replace the bill-number strategies**
+
+Replace the body of `generateBillNumber()` with the cashier's four strategies, taken from
+`PharmacySaleForCashierController.savePreBillFinallyForRetailSaleForCashier()` (line 2999):
+
+```java
+    private String generateBillNumber() {
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Institution Code + Department Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        }
+        return billNumberGenerator.departmentBillNumberGenerator(
+                sessionController.getDepartment(), BillType.PharmacyPre,
+                BillClassType.PreBill, BillNumberSuffix.SALE);
+    }
+```
+
+Add imports `com.divudi.core.data.BillClassType` and `com.divudi.core.data.BillNumberSuffix`.
+Before compiling, confirm the exact `departmentBillNumberGenerator` overload:
+
+```bash
+grep -n "departmentBillNumberGenerator\b" src/main/java/com/divudi/ejb/BillNumberGenerator.java
+```
+
+- [ ] **Step 6: Rewrite the settle call**
+
+In `settleBillWithPay()`, replace from `PreBill preBillEntity = buildPreBill();` through the
+end of the `try` block with:
+
+```java
+        PreBill preBillEntity = buildPreBill();
+
+        // Stamp the multiple-payment breakdown onto the bill's own columns. No Payment
+        // entity is created for a NO_PAYMENT bill type; this is what the cashier-side
+        // settle page later reads. Mirrors legacy savePreBillFinallyForRetailSaleForCashier.
+        preBillEntity.setCashPaid(cashPaid);
+        billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
+
+        // Stamp dept/institution IDs on each item (needed by the native service for
+        // StockHistory aggregates).
+        long deptId = sessionController.getLoggedUser().getDepartment().getId();
+        long instId = sessionController.getLoggedUser().getDepartment().getInstitution().getId();
+        for (BillItemData bid : billItemDataList) {
+            bid.setDepartmentId(deptId);
+            bid.setInstitutionId(instId);
+        }
+
+        try {
+            nativeSqlService.settle(preBillEntity, billItemDataList,
+                    paymentMethod, getPaymentMethodData(), paymentScheme);
+
+            settleTokenIfEnabled(preBillEntity);
+
+            buildPrintBill(preBillEntity);
+            clearBill();
+            clearBillItem();
+            billPreview = true;
+            billSettlingStarted = false;
+            JsfUtil.addSuccessMessage("Bill settled successfully.");
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+        }
+        return null;
+```
+
+Note what is deliberately **removed**: `paymentService.updateBalances(payments)` and
+`drawerController.updateDrawerForIns(payments)`. No money changes hands on this page — the
+cashier's drawer is updated later by `PharmacyPreSettleController`. Calling them here would
+double-count. Remove the `DrawerController` and `PaymentService` injections and the `Payment`
+import if nothing else uses them.
+
+Add the injection needed by `setPaymentMethodData`:
+
+```java
+    @EJB
+    private com.divudi.ejb.BillBeanController billBean;
+```
+
+Confirm the correct type and method signature first:
+
+```bash
+grep -rn "setPaymentMethodData" src/main/java/com/divudi/ejb/BillBeanController.java \
+  src/main/java/com/divudi/bean/common/BillBeanController.java 2>/dev/null | head
+```
+
+Use whichever class actually declares it, matching how `PharmacySaleForCashierController`
+injects it (`getBillBean()` there).
+
+- [ ] **Step 7: Add the token integration**
+
+Port from `PharmacySaleForCashierController` lines 3852-3872 and `settlePharmacyToken`
+(line 3530). Add the field, accessors and this method:
+
+```java
+    private Token currentToken;
+
+    /**
+     * Cashier-page token integration, gated on config
+     * "Enable token system in sale for cashier". Ported from
+     * PharmacySaleForCashierController.settlePreBillAndNavigateToPrint().
+     */
+    private void settleTokenIfEnabled(Bill settledBill) {
+        if (!configOptionController.getBooleanValueByKey("Enable token system in sale for cashier", false)) {
+            return;
+        }
+        if (patient == null) {
+            return;
+        }
+        Token existing = tokenController.findPharmacyTokens(settledBill);
+        if (existing == null) {
+            Token saleForCashierToken = tokenController.findPharmacyTokenSaleForCashier(
+                    settledBill, TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER);
+            if (saleForCashierToken == null) {
+                settlePharmacyToken(TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER, settledBill);
+            }
+            markInprogress();
+        } else {
+            markToken();
+        }
+        if (currentToken != null) {
+            currentToken.setBill(settledBill);
+            tokenFacade.edit(currentToken);
+        }
+    }
+```
+
+Copy `settlePharmacyToken`, `markToken` and `markInprogress` from
+`PharmacySaleForCashierController` verbatim, adding the `Bill` parameter to
+`settlePharmacyToken` so it does not depend on a `getPreBill()` field that this controller
+uses differently. Add injections `TokenController tokenController` and `TokenFacade
+tokenFacade`, and imports for `Token`, `TokenType`.
+
+- [ ] **Step 8: Add the four qty helpers**
+
+Ported from `PharmacySaleForCashierController`, adapted to `BillItemData` (the native cart
+row) instead of `BillItem`:
+
+```java
+    public void multiplyQuantityByTwo(BillItemData bid) {
+        if (bid == null) {
+            return;
+        }
+        bid.setQty(bid.getQty() * 2);
+        recalculateRow(bid);
+        calTotal();
+    }
+
+    public void divideQuantityByHalf(BillItemData bid) {
+        if (bid == null) {
+            return;
+        }
+        bid.setQty(bid.getQty() / 2);
+        recalculateRow(bid);
+        calTotal();
+    }
+
+    public void multiplyAllQuantitiesByTwo() {
+        if (billItemDataList == null) {
+            return;
+        }
+        for (BillItemData bid : billItemDataList) {
+            bid.setQty(bid.getQty() * 2);
+            recalculateRow(bid);
+        }
+        calTotal();
+    }
+
+    public void divideAllQuantitiesByHalf() {
+        if (billItemDataList == null) {
+            return;
+        }
+        for (BillItemData bid : billItemDataList) {
+            bid.setQty(bid.getQty() / 2);
+            recalculateRow(bid);
+        }
+        calTotal();
+    }
+```
+
+`recalculateRow(BillItemData)` must be the controller's existing per-row recalculation. Find
+its real name before writing these — the native controller recalculates rows inside
+`quantityInTableChangeEvent`:
+
+```bash
+grep -n "quantityInTableChangeEvent" -A 25 \
+  src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+```
+
+Extract that per-row logic into a private `recalculateRow(BillItemData)` and call it from both
+`quantityInTableChangeEvent` and the four helpers, so quantity maths lives in exactly one
+place. Also enforce the same stock-availability and qty > 0 checks the row editor applies —
+doubling a quantity must not be able to exceed available stock.
+
+- [ ] **Step 9: Add the departmentType-filtered autocomplete**
+
+Copy `completeAvailableStockOptimizedDtoFilteredByDepartmentType(String)` from
+`PharmacySaleForCashierController`, but keep this controller's `StockDTO` projection —
+port the **`departmentType` predicate only**, not the legacy entity query. Start from the
+existing `completeAvailableStockOptimizedDto` in this file and add the predicate:
+
+```bash
+grep -n "completeAvailableStockOptimizedDto" -A 45 \
+  src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+grep -n "completeAvailableStockOptimizedDtoFilteredByDepartmentType" -A 45 \
+  src/main/java/com/divudi/bean/pharmacy/PharmacySaleForCashierController.java
+```
+
+- [ ] **Step 10: Replace the navigation methods**
+
+```java
+    public String navigateToPharmacyBillForCashierNativeFromMenu() {
+        resetAll();
+        billSettlingStarted = false;
+        return "/pharmacy/pharmacy_bill_retail_sale_for_cashier_native?faces-redirect=true";
+    }
+```
+
+Delete `pharmacyRetailSaleNative()`. Retarget `switchToThisSaleWindow()` and
+`viewByBillId(Long)` to `/pharmacy/pharmacy_bill_retail_sale_for_cashier_native`.
+Keep `switchToThisSaleWindow()` — Phase 4 (#22444) needs it, and its no-reset semantics are
+already correct.
+
+- [ ] **Step 11: Populate the new print fields**
+
+In `buildPrintBill(Bill bill)`, after `pbd.setBillNo(bill.getDeptId());`:
+
+```java
+        pbd.setBillIdStr(bill.getIdStr());
+        pbd.setCancelled(bill.isCancelled());
+```
+
+Confirm `getIdStr()` and `isCancelled()` exist on `Bill` before relying on them — an
+automated-tool-style guess at a boolean getter name is the exact failure CLAUDE.md warns
+about:
+
+```bash
+grep -n "public String getIdStr\|public boolean isCancelled\|public Boolean getCancelled" \
+  src/main/java/com/divudi/core/entity/Bill.java
+```
+
+`buildPrintPaymentLines()` needs **no change** — it already builds from the in-memory
+`PaymentMethodData`, not from `Payment` entities.
+
+- [ ] **Step 12: Update the class javadoc**
+
+```java
+/**
+ * Controller for the native-SQL pharmacy "Sale for Cashier" page.
+ *
+ * Settles through RetailSaleForCashierNativeSqlService, writing a SINGLE PreBill of
+ * BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER with no Payment rows.
+ * Stock is deducted here; the cashier takes payment later via PharmacyPreSettleController.
+ *
+ * Derived from RetailSaleNativeSqlController (#20260) with the cashier deltas re-applied:
+ * token system, qty helpers, departmentType-filtered autocomplete, cashier bill numbering.
+ *
+ * Issue: #20261
+ */
+```
+
+- [ ] **Step 13: Compile**
+
+Run: `mvn -q compile`
+Expected: exit code 0.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+git commit -m "feat(pharmacy): native-SQL controller for Sale for Cashier
+
+Derived from RetailSaleNativeSqlController with the cashier deltas re-applied:
+token system, four qty helpers, departmentType-filtered autocomplete, and the
+four cashier bill-number strategies.
+
+Single-bill settle; drawer and balance updates deliberately omitted since no
+money changes hands on this page (the cashier-side settle does that).
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Native token print composites (3)
+
+**Files:**
+- Create: `src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml`
+- Create: `src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml`
+- Create: `src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml`
+- Reference: the three non-`_native` files of the same names.
+
+**Interfaces:**
+- Consumes: `PrintBillData` incl. `billIdStr`/`cancelled` (Task 1), `List<BillItemData>`.
+- Produces: composites `phi:saleBill_five_five_token_native`, `phi:saleBillToken_native`,
+  `phi:saleBillToken_Custom_1_native`. Task 7 uses them.
+
+**Transform recipe** — apply to each file. These are mechanical ports of existing markup;
+transcribing all three verbatim into this plan would invite drift from the originals, so
+work from the originals with this mapping.
+
+- [ ] **Step 1: Copy each file to its `_native` name**
+
+```bash
+cd src/main/webapp/resources/pharmacy
+for f in saleBill_five_five_token saleBillToken saleBillToken_Custom_1; do
+  cp "$f.xhtml" "${f}_native.xhtml"
+done
+cd -
+```
+
+- [ ] **Step 2: Change the interface block in each**
+
+Replace:
+
+```xml
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill"/>
+```
+
+with:
+
+```xml
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+```
+
+Keep any existing `duplicate` attribute.
+
+- [ ] **Step 3: Rewrite every `#{cc.attrs.bill.*}` expression**
+
+`PrintBillData` is flat — entity navigation must collapse to a single property:
+
+| Entity expression | `PrintBillData` expression |
+|---|---|
+| `bill.department.printingName` | `bill.departmentPrintingName` |
+| `bill.department.name` | `bill.departmentName` |
+| `bill.department.telephone1` | `bill.departmentTelephone1` |
+| `bill.department.address` | `bill.departmentAddress` |
+| `bill.institution.name` | `bill.institutionName` |
+| `bill.deptId` / `bill.insId` | `bill.billNo` |
+| `bill.createdAt` | `bill.createdAt` (unchanged) |
+| `bill.creater.staff.name` / `bill.creater.name` | `bill.creatorName` |
+| `bill.patient.person.nameWithTitle` | `bill.patientName` |
+| `bill.patient.person.phone` | `bill.patientPhone` |
+| `bill.patient.phn` | `bill.patientPhn` |
+| `bill.netTotal` / `bill.total` / `bill.discount` | same names (unchanged) |
+| `bill.cashPaid` / `bill.balance` | same names (unchanged) |
+| `bill.paymentMethod.label` | `bill.paymentMethodLabel` |
+| `bill.paymentScheme.printingName` | `bill.paymentSchemePrintingName` |
+| `bill.comments` | `bill.comment` |
+| `bill.idStr` | `bill.billIdStr` |
+| `bill.cancelled` | `bill.cancelled` (unchanged) |
+| `bill.toStaff.person.nameWithTitle` | `bill.toStaffName` |
+
+Any `rendered="#{cc.attrs.bill.patient ne null}"` becomes
+`rendered="#{not empty cc.attrs.bill.patientName}"`.
+
+- [ ] **Step 4: Rewrite item iteration**
+
+Where the original iterates `#{cc.attrs.bill.billItems}` with `var="bi"` and reads
+`bi.item.name`, `bi.qty`, `bi.rate`, `bi.netValue`, iterate `#{cc.attrs.items}` instead and
+read the `BillItemData` properties. Confirm the exact property names first:
+
+```bash
+grep -n "private \|public .* get" src/main/java/com/divudi/core/data/dto/BillItemData.java | head -40
+```
+
+Cross-check against a working example — `saleBill_native.xhtml` already does exactly this
+iteration and is the reference implementation:
+
+```bash
+grep -n "ui:repeat\|cc.attrs.items" src/main/webapp/resources/pharmacy/saleBill_native.xhtml
+```
+
+Use `ui:repeat` — `p:repeat` does not exist in this PrimeFaces version.
+
+- [ ] **Step 5: Verify no entity expressions survive**
+
+```bash
+grep -nE 'cc\.attrs\.bill\.(department|institution|patient|creater|paymentMethod|paymentScheme|billItems|toStaff|deptId|insId|comments|idStr)\b' \
+  src/main/webapp/resources/pharmacy/*_native.xhtml
+```
+Expected: **no output.** Any hit is an unconverted entity navigation that will throw
+`PropertyNotFound` at render time.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml \
+        src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml \
+        src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
+git commit -m "feat(pharmacy): native token print composites for Sale for Cashier
+
+PrintBillData/BillItemData versions of the three token formats, so the native
+page prints without reloading the Bill entity after settle.
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Native cashier bill print composites (6)
+
+**Files:**
+- Create in `src/main/webapp/resources/pharmacy/`:
+  `saleBill_for_Cashier_native.xhtml`,
+  `saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml`,
+  `saleBill_five_five_for_Cashier_native.xhtml`
+- Create in `src/main/webapp/resources/pharmacy/print/`:
+  `retail_sale_for_cashier_custom_1_native.xhtml`,
+  `retail_sale_for_cashier_custom_2_native.xhtml`,
+  `retail_sale_for_cashier_custom_3_native.xhtml`
+
+**Interfaces:**
+- Consumes: `PrintBillData` (Task 1), `List<BillItemData>`.
+- Produces: composites `phi:saleBill_for_Cashier_native`,
+  `phi:saleBill_for_Cashier_Pos_paper_Custom_1_native`,
+  `phi:saleBill_five_five_for_Cashier_native`,
+  `pp:retail_sale_for_cashier_custom_1_native`, `..._2_native`, `..._3_native`.
+
+`phi:` resolves to `resources/pharmacy/`, `pp:` to `resources/pharmacy/print/`.
+
+**Not ported:** `phi:saleBill_Header` — the native retail page already uses
+`phi:saleBill_Header_Inward_native` under the same config key
+(`Pharmacy Retail Sale Bill Paper is POS paper with header`). Reuse it as-is.
+
+- [ ] **Step 1: Copy the six files**
+
+```bash
+cd src/main/webapp/resources/pharmacy
+for f in saleBill_for_Cashier saleBill_for_Cashier_Pos_paper_Custom_1 saleBill_five_five_for_Cashier; do
+  cp "$f.xhtml" "${f}_native.xhtml"
+done
+cd print
+for f in retail_sale_for_cashier_custom_1 retail_sale_for_cashier_custom_2 retail_sale_for_cashier_custom_3; do
+  cp "$f.xhtml" "${f}_native.xhtml"
+done
+cd -
+```
+
+- [ ] **Step 2: Apply the same transform as Task 4**
+
+Identical recipe: swap the `cc:attribute` interface to
+`PrintBillData` + `items`, apply the expression mapping table from Task 4 Step 3, and convert
+item iteration per Task 4 Step 4.
+
+These are bill formats, so they use more of the totals block than the token formats do. Pay
+particular attention to `bill.total`, `bill.discount`, `bill.netTotal`, `bill.cashPaid`,
+`bill.balance` — all present on `PrintBillData` under the same names — and to
+`bill.discountPercentPharmacy` where a discount percentage is shown.
+
+For any expression with no `PrintBillData` equivalent, **stop and report it** rather than
+inventing a field. Adding a field is fine, but it must be a deliberate decision, and every
+addition needs the same treatment in `loadViewDataByBillId` so reprints match fresh prints.
+
+- [ ] **Step 3: Verify no entity expressions survive**
+
+```bash
+grep -nE 'cc\.attrs\.bill\.(department|institution|patient|creater|paymentMethod|paymentScheme|billItems|toStaff|deptId|insId|comments|idStr)\b' \
+  src/main/webapp/resources/pharmacy/*_native.xhtml \
+  src/main/webapp/resources/pharmacy/print/*_native.xhtml
+```
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/webapp/resources/pharmacy/saleBill_for_Cashier_native.xhtml \
+        src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml \
+        src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml \
+        src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_1_native.xhtml \
+        src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_2_native.xhtml \
+        src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_3_native.xhtml
+git commit -m "feat(pharmacy): native bill print composites for Sale for Cashier
+
+PrintBillData/BillItemData versions of the six cashier bill formats.
+saleBill_Header is not ported: saleBill_Header_Inward_native already covers
+the same config key.
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: The page
+
+**Files:**
+- Create: `src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml`
+- Reference: `src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml` (structure),
+  `src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml` (cashier extras),
+  `src/main/webapp/pharmacy/printing/retail_sale_for_cashier.xhtml` (print panel layout)
+
+**Interfaces:**
+- Consumes: everything in Task 3's Produces block, plus the 9 composites from Tasks 4-5.
+- Produces: the view id `/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml`,
+  referenced by Task 7's menu wiring and by Task 3's navigation methods.
+
+- [ ] **Step 1: Copy the native retail page as the base**
+
+```bash
+cp src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml \
+   src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+sed -i 's/\bretailSaleNativeSqlController\b/retailSaleForCashierNativeSqlController/g' \
+   src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+```
+
+The unanchored `sed` is safe **only** because this page has no numbered controller
+references. Phase 4's numbered copies must use the guarded three-step replace in
+`developer_docs/pharmacy/PHARMACY_RETAIL_SALE_MULTI_WINDOW_GUIDE.md.md` §3.2 — an unanchored
+replace there is what caused #15845.
+
+- [ ] **Step 2: Set the page title**
+
+Change the page heading to `Pharmacy Sale for Cashier (Native)`.
+
+- [ ] **Step 3: Add the token header block**
+
+Port from `pharmacy_bill_retail_sale_for_cashier.xhtml` lines 40-100: the "Back to token
+management" button and the token panel, both gated on
+`#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}`.
+Use `h:panelGroup rendered="..."` — never `ui:fragment`.
+
+- [ ] **Step 4: Add the four qty-helper buttons**
+
+In the cart datatable's row-action column, port the four buttons from
+`pharmacy_bill_retail_sale_for_cashier.xhtml`, binding to the Task 3 methods. Per the project's
+accessibility rule, give each a `title` including the row identifier so Playwright can target
+a specific row, e.g.:
+
+```xml
+<p:commandButton id="btnQtyX2"
+                 icon="fas fa-times"
+                 title="Double quantity #{bid.description}"
+                 actionListener="#{retailSaleForCashierNativeSqlController.multiplyQuantityByTwo(bid)}"
+                 update="@form" />
+```
+
+Set `rowKey`, `id` and `widgetVar` on the datatable if the copied page lacks them.
+
+- [ ] **Step 5: Replace the print panel**
+
+Replace the retail print panel (the `gpBillPreview` block, around line 904 of the source page)
+with the cashier's formats, laid out as in `printing/retail_sale_for_cashier.xhtml`: a token
+group with `page-break-after: always`, then the bill group. Each entry follows this shape,
+using the **same config keys** as the legacy page so existing site settings keep working:
+
+```xml
+<h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS Paper', true)}">
+    <phi:saleBill_for_Cashier_native
+        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+</h:panelGroup>
+```
+
+The full key → composite mapping is the table in spec §7.2. Declare both namespaces in the
+page root:
+
+```xml
+xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
+xmlns:pp="http://xmlns.jcp.org/jsf/composite/pharmacy/print"
+```
+
+- [ ] **Step 6: Retarget the printer-config dialog**
+
+Rename the dialog id and header to the cashier page (e.g.
+`saleForCashierNativeConfigDialog`, "Sale for Cashier (Native) Printer Configuration"), keeping
+`rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"` and pointing
+its toggles at the same config keys used in Step 5.
+
+- [ ] **Step 7: Verify every referenced bean exists**
+
+This is the #15845 guard, adapted from the multi-window guide:
+
+```bash
+for b in $(grep -oE '\bretailSaleForCashierNativeSqlController[0-9]*\b' \
+             src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml | sort -u); do
+  n=$(grep -rl "class ${b^}" src/main/java/ | wc -l)
+  [ "$n" -eq 0 ] && echo "PHANTOM BEAN: $b"
+done
+```
+Expected: **no output.**
+
+- [ ] **Step 8: Verify every referenced composite exists**
+
+```bash
+for c in $(grep -oE '<(phi|pp):[a-zA-Z0-9_]+' \
+             src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml \
+           | sed 's/<//' | sort -u); do
+  ns="${c%%:*}"; name="${c#*:}"
+  case "$ns" in
+    phi) d=src/main/webapp/resources/pharmacy ;;
+    pp)  d=src/main/webapp/resources/pharmacy/print ;;
+  esac
+  [ -f "$d/$name.xhtml" ] || echo "MISSING COMPOSITE: $ns:$name -> $d/$name.xhtml"
+done
+```
+Expected: **no output.** A missing composite renders as silently empty markup, not an error —
+this check is the only thing that catches it before E2E.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+git commit -m "feat(pharmacy): native Sale for Cashier page
+
+Built from pharmacy_bill_retail_sale_native.xhtml with the token panel, the
+four qty helpers and the cashier print formats. Printing is inline from
+PrintBillData, so there is no entity reload after settle.
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Menu wiring
+
+**Files:**
+- Modify: `src/main/webapp/resources/ezcomp/menu.xhtml` (around line 1116)
+
+**Interfaces:**
+- Consumes: `retailSaleForCashierNativeSqlController
+  .navigateToPharmacyBillForCashierNativeFromMenu()` (Task 3), the page (Task 6).
+- Produces: nothing downstream.
+
+Mirrors the "Sale" / "Sale (Legacy)" pattern already at line ~1084.
+
+- [ ] **Step 1: Retarget the existing item and add the legacy entry**
+
+Replace:
+
+```xml
+                        <p:menuitem
+                            ajax="false"
+                            action="#{pharmacySaleForCashierController.navigateToPharmacyBillForCashierFromMenu()}"
+                            value="Sale for cashier"
+                            icon="fas fa-cash-register"
+                            rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier')}" ></p:menuitem>
+```
+
+with:
+
+```xml
+                        <p:menuitem
+                            ajax="false"
+                            action="#{retailSaleForCashierNativeSqlController.navigateToPharmacyBillForCashierNativeFromMenu()}"
+                            value="Sale for cashier"
+                            icon="fas fa-cash-register"
+                            styleClass="menu-item-optimised"
+                            rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier')}" ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
+                            action="#{pharmacySaleForCashierController.navigateToPharmacyBillForCashierFromMenu()}"
+                            value="Sale for cashier (Legacy)"
+                            icon="fas fa-cash-register"
+                            rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier') and configOptionApplicationController.getBooleanValueByKey('Legacy Functions Allowed', false)}" ></p:menuitem>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/main/webapp/resources/ezcomp/menu.xhtml
+git commit -m "feat(pharmacy): point Sale for cashier menu at the native page
+
+Mirrors the Sale / Sale (Legacy) switchover: the native page takes the menu
+item, legacy moves behind Legacy Functions Allowed.
+
+Refs #20261
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Build and deploy locally
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full build**
+
+Run: `mvn -q clean package -DskipTests`
+Expected: exit code 0, WAR produced under `target/`.
+
+- [ ] **Step 2: Confirm `persistence.xml` still holds local JNDI**
+
+```bash
+grep -n "jta-data-source" src/main/resources/META-INF/persistence.xml
+```
+Expected: `jdbc/coop` and `jdbc/ruhunuAudit` — **not** `${JDBC_DATASOURCE}`. It must remain
+an unstaged modification; never commit it.
+
+- [ ] **Step 3: Deploy to the local Payara domain**
+
+Always pass `--port 9048`. Bare `asadmin` targets port 4848, which is a **different Payara
+instance** on this machine and has previously caused a wrong-domain undeploy.
+
+```bash
+~/payara/bin/asadmin --port 9048 undeploy rh || true
+~/payara/bin/asadmin --port 9048 deploy --name rh --force=true target/rh.war
+```
+
+Confirm the WAR name from `target/` first — do not assume `rh.war`.
+
+- [ ] **Step 4: Check the log for deployment errors**
+
+```bash
+tail -n 100 ~/payara/glassfish/domains/rh/logs/server.log | grep -iE "SEVERE|Exception" || echo "clean"
+```
+Expected: `clean`, or no entries newer than the deploy.
+
+---
+
+## Task 9: E2E verification
+
+**Files:** none modified. Use the `playwright-e2e` skill; app at `http://localhost:9080/rh/`.
+
+**After login, click Select on the department screen before navigating anywhere** — inner
+pages fail without a selected department. Use a pharmacy department (e.g. OPD Pharmacy).
+
+- [ ] **Step 1: Page loads**
+
+Navigate via menu → Pharmacy → Sale for cashier. Confirm: page renders, title reads
+"Pharmacy Sale for Cashier (Native)", no `PropertyNotFound` in the console, no new `SEVERE`
+in `server.log`.
+
+- [ ] **Step 2: Settle a bill**
+
+Add 2 items with different batches, set quantities, choose a payment method, settle. Note the
+printed bill number.
+
+- [ ] **Step 3: Verify the database — the core assertion**
+
+```sql
+SET @billno = 'PASTE_BILL_NUMBER_HERE';
+
+-- Expect exactly ONE row, billTypeAtomic = PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER
+SELECT id, deptId, billTypeAtomic, dtype, total, netTotal, discount, paymentMethod,
+       cashPaid, balance, paidAmount
+FROM Bill WHERE deptId = @billno;
+
+-- Expect ZERO rows
+SELECT COUNT(*) AS payment_rows FROM Payment p
+JOIN Bill b ON p.bill_ID = b.id WHERE b.deptId = @billno;
+
+-- Expect one BillItem and one PharmaceuticalBillItem per cart line, no duplicates
+SELECT bi.id, bi.item_ID, bi.qty, bi.netValue,
+       pbi.id AS pbi_id, pbi.stock_ID, pbi.costRate, pbi.retailRate, pbi.purchaseRate
+FROM BillItem bi
+JOIN Bill b ON bi.bill_ID = b.id
+LEFT JOIN PharmaceuticalBillItem pbi ON pbi.billItem_ID = bi.id
+WHERE b.deptId = @billno;
+```
+
+Assert: exactly one `Bill`; `dtype` is `PreBill`; **zero** `Payment` rows; one `BillItem` +
+one `PharmaceuticalBillItem` per line; and **`costRate`/`retailRate`/`purchaseRate` are
+non-zero** on every PBI — that is the Task 2 Step 6 change, and zeros there mean it was
+missed.
+
+- [ ] **Step 4: Verify stock and stock history**
+
+Record `Stock.stock` for each batch before settling, then:
+
+```sql
+SELECT id, stock FROM Stock WHERE id IN (/* stock ids from Step 3 */);
+SELECT id, pbItem_ID, stockQty, itemQty FROM StockHistory
+WHERE pbItem_ID IN (/* pbi ids from Step 3 */);
+```
+
+Assert: `Stock.stock` decreased by exactly the sold qty per batch; one `StockHistory` row per
+item.
+
+- [ ] **Step 5: Verify finance details — the deliberate deviation**
+
+```sql
+SELECT bfd.* FROM BillFinanceDetails bfd
+JOIN Bill b ON bfd.bill_ID = b.id WHERE b.deptId = @billno;
+
+SELECT bifd.* FROM BillItemFinanceDetails bifd
+JOIN BillItem bi ON bifd.billItem_ID = bi.id
+JOIN Bill b ON bi.bill_ID = b.id WHERE b.deptId = @billno;
+```
+
+Assert: BFD present with non-zero `totalRetailSaleValue`; one BIFD per item. Confirm the real
+table/column names from the entities first — these differ from the class names in places:
+
+```bash
+grep -n "@Table\|@Column" src/main/java/com/divudi/core/entity/BillFinanceDetails.java | head
+```
+
+- [ ] **Step 6: Downstream cross-check — the most important test**
+
+Log in as a cashier, open the cashier-side settle page (Pharmacy → Search Sale for Cashier
+Bills, or `PharmacyPreSettleController`'s entry point), find the bill from Step 2 and settle
+it. Assert: the bill is found, its items and totals display correctly, settling produces the
+`PHARMACY_RETAIL_SALE` bill and `Payment` rows as it does for a legacy-created bill, and stock
+is **not** deducted a second time.
+
+A native bill must be indistinguishable to this page. If it is not, stop and report — this
+gates everything else.
+
+- [ ] **Step 7: Token path**
+
+Set `Enable token system in sale for cashier` to `true`, settle another bill, confirm the
+token prints and a `Token` row is created linked to the bill. Set it back to `false`, settle
+again, confirm no token is created and no error appears.
+
+- [ ] **Step 8: Multiple payment methods**
+
+Settle with `MultiplePaymentMethods` split across two components. Assert: still **zero**
+`Payment` rows; the breakdown is on the bill's own columns (`creditCardRefNo`, `chequeRefNo`,
+etc. — confirm which via `billBean.setPaymentMethodData`); the printed bill shows both
+component lines.
+
+- [ ] **Step 9: Discount path**
+
+Settle with a discount-bearing payment scheme. Assert `total`, `discount` and `netTotal` on
+the bill are consistent (`total - discount = netTotal`) and match the printed values.
+
+- [ ] **Step 10: Qty helpers**
+
+Add an item, use ×2 and ÷2 on the row and the all-rows variants. Assert quantities and the
+net total update correctly, and that ×2 cannot push a quantity beyond available stock.
+
+- [ ] **Step 11: Print formats**
+
+Enable each of the 10 formats in turn via the printer-config dialog and confirm each renders
+with correct values, the token barcode included. A blank render means a missing composite —
+re-run Task 6 Step 8.
+
+- [ ] **Step 12: Record the results**
+
+Append the outcome (bill numbers, stock deltas, row counts) to
+`tmp/retail-sale-native-migration-master-plan.md` under Phase 2, matching how Phase 1's E2E
+result was recorded.
+
+---
+
+## Task 10: Push and open the PR
+
+- [ ] **Step 1: Confirm nothing unwanted is staged**
+
+```bash
+git status --short
+```
+Expected: only `M src/main/resources/META-INF/persistence.xml`, unstaged.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin 20261-native-sale-for-cashier
+```
+
+- [ ] **Step 3: Restore local JNDI immediately after pushing**
+
+Required by CLAUDE.md after **every** push. If CI placeholders ended up in the working tree,
+put `jdbc/coop` and `jdbc/ruhunuAudit` back and leave the change unstaged.
+
+- [ ] **Step 4: Open the PR against `development`**
+
+Never target `master`. Body must include `Closes #20261`, a summary of the single-bill
+structure, the BFD/BIFD deviation, and the E2E evidence from Task 9. End with:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 5: Update the tracker**
+
+Mark Phase 2 `[x]` in `tmp/retail-sale-native-migration-master-plan.md` with the PR number,
+and note that Phase 3 (production testing gate) is now the blocker for Phase 4.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| §5.1 new files | 2, 3, 4, 5, 6 |
+| §5.2 service, single bill, PBI population, BFD deviation | 2 (Steps 5-10) |
+| §5.3 controller, bill types, deltas | 3 (Steps 3-11) |
+| §5.4 `PrintBillData` fields | 1 |
+| §6.1 cart building, deptType autocomplete, qty helpers | 3 (Steps 8-9) |
+| §6.2 settle sequence | 3 (Steps 5-7) |
+| §6.2 stock locking not carried over | 2 (inherited `deductStock`) |
+| §7.1 page, inline print | 6 |
+| §7.2 nine composites | 4, 5 |
+| §7.3 menu | 7 |
+| §8 error handling | 3 (Step 6 try/catch, inherited guards) |
+| §9 verification | 9 |
+| §10 out of scope | not implemented, cross-checked in 9 Step 6 |
+
+**Known gaps, deliberate:**
+
+- `showItemDetailsForSelectedStock` (spec §4) has no dedicated step. It is a UI convenience
+  bound from the legacy page; port it in Task 3 only if Task 6 Step 3/4 turns out to reference
+  it. Flagged rather than silently dropped.
+- Tasks 4 and 5 give a transform recipe plus verification greps instead of full markup for
+  nine files. Transcribing ~2,000 lines of existing markup into a plan would introduce drift
+  from the originals; the recipe plus the two `grep` gates is more reliable and is how the
+  existing `*_native` composites were produced.
+
+**Type consistency:** `settle(...)` is `void` and 5-arg in Task 2's Produces block, Task 3's
+call site, and the spec. `buildPrintBill(Bill)` keeps its one-arg entity signature (Task 3
+Steps 6, 11). `recalculateRow(BillItemData)` is introduced in Task 3 Step 8 and used only
+there. `navigateToPharmacyBillForCashierNativeFromMenu()` is defined in Task 3 Step 10 and
+consumed in Task 7 Step 1 — names match.

--- a/docs/superpowers/specs/2026-07-27-native-sale-for-cashier-design.md
+++ b/docs/superpowers/specs/2026-07-27-native-sale-for-cashier-design.md
@@ -1,0 +1,330 @@
+# Native-SQL "Sale for Cashier" — Design
+
+**Issue:** [#20261](https://github.com/hmislk/hmis/issues/20261)
+**Master issue:** [#22442](https://github.com/hmislk/hmis/issues/22442) — Phase 2 of the
+pharmacy retail sale native migration.
+**Date:** 2026-07-27
+**Branch:** `20261-native-sale-for-cashier`
+
+---
+
+## 1. Goal
+
+Replace the entity-based "Sale for Cashier" page with a native-SQL implementation that
+avoids the EAGER `Stock → ItemBatch → Item` cascade load, mirroring what
+`RetailSaleNativeSqlController` / `RetailSaleNativeSqlService` did for plain "Sale"
+(#20260 / PR #20362).
+
+**Requirement: 100% functional replication.** Token system, discounts, multiple payment
+methods, patient validation, bill-number strategies and every print format carry over.
+Nothing is deferred to a follow-up.
+
+Phase 1 (#22443, PR #22449, merged 2026-07-26) delivered 4 simultaneous windows for the
+native retail sale. Phase 4 (#22444) will do the same for this page, gated on production
+testing (Phase 3). This spec covers Phase 2 only — the single, unnumbered page.
+
+---
+
+## 2. What "Sale for Cashier" actually does
+
+Established by reading `PharmacySaleForCashierController.settlePreBillAndNavigateToPrint()`
+(line 3580) and `savePreBillFinallyForRetailSaleForCashier()` (line 2957):
+
+- Creates **one** bill: a `PreBill` of `BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`.
+  There is no `BilledBill`, and no `Payment` rows — that atomic type is declared
+  `BillFinanceType.NO_FINANCE_TRANSACTIONS` / `PaymentCategory.NO_PAYMENT`
+  (`BillTypeAtomic.java:129`).
+- **Deducts stock at pharmacy time**, before the patient has paid.
+- Captures `paymentMethod`, `paymentScheme`, `cashPaid` and the multiple-payment breakdown
+  on the bill's **own columns** via `billBean.setPaymentMethodData(bill, pm, pmd)` — as
+  information for the cashier, not as `Payment` entities.
+- Optional token integration gated on config `Enable token system in sale for cashier`.
+- Prints via `/pharmacy/printing/retail_sale_for_cashier.xhtml`.
+
+The cashier then takes payment on a **separate** page — `PharmacyPreSettleController` →
+`/pharmacy/printing/settle_retail_sale_for_cashier.xhtml`. That page is **out of scope**;
+it must continue to work unchanged against natively-created bills.
+
+---
+
+## 3. Approach
+
+**Chosen: copy the native pair, re-apply the cashier deltas.**
+
+Clone `RetailSaleNativeSqlController` (1,822 lines) and `RetailSaleNativeSqlService`
+(1,017 lines), then port cashier-specific behaviour back from
+`PharmacySaleForCashierController` (6,282 lines).
+
+Rationale:
+
+- The native pair carries five rounds of production hardening (PRs #20600, #20637,
+  #20667, #21698, #21705) — native settle ordering, L2 cache eviction, `PrintBillData`
+  plumbing, discount/gross-total persistence, multiple-payment print lines. Starting from
+  the legacy controller would discard all of it.
+- It matches this codebase's own precedent: `WholesaleSaleNativeSqlController` /
+  `...Service` (1,703 / 1,012 lines) were produced exactly this way.
+
+Rejected alternatives:
+
+- **Copy the legacy cashier controller and swap its persistence layer.** Parity would be
+  guaranteed, but it retains the entity-based `Stock` autocomplete that causes the
+  slowness in the first place, and loses every native-path fix.
+- **Extract a shared abstract base first.** Architecturally better — Phase 4 multiplies
+  whatever we build ×4 — but refactoring a live, production-proven page to serve a
+  different feature is the "unrelated refactoring" CLAUDE.md warns against. Worth revisiting
+  as a standalone issue after Phase 4.
+
+The risk in the chosen approach is **omission**. It is mitigated by the inventory diff in §4.
+
+---
+
+## 4. Feature-inventory diff
+
+Method sets extracted from all three controllers and compared. Cashier-family behaviour
+with no equivalent in `RetailSaleNativeSqlController`:
+
+| Delta | Detail |
+|---|---|
+| Token system | `settlePharmacyToken`, `markToken`, `markInprogress`, `currentToken`, `TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER`. Native has zero token code. |
+| Qty helpers | `multiplyQuantityByTwo`, `divideQuantityByHalf`, `multiplyAllQuantitiesByTwo`, `divideAllQuantitiesByHalf` — all four bound in the cashier page, absent from the native page. |
+| DeptType autocomplete | `completeAvailableStockOptimizedDtoFilteredByDepartmentType`. Native has only the unfiltered `completeAvailableStockOptimizedDto`. |
+| Single-bill settle | `savePreBillFinallyForRetailSaleForCashier` + 4 configurable bill-number strategies, bill-number suffix `SCPB`. |
+| Navigation | `navigateToPharmacyBillForCashierFromMenu`, `toPharmacyRetailSaleForCashier`, `navigateToSaleBillForCashierPrint`. |
+| Item details | `showItemDetailsForSelectedStock`. |
+
+Everything else the cashier controller has is either already present in the native
+controller under a different name, or is entity-persistence machinery the native service
+replaces.
+
+---
+
+## 5. Components
+
+### 5.1 New files
+
+```
+src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+src/main/webapp/resources/pharmacy/       — 6 new *_native composites
+src/main/webapp/resources/pharmacy/print/ — 3 new *_native composites
+```
+
+### 5.2 Service
+
+`RetailSaleForCashierNativeSqlService.settle(...)` derives from
+`RetailSaleNativeSqlService.settle(...)` with the two-bill structure collapsed to one:
+
+```java
+public void settle(PreBill preBill, List<BillItemData> items,
+                   PaymentMethod paymentMethod, PaymentMethodData paymentMethodData,
+                   PaymentScheme paymentScheme)
+```
+
+| Step in `RetailSaleNativeSqlService` | Cashier variant |
+|---|---|
+| 1a persist `PreBill` | kept |
+| 1b persist `BilledBill` | **deleted** |
+| 1c cross-link the two bills | **deleted** |
+| 2a `BillItem` + bare PBI on `PreBill` | kept, but PBI is **fully populated** (see below) |
+| 2b `BillItem` + populated PBI on `BilledBill` | **deleted** |
+| 3 stock deduct + aggregates + `StockHistory` | kept |
+| L2 cache evict | kept, minus `BilledBill.class` |
+| 4 `insertFinanceDetails` (BFD + BIFD) | kept, **retargeted to the PreBill** |
+| 5 totals update | kept, single bill ID |
+| 6 `insertPayment` | **deleted** |
+
+Return type becomes `void` — there are no `Payment` entities to hand back.
+
+**Print payment lines.** `RetailSaleNativeSqlController` builds `PrintBillData.payments`
+from the `Payment` rows the service returns. With none created here, the cashier controller
+builds those lines directly from the in-memory `PaymentMethodData` components instead —
+same DTO shape, same print output, sourced from the cart rather than the database.
+
+**PBI population.** In the two-bill retail flow the PreBill's `PharmaceuticalBillItem`
+carries rates only, with `costValue`/`retailValue`/`purchaseValue` zeroed, because the
+BilledBill's PBI carries the real values. With no BilledBill, the single PreBill PBI must
+be fully populated or costing and F15 lose their source values.
+
+**Finance details (deliberate deviation from legacy).** Legacy writes no BFD/BIFD for
+these bills at all — which is precisely why
+`DataAdministrationController.backfillBfdForPreToSettleAtCashierBills()` had to be written:
+without BFD, F15's `totalRetailSaleValue` reads 0 for every cashier bill
+(`DataAdministrationController.java:1356-1364`). Writing them at settle means natively
+created cashier bills never need that backfill. Approved as an intentional improvement.
+
+### 5.3 Controller
+
+`RetailSaleForCashierNativeSqlController` — `@Named @SessionScoped`, derived from
+`RetailSaleNativeSqlController`.
+
+Unchanged from the native retail controller: `StockDTO` autocomplete, `BillItemData` cart
+model, discount handling, `PrintBillData` / `printBillItems` print plumbing, allergy check,
+`billSettlingStarted` double-submit guard.
+
+Changed:
+
+- `BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`, `BillType.PharmacyPre`.
+- `saleBill` (`BilledBill`) field removed.
+- The six deltas from §4 ported in.
+
+### 5.4 DTO change
+
+`PrintBillData` gains two additive fields — `billIdStr` and `cancelled` — required by the
+token composites, which render `#{bill.idStr}` as a Code128 barcode and
+`#{bill.cancelled}` as a "**Cancelled**" marker. Fields plus getters/setters only; no
+constructor is modified (per CLAUDE.md's constructor rule).
+
+---
+
+## 6. Data flow
+
+### 6.1 Cart building
+
+Unchanged from native retail: `StockDTO` autocomplete → `BillItemData` rows held in the
+controller, no `Stock` entities loaded. Adds the deptType-filtered autocomplete variant and
+the four qty helpers.
+
+### 6.2 Settle
+
+1. Validation, ported wholesale from legacy `settlePreBillAndNavigateToPrint`:
+   session present, cart non-empty, no qty ≤ 0, no duplicate stock ID,
+   `discountSchemeValidationService.validateDiscountScheme(paymentMethod, paymentScheme)`,
+   departmentType consistency across items, and the patient-field config gauntlet
+   (`Patient / Patient Name / Phone / Gender / Address is required in Pharmacy Retail Sale`).
+2. `savePatient()` when a patient is required or a valid name was entered.
+3. Bill-number generation — all four config strategies, falling back to
+   `departmentBillNumberGenerator(..., BillClassType.PreBill, BillNumberSuffix.SALE)`.
+4. `billBean.setPaymentMethodData(preBill, paymentMethod, paymentMethodData)`.
+5. Balance rule: `Credit` / `Staff` → `balance = netTotal`, `paidAmount = 0`;
+   all other methods (including `MultiplePaymentMethods`) → `balance = 0`,
+   `paidAmount = netTotal`.
+6. `service.settle(...)`.
+7. Token block when `Enable token system in sale for cashier` is true:
+   `tokenController.findPharmacyTokens` → `findPharmacyTokenSaleForCashier` →
+   `settlePharmacyToken(TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER)` + `markInprogress()`,
+   else `markToken()`.
+8. Build `PrintBillData` + `printBillItems` from in-memory state. **No entity reload.**
+9. `resetAll()`, `billPreview = true`, render the inline print panel.
+
+**Stock locking.** The legacy `stockLockingService.lockAndValidateStocks` / `releaseLocks`
+scaffolding is not carried over. The native `deductStock` performs an atomic
+`UPDATE ... WHERE qty >= ?` that provides the same guarantee in one statement — this is
+what native retail sale already does in production.
+
+---
+
+## 7. Page and print
+
+### 7.1 Page
+
+`pharmacy_bill_retail_sale_for_cashier_native.xhtml`, built from
+`pharmacy_bill_retail_sale_native.xhtml`, adding:
+
+- the token header block (`Back to token management`, token panel),
+- the four qty-helper buttons,
+- the cashier print formats in place of the retail ones,
+- the printer-config dialog gated on `hasPrivilege('ChangeReceiptPrintingPaperTypes')`.
+
+Printing is **inline** in the page, following the native pattern, rather than navigating to
+`/pharmacy/printing/retail_sale_for_cashier.xhtml`. `navigateToSaleBillForCashierPrint` is
+therefore not ported.
+
+### 7.2 Print composites
+
+The legacy print page references 10 composites. One — `phi:saleBill_Header`, under config
+key `Pharmacy Retail Sale Bill Paper is POS paper with header` — already has a native
+equivalent that the native retail page uses (`saleBill_Header_Inward_native`), so it is
+reused. The other **9 are new**, each taking
+`bill="com.divudi.core.data.dto.PrintBillData"` + `items="java.util.List"`:
+
+| New composite | Ports | Config key |
+|---|---|---|
+| `saleBill_five_five_token_native` | `phi:saleBill_five_five_token` | `Pharmacy Retail Sale Token Paper is FiveFivePaper With Blank Space For Printed Heading` |
+| `saleBillToken_native` | `phi:saleBillToken` | `Pharmacy Retail Sale Token Paper is POS Paper` |
+| `saleBillToken_Custom_1_native` | `phi:saleBillToken_Custom_1` | `Pharmacy Retail Sale Token Paper is POS Paper Custom 1` |
+| `saleBill_for_Cashier_native` | `phi:saleBill_for_Cashier` | `Pharmacy Retail Sale Bill Paper is POS Paper` |
+| `saleBill_for_Cashier_Pos_paper_Custom_1_native` | `phi:saleBill_for_Cashier_Pos_paper_Custom_1` | `Pharmacy Retail Sale Bill Paper is POS Paper Custom 1` |
+| `saleBill_five_five_for_Cashier_native` | `phi:saleBill_five_five_for_Cashier` | `Pharmacy Retail Sale Bill Paper is FiveFive Paper without Blank Space for Header` |
+| `retail_sale_for_cashier_custom_1_native` | `pp:retail_sale_for_cashier_custom_1` | `Pharmacy Retail Sale Bill Paper is Custom 1` |
+| `retail_sale_for_cashier_custom_2_native` | `pp:retail_sale_for_cashier_custom_2` | `Pharmacy Retail Sale Bill Paper is Custom 2` |
+| `retail_sale_for_cashier_custom_3_native` | `pp:retail_sale_for_cashier_custom_3` | `Pharmacy Retail Sale Bill Paper is Custom 3` |
+
+Namespaces: `phi` → `src/main/webapp/resources/pharmacy/`,
+`pp` → `src/main/webapp/resources/pharmacy/print/`.
+
+Config keys are reused verbatim so a site's existing paper-format selection keeps working
+after the switchover.
+
+### 7.3 Menu
+
+`src/main/webapp/resources/ezcomp/menu.xhtml` — mirrors what "Sale" already does
+(line ~1089):
+
+- Line ~1116, "Sale for cashier" → retarget to
+  `/pharmacy/pharmacy_bill_retail_sale_for_cashier_native?faces-redirect=true`,
+  keeping `rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier')}"`.
+- New item "Sale for cashier (Legacy)" →
+  `#{pharmacySaleForCashierController.navigateToPharmacyBillForCashierFromMenu()}`,
+  rendered when `hasPrivilege('PharmacySaleForCashier')` **and**
+  `Legacy Functions Allowed` is true.
+
+---
+
+## 8. Error handling
+
+- `billSettlingStarted` guards double-submit; every early return resets it to `false`.
+- Every validation failure raises `JsfUtil.addErrorMessage` and returns without persisting.
+- Service exceptions are caught at the controller boundary, logged at `SEVERE`, and
+  surfaced as "Settlement failed. Please try again."
+- The service participates in the caller's transaction, so a failing native insert rolls the
+  whole settle back. There is no half-written bill and no orphaned stock deduction.
+
+---
+
+## 9. Verification
+
+No unit-test harness exists for these controllers; verification is E2E against the local
+Payara domain `rh`, matching how Phase 1 was signed off.
+
+- `mvn compile` clean; deploy locally.
+- Settle a bill, then assert in MySQL:
+  - exactly **one** `Bill` row, `billTypeAtomic = PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`;
+  - **no** `BilledBill` row and **zero** `Payment` rows for it;
+  - `BillItem` and `PharmaceuticalBillItem` counts match the cart, no duplicates;
+  - `Stock.stock` decremented by exactly the sold qty;
+  - `StockHistory` row written per item;
+  - **`BillFinanceDetails` and `BillItemFinanceDetails` present** (the §5.2 deviation).
+- Multiple-payment breakdown lands on the bill's own columns.
+- Token path verified with `Enable token system in sale for cashier` both on and off.
+- Discount path (bill-level and item-level) produces correct `total` / `discount` / `netTotal`.
+- Bill number matches the configured generation strategy.
+- **Downstream cross-check:** the natively created bill settles cleanly through
+  `PharmacyPreSettleController` → `settle_retail_sale_for_cashier.xhtml`. The native bill
+  must be indistinguishable to the cashier-side page.
+- All 10 print formats render with correct values, including the token barcode.
+
+---
+
+## 10. Out of scope
+
+- `PharmacyPreSettleController` and the cashier-side settle page — unchanged, but
+  cross-checked (§9).
+- `/pharmacy_wholesale/pharmacy_bill_retail_sale_for_cashier.xhtml` — wholesale-for-cashier,
+  a separate page sharing the legacy controller.
+- Numbered `_1` / `_2` / `_3` copies — Phase 4, issue #22444, gated on Phase 3.
+- Retiring the entity-based Family A pages — Phase 5, issue #22445.
+- Issue #15845 (legacy cashier windows 2/3/4 phantom beans) — independent, not gated.
+
+---
+
+## 11. References
+
+- `developer_docs/pharmacy/native-sql-bill-migration-guide.md` — native rewrite
+  architecture: persist order, sign conventions, cache-coherence pitfalls.
+- `developer_docs/pharmacy/PHARMACY_RETAIL_SALE_MULTI_WINDOW_GUIDE.md.md` — corrected in
+  Phase 1; relevant to Phase 4, not this spec.
+- PR #20362 — native retail sale (#20260), the template for this work.
+- PR #22449 — Phase 1, 4 native retail sale windows (#22443).
+- `tmp/retail-sale-native-migration-master-plan.md` — untracked progress tracker for the
+  whole migration.

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -446,6 +446,13 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                         return null;
                     } else {
                         pt = savePatient();
+                        // savePatient() logs and returns null if the write fails. Settling
+                        // anyway would produce a patient-less bill on a department that
+                        // requires one, so abort instead.
+                        if (pt == null) {
+                            JsfUtil.addErrorMessage("Could not save the patient. Please try again.");
+                            return null;
+                        }
                     }
                 } else {
                     if (hasValidName) {
@@ -477,9 +484,20 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 bid.setInstitutionId(instId);
             }
 
+            // Only the settle() call is allowed to report "failed". Nothing has been
+            // committed if it throws, so the cart is left intact and a retry is safe.
             try {
                 nativeSqlService.settle(preBillEntity, billItemDataList);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
+                JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+                return null;
+            }
 
+            // Past this point settle() has committed: the bill exists and the stock is
+            // already deducted. Anything failing from here must NOT be reported as a failed
+            // settle — the operator would press Settle again and deduct the stock twice.
+            try {
                 // settle() is a @Stateless REQUIRED boundary, so the bill and the stock
                 // deduction are already committed here. A token failure must not make a
                 // completed sale report as failed and skip the printout.
@@ -508,8 +526,16 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 billPreview = true;
                 JsfUtil.addSuccessMessage("Bill settled successfully.");
             } catch (RuntimeException e) {
-                LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
-                JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+                LOGGER.log(Level.SEVERE,
+                        "Cashier bill was settled but post-settle processing failed", e);
+                // Clear the cart so the bill cannot be settled a second time, and say
+                // plainly that the sale itself went through.
+                resetAll();
+                billPreview = false;
+                JsfUtil.addErrorMessage("Bill " + preBillEntity.getDeptId()
+                        + " WAS settled and stock was deducted, but the printout could not be"
+                        + " prepared. Do not settle again — reprint it from Search Sale for"
+                        + " Cashier Bills.");
             }
             return null;
         } finally {
@@ -942,6 +968,12 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                     settledBill, TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER);
             if (saleForCashierToken == null) {
                 settlePharmacyToken(TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER, settledBill);
+            } else {
+                // Adopt the token that already exists for this bill, otherwise token and
+                // currentToken stay null and markInprogress() below is a no-op — the
+                // existing token would never be attached to the settled bill.
+                setToken(saleForCashierToken);
+                setCurrentToken(saleForCashierToken);
             }
             markInprogress(settledBill);
         } else {
@@ -1495,9 +1527,20 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         if (bid == null) {
             return;
         }
-        bid.setQty(bid.getQty() / 2);
+        bid.setQty(halveQty(bid.getQty()));
         recalculateRow(bid);
         calTotal();
+    }
+
+    /**
+     * Halves a dispense quantity the way legacy
+     * PharmacySaleForCashierController.divideQuantityByHalf() does (:1234):
+     * {@code Math.max(1.0, qty / 2.0)}. A plain division would leave 0.5 on an odd
+     * quantity — a fractional dispense that the qty column renders with
+     * {@code integerOnly="true"}, so the operator would never see it.
+     */
+    private double halveQty(double qty) {
+        return Math.max(1.0, Math.floor(qty / 2.0));
     }
 
     public void multiplyAllQuantitiesByTwo() {
@@ -1516,7 +1559,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return;
         }
         for (BillItemData bid : billItemDataList) {
-            bid.setQty(bid.getQty() / 2);
+            bid.setQty(halveQty(bid.getQty()));
             recalculateRow(bid);
         }
         calTotal();

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -221,14 +221,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         }
         billSettlingStarted = true;
 
-        if (sessionController.getApplicationPreference().isCheckPaymentSchemeValidation()) {
-            if (paymentScheme == null) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please select Payment Scheme");
-                return null;
-            }
-        }
-
         if (paymentMethod == null) {
             billSettlingStarted = false;
             JsfUtil.addErrorMessage("Please select Payment Method");
@@ -239,35 +231,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             billSettlingStarted = false;
             JsfUtil.addErrorMessage("Please add items to the bill.");
             return null;
-        }
-
-        if ((getPatient().getMobileNumberStringTransient() == null
-                || getPatient().getMobileNumberStringTransient().trim().isEmpty()
-                || getPatient().getPerson().getName().trim().isEmpty())
-                && configOptionApplicationController.getBooleanValueByKey("Patient details are required for retail sale")) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Please enter patient name and mobile number.");
-            return null;
-        }
-
-        if (paymentMethod == PaymentMethod.Card) {
-            String cardNumber = getPaymentMethodData().getCreditCard().getNo();
-            if ((cardNumber == null || cardNumber.trim().isEmpty() || cardNumber.trim().length() != 4)
-                    && configOptionApplicationController.getBooleanValueByKey("Pharmacy retail sale CreditCard last digits is Mandatory")) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter a Credit Card last 4 digits");
-                return null;
-            }
-        }
-
-        if (paymentMethod == PaymentMethod.Staff_Welfare
-                && configOptionApplicationController.getBooleanValueByKey(
-                        "Pharmacy discount should be staff when select Staff_welfare as payment method", false)) {
-            if (paymentScheme == null || !paymentScheme.getName().equalsIgnoreCase("staff")) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Staff Welfare needs to set staff discount scheme.");
-                return null;
-            }
         }
 
         BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -759,9 +759,17 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             String age = billPatient.getPerson().getAgeAsShortString();
             String sex = billPatient.getPerson().getSex() != null
                     ? billPatient.getPerson().getSex().getLabel() : null;
-            if (age != null || sex != null) {
-                pbd.setPatientAgeSex((age != null ? age : "") + " / " + (sex != null ? sex : ""));
+            boolean hasAge = age != null && !age.trim().isEmpty();
+            boolean hasSex = sex != null && !sex.trim().isEmpty();
+            if (hasAge && hasSex) {
+                pbd.setPatientAgeSex(age + " / " + sex);
+            } else if (hasAge) {
+                pbd.setPatientAgeSex(age);
+            } else if (hasSex) {
+                pbd.setPatientAgeSex(sex);
             }
+            // Left null when neither is known, so the print shows an empty Age/Sex cell
+            // rather than a bare " / ".
         }
 
         // Payment

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -39,12 +39,8 @@ import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.PaymentScheme;
-import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.Staff;
-import com.divudi.core.entity.clinical.Prescription;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
-import com.divudi.core.entity.pharmacy.Stock;
-import com.divudi.core.entity.pharmacy.ItemBatch;
 import com.divudi.core.facade.ItemBatchFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PatientFacade;
@@ -63,8 +59,10 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
@@ -280,16 +278,108 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return null;
         }
 
+        // Validate department type consistency before settlement.
+        // Mirrors PharmacySaleForCashierController.settlePreBillAndNavigateToPrint() :3622-3632;
+        // the entity getter Item.getDepartmentType() defaults a null column to Pharmacy, so the
+        // item is resolved through itemFacade rather than a JPQL projection to keep that default.
+        if (getPreBill().getDepartmentType() != null) {
+            for (BillItemData bid : billItemDataList) {
+                if (bid.getItemId() == null) {
+                    continue;
+                }
+                Item lineItem = itemFacade.find(bid.getItemId());
+                if (lineItem != null && lineItem.getDepartmentType() != null
+                        && !lineItem.getDepartmentType().equals(getPreBill().getDepartmentType())) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Inconsistent department types detected. All items must belong to the same department type.");
+                    return null;
+                }
+            }
+        }
+
+        // Pharmacy Sale Validation - Patient and Patient Details.
+        // Keys and messages are those of the legacy cashier path
+        // (PharmacySaleForCashierController :3635-3746), not the pay-now Sale page.
         boolean patientRequired = configOptionApplicationController.getBooleanValueByKey(
-                "Patient is required in Pharmacy Retail Sale Bill for "
-                + sessionController.getDepartment().getName(), false);
+                "Patient is required in Pharmacy Retail Sale", false);
+
         if (patientRequired) {
-            if (getPatient() == null || getPatient().getPerson() == null
-                    || getPatient().getPerson().getName() == null
-                    || getPatient().getPerson().getName().trim().isEmpty()) {
+            if (getPatient() == null || getPatient().getPerson() == null) {
                 billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please Select a Patient");
+                JsfUtil.addErrorMessage("Patient is required.");
                 return null;
+            }
+        }
+
+        // Only validate patient details if patient is required OR if patient exists
+        boolean hasPatient = getPatient() != null && getPatient().getPerson() != null;
+
+        if (hasPatient || patientRequired) {
+            // Patient Name validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Name is required in Pharmacy Retail Sale", false)) {
+                if (getPatient() == null || getPatient().getPerson() == null
+                        || getPatient().getPerson().getName() == null
+                        || getPatient().getPerson().getName().trim().isEmpty()) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient name is required.");
+                    return null;
+                }
+            }
+
+            // Patient Phone validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Phone is required in Pharmacy Retail Sale", false)) {
+                if (getPatient() == null || getPatient().getPerson() == null) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient is required.");
+                    return null;
+                }
+                // Check both phone and mobile - at least one should be present
+                boolean hasPhone = getPatient().getPerson().getPhone() != null
+                        && !getPatient().getPerson().getPhone().trim().isEmpty();
+                boolean hasMobile = getPatient().getPerson().getMobile() != null
+                        && !getPatient().getPerson().getMobile().trim().isEmpty();
+
+                if (!hasPhone && !hasMobile) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient phone number is required.");
+                    return null;
+                }
+            }
+
+            // Patient Gender validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Gender is required in Pharmacy Retail Sale", false)) {
+                if (getPatient() == null || getPatient().getPerson() == null
+                        || getPatient().getPerson().getSex() == null) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient gender is required.");
+                    return null;
+                }
+            }
+
+            // Patient Address validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Address is required in Pharmacy Retail Sale", false)) {
+                if (getPatient() == null || getPatient().getPerson() == null
+                        || getPatient().getPerson().getAddress() == null
+                        || getPatient().getPerson().getAddress().trim().isEmpty()) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient address is required.");
+                    return null;
+                }
+            }
+
+            // Patient Area validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Area is required in Pharmacy Retail Sale", false)) {
+                if (getPatient() == null || getPatient().getPerson() == null
+                        || getPatient().getPerson().getArea() == null) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Patient area is required.");
+                    return null;
+                }
             }
         }
 
@@ -299,95 +389,61 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return null;
         }
 
+        // Referring Doctor validation
         if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getTitle() == null) {
+                "Referring Doctor is required in Pharmacy Retail Sale", false)) {
+            if (getPreBill() == null || getPreBill().getReferredBy() == null) {
                 billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please select title.");
-                return null;
-            }
-            if (getPatient().getPerson().getSex() == null) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please select gender.");
+                JsfUtil.addErrorMessage("Referring doctor is required.");
                 return null;
             }
         }
 
+        // Defaults to TRUE - every deployment enforces this unless it is explicitly turned off.
         if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Name to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getName() == null
-                    || getPatient().getPerson().getName().trim().isEmpty()) {
+                "Patient Phone number is mandotary in sale for cashier", true)) {
+            if (getPatient() != null && getPatient().getPerson() != null) {
+                if (getPatient().getPatientPhoneNumber() == null && getPatient().getPatientMobileNumber() == null) {
+                    JsfUtil.addErrorMessage("Please enter phone number of the patient");
+                    return null;
+                } else if (getPatient().getId() == null) {
+                    if (getPatient().getPatientPhoneNumber() != null
+                            && !(String.valueOf(getPatient().getPatientPhoneNumber()).length() >= 9)) {
+                        JsfUtil.addErrorMessage("Please enter valid phone number with more than or equal 10 digits of the patient");
+                        return null;
+                    } else if (getPatient().getPatientMobileNumber() != null
+                            && !(String.valueOf(getPatient().getPatientMobileNumber()).length() >= 9)) {
+                        JsfUtil.addErrorMessage("Please enter valid mobile number with more than or equal 10 digits of the patient");
+                        return null;
+                    }
+                }
+            } else if (patientRequired) {
+                JsfUtil.addErrorMessage("Patient is required.");
                 billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter name.");
                 return null;
             }
         }
 
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Age to Save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getDob() == null) {
+        // Duplicate bill item detection - prevent double stock deduction (Closes #18874).
+        // Ported from PharmacySaleForCashierController :3749-3772; the native cart holds
+        // BillItemData rows instead of BillItem entities, so the stock id is read straight
+        // off the row rather than through PharmaceuticalBillItem.
+        // Check 1: same row object appearing twice (rapid Add button click)
+        Set<Integer> seenIdentities = new HashSet<>();
+        for (BillItemData bid : billItemDataList) {
+            if (!seenIdentities.add(System.identityHashCode(bid))) {
                 billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter patient date of birth.");
+                JsfUtil.addErrorMessage("Duplicate item detected. Please remove duplicate items and try again.");
                 return null;
             }
         }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Phone Number to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getPhone() == null
-                    || getPatient().getPerson().getPhone().trim().isEmpty()) {
+        // Check 2: different rows pointing at the same Stock batch
+        Set<Long> seenStockIds = new HashSet<>();
+        for (BillItemData bid : billItemDataList) {
+            if (bid.getStockId() != null && !seenStockIds.add(bid.getStockId())) {
                 billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter phone number.");
-                return null;
-            }
-        }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Address to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getAddress() == null
-                    || getPatient().getPerson().getAddress().trim().isEmpty()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter patient address.");
-                return null;
-            }
-        }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Mail to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getEmail() == null
-                    || getPatient().getPerson().getEmail().trim().isEmpty()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter patient email.");
-                return null;
-            }
-        }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient NIC to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getNic() == null
-                    || getPatient().getPerson().getNic().trim().isEmpty()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter patient NIC.");
-                return null;
-            }
-        }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Patient Area to save Patient in Pharmacy Sale", false)) {
-            if (getPatient().getPerson().getArea() == null
-                    || getPatient().getPerson().getArea().getName() == null
-                    || getPatient().getPerson().getArea().getName().trim().isEmpty()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please select patient area.");
-                return null;
-            }
-        }
-
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Need Referring Doctor to settlle bill in Pharmacy Sale", false)) {
-            if (getPreBill().getReferredBy() == null) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please select referring doctor.");
+                JsfUtil.addErrorMessage("Duplicate item batch detected: "
+                        + bid.getItemName() + ". Please remove duplicate items and try again.");
                 return null;
             }
         }
@@ -401,9 +457,12 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
 
         PreBill preBillEntity = buildPreBill();
 
-        // Stamp the multiple-payment breakdown onto the bill's own columns. No Payment
-        // entity is created for a NO_PAYMENT bill type; this is what the cashier-side
-        // settle page later reads. Mirrors legacy savePreBillFinallyForRetailSaleForCashier.
+        // Stamps the single-method payment reference fields on the bill itself: cheque /
+        // slip / card / online-settlement / ewallet numbers, dates and banks, plus the
+        // creditBill flag. BillBeanController.setPaymentMethodData (:2916-2951) has no
+        // MultiplePaymentMethods branch, so a multiple-payment breakdown is deliberately
+        // NOT written here - the cashier collects and records the money later. Mirrors
+        // legacy savePreBillFinallyForRetailSaleForCashier (:2997).
         preBillEntity.setCashPaid(cashPaid);
         billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
 
@@ -424,13 +483,26 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             // completed sale report as failed and skip the printout.
             try {
                 settleTokenIfEnabled(preBillEntity);
+                // Legacy runs this OUTSIDE the "Enable token system in sale for cashier"
+                // check (:3869-3872), so a token created by any other route is still
+                // attached to the settled bill.
+                if (getCurrentToken() != null) {
+                    getCurrentToken().setBill(preBillEntity);
+                    tokenFacade.edit(getCurrentToken());
+                }
             } catch (RuntimeException tokenEx) {
                 LOGGER.log(Level.WARNING, "Token handling failed after cashier settle", tokenEx);
             }
 
             buildPrintBill(preBillEntity);
-            clearBill();
-            clearBillItem();
+            // Legacy calls resetAll() here (:3874) so nothing from the settled bill leaks
+            // into the next one. resetAll() also clears the just-built printout, which the
+            // legacy controller keeps in a separate printBill field, so it is restored.
+            PrintBillData settledPrintBill = printBill;
+            List<BillItemData> settledPrintBillItems = printBillItems;
+            resetAll();
+            printBill = settledPrintBill;
+            printBillItems = settledPrintBillItems;
             billPreview = true;
             billSettlingStarted = false;
             JsfUtil.addSuccessMessage("Bill settled successfully.");
@@ -468,8 +540,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
     }
 
     private PreBill buildPreBill() {
-        String billNo = generateBillNumber();
-
         double netTot = 0.0;
         double grossTot = 0.0;
         double discountTot = 0.0;
@@ -482,8 +552,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         PreBill pb = new PreBill();
         pb.setBillType(BillType.PharmacyPre);
         pb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
-        pb.setInsId(billNo);
-        pb.setDeptId(billNo);
         pb.setDepartment(sessionController.getLoggedUser().getDepartment());
         pb.setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
         pb.setPatient(patient);
@@ -508,19 +576,10 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             pb.setPaidAmount(netTot);
         }
 
-        // Single-bill flow: the counterparty of a credit / staff bill used to be stamped
-        // on the (now deleted) BilledBill. It has to live on the PreBill instead, which is
-        // also what legacy savePreBillFinallyForRetailSaleForCashier() does.
-        if (paymentMethod == PaymentMethod.Credit && getPaymentMethodData().getCredit().getInstitution() != null) {
-            pb.setToInstitution(getPaymentMethodData().getCredit().getInstitution());
-            pb.setCreditCompany(getPaymentMethodData().getCredit().getInstitution());
-        } else if (toInstitution != null) {
-            pb.setToInstitution(toInstitution);
-        }
-        if ((paymentMethod == PaymentMethod.Staff || paymentMethod == PaymentMethod.Staff_Welfare)
-                && toStaff != null) {
-            pb.setToStaff(toStaff);
-        }
+        // Legacy stamps both counterparties unconditionally and never sets creditCompany on
+        // the cashier PreBill (PharmacySaleForCashierController :2972-2973).
+        pb.setToStaff(toStaff);
+        pb.setToInstitution(toInstitution);
 
         if (getPreBill().getReferredBy() != null) {
             pb.setReferredBy(getPreBill().getReferredBy());
@@ -528,10 +587,20 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         // Carried over from the cart so the cashier-side settle page can keep filtering
         // by department type (see completeAvailableStockOptimizedDtoFilteredByDepartmentType).
         pb.setDepartmentType(getPreBill().getDepartmentType());
+
+        // Bill numbering. Legacy runs a SEPARATE institution generator for insId
+        // (:3016-3029); the two numbers only collapse under the Dept+Ins strategy.
+        String deptId = generateDepartmentBillNumber();
+        String insId = generateInstitutionBillNumber(pb, deptId);
+        pb.setInsId(insId);
+        pb.setDeptId(deptId);
+        pb.setInvoiceNumber(billNumberGenerator.fetchPaymentSchemeCount(
+                pb.getPaymentScheme(), pb.getBillType(), pb.getInstitution()));
         return pb;
     }
 
-    private String generateBillNumber() {
+    /** Ported verbatim from PharmacySaleForCashierController :3000-3013. */
+    private String generateDepartmentBillNumber() {
         if (configOptionApplicationController.getBooleanValueByKey(
                 "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
             return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
@@ -545,9 +614,26 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
                     sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
         }
+        // Use existing method for backward compatibility
         return billNumberGenerator.departmentBillNumberGenerator(
                 sessionController.getDepartment(), BillType.PharmacyPre,
                 BillClassType.PreBill, BillNumberSuffix.SALE);
+    }
+
+    /** Ported verbatim from PharmacySaleForCashierController :3015-3028. */
+    private String generateInstitutionBillNumber(PreBill pb, String deptId) {
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
+            return deptId; // Use same number as department to avoid consuming counter twice
+        }
+        // Use existing method for backward compatibility
+        return billNumberGenerator.institutionBillNumberGenerator(
+                pb.getInstitution(), pb.getBillType(), BillClassType.PreBill, BillNumberSuffix.SALE);
     }
 
     private void buildPrintBill(Bill bill) {
@@ -756,10 +842,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         } else {
             markToken(settledBill);
         }
-        if (currentToken != null) {
-            currentToken.setBill(settledBill);
-            tokenFacade.edit(currentToken);
-        }
     }
 
     /**
@@ -900,6 +982,44 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             }
         }
 
+        // Department type validation, ported from PharmacySaleForCashierController :2384-2425.
+        // Runs on EVERY add, including the first item of an empty cart - at that point the
+        // autocomplete is still unfiltered because the bill's department type is not yet fixed.
+        Item selectedItem = itemFacade.find(stockDto.getItemId());
+
+        // Null-check for selected item (prevents NPE if item not found in database)
+        if (selectedItem == null) {
+            JsfUtil.addErrorMessage("Selected item not found. Please try again.");
+            return;
+        }
+
+        // Note: Item.getDepartmentType() already defaults a null column to DepartmentType.Pharmacy
+        DepartmentType itemDepartmentType = selectedItem.getDepartmentType();
+        if (itemDepartmentType == null) {
+            itemDepartmentType = DepartmentType.Pharmacy; // Defensive fallback (should never execute)
+        }
+
+        List<DepartmentType> allowedTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
+        if (allowedTypes == null || allowedTypes.isEmpty()) {
+            JsfUtil.addErrorMessage("No department types are configured for pharmacy transactions.");
+            return;
+        }
+
+        if (!allowedTypes.contains(itemDepartmentType)) {
+            JsfUtil.addErrorMessage("Items of type " + itemDepartmentType.getLabel()
+                    + " are not allowed for pharmacy transactions.");
+            return;
+        }
+
+        // If the bill already has a department type set, validate the item matches it
+        if (getPreBill().getDepartmentType() != null
+                && !itemDepartmentType.equals(getPreBill().getDepartmentType())) {
+            JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                    + "Bill is set for " + getPreBill().getDepartmentType().getLabel()
+                    + " items, but you are trying to add a " + itemDepartmentType.getLabel() + " item.");
+            return;
+        }
+
         double requestedQty = intQty.doubleValue();
         double remainingQty = requestedQty;
 
@@ -909,7 +1029,9 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 JsfUtil.addErrorMessage("This batch is already added to the bill. Edit the quantity instead.");
                 return;
             }
-            addBillItemLineForStock(stockDto, requestedQty);
+            if (!addBillItemLineForStock(stockDto, requestedQty)) {
+                return;
+            }
             calTotal();
             clearBillItem();
             return;
@@ -939,7 +1061,9 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             if (take <= 0) {
                 continue;
             }
-            addBillItemLineForStock(next, take);
+            if (!addBillItemLineForStock(next, take)) {
+                continue;
+            }
             addedQty += take;
             remainingQty -= take;
         }
@@ -975,8 +1099,19 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
      * Build a single bill line for the given stock/batch at the given quantity and append it to
      * {@link #billItemDataList}. Shared by the single-batch and multi-batch (#13260) paths so the
      * rate, discount and value calculations stay identical regardless of how the batch was chosen.
+     *
+     * @return false when the item could not be resolved and no line was added.
      */
-    private void addBillItemLineForStock(StockDTO stk, double qty) {
+    private boolean addBillItemLineForStock(StockDTO stk, double qty) {
+        // Resolve the item up front and abort on null, matching legacy
+        // PharmacySaleForCashierController :2389-2392. Doing it inside the discount try/catch
+        // below would swallow the NPE and silently skip the department-type lock.
+        Item itemRef = itemFacade.find(stk.getItemId());
+        if (itemRef == null) {
+            JsfUtil.addErrorMessage("Selected item not found. Please try again.");
+            return false;
+        }
+
         double[] batchRates = fetchBatchRates(stk.getItemBatchId());
         double batchRetailRate    = batchRates[0];
         double batchPurchaseRate  = batchRates[1];
@@ -1012,22 +1147,22 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         double discountPct = 0.0;
         double discountValue = 0.0;
         try {
-            Item itemRef = itemFacade.find(stk.getItemId());
             if (Boolean.TRUE.equals(itemRef.isDiscountAllowed())) {
                 Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
                         paymentMethod, paymentScheme, sessionController.getDepartment(), itemRef);
                 discountPct = pct != null ? pct : 0.0;
                 discountValue = (discountPct / 100.0) * grossValue;
             }
-            // The first item added fixes the department type of the whole bill; the
-            // autocomplete then only offers matching items. Mirrors
-            // PharmacySaleForCashierController.addBillItem().
-            if (getPreBill().getDepartmentType() == null) {
-                getPreBill().setDepartmentType(itemRef.getDepartmentType());
-            }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Discount lookup failed for item {0}: {1}",
                     new Object[]{stk.getItemId(), e.getMessage()});
+        }
+        // The first item added fixes the department type of the whole bill; the autocomplete
+        // then only offers matching items. Kept OUTSIDE the discount try/catch so a discount
+        // lookup failure can never leave the cart unlocked. Mirrors
+        // PharmacySaleForCashierController.addBillItemSingleItem().
+        if (getPreBill().getDepartmentType() == null) {
+            getPreBill().setDepartmentType(itemRef.getDepartmentType());
         }
         double netValue = grossValue - discountValue;
         double netRate = qty > 0 ? netValue / qty : lineRetailRate;
@@ -1044,6 +1179,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             billItemDataList = new ArrayList<>();
         }
         billItemDataList.add(bid);
+        return true;
     }
 
     /**
@@ -1569,11 +1705,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         token = null;
     }
 
-    private void clearBill() {
-        preBill = null;
-        billItemDataList = null;
-    }
-
     private void clearBillItem() {
         billItem = null;
         intQty = null;
@@ -1915,6 +2046,19 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             getPaymentMethodData().getStaffCredit().setToStaff(toStaff);
             getPaymentMethodData().getStaffWelfare().setToStaff(toStaff);
         }
+    }
+
+    /**
+     * Credit counterparty of the bill. buildPreBill() stamps it on the PreBill
+     * unconditionally, matching PharmacySaleForCashierController :2973, so the page needs
+     * to be able to set it (the legacy controller exposes the same pair at :3395-3401).
+     */
+    public Institution getToInstitution() {
+        return toInstitution;
+    }
+
+    public void setToInstitution(Institution toInstitution) {
+        this.toInstitution = toInstitution;
     }
 
     public Double getPreviewRate() {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -243,21 +243,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return null;
         }
 
-        if (paymentMethod == PaymentMethod.Cash
-                && configOptionApplicationController.getBooleanValueByKey(
-                        "Need to Enter the Cash Tendered Amount to Settle Pharmacy Retail Bill", true)) {
-            if (cashPaid == 0.0) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Please enter the paid amount.");
-                return null;
-            }
-            if (cashPaid < getPreBill().getNetTotal()) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Tendered amount is less than net total.");
-                return null;
-            }
-        }
-
         if ((getPatient().getMobileNumberStringTransient() == null
                 || getPatient().getMobileNumberStringTransient().trim().isEmpty()
                 || getPatient().getPerson().getName().trim().isEmpty())
@@ -410,16 +395,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         // Ensure discounts reflect current payment scheme before building the bill
         recalculateDiscountsForAll();
         calTotal();
-
-        // For Multiple Payment Methods, the entered components must cover the net
-        // total (and balance-backed components must have sufficient balance)
-        // before the bill is settled as paid. Mirrors the legacy retail sale
-        // page validation (PharmacySaleController.errorCheck).
-        if (paymentMethod == PaymentMethod.MultiplePaymentMethods
-                && validateMultiplePaymentsFailed()) {
-            billSettlingStarted = false;
-            return null;
-        }
 
         // Save or update the patient record
         savePatientIfNeeded();
@@ -650,10 +625,11 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             for (PrintBillData.PaymentLine line : pbd.getPayments()) {
                 tendered += line.getValue();
             }
-            // settle accepts the split when it is within 1.0 of the net total
-            // (validateMultiplePaymentsFailed); clamp the printed balance to zero
-            // within the same tolerance so an already-settled bill never shows a
-            // residual balance.
+            // No payment is actually taken on this cashier page, so the entered
+            // component split is not validated against the net total at settle
+            // time (unlike the pay-now retail sale page). Clamp a near-zero
+            // printed balance to zero so an already-settled bill doesn't show a
+            // stray residual from rounding.
             printedBalance = tendered - netTot;
             if (Math.abs(printedBalance) <= 1.0) {
                 printedBalance = 0.0;
@@ -1165,14 +1141,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
     public void onEdit(RowEditEvent<BillItemData> event) {
         recalculateRow(event.getObject());
         calTotal();
-    }
-
-    /**
-     * EL alias of {@link #onEdit(RowEditEvent)} kept under the name the legacy cashier
-     * page uses for its row editor, so the page can bind either spelling.
-     */
-    public void quantityInTableChangeEvent(RowEditEvent<BillItemData> event) {
-        onEdit(event);
     }
 
     /**
@@ -1924,107 +1892,6 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 }
             }
         }
-    }
-
-    /**
-     * Validates a Multiple Payment Methods bill before settling: there must be
-     * at least one component, balance-backed components (Patient Deposit, Staff,
-     * Staff Welfare) must have sufficient balance, and the sum of the entered
-     * component values must match the bill net total (within a 1.0 tolerance).
-     * Adds a user-facing error message and returns {@code true} when settling
-     * must be aborted. Mirrors {@code PharmacySaleController.errorCheck}.
-     */
-    private boolean validateMultiplePaymentsFailed() {
-        if (getPaymentMethodData().getPaymentMethodMultiple() == null
-                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null
-                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().isEmpty()) {
-            JsfUtil.addErrorMessage("No Details on multiple payment methods given");
-            return true;
-        }
-
-        double netTotal = Math.abs(getPreBill().getNetTotal());
-        double multiplePaymentMethodTotalValue = 0.0;
-        for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
-            if (cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
-                continue;
-            }
-            switch (cd.getPaymentMethod()) {
-                case Cash:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCash().getTotalValue();
-                    break;
-                case Card:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCreditCard().getTotalValue();
-                    break;
-                case Cheque:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCheque().getTotalValue();
-                    break;
-                case ewallet:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getEwallet().getTotalValue();
-                    break;
-                case Slip:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getSlip().getTotalValue();
-                    break;
-                case OnlineSettlement:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getOnlineSettlement().getTotalValue();
-                    break;
-                case IOU:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getIou().getTotalValue();
-                    break;
-                case Credit:
-                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCredit().getTotalValue();
-                    break;
-                case PatientDeposit: {
-                    double value = cd.getPaymentMethodData().getPatient_deposit().getTotalValue();
-                    PatientDeposit pd = patientDepositController.getDepositOfThePatient(getPatient(), sessionController.getDepartment());
-                    if (pd == null) {
-                        JsfUtil.addErrorMessage("No Patient Deposit.");
-                        return true;
-                    }
-                    if (value > pd.getBalance()) {
-                        JsfUtil.addErrorMessage("No Sufficient Patient Deposit");
-                        return true;
-                    }
-                    multiplePaymentMethodTotalValue += value;
-                    break;
-                }
-                case Staff: {
-                    double value = cd.getPaymentMethodData().getStaffCredit().getTotalValue();
-                    Staff selectedStaff = cd.getPaymentMethodData().getStaffCredit().getToStaff();
-                    if (value == 0.0 || selectedStaff == null) {
-                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
-                        return true;
-                    }
-                    if (selectedStaff.getCurrentCreditValue() + value > selectedStaff.getCreditLimitQualified()) {
-                        JsfUtil.addErrorMessage("No enough Credit.");
-                        return true;
-                    }
-                    multiplePaymentMethodTotalValue += value;
-                    break;
-                }
-                case Staff_Welfare: {
-                    double value = cd.getPaymentMethodData().getStaffWelfare().getTotalValue();
-                    Staff welfareStaff = cd.getPaymentMethodData().getStaffWelfare().getToStaff();
-                    if (value == 0.0 || welfareStaff == null) {
-                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
-                        return true;
-                    }
-                    if (Math.abs(welfareStaff.getAnnualWelfareUtilized()) + value > welfareStaff.getAnnualWelfareQualified()) {
-                        JsfUtil.addErrorMessage("No enough credit.");
-                        return true;
-                    }
-                    multiplePaymentMethodTotalValue += value;
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
-
-        if (Math.abs(netTotal - multiplePaymentMethodTotalValue) > 1.0) {
-            JsfUtil.addErrorMessage("Mismatch in differences of multiple payment method total and bill total");
-            return true;
-        }
-        return false;
     }
 
     public PaymentMethodData getPaymentMethodData() {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -1,0 +1,2105 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.ControllerWithMultiplePayments;
+import com.divudi.bean.common.ControllerWithPatient;
+import com.divudi.bean.common.TokenController;
+import com.divudi.service.DiscountSchemeValidationService;
+import com.divudi.bean.common.PatientDepositController;
+import com.divudi.bean.common.PriceMatrixController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.BillNumberSuffix;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BooleanMessage;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.TokenType;
+import com.divudi.core.data.dataStructure.ComponentDetail;
+import com.divudi.core.data.dataStructure.PaymentMethodData;
+import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.entity.PatientDeposit;
+import com.divudi.core.data.dto.PrintBillData;
+import com.divudi.core.data.dto.StockDTO;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.PreBill;
+import com.divudi.core.entity.Token;
+import com.divudi.core.entity.clinical.ClinicalFindingValue;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.PriceMatrix;
+import com.divudi.core.entity.Staff;
+import com.divudi.core.entity.clinical.Prescription;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.pharmacy.ItemBatch;
+import com.divudi.core.facade.ItemBatchFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.PatientFacade;
+import com.divudi.core.facade.PersonFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.facade.TokenFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.PharmacyService;
+import com.divudi.service.pharmacy.RetailSaleForCashierNativeSqlService;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.TemporalType;
+import org.primefaces.event.RowEditEvent;
+import org.primefaces.event.SelectEvent;
+
+/**
+ * Controller for the native-SQL pharmacy "Sale for Cashier" page.
+ *
+ * Settles through RetailSaleForCashierNativeSqlService, writing a SINGLE PreBill of
+ * BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER with no Payment rows.
+ * Stock is deducted here; the cashier takes payment later via PharmacyPreSettleController.
+ *
+ * Derived from RetailSaleNativeSqlController (#20260) with the cashier deltas re-applied:
+ * token system, qty helpers, departmentType-filtered autocomplete, cashier bill numbering.
+ *
+ * Issue: #20261
+ */
+@Named
+@SessionScoped
+public class RetailSaleForCashierNativeSqlController implements Serializable, ControllerWithPatient, ControllerWithMultiplePayments {
+
+    private static final Logger LOGGER = Logger.getLogger(RetailSaleForCashierNativeSqlController.class.getName());
+
+    // ---- CDI ----
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private BillBeanController billBean;
+    @Inject
+    private TokenController tokenController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
+    private PriceMatrixController priceMatrixController;
+    @Inject
+    private PatientDepositController patientDepositController;
+
+    // ---- EJB ----
+    @EJB
+    private StockFacade stockFacade;
+    @EJB
+    private ItemFacade itemFacade;
+    @EJB
+    private ItemBatchFacade itemBatchFacade;
+    @EJB
+    private BillNumberGenerator billNumberGenerator;
+    @EJB
+    private PharmacyService pharmacyService;
+    @EJB
+    private RetailSaleForCashierNativeSqlService nativeSqlService;
+    @EJB
+    private TokenFacade tokenFacade;
+    @EJB
+    private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
+    @EJB
+    private DiscountSchemeValidationService discountSchemeValidationService;
+    @EJB
+    private PatientFacade patientFacade;
+    @EJB
+    private PersonFacade personFacade;
+
+    // ---- Working state ----
+    private Patient patient;
+    private Bill preBill;
+    private PrintBillData printBill;
+    private List<BillItemData> printBillItems;
+    private BillItem billItem;
+    private Integer intQty;
+    private StockDTO stockDto;
+    private Long selectedStockId;
+    private List<StockDTO> lastAutocompleteResults;
+    private List<BillItemData> billItemDataList;
+    private boolean billPreview = false;
+    private boolean billSettlingStarted = false;
+    private boolean patientDetailsEditable = false;
+    private String comment = "";
+    private double cashPaid;
+    private double balance;
+    private PaymentMethod paymentMethod;
+    private PaymentScheme paymentScheme;
+    private PaymentMethodData paymentMethodData;
+    private Staff toStaff;
+    private Institution toInstitution;
+    private List<ClinicalFindingValue> allergyListOfPatient;
+    private List<BillItemData> selectedBillItemDataList;
+
+    // ---- Token system (cashier page only) ----
+    private Token currentToken;
+    private Token token;
+    private Department counter;
+
+    @PostConstruct
+    public void init() {
+        resetAll();
+    }
+
+    // -----------------------------------------------------------------------
+    // Navigation
+    // -----------------------------------------------------------------------
+
+    public String navigateToPharmacyBillForCashierNativeFromMenu() {
+        resetAll();
+        billSettlingStarted = false;
+        return "/pharmacy/pharmacy_bill_retail_sale_for_cashier_native?faces-redirect=true";
+    }
+
+    /**
+     * Navigation target of the 4-window switch buttons (Sale 1..4).
+     *
+     * Unlike {@link #navigateToPharmacyBillForCashierNativeFromMenu()} this deliberately
+     * does <b>not</b> reset the window: a cart parked in another window must survive a
+     * switch. It only clears the settle-in-progress latch so a window abandoned mid-settle
+     * is usable again. Mirrors PharmacySaleController.pharmacyRetailSale(). Issue #22443.
+     */
+    public String switchToThisSaleWindow() {
+        billSettlingStarted = false;
+        return "/pharmacy/pharmacy_bill_retail_sale_for_cashier_native?faces-redirect=true";
+    }
+
+    @SuppressWarnings("unchecked")
+    public String viewByBillId(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        resetAll();
+        Object[] result = nativeSqlService.loadViewDataByBillId(billId);
+        if (result == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
+        printBill = (PrintBillData) result[0];
+        printBillItems = (List<BillItemData>) result[1];
+        billPreview = true;
+        return "/pharmacy/pharmacy_bill_retail_sale_for_cashier_native?faces-redirect=true";
+    }
+
+    // -----------------------------------------------------------------------
+    // Settle
+    // -----------------------------------------------------------------------
+
+    public String settleBillWithPay() {
+        if (billSettlingStarted) {
+            return null;
+        }
+        billSettlingStarted = true;
+
+        if (sessionController.getApplicationPreference().isCheckPaymentSchemeValidation()) {
+            if (paymentScheme == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select Payment Scheme");
+                return null;
+            }
+        }
+
+        if (paymentMethod == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please select Payment Method");
+            return null;
+        }
+
+        if (billItemDataList == null || billItemDataList.isEmpty()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please add items to the bill.");
+            return null;
+        }
+
+        if (paymentMethod == PaymentMethod.Cash
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Need to Enter the Cash Tendered Amount to Settle Pharmacy Retail Bill", true)) {
+            if (cashPaid == 0.0) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter the paid amount.");
+                return null;
+            }
+            if (cashPaid < getPreBill().getNetTotal()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Tendered amount is less than net total.");
+                return null;
+            }
+        }
+
+        if ((getPatient().getMobileNumberStringTransient() == null
+                || getPatient().getMobileNumberStringTransient().trim().isEmpty()
+                || getPatient().getPerson().getName().trim().isEmpty())
+                && configOptionApplicationController.getBooleanValueByKey("Patient details are required for retail sale")) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please enter patient name and mobile number.");
+            return null;
+        }
+
+        if (paymentMethod == PaymentMethod.Card) {
+            String cardNumber = getPaymentMethodData().getCreditCard().getNo();
+            if ((cardNumber == null || cardNumber.trim().isEmpty() || cardNumber.trim().length() != 4)
+                    && configOptionApplicationController.getBooleanValueByKey("Pharmacy retail sale CreditCard last digits is Mandatory")) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter a Credit Card last 4 digits");
+                return null;
+            }
+        }
+
+        if (paymentMethod == PaymentMethod.Staff_Welfare
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Pharmacy discount should be staff when select Staff_welfare as payment method", false)) {
+            if (paymentScheme == null || !paymentScheme.getName().equalsIgnoreCase("staff")) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Staff Welfare needs to set staff discount scheme.");
+                return null;
+            }
+        }
+
+        BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(
+                paymentMethod, paymentScheme, getPaymentMethodData());
+        if (!discountValidation.isFlag()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage(discountValidation.getMessage());
+            return null;
+        }
+
+        boolean patientRequired = configOptionApplicationController.getBooleanValueByKey(
+                "Patient is required in Pharmacy Retail Sale Bill for "
+                + sessionController.getDepartment().getName(), false);
+        if (patientRequired) {
+            if (getPatient() == null || getPatient().getPerson() == null
+                    || getPatient().getPerson().getName() == null
+                    || getPatient().getPerson().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please Select a Patient");
+                return null;
+            }
+        }
+
+        if (getPatient().isBlacklisted()) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+            return null;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Title And Gender To Save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getTitle() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select title.");
+                return null;
+            }
+            if (getPatient().getPerson().getSex() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select gender.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Name to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getName() == null
+                    || getPatient().getPerson().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter name.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Age to Save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getDob() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient date of birth.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Phone Number to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getPhone() == null
+                    || getPatient().getPerson().getPhone().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter phone number.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Address to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getAddress() == null
+                    || getPatient().getPerson().getAddress().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient address.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Mail to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getEmail() == null
+                    || getPatient().getPerson().getEmail().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient email.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient NIC to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getNic() == null
+                    || getPatient().getPerson().getNic().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please enter patient NIC.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Patient Area to save Patient in Pharmacy Sale", false)) {
+            if (getPatient().getPerson().getArea() == null
+                    || getPatient().getPerson().getArea().getName() == null
+                    || getPatient().getPerson().getArea().getName().trim().isEmpty()) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select patient area.");
+                return null;
+            }
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Need Referring Doctor to settlle bill in Pharmacy Sale", false)) {
+            if (getPreBill().getReferredBy() == null) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Please select referring doctor.");
+                return null;
+            }
+        }
+
+        // Ensure discounts reflect current payment scheme before building the bill
+        recalculateDiscountsForAll();
+        calTotal();
+
+        // For Multiple Payment Methods, the entered components must cover the net
+        // total (and balance-backed components must have sufficient balance)
+        // before the bill is settled as paid. Mirrors the legacy retail sale
+        // page validation (PharmacySaleController.errorCheck).
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods
+                && validateMultiplePaymentsFailed()) {
+            billSettlingStarted = false;
+            return null;
+        }
+
+        // Save or update the patient record
+        savePatientIfNeeded();
+
+        PreBill preBillEntity = buildPreBill();
+
+        // Stamp the multiple-payment breakdown onto the bill's own columns. No Payment
+        // entity is created for a NO_PAYMENT bill type; this is what the cashier-side
+        // settle page later reads. Mirrors legacy savePreBillFinallyForRetailSaleForCashier.
+        preBillEntity.setCashPaid(cashPaid);
+        billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
+
+        // Stamp dept/institution IDs on each item (needed by the native service for
+        // StockHistory aggregates).
+        long deptId = sessionController.getLoggedUser().getDepartment().getId();
+        long instId = sessionController.getLoggedUser().getDepartment().getInstitution().getId();
+        for (BillItemData bid : billItemDataList) {
+            bid.setDepartmentId(deptId);
+            bid.setInstitutionId(instId);
+        }
+
+        try {
+            nativeSqlService.settle(preBillEntity, billItemDataList);
+
+            // settle() is a @Stateless REQUIRED boundary, so the bill and the stock
+            // deduction are already committed here. A token failure must not make a
+            // completed sale report as failed and skip the printout.
+            try {
+                settleTokenIfEnabled(preBillEntity);
+            } catch (RuntimeException tokenEx) {
+                LOGGER.log(Level.WARNING, "Token handling failed after cashier settle", tokenEx);
+            }
+
+            buildPrintBill(preBillEntity);
+            clearBill();
+            clearBillItem();
+            billPreview = true;
+            billSettlingStarted = false;
+            JsfUtil.addSuccessMessage("Bill settled successfully.");
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void savePatientIfNeeded() {
+        try {
+            if (patient == null) {
+                return;
+            }
+            if (patient.getPerson() != null) {
+                patient.setMobileNumberStringTransient(patient.getMobileNumberStringTransient());
+                patient.setPhoneNumberStringTransient(patient.getPhoneNumberStringTransient());
+            }
+            if (patient.getId() == null) {
+                if (patient.getPerson() != null) {
+                    personFacade.create(patient.getPerson());
+                }
+                patientFacade.create(patient);
+            } else {
+                if (patient.getPerson() != null) {
+                    personFacade.edit(patient.getPerson());
+                }
+                patientFacade.edit(patient);
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not save patient", e);
+        }
+    }
+
+    private PreBill buildPreBill() {
+        String billNo = generateBillNumber();
+
+        double netTot = 0.0;
+        double grossTot = 0.0;
+        double discountTot = 0.0;
+        for (BillItemData bid : billItemDataList) {
+            netTot += Math.abs(bid.getNetValue());
+            grossTot += Math.abs(bid.getGrossValue());
+            discountTot += bid.getDiscountValue();
+        }
+
+        PreBill pb = new PreBill();
+        pb.setBillType(BillType.PharmacyPre);
+        pb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        pb.setInsId(billNo);
+        pb.setDeptId(billNo);
+        pb.setDepartment(sessionController.getLoggedUser().getDepartment());
+        pb.setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+        pb.setPatient(patient);
+        pb.setFromDepartment(sessionController.getLoggedUser().getDepartment());
+        pb.setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
+        pb.setBillDate(new Date());
+        pb.setBillTime(new Date());
+        pb.setCreatedAt(Calendar.getInstance().getTime());
+        pb.setCreater(sessionController.getLoggedUser());
+        pb.setComments(comment);
+        pb.setPaymentMethod(paymentMethod);
+        pb.setPaymentScheme(paymentScheme);
+        pb.setTotal(grossTot);
+        pb.setNetTotal(netTot);
+        pb.setGrantTotal(grossTot);
+        pb.setDiscount(discountTot);
+        if (paymentMethod == PaymentMethod.Credit || paymentMethod == PaymentMethod.Staff) {
+            pb.setBalance(netTot);
+            pb.setPaidAmount(0.0);
+        } else {
+            pb.setBalance(0.0);
+            pb.setPaidAmount(netTot);
+        }
+
+        // Single-bill flow: the counterparty of a credit / staff bill used to be stamped
+        // on the (now deleted) BilledBill. It has to live on the PreBill instead, which is
+        // also what legacy savePreBillFinallyForRetailSaleForCashier() does.
+        if (paymentMethod == PaymentMethod.Credit && getPaymentMethodData().getCredit().getInstitution() != null) {
+            pb.setToInstitution(getPaymentMethodData().getCredit().getInstitution());
+            pb.setCreditCompany(getPaymentMethodData().getCredit().getInstitution());
+        } else if (toInstitution != null) {
+            pb.setToInstitution(toInstitution);
+        }
+        if ((paymentMethod == PaymentMethod.Staff || paymentMethod == PaymentMethod.Staff_Welfare)
+                && toStaff != null) {
+            pb.setToStaff(toStaff);
+        }
+
+        if (getPreBill().getReferredBy() != null) {
+            pb.setReferredBy(getPreBill().getReferredBy());
+        }
+        // Carried over from the cart so the cashier-side settle page can keep filtering
+        // by department type (see completeAvailableStockOptimizedDtoFilteredByDepartmentType).
+        pb.setDepartmentType(getPreBill().getDepartmentType());
+        return pb;
+    }
+
+    private String generateBillNumber() {
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Department Code + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Institution Code + Department Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        } else if (configOptionApplicationController.getBooleanValueByKey(
+                "Bill Number Generation Strategy for Pharmacy Sale Cashier Pre Bill - Prefix + Institution Code + Year + Yearly Number", false)) {
+            return billNumberGenerator.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(), BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
+        }
+        return billNumberGenerator.departmentBillNumberGenerator(
+                sessionController.getDepartment(), BillType.PharmacyPre,
+                BillClassType.PreBill, BillNumberSuffix.SALE);
+    }
+
+    private void buildPrintBill(Bill bill) {
+        PrintBillData pbd = new PrintBillData();
+
+        // Department / institution header
+        Department dept = sessionController.getLoggedUser().getDepartment();
+        pbd.setDepartmentName(dept.getName());
+        pbd.setDepartmentPrintingName(dept.getPrintingName() != null ? dept.getPrintingName() : dept.getName());
+        pbd.setDepartmentTelephone1(dept.getTelephone1());
+        pbd.setDepartmentAddress(dept.getAddress());
+        if (dept.getInstitution() != null) {
+            pbd.setInstitutionName(dept.getInstitution().getName());
+            pbd.setInstitutionAddress(dept.getInstitution().getAddress());
+            pbd.setInstitutionEmail(dept.getInstitution().getEmail());
+            pbd.setInstitutionWeb(dept.getInstitution().getWeb());
+        }
+
+        // Bill identity
+        pbd.setBillNo(bill.getDeptId());
+        pbd.setBillIdStr(bill.getIdStr());
+        pbd.setCancelled(bill.isCancelled());
+        pbd.setCreatedAt(bill.getCreatedAt());
+        if (bill.getCreater() != null) {
+            pbd.setCreatorName(bill.getCreater().getName());
+        }
+
+        // Patient
+        if (patient != null && patient.getPerson() != null) {
+            pbd.setPatientName(patient.getPerson().getNameWithTitle());
+            pbd.setPatientPhone(patient.getPerson().getPhone());
+            pbd.setPatientPhn(patient.getPhn());
+        }
+
+        // Payment
+        pbd.setPaymentMethodLabel(paymentMethod != null ? paymentMethod.getLabel() : "");
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            pbd.setPayments(buildPrintPaymentLines());
+        }
+        if (paymentScheme != null) {
+            pbd.setPaymentSchemePrintingName(
+                    paymentScheme.getPrintingName() != null ? paymentScheme.getPrintingName() : paymentScheme.getName());
+        }
+        pbd.setComment(comment);
+
+        // Targets for credit/staff/dept bills
+        if (toStaff != null && toStaff.getPerson() != null) {
+            pbd.setToStaffName(toStaff.getPerson().getNameWithTitle());
+        }
+        if (paymentMethod == PaymentMethod.Credit
+                && getPaymentMethodData().getCredit().getInstitution() != null) {
+            pbd.setToInstitutionName(getPaymentMethodData().getCredit().getInstitution().getName());
+        }
+
+        // Totals
+        double grossTot = 0.0;
+        double discTot  = 0.0;
+        double netTot   = 0.0;
+        for (BillItemData bid : billItemDataList) {
+            grossTot += Math.abs(bid.getGrossValue());
+            discTot  += bid.getDiscountValue();
+            netTot   += Math.abs(bid.getNetValue());
+        }
+        pbd.setTotal(grossTot);
+        pbd.setDiscount(discTot);
+        pbd.setNetTotal(netTot);
+        pbd.setDiscountPercentPharmacy(grossTot > 0 ? (discTot / grossTot) * 100.0 : 0.0);
+        // For Multiple Payment Methods the Tendered field is not used; the amount
+        // paid is the sum of the entered components. Show that (and a zero
+        // balance) instead of the unused single cashPaid (which is 0.0).
+        double tendered = cashPaid;
+        double printedBalance = tendered - netTot;
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            tendered = 0.0;
+            for (PrintBillData.PaymentLine line : pbd.getPayments()) {
+                tendered += line.getValue();
+            }
+            // settle accepts the split when it is within 1.0 of the net total
+            // (validateMultiplePaymentsFailed); clamp the printed balance to zero
+            // within the same tolerance so an already-settled bill never shows a
+            // residual balance.
+            printedBalance = tendered - netTot;
+            if (Math.abs(printedBalance) <= 1.0) {
+                printedBalance = 0.0;
+            }
+        }
+        pbd.setCashPaid(tendered);
+        pbd.setBalance(printedBalance);
+
+        printBill = pbd;
+
+        List<BillItemData> printCopy = new ArrayList<>();
+        for (BillItemData src : billItemDataList) {
+            BillItemData p = new BillItemData();
+            p.setItemId(src.getItemId());
+            p.setItemName(src.getItemName());
+            p.setQty(Math.abs(src.getQty()));
+            p.setRate(src.getRate());
+            p.setNetRate(src.getNetRate());
+            p.setNetValue(Math.abs(src.getNetValue()));
+            p.setGrossValue(Math.abs(src.getGrossValue()));
+            p.setDoe(src.getDoe());
+            printCopy.add(p);
+        }
+        printBillItems = printCopy;
+    }
+
+    /**
+     * Builds one {@link PrintBillData.PaymentLine} per entered component of a
+     * Multiple Payment Methods bill, so the printout itemises each payment
+     * (e.g. "Cash 50.00", "Credit Card 145.90") instead of showing the bundled
+     * "Multiple Payment Methods" label with a single value. Components with no
+     * value are skipped (matching the settle path).
+     */
+    private List<PrintBillData.PaymentLine> buildPrintPaymentLines() {
+        List<PrintBillData.PaymentLine> lines = new ArrayList<>();
+        if (getPaymentMethodData().getPaymentMethodMultiple() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null) {
+            return lines;
+        }
+        for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd == null || cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            PaymentMethodData cpmd = cd.getPaymentMethodData();
+            double value = 0.0;
+            String reference = "";
+            switch (cd.getPaymentMethod()) {
+                case Cash:
+                    value = cpmd.getCash().getTotalValue();
+                    break;
+                case Card:
+                    value = cpmd.getCreditCard().getTotalValue();
+                    reference = cpmd.getCreditCard().getNo();
+                    break;
+                case Cheque:
+                    value = cpmd.getCheque().getTotalValue();
+                    reference = cpmd.getCheque().getNo();
+                    break;
+                case ewallet:
+                    value = cpmd.getEwallet().getTotalValue();
+                    reference = cpmd.getEwallet().getReferenceNo();
+                    break;
+                case Slip:
+                    value = cpmd.getSlip().getTotalValue();
+                    reference = cpmd.getSlip().getReferenceNo();
+                    break;
+                case OnlineSettlement:
+                    value = cpmd.getOnlineSettlement().getTotalValue();
+                    reference = cpmd.getOnlineSettlement().getReferenceNo();
+                    break;
+                case IOU:
+                    value = cpmd.getIou().getTotalValue();
+                    reference = cpmd.getIou().getReferenceNo();
+                    break;
+                case Credit:
+                    value = cpmd.getCredit().getTotalValue();
+                    reference = cpmd.getCredit().getReferenceNo();
+                    break;
+                case PatientDeposit:
+                    value = cpmd.getPatient_deposit().getTotalValue();
+                    break;
+                case Staff:
+                    value = cpmd.getStaffCredit().getTotalValue();
+                    break;
+                case Staff_Welfare:
+                    value = cpmd.getStaffWelfare().getTotalValue();
+                    break;
+                default:
+                    break;
+            }
+            if (value <= 0.0) {
+                continue;
+            }
+            lines.add(new PrintBillData.PaymentLine(
+                    cd.getPaymentMethod().getLabel(), value, reference == null ? "" : reference));
+        }
+        return lines;
+    }
+
+    // -----------------------------------------------------------------------
+    // Token system (cashier page)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Cashier-page token integration, gated on config
+     * "Enable token system in sale for cashier". Ported from
+     * PharmacySaleForCashierController.settlePreBillAndNavigateToPrint().
+     */
+    private void settleTokenIfEnabled(Bill settledBill) {
+        if (!configOptionController.getBooleanValueByKey("Enable token system in sale for cashier", false)) {
+            return;
+        }
+        if (patient == null) {
+            return;
+        }
+        Token existing = tokenController.findPharmacyTokens(settledBill);
+        if (existing == null) {
+            Token saleForCashierToken = tokenController.findPharmacyTokenSaleForCashier(
+                    settledBill, TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER);
+            if (saleForCashierToken == null) {
+                settlePharmacyToken(TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER, settledBill);
+            }
+            markInprogress(settledBill);
+        } else {
+            markToken(settledBill);
+        }
+        if (currentToken != null) {
+            currentToken.setBill(settledBill);
+            tokenFacade.edit(currentToken);
+        }
+    }
+
+    /**
+     * Ported from PharmacySaleForCashierController.settlePharmacyToken(TokenType), with
+     * the settled bill passed in instead of read from a getPreBill() field this controller
+     * uses differently (here getPreBill() is the in-progress cart header, not the saved
+     * bill). The patient is already persisted by savePatientIfNeeded() at this point, so
+     * the legacy savePatient() call is not repeated.
+     */
+    public void settlePharmacyToken(TokenType tokenType, Bill settledBill) {
+        if (patient == null || patient.getId() == null
+                || patient.getPerson() == null
+                || patient.getPerson().getName() == null
+                || patient.getPerson().getName().trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please select a patient");
+            return;
+        }
+        currentToken = new Token();
+        currentToken.setTokenType(tokenType);
+        currentToken.setDepartment(sessionController.getDepartment());
+        currentToken.setFromDepartment(sessionController.getDepartment());
+        currentToken.setPatient(patient);
+        currentToken.setInstitution(sessionController.getInstitution());
+        currentToken.setFromInstitution(sessionController.getInstitution());
+        if (getCounter() == null) {
+            if (sessionController.getLoggableSubDepartments() != null
+                    && !sessionController.getLoggableSubDepartments().isEmpty()) {
+                counter = sessionController.getLoggableSubDepartments().get(0);
+            }
+        }
+        currentToken.setCounter(getCounter());
+        if (counter != null) {
+            currentToken.setToDepartment(counter.getSuperDepartment());
+            if (counter.getSuperDepartment() != null) {
+                currentToken.setToInstitution(counter.getSuperDepartment().getInstitution());
+            }
+        }
+        if (currentToken.getToDepartment() == null) {
+            currentToken.setToDepartment(sessionController.getDepartment());
+        }
+        if (currentToken.getToInstitution() == null) {
+            currentToken.setToInstitution(sessionController.getInstitution());
+        }
+        tokenFacade.create(currentToken);
+        currentToken.setTokenNumber(billNumberGenerator.generateDailyTokenNumber(
+                currentToken.getFromDepartment(), null, null, tokenType));
+        currentToken.setCounter(counter);
+        currentToken.setTokenDate(new Date());
+        currentToken.setTokenAt(new Date());
+        currentToken.setBill(settledBill);
+        tokenFacade.edit(currentToken);
+        setToken(currentToken);
+    }
+
+    /** Ported from PharmacySaleForCashierController.markInprogress(). */
+    public void markInprogress(Bill settledBill) {
+        Token t = getToken();
+        if (t == null) {
+            return;
+        }
+        t.setBill(settledBill);
+        t.setCalled(false);
+        t.setCalledAt(null);
+        t.setInProgress(true);
+        t.setCompleted(false);
+        tokenController.save(t);
+    }
+
+    /** Ported from PharmacySaleForCashierController.markToken(). */
+    public void markToken(Bill settledBill) {
+        Token t = getToken();
+        if (t == null) {
+            return;
+        }
+        t.setBill(settledBill);
+        t.setCalled(true);
+        t.setCalledAt(new Date());
+        t.setInProgress(false);
+        t.setCompleted(false);
+        tokenController.save(t);
+    }
+
+    // -----------------------------------------------------------------------
+    // Add item
+    // -----------------------------------------------------------------------
+
+    public void addBillItem() {
+        if (stockDto == null || selectedStockId == null || stockDto.getItemId() == null) {
+            JsfUtil.addErrorMessage("No stock selected.");
+            return;
+        }
+        if (intQty == null || intQty <= 0) {
+            JsfUtil.addErrorMessage("Please enter a quantity.");
+            return;
+        }
+        if (stockDto.getDateOfExpire() != null
+                && stockDto.getDateOfExpire().before(CommonFunctions.getCurrentDateTime())) {
+            JsfUtil.addErrorMessage("You are not allowed to select expired items.");
+            return;
+        }
+
+        // Issue #13260: when "Add quantity from multiple batches in pharmacy retail billing" is on,
+        // a requested quantity larger than the selected batch's stock is filled from the next
+        // available batches of the same item (FEFO — earliest expiry first), creating one bill line
+        // per batch consumed. When off, the requested qty must fit within the selected batch.
+        boolean multipleBatches = configOptionApplicationController.getBooleanValueByKey(
+                "Add quantity from multiple batches in pharmacy retail billing", false);
+
+        if (!multipleBatches) {
+            if (stockDto.getStockQty() != null && intQty > stockDto.getStockQty()) {
+                JsfUtil.addErrorMessage("No sufficient stock available.");
+                return;
+            }
+        }
+
+        // Allergy check is per item, not per batch — do it once up front.
+        boolean shouldCheckAllergies = configOptionApplicationController.getBooleanValueByKey(
+                "Check for Allergies during Dispensing", false)
+                && patient != null && patient.getId() != null;
+        try {
+            if (shouldCheckAllergies) {
+                Item itemRef = itemFacade.find(stockDto.getItemId());
+                if (allergyListOfPatient == null) {
+                    allergyListOfPatient = pharmacyService.getAllergyListForPatient(patient);
+                }
+                String allergyMsg = pharmacyService.getAllergyMessageForItem(patient, itemRef, allergyListOfPatient);
+                if (allergyMsg != null && !allergyMsg.isEmpty()) {
+                    JsfUtil.addErrorMessage(allergyMsg);
+                    return;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Allergy check failed for item {0}: {1}",
+                    new Object[]{stockDto.getItemId(), e.getMessage()});
+            if (shouldCheckAllergies) {
+                JsfUtil.addErrorMessage("Could not complete allergy check. Please try again.");
+                return;
+            }
+        }
+
+        double requestedQty = intQty.doubleValue();
+        double remainingQty = requestedQty;
+
+        if (!multipleBatches) {
+            // Single-batch behaviour (unchanged): block if already added, then add the full qty.
+            if (isStockAlreadyOnBill(selectedStockId)) {
+                JsfUtil.addErrorMessage("This batch is already added to the bill. Edit the quantity instead.");
+                return;
+            }
+            addBillItemLineForStock(stockDto, requestedQty);
+            calTotal();
+            clearBillItem();
+            return;
+        }
+
+        // Multi-batch FEFO fill: merge the user-selected batch with additional batches and
+        // sort all candidates by expiry before allocating, so earlier-expiring stock is always
+        // dispensed first regardless of which batch the user picked.
+        double addedQty = 0.0;
+
+        List<StockDTO> candidates = new ArrayList<>();
+        candidates.add(stockDto);
+        candidates.addAll(findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId));
+        candidates.sort(Comparator.comparing(
+                StockDTO::getDateOfExpire,
+                Comparator.nullsLast(Date::compareTo)));
+
+        for (StockDTO next : candidates) {
+            if (remainingQty <= 0) {
+                break;
+            }
+            if (isStockAlreadyOnBill(next.getId())) {
+                continue;
+            }
+            double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
+            double take = Math.min(remainingQty, available);
+            if (take <= 0) {
+                continue;
+            }
+            addBillItemLineForStock(next, take);
+            addedQty += take;
+            remainingQty -= take;
+        }
+
+        if (addedQty <= 0) {
+            JsfUtil.addErrorMessage("No sufficient stock available.");
+            return;
+        }
+        if (remainingQty > 0) {
+            JsfUtil.addErrorMessage("Only " + String.format("%.0f", addedQty)
+                    + " of the requested " + String.format("%.0f", requestedQty)
+                    + " is available across all batches.");
+        }
+
+        calTotal();
+        clearBillItem();
+    }
+
+    /** True if a bill line already exists for the given stock id. */
+    private boolean isStockAlreadyOnBill(Long stockId) {
+        if (billItemDataList == null || stockId == null) {
+            return false;
+        }
+        for (BillItemData existing : billItemDataList) {
+            if (stockId.equals(existing.getStockId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build a single bill line for the given stock/batch at the given quantity and append it to
+     * {@link #billItemDataList}. Shared by the single-batch and multi-batch (#13260) paths so the
+     * rate, discount and value calculations stay identical regardless of how the batch was chosen.
+     */
+    private void addBillItemLineForStock(StockDTO stk, double qty) {
+        double[] batchRates = fetchBatchRates(stk.getItemBatchId());
+        double batchRetailRate    = batchRates[0];
+        double batchPurchaseRate  = batchRates[1];
+        double batchWholesaleRate = batchRates[2];
+        Double batchCostRate      = batchRates[3] > 0 ? batchRates[3] : null;
+
+        long ampItemId = resolveAmpItemId(stk.getItemId());
+
+        BillItemData bid = new BillItemData();
+        bid.setItemId(stk.getItemId());
+        bid.setItemName(stk.getItemName());
+        bid.setAmpItemId(ampItemId);
+        bid.setStockId(stk.getId());
+        bid.setItemBatchId(stk.getItemBatchId());
+        bid.setQty(qty);
+        bid.setPbiQty(-Math.abs(qty));
+        bid.setFreeQty(0.0);
+        bid.setRetailRate(stk.getRetailRate() != null ? stk.getRetailRate() : 0.0);
+        bid.setPurchaseRate(batchPurchaseRate);
+        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
+        bid.setBatchRetailRate(batchRetailRate);
+        bid.setBatchPurchaseRate(batchPurchaseRate);
+        bid.setBatchWholesaleRate(batchWholesaleRate);
+        bid.setBatchCostRate(batchCostRate);
+        bid.setDoe(stk.getDateOfExpire());
+        bid.setDescription(stk.getItemName());
+        bid.setCreatedAt(new Date());
+        bid.setCreaterId(sessionController.getLoggedUser().getId());
+
+        double lineRetailRate = stk.getRetailRate() != null ? stk.getRetailRate() : 0.0;
+        double grossValue = lineRetailRate * qty;
+        double discountPct = 0.0;
+        double discountValue = 0.0;
+        try {
+            Item itemRef = itemFacade.find(stk.getItemId());
+            if (Boolean.TRUE.equals(itemRef.isDiscountAllowed())) {
+                Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
+                        paymentMethod, paymentScheme, sessionController.getDepartment(), itemRef);
+                discountPct = pct != null ? pct : 0.0;
+                discountValue = (discountPct / 100.0) * grossValue;
+            }
+            // The first item added fixes the department type of the whole bill; the
+            // autocomplete then only offers matching items. Mirrors
+            // PharmacySaleForCashierController.addBillItem().
+            if (getPreBill().getDepartmentType() == null) {
+                getPreBill().setDepartmentType(itemRef.getDepartmentType());
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Discount lookup failed for item {0}: {1}",
+                    new Object[]{stk.getItemId(), e.getMessage()});
+        }
+        double netValue = grossValue - discountValue;
+        double netRate = qty > 0 ? netValue / qty : lineRetailRate;
+
+        bid.setRate(lineRetailRate);
+        bid.setNetRate(netRate);
+        bid.setDiscountPercent(discountPct);
+        bid.setDiscountValue(discountValue);
+        bid.setMarginValue(0.0);
+        bid.setNetValue(-netValue);
+        bid.setGrossValue(-grossValue);
+
+        if (billItemDataList == null) {
+            billItemDataList = new ArrayList<>();
+        }
+        billItemDataList.add(bid);
+    }
+
+    /**
+     * FEFO lookup (#13260): non-expired, in-stock batches of the same item in this department,
+     * excluding the already-picked stock, ordered by earliest expiry first. JPQL DTO projection —
+     * consistent with the rest of this controller (no JPA entity graph / cascade).
+     */
+    private List<StockDTO> findNextAvailableStockDtos(Long itemId, Long excludeStockId) {
+        if (itemId == null) {
+            return new ArrayList<>();
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemId", itemId);
+        params.put("department", sessionController.getDepartment());
+        params.put("stockMin", 0.0);
+        params.put("excludeStockId", excludeStockId != null ? excludeStockId : -1L);
+        params.put("now", CommonFunctions.getCurrentDateTime());
+
+        String jpql = "SELECT NEW com.divudi.core.data.dto.StockDTO("
+                + "s.id, s.itemBatch.id, s.itemBatch.item.id, s.itemBatch.item.name, s.itemBatch.item.code, "
+                + "s.itemBatch.item.name, s.itemBatch.retailsaleRate, s.stock, s.itemBatch.dateOfExpire) "
+                + "FROM Stock s "
+                + "WHERE s.itemBatch.item.id = :itemId "
+                + "AND s.department = :department "
+                + "AND s.stock > :stockMin "
+                + "AND s.id <> :excludeStockId "
+                + "AND s.itemBatch.dateOfExpire > :now "
+                + "ORDER BY s.itemBatch.dateOfExpire";
+
+        List<StockDTO> result = (List<StockDTO>) stockFacade.findLightsByJpql(
+                jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    private double[] fetchBatchRates(Long itemBatchId) {
+        if (itemBatchId == null) {
+            return new double[]{0, 0, 0, 0};
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", itemBatchId);
+        String jpql = "SELECT ib.retailsaleRate, ib.purcahseRate, ib.wholesaleRate, COALESCE(ib.costRate, 0) "
+                + "FROM ItemBatch ib WHERE ib.id = :id";
+        try {
+            Object[] row = (Object[]) itemBatchFacade.findLightsByJpql(jpql, params, TemporalType.DATE, 1)
+                    .stream().findFirst().orElse(null);
+            if (row == null) return new double[]{0, 0, 0, 0};
+            return new double[]{toDouble(row[0]), toDouble(row[1]), toDouble(row[2]), toDouble(row[3])};
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not fetch batch rates for itemBatchId={0}", itemBatchId);
+            return new double[]{0, 0, 0, 0};
+        }
+    }
+
+    private Double fetchCurrentStockQty(Long stockId) {
+        if (stockId == null) {
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", stockId);
+        List<?> result = stockFacade.findLightsByJpql(
+                "SELECT s.stock FROM Stock s WHERE s.id = :id",
+                params, TemporalType.DATE, 1);
+        if (result == null || result.isEmpty() || result.get(0) == null) {
+            return null;
+        }
+        return ((Number) result.get(0)).doubleValue();
+    }
+
+    private long resolveAmpItemId(Long itemId) {
+        if (itemId == null) return 0L;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", itemId);
+            List<?> result = itemFacade.findLightsByJpql(
+                    "SELECT i.amp.id FROM Item i WHERE i.id = :id AND TYPE(i) = Ampp",
+                    params, TemporalType.DATE, 1);
+            if (result != null && !result.isEmpty() && result.get(0) != null) {
+                return ((Number) result.get(0)).longValue();
+            }
+            return itemId;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not resolve AMP for itemId={0}", itemId);
+            return itemId;
+        }
+    }
+
+    private static double toDouble(Object o) {
+        return o == null ? 0.0 : ((Number) o).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Edit row
+    // -----------------------------------------------------------------------
+
+    public void onEdit(RowEditEvent<BillItemData> event) {
+        recalculateRow(event.getObject());
+        calTotal();
+    }
+
+    /**
+     * EL alias of {@link #onEdit(RowEditEvent)} kept under the name the legacy cashier
+     * page uses for its row editor, so the page can bind either spelling.
+     */
+    public void quantityInTableChangeEvent(RowEditEvent<BillItemData> event) {
+        onEdit(event);
+    }
+
+    /**
+     * Single home of the per-row quantity maths and the qty guards (qty &gt; 0 and
+     * qty &lt;= available stock). Called by the row editor and by the four qty helpers,
+     * so doubling a quantity can never exceed available stock either.
+     */
+    private void recalculateRow(BillItemData bid) {
+        if (bid == null) {
+            return;
+        }
+        if (bid.getQty() <= 0) {
+            bid.setQty(0);
+            JsfUtil.addErrorMessage("Quantity must be greater than zero.");
+            return;
+        }
+        if (bid.getStockId() != null) {
+            try {
+                Double availableQty = fetchCurrentStockQty(bid.getStockId());
+                if (availableQty != null && bid.getQty() > availableQty) {
+                    bid.setQty(availableQty);
+                    JsfUtil.addErrorMessage("Quantity cannot exceed available stock ("
+                            + availableQty.intValue() + "). Quantity has been set to the maximum available.");
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Could not verify stock qty for stockId={0}", bid.getStockId());
+            }
+        }
+        double absQty = Math.abs(bid.getQty());
+        double gross = absQty * bid.getRate();
+        double discountVal = (bid.getDiscountPercent() / 100.0) * gross;
+        double netVal = gross - discountVal;
+        bid.setGrossValue(-gross);
+        bid.setDiscountValue(discountVal);
+        bid.setNetValue(-netVal);
+        bid.setNetRate(absQty > 0 ? netVal / absQty : bid.getRate());
+        bid.setPbiQty(-absQty);
+    }
+
+    public void onEditCancel(RowEditEvent<BillItemData> event) {
+        calTotal();
+    }
+
+    public void removeBillItem(BillItemData bid) {
+        if (billItemDataList != null) {
+            billItemDataList.remove(bid);
+        }
+        if (selectedBillItemDataList != null) {
+            selectedBillItemDataList.remove(bid);
+        }
+        clearDepartmentTypeIfCartEmpty();
+        calTotal();
+    }
+
+    public void removeSelectedBillItems() {
+        if (selectedBillItemDataList == null || selectedBillItemDataList.isEmpty()) {
+            JsfUtil.addErrorMessage("Please select items to delete");
+            return;
+        }
+        if (billItemDataList != null) {
+            billItemDataList.removeAll(selectedBillItemDataList);
+        }
+        selectedBillItemDataList = new ArrayList<>();
+        clearDepartmentTypeIfCartEmpty();
+        calTotal();
+    }
+
+    /** An empty cart releases the department-type lock so the next item can set it afresh. */
+    private void clearDepartmentTypeIfCartEmpty() {
+        if (billItemDataList == null || billItemDataList.isEmpty()) {
+            getPreBill().setDepartmentType(null);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Quantity helpers (cashier page)
+    // -----------------------------------------------------------------------
+
+    public void multiplyQuantityByTwo(BillItemData bid) {
+        if (bid == null) {
+            return;
+        }
+        bid.setQty(bid.getQty() * 2);
+        recalculateRow(bid);
+        calTotal();
+    }
+
+    public void divideQuantityByHalf(BillItemData bid) {
+        if (bid == null) {
+            return;
+        }
+        bid.setQty(bid.getQty() / 2);
+        recalculateRow(bid);
+        calTotal();
+    }
+
+    public void multiplyAllQuantitiesByTwo() {
+        if (billItemDataList == null) {
+            return;
+        }
+        for (BillItemData bid : billItemDataList) {
+            bid.setQty(bid.getQty() * 2);
+            recalculateRow(bid);
+        }
+        calTotal();
+    }
+
+    public void divideAllQuantitiesByHalf() {
+        if (billItemDataList == null) {
+            return;
+        }
+        for (BillItemData bid : billItemDataList) {
+            bid.setQty(bid.getQty() / 2);
+            recalculateRow(bid);
+        }
+        calTotal();
+    }
+
+    // -----------------------------------------------------------------------
+    // Autocomplete
+    // -----------------------------------------------------------------------
+
+    public List<StockDTO> completeAvailableStockOptimizedDto(String qry) {
+        return searchAvailableStock(qry, null);
+    }
+
+    /**
+     * Same autocomplete, restricted to the department type already fixed by the first
+     * item on the cart ({@code getPreBill().getDepartmentType()}), so a single cashier
+     * bill cannot mix pharmacy and non-pharmacy items. Ported from
+     * PharmacySaleForCashierController; only the departmentType predicate is taken —
+     * the StockDTO projection stays this controller's.
+     */
+    public List<StockDTO> completeAvailableStockOptimizedDtoFilteredByDepartmentType(String qry) {
+        return searchAvailableStock(qry, getPreBill().getDepartmentType());
+    }
+
+    /**
+     * @param filterType when non-null, only stock of items with this department type is
+     * returned. Items with no department type at all are treated as Pharmacy, matching
+     * {@code Item.getDepartmentType()}, which defaults a null column to Pharmacy.
+     */
+    private List<StockDTO> searchAvailableStock(String qry, DepartmentType filterType) {
+        if (qry == null || qry.trim().isEmpty()) {
+            lastAutocompleteResults = new ArrayList<>();
+            return lastAutocompleteResults;
+        }
+        qry = qry.replaceAll("[\\n\\r]", "").trim();
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("stockMin", 0.0);
+        parameters.put("query", "%" + qry + "%");
+
+        boolean searchByItemCode = configOptionApplicationController.getBooleanValueByKey(
+                "Enable search medicines by item code", true);
+        boolean searchByBarcode = qry.length() > 6
+                ? configOptionApplicationController.getBooleanValueByKey("Enable search medicines by barcode", true)
+                : configOptionApplicationController.getBooleanValueByKey("Enable search medicines by barcode", false);
+        boolean searchByGeneric = configOptionApplicationController.getBooleanValueByKey(
+                "Enable search medicines by generic name(VMP)", false);
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT NEW com.divudi.core.data.dto.StockDTO("
+                + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "FROM Stock i "
+                + "WHERE i.stock > :stockMin "
+                + "AND i.department = :department ");
+
+        if (filterType != null) {
+            if (filterType == DepartmentType.Pharmacy) {
+                sql.append("AND (i.itemBatch.item.departmentType = :departmentType "
+                        + "OR i.itemBatch.item.departmentType IS NULL) ");
+            } else {
+                sql.append("AND i.itemBatch.item.departmentType = :departmentType ");
+            }
+            parameters.put("departmentType", filterType);
+        }
+
+        sql.append("AND (i.itemBatch.item.name LIKE :query ");
+
+        if (searchByItemCode) {
+            sql.append("OR i.itemBatch.item.code LIKE :query ");
+        }
+        if (searchByBarcode) {
+            sql.append("OR i.itemBatch.item.barcode = :query ");
+        }
+        if (searchByGeneric) {
+            sql.append("OR i.itemBatch.item.vmp.vtm.name LIKE :query ");
+        }
+        sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
+
+        lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+    }
+
+    public void handleSelect(SelectEvent<StockDTO> event) {
+        StockDTO selected = event.getObject();
+        this.stockDto = selected;
+        this.selectedStockId = selected != null ? selected.getId() : null;
+        if (billItem == null) getBillItem();
+        billItem.setNetRate(selected != null && selected.getRetailRate() != null ? selected.getRetailRate() : 0.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Totals
+    // -----------------------------------------------------------------------
+
+    public void calTotal() {
+        double netTot = 0.0;
+        double grossTot = 0.0;
+        double discountTot = 0.0;
+        if (billItemDataList != null) {
+            for (BillItemData bid : billItemDataList) {
+                netTot += Math.abs(bid.getNetValue());
+                grossTot += Math.abs(bid.getGrossValue());
+                discountTot += bid.getDiscountValue();
+            }
+        }
+        getPreBill().setNetTotal(netTot);
+        getPreBill().setTotal(grossTot);
+        getPreBill().setGrantTotal(grossTot);
+        getPreBill().setDiscount(discountTot);
+        balance = cashPaid - netTot;
+    }
+
+    public void listnerForPaymentMethodChange() {
+        recalculateDiscountsForAll();
+        calTotal();
+    }
+
+    // ===================================================================
+    // On-demand substitute (alternative) medicines (issue #21697)
+    // ===================================================================
+    private BillItemData itemDataForSubstitution;
+    private com.divudi.core.data.dto.StockDTO selectedSubstituteStock;
+    private List<com.divudi.core.data.dto.StockDTO> substituteStocks;
+
+    public void prepareSubstitute(BillItemData bid) {
+        itemDataForSubstitution = bid;
+        selectedSubstituteStock = null;
+        substituteStocks = new ArrayList<>();
+        if (bid == null || bid.getItemId() == null) {
+            return;
+        }
+        Item item = itemFacade.find(bid.getItemId());
+        if (item == null) {
+            return;
+        }
+        double requiredQty = Math.abs(bid.getQty());
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(item, sessionController.getDepartment(), requiredQty);
+    }
+
+    public void replaceSelectedSubstitute() {
+        if (itemDataForSubstitution == null || selectedSubstituteStock == null
+                || selectedSubstituteStock.getStockId() == null) {
+            JsfUtil.addErrorMessage("Please select a substitute stock.");
+            return;
+        }
+
+        com.divudi.core.data.dto.StockDTO sub = selectedSubstituteStock;
+        BillItemData bid = itemDataForSubstitution;
+
+        // Same quantity as the line being substituted. All rate/batch fields come
+        // from the single native lookup already on the DTO - no extra queries.
+        double qty = Math.abs(bid.getQty());
+
+        double batchRetailRate = sub.getRetailRate() != null ? sub.getRetailRate() : 0.0;
+        double batchPurchaseRate = sub.getPurchaseRate() != null ? sub.getPurchaseRate() : 0.0;
+        double batchWholesaleRate = sub.getWholesaleRate() != null ? sub.getWholesaleRate() : 0.0;
+        Double batchCostRate = (sub.getCostRate() != null && sub.getCostRate() > 0) ? sub.getCostRate() : null;
+
+        long ampItemId = resolveAmpItemId(sub.getItemId());
+
+        bid.setItemId(sub.getItemId());
+        bid.setItemName(sub.getItemName());
+        bid.setAmpItemId(ampItemId);
+        bid.setStockId(sub.getStockId());
+        bid.setItemBatchId(sub.getItemBatchId());
+        bid.setPbiQty(-Math.abs(qty));
+        bid.setRetailRate(batchRetailRate);
+        bid.setPurchaseRate(batchPurchaseRate);
+        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
+        bid.setBatchRetailRate(batchRetailRate);
+        bid.setBatchPurchaseRate(batchPurchaseRate);
+        bid.setBatchWholesaleRate(batchWholesaleRate);
+        bid.setBatchCostRate(batchCostRate);
+        bid.setDoe(sub.getDateOfExpire());
+        bid.setDescription(sub.getItemName());
+
+        double lineRetailRate = batchRetailRate;
+        double grossValue = lineRetailRate * qty;
+        double discountPct = 0.0;
+        double discountValue = 0.0;
+        try {
+            Item substituteItem = itemFacade.find(sub.getItemId());
+            if (substituteItem != null && Boolean.TRUE.equals(substituteItem.isDiscountAllowed())) {
+                Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
+                        paymentMethod, paymentScheme, sessionController.getDepartment(), substituteItem);
+                discountPct = pct != null ? pct : 0.0;
+                discountValue = (discountPct / 100.0) * grossValue;
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Discount lookup failed for substitute item {0}: {1}",
+                    new Object[]{sub.getItemId(), e.getMessage()});
+        }
+        double netValue = grossValue - discountValue;
+        double netRate = qty > 0 ? netValue / qty : lineRetailRate;
+
+        bid.setRate(lineRetailRate);
+        bid.setNetRate(netRate);
+        bid.setDiscountPercent(discountPct);
+        bid.setDiscountValue(discountValue);
+        bid.setMarginValue(0.0);
+        bid.setNetValue(-netValue);
+        bid.setGrossValue(-grossValue);
+
+        calTotal();
+        JsfUtil.addSuccessMessage("Stock replaced successfully.");
+    }
+
+    public BillItemData getItemDataForSubstitution() {
+        return itemDataForSubstitution;
+    }
+
+    public void setItemDataForSubstitution(BillItemData itemDataForSubstitution) {
+        this.itemDataForSubstitution = itemDataForSubstitution;
+    }
+
+    public com.divudi.core.data.dto.StockDTO getSelectedSubstituteStock() {
+        return selectedSubstituteStock;
+    }
+
+    public void setSelectedSubstituteStock(com.divudi.core.data.dto.StockDTO selectedSubstituteStock) {
+        this.selectedSubstituteStock = selectedSubstituteStock;
+    }
+
+    public List<com.divudi.core.data.dto.StockDTO> getSubstituteStocks() {
+        return substituteStocks;
+    }
+
+    public void setSubstituteStocks(List<com.divudi.core.data.dto.StockDTO> substituteStocks) {
+        this.substituteStocks = substituteStocks;
+    }
+
+    public void recalculateDiscountsForAll() {
+        if (billItemDataList == null || billItemDataList.isEmpty()) {
+            return;
+        }
+        for (BillItemData bid : billItemDataList) {
+            if (bid.getItemId() == null) continue;
+            try {
+                Item itemRef = itemFacade.find(bid.getItemId());
+                if (itemRef == null) continue;
+                double grossValue = Math.abs(bid.getGrossValue());
+                double discountPct = 0.0;
+                double discountValue = 0.0;
+                if (Boolean.TRUE.equals(itemRef.isDiscountAllowed())) {
+                    Double pct = priceMatrixController.getPaymentSchemeDiscountPercent(
+                            paymentMethod, paymentScheme, sessionController.getDepartment(), itemRef);
+                    discountPct = pct != null ? pct : 0.0;
+                    discountValue = (discountPct / 100.0) * grossValue;
+                }
+                double netValue = grossValue - discountValue;
+                double qty = Math.abs(bid.getQty());
+                double netRate = qty > 0 ? netValue / qty : bid.getRate();
+                bid.setDiscountPercent(discountPct);
+                bid.setDiscountValue(discountValue);
+                bid.setNetValue(-netValue);
+                bid.setNetRate(netRate);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Discount recalc failed for itemId={0}: {1}",
+                        new Object[]{bid.getItemId(), e.getMessage()});
+            }
+        }
+    }
+
+    public void calculateDobFromAge() {
+        // Called from age year/month/day keyup events to recalculate DOB
+        if (patient != null && patient.getPerson() != null) {
+            patient.getPerson().calDobFromAge();
+        }
+    }
+
+    public void calculateBillItemListner() {
+        if (stockDto != null && intQty != null) {
+            double rate = stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0;
+            getBillItem().setRate(rate);
+            getBillItem().setNetRate(rate);
+            getBillItem().setNetValue(rate * intQty);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Reset / clear
+    // -----------------------------------------------------------------------
+
+    public void resetAll() {
+        patient = null;
+        preBill = null;
+        printBill = null;
+        printBillItems = null;
+        billItem = null;
+        intQty = null;
+        stockDto = null;
+        selectedStockId = null;
+        lastAutocompleteResults = null;
+        billItemDataList = null;
+        billPreview = false;
+        billSettlingStarted = false;
+        patientDetailsEditable = false;
+        comment = "";
+        cashPaid = 0.0;
+        balance = 0.0;
+        paymentMethod = null;
+        paymentScheme = null;
+        paymentMethodData = null;
+        toStaff = null;
+        toInstitution = null;
+        allergyListOfPatient = null;
+        selectedBillItemDataList = null;
+        currentToken = null;
+        token = null;
+    }
+
+    private void clearBill() {
+        preBill = null;
+        billItemDataList = null;
+    }
+
+    private void clearBillItem() {
+        billItem = null;
+        intQty = null;
+        stockDto = null;
+        selectedStockId = null;
+        lastAutocompleteResults = null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Getters / Setters
+    // -----------------------------------------------------------------------
+
+    public Patient getPatient() {
+        if (patient == null) {
+            patient = new Patient();
+        }
+        return patient;
+    }
+
+    public void setPatient(Patient patient) {
+        this.patient = patient;
+        allergyListOfPatient = null;
+    }
+
+    public Bill getPreBill() {
+        if (preBill == null) {
+            preBill = new Bill();
+        }
+        return preBill;
+    }
+
+    public void setPreBill(Bill preBill) {
+        this.preBill = preBill;
+    }
+
+    public PrintBillData getPrintBill() {
+        return printBill;
+    }
+
+    public List<BillItemData> getPrintBillItems() {
+        return printBillItems;
+    }
+
+    public BillItem getBillItem() {
+        if (billItem == null) {
+            billItem = new BillItem();
+            PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+            pbi.setBillItem(billItem);
+            billItem.setPharmaceuticalBillItem(pbi);
+        }
+        return billItem;
+    }
+
+    public void setBillItem(BillItem billItem) {
+        this.billItem = billItem;
+    }
+
+    public Integer getIntQty() {
+        return intQty;
+    }
+
+    public void setIntQty(Integer intQty) {
+        this.intQty = intQty;
+    }
+
+    public StockDTO getStockDto() {
+        return stockDto;
+    }
+
+    public void setStockDto(StockDTO stockDto) {
+        this.stockDto = stockDto;
+        this.selectedStockId = stockDto != null ? stockDto.getId() : null;
+    }
+
+    public List<BillItemData> getBillItemDataList() {
+        if (billItemDataList == null) {
+            billItemDataList = new ArrayList<>();
+        }
+        return billItemDataList;
+    }
+
+    public void setBillItemDataList(List<BillItemData> billItemDataList) {
+        this.billItemDataList = billItemDataList;
+    }
+
+    public List<BillItemData> getSelectedBillItemDataList() {
+        if (selectedBillItemDataList == null) {
+            selectedBillItemDataList = new ArrayList<>();
+        }
+        return selectedBillItemDataList;
+    }
+
+    public void setSelectedBillItemDataList(List<BillItemData> selectedBillItemDataList) {
+        this.selectedBillItemDataList = selectedBillItemDataList;
+    }
+
+    public Token getCurrentToken() {
+        return currentToken;
+    }
+
+    public void setCurrentToken(Token currentToken) {
+        this.currentToken = currentToken;
+    }
+
+    public Token getToken() {
+        return token;
+    }
+
+    public void setToken(Token token) {
+        this.token = token;
+    }
+
+    public Department getCounter() {
+        return counter;
+    }
+
+    public void setCounter(Department counter) {
+        this.counter = counter;
+    }
+
+    public boolean isBillPreview() {
+        return billPreview;
+    }
+
+    public void setBillPreview(boolean billPreview) {
+        this.billPreview = billPreview;
+    }
+
+    public boolean isBillSettlingStarted() {
+        return billSettlingStarted;
+    }
+
+    public boolean isPatientDetailsEditable() {
+        return patientDetailsEditable;
+    }
+
+    public void setPatientDetailsEditable(boolean patientDetailsEditable) {
+        this.patientDetailsEditable = patientDetailsEditable;
+    }
+
+    public void toggalePatientEditable() {
+        patientDetailsEditable = !patientDetailsEditable;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public double getCashPaid() {
+        return cashPaid;
+    }
+
+    public void setCashPaid(double cashPaid) {
+        this.cashPaid = cashPaid;
+        calTotal();
+    }
+
+    public double getBalance() {
+        return balance;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    @Override
+    public double calculatRemainForMultiplePaymentTotal() {
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            double multiplePaymentMethodTotalValue = 0.0;
+            for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+                if (cd == null) {
+                    continue;
+                }
+                if (cd.getPaymentMethodData() != null && cd.getPaymentMethod() != null) {
+                    // Only add the value from the selected payment method for this ComponentDetail
+                    switch (cd.getPaymentMethod()) {
+                        case Cash:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCash().getTotalValue();
+                            break;
+                        case Card:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCreditCard().getTotalValue();
+                            break;
+                        case Cheque:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCheque().getTotalValue();
+                            break;
+                        case ewallet:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getEwallet().getTotalValue();
+                            break;
+                        case PatientDeposit:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getPatient_deposit().getTotalValue();
+                            break;
+                        case Slip:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getSlip().getTotalValue();
+                            break;
+                        case Staff:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getStaffCredit().getTotalValue();
+                            break;
+                        case Staff_Welfare:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getStaffWelfare().getTotalValue();
+                            break;
+                        case Credit:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCredit().getTotalValue();
+                            break;
+                        case OnlineSettlement:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getOnlineSettlement().getTotalValue();
+                            break;
+                        case IOU:
+                            multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getIou().getTotalValue();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            return getPreBill().getNetTotal() - multiplePaymentMethodTotalValue;
+        }
+        return getPreBill().getTotal();
+    }
+
+    @Override
+    public void recieveRemainAmountAutomatically() {
+        double remainAmount = calculatRemainForMultiplePaymentTotal();
+        // Already fully covered (or over-paid): do not auto-fill a negative
+        // remaining amount into the last component, which would later persist a
+        // negative Payment.paidValue and distort drawer/balance updates.
+        if (remainAmount <= 0.0) {
+            return;
+        }
+        if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+            int arrSize = getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().size();
+            if (arrSize == 0) {
+                return; // No payment methods added yet
+            }
+            ComponentDetail pm = getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().get(arrSize - 1);
+            if (pm.getPaymentMethodData() == null) {
+                return; // Payment method data not initialized
+            }
+            if (pm.getPaymentMethod() == PaymentMethod.Cash) {
+                // Only set value automatically if not already set by user
+                if (pm.getPaymentMethodData().getCash().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCash().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Card) {
+                if (pm.getPaymentMethodData().getCreditCard().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCreditCard().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Cheque) {
+                if (pm.getPaymentMethodData().getCheque().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCheque().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Slip) {
+                if (pm.getPaymentMethodData().getSlip().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getSlip().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.ewallet) {
+                if (pm.getPaymentMethodData().getEwallet().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getEwallet().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.PatientDeposit) {
+                if (patient == null || patient.getId() == null) {
+                    pm.getPaymentMethodData().getPatient_deposit().setTotalValue(0.0);
+                    return; // Patient not selected yet, ignore
+                }
+                // Initialize patient deposit data for UI component
+                pm.getPaymentMethodData().getPatient_deposit().setPatient(patient);
+                PatientDeposit pd = patientDepositController.getDepositOfThePatient(patient, sessionController.getDepartment());
+                if (pd != null && pd.getId() != null) {
+                    pm.getPaymentMethodData().getPatient_deposit().getPatient().setHasAnAccount(true);
+                    pm.getPaymentMethodData().getPatient_deposit().setPatientDepost(pd);
+                    // Set total value to remain amount only if there's sufficient balance, otherwise set to available balance
+                    double availableBalance = pd.getBalance();
+                    if (availableBalance >= remainAmount) {
+                        pm.getPaymentMethodData().getPatient_deposit().setTotalValue(remainAmount);
+                    } else {
+                        pm.getPaymentMethodData().getPatient_deposit().setTotalValue(availableBalance);
+                    }
+                } else {
+                    pm.getPaymentMethodData().getPatient_deposit().getPatient().setHasAnAccount(false);
+                    pm.getPaymentMethodData().getPatient_deposit().setTotalValue(0.0);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Credit) {
+                if (pm.getPaymentMethodData().getCredit().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getCredit().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Staff) {
+                if (pm.getPaymentMethodData().getStaffCredit().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getStaffCredit().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.Staff_Welfare) {
+                if (pm.getPaymentMethodData().getStaffWelfare().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getStaffWelfare().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.OnlineSettlement) {
+                if (pm.getPaymentMethodData().getOnlineSettlement().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getOnlineSettlement().setTotalValue(remainAmount);
+                }
+            } else if (pm.getPaymentMethod() == PaymentMethod.IOU) {
+                if (pm.getPaymentMethodData().getIou().getTotalValue() == 0.0) {
+                    pm.getPaymentMethodData().getIou().setTotalValue(remainAmount);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates a Multiple Payment Methods bill before settling: there must be
+     * at least one component, balance-backed components (Patient Deposit, Staff,
+     * Staff Welfare) must have sufficient balance, and the sum of the entered
+     * component values must match the bill net total (within a 1.0 tolerance).
+     * Adds a user-facing error message and returns {@code true} when settling
+     * must be aborted. Mirrors {@code PharmacySaleController.errorCheck}.
+     */
+    private boolean validateMultiplePaymentsFailed() {
+        if (getPaymentMethodData().getPaymentMethodMultiple() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails().isEmpty()) {
+            JsfUtil.addErrorMessage("No Details on multiple payment methods given");
+            return true;
+        }
+
+        double netTotal = Math.abs(getPreBill().getNetTotal());
+        double multiplePaymentMethodTotalValue = 0.0;
+        for (ComponentDetail cd : getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            switch (cd.getPaymentMethod()) {
+                case Cash:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCash().getTotalValue();
+                    break;
+                case Card:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCreditCard().getTotalValue();
+                    break;
+                case Cheque:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCheque().getTotalValue();
+                    break;
+                case ewallet:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getEwallet().getTotalValue();
+                    break;
+                case Slip:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getSlip().getTotalValue();
+                    break;
+                case OnlineSettlement:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getOnlineSettlement().getTotalValue();
+                    break;
+                case IOU:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getIou().getTotalValue();
+                    break;
+                case Credit:
+                    multiplePaymentMethodTotalValue += cd.getPaymentMethodData().getCredit().getTotalValue();
+                    break;
+                case PatientDeposit: {
+                    double value = cd.getPaymentMethodData().getPatient_deposit().getTotalValue();
+                    PatientDeposit pd = patientDepositController.getDepositOfThePatient(getPatient(), sessionController.getDepartment());
+                    if (pd == null) {
+                        JsfUtil.addErrorMessage("No Patient Deposit.");
+                        return true;
+                    }
+                    if (value > pd.getBalance()) {
+                        JsfUtil.addErrorMessage("No Sufficient Patient Deposit");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                case Staff: {
+                    double value = cd.getPaymentMethodData().getStaffCredit().getTotalValue();
+                    Staff selectedStaff = cd.getPaymentMethodData().getStaffCredit().getToStaff();
+                    if (value == 0.0 || selectedStaff == null) {
+                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
+                        return true;
+                    }
+                    if (selectedStaff.getCurrentCreditValue() + value > selectedStaff.getCreditLimitQualified()) {
+                        JsfUtil.addErrorMessage("No enough Credit.");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                case Staff_Welfare: {
+                    double value = cd.getPaymentMethodData().getStaffWelfare().getTotalValue();
+                    Staff welfareStaff = cd.getPaymentMethodData().getStaffWelfare().getToStaff();
+                    if (value == 0.0 || welfareStaff == null) {
+                        JsfUtil.addErrorMessage("Please fill the Paying Amount and Staff Name");
+                        return true;
+                    }
+                    if (Math.abs(welfareStaff.getAnnualWelfareUtilized()) + value > welfareStaff.getAnnualWelfareQualified()) {
+                        JsfUtil.addErrorMessage("No enough credit.");
+                        return true;
+                    }
+                    multiplePaymentMethodTotalValue += value;
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        if (Math.abs(netTotal - multiplePaymentMethodTotalValue) > 1.0) {
+            JsfUtil.addErrorMessage("Mismatch in differences of multiple payment method total and bill total");
+            return true;
+        }
+        return false;
+    }
+
+    public PaymentMethodData getPaymentMethodData() {
+        if (paymentMethodData == null) {
+            paymentMethodData = new PaymentMethodData();
+        }
+        return paymentMethodData;
+    }
+
+    public void setPaymentMethodData(PaymentMethodData paymentMethodData) {
+        this.paymentMethodData = paymentMethodData;
+    }
+
+    public Staff getToStaff() {
+        return toStaff;
+    }
+
+    public void setToStaff(Staff toStaff) {
+        this.toStaff = toStaff;
+        if (toStaff != null) {
+            getPaymentMethodData().getStaffCredit().setToStaff(toStaff);
+            getPaymentMethodData().getStaffWelfare().setToStaff(toStaff);
+        }
+    }
+
+    public Double getPreviewRate() {
+        if (stockDto == null) return null;
+        return stockDto.getRetailRate();
+    }
+
+    public Double getPreviewNetValue() {
+        if (stockDto == null || intQty == null) return null;
+        double rate = stockDto.getRetailRate() != null ? stockDto.getRetailRate() : 0.0;
+        return rate * intQty;
+    }
+
+    public StockDtoConverter getStockDtoConverter() {
+        return new StockDtoConverter();
+    }
+
+    public class StockDtoConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext context, UIComponent component, String value) {
+            if (value == null || value.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                Long id = Long.valueOf(value);
+                if (stockDto != null && id.equals(stockDto.getId())) {
+                    return stockDto;
+                }
+                if (lastAutocompleteResults != null) {
+                    for (StockDTO dto : lastAutocompleteResults) {
+                        if (dto != null && id.equals(dto.getId())) {
+                            return dto;
+                        }
+                    }
+                }
+                StockDTO dto = new StockDTO();
+                dto.setId(id);
+                return dto;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public String getAsString(FacesContext context, UIComponent component, Object value) {
+            if (value == null) return "";
+            if (value instanceof StockDTO) {
+                StockDTO dto = (StockDTO) value;
+                return dto.getId() != null ? dto.getId().toString() : "";
+            }
+            return value.toString();
+        }
+    }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -220,322 +220,301 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return null;
         }
         billSettlingStarted = true;
+        try {
 
-        // Session guard, ported from PharmacySaleForCashierController :3582-3586 (also :2958-2962).
-        // Without it buildPreBill() would dereference getLoggedUser().getDepartment() and NPE to a
-        // JSF error page with the latch left true, permanently disabling settle for the session.
-        if (sessionController.getLoggedUser() == null) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Session expired. Please log in again.");
-            return null;
-        }
-
-        if (paymentMethod == null) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Please select Payment Method");
-            return null;
-        }
-
-        if (billItemDataList == null || billItemDataList.isEmpty()) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Please add items to the bill.");
-            return null;
-        }
-
-        // Zero-quantity gate, ported from PharmacySaleForCashierController :3591-3604 (message
-        // spelling is legacy's). recalculateRow() can leave a row at qty 0 while the money fields
-        // still hold the previous quantity's values, so without this gate buildPreBill() would
-        // charge for a line the service dispenses no stock for.
-        for (BillItemData bid : billItemDataList) {
-            if (bid.getQty() <= 0.0) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Some BillItem Quntity is Zero or less than Zero");
+            // Session guard, ported from PharmacySaleForCashierController :3582-3586 (also :2958-2962).
+            // Without it buildPreBill() would dereference getLoggedUser().getDepartment() and NPE to a
+            // JSF error page with the latch left true, permanently disabling settle for the session.
+            if (sessionController.getLoggedUser() == null) {
+                JsfUtil.addErrorMessage("Session expired. Please log in again.");
                 return null;
             }
-        }
 
-        BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(
-                paymentMethod, paymentScheme, getPaymentMethodData());
-        if (!discountValidation.isFlag()) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage(discountValidation.getMessage());
-            return null;
-        }
+            if (paymentMethod == null) {
+                JsfUtil.addErrorMessage("Please select Payment Method");
+                return null;
+            }
 
-        // Validate department type consistency before settlement.
-        // Mirrors PharmacySaleForCashierController.settlePreBillAndNavigateToPrint() :3622-3632;
-        // the entity getter Item.getDepartmentType() defaults a null column to Pharmacy, so the
-        // item is resolved through itemFacade rather than a JPQL projection to keep that default.
-        if (getPreBill().getDepartmentType() != null) {
+            if (billItemDataList == null || billItemDataList.isEmpty()) {
+                JsfUtil.addErrorMessage("Please add items to the bill.");
+                return null;
+            }
+
+            // Zero-quantity gate, ported from PharmacySaleForCashierController :3591-3604 (message
+            // spelling is legacy's). recalculateRow() can leave a row at qty 0 while the money fields
+            // still hold the previous quantity's values, so without this gate buildPreBill() would
+            // charge for a line the service dispenses no stock for.
             for (BillItemData bid : billItemDataList) {
-                if (bid.getItemId() == null) {
-                    continue;
-                }
-                Item lineItem = itemFacade.find(bid.getItemId());
-                if (lineItem != null && lineItem.getDepartmentType() != null
-                        && !lineItem.getDepartmentType().equals(getPreBill().getDepartmentType())) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Inconsistent department types detected. All items must belong to the same department type.");
+                if (bid.getQty() <= 0.0) {
+                    JsfUtil.addErrorMessage("Some BillItem Quntity is Zero or less than Zero");
                     return null;
                 }
             }
-        }
 
-        // Pharmacy Sale Validation - Patient and Patient Details.
-        // Keys and messages are those of the legacy cashier path
-        // (PharmacySaleForCashierController :3635-3746), not the pay-now Sale page.
-        boolean patientRequired = configOptionApplicationController.getBooleanValueByKey(
-                "Patient is required in Pharmacy Retail Sale", false);
-
-        if (patientRequired) {
-            if (getPatient() == null || getPatient().getPerson() == null) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Patient is required.");
+            BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(
+                    paymentMethod, paymentScheme, getPaymentMethodData());
+            if (!discountValidation.isFlag()) {
+                JsfUtil.addErrorMessage(discountValidation.getMessage());
                 return null;
             }
-        }
 
-        // Only validate patient details if patient is required OR if patient exists
-        boolean hasPatient = getPatient() != null && getPatient().getPerson() != null;
-
-        if (hasPatient || patientRequired) {
-            // Patient Name validation
-            if (configOptionApplicationController.getBooleanValueByKey(
-                    "Patient Name is required in Pharmacy Retail Sale", false)) {
-                if (getPatient() == null || getPatient().getPerson() == null
-                        || getPatient().getPerson().getName() == null
-                        || getPatient().getPerson().getName().trim().isEmpty()) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient name is required.");
-                    return null;
-                }
-            }
-
-            // Patient Phone validation
-            if (configOptionApplicationController.getBooleanValueByKey(
-                    "Patient Phone is required in Pharmacy Retail Sale", false)) {
-                if (getPatient() == null || getPatient().getPerson() == null) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient is required.");
-                    return null;
-                }
-                // Check both phone and mobile - at least one should be present
-                boolean hasPhone = getPatient().getPerson().getPhone() != null
-                        && !getPatient().getPerson().getPhone().trim().isEmpty();
-                boolean hasMobile = getPatient().getPerson().getMobile() != null
-                        && !getPatient().getPerson().getMobile().trim().isEmpty();
-
-                if (!hasPhone && !hasMobile) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient phone number is required.");
-                    return null;
-                }
-            }
-
-            // Patient Gender validation
-            if (configOptionApplicationController.getBooleanValueByKey(
-                    "Patient Gender is required in Pharmacy Retail Sale", false)) {
-                if (getPatient() == null || getPatient().getPerson() == null
-                        || getPatient().getPerson().getSex() == null) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient gender is required.");
-                    return null;
-                }
-            }
-
-            // Patient Address validation
-            if (configOptionApplicationController.getBooleanValueByKey(
-                    "Patient Address is required in Pharmacy Retail Sale", false)) {
-                if (getPatient() == null || getPatient().getPerson() == null
-                        || getPatient().getPerson().getAddress() == null
-                        || getPatient().getPerson().getAddress().trim().isEmpty()) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient address is required.");
-                    return null;
-                }
-            }
-
-            // Patient Area validation
-            if (configOptionApplicationController.getBooleanValueByKey(
-                    "Patient Area is required in Pharmacy Retail Sale", false)) {
-                if (getPatient() == null || getPatient().getPerson() == null
-                        || getPatient().getPerson().getArea() == null) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Patient area is required.");
-                    return null;
-                }
-            }
-        }
-
-        if (getPatient().isBlacklisted()) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
-            return null;
-        }
-
-        // Referring Doctor validation
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Referring Doctor is required in Pharmacy Retail Sale", false)) {
-            if (getPreBill() == null || getPreBill().getReferredBy() == null) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Referring doctor is required.");
-                return null;
-            }
-        }
-
-        // Defaults to TRUE - every deployment enforces this unless it is explicitly turned off.
-        if (configOptionApplicationController.getBooleanValueByKey(
-                "Patient Phone number is mandotary in sale for cashier", true)) {
-            // NOTE: legacy leaves the latch untouched on these three branches, but legacy's
-            // settlePreBillAndNavigateToPrint() never sets billSettlingStarted at all (only its
-            // separate settleBillWithPay() at :4505 does), so there it is harmless. Here the latch
-            // IS set above, so not clearing it would deadlock the page for the whole session:
-            // the retry after entering the phone number would hit the re-entry guard silently.
-            if (getPatient() != null && getPatient().getPerson() != null) {
-                if (getPatient().getPatientPhoneNumber() == null && getPatient().getPatientMobileNumber() == null) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Please enter phone number of the patient");
-                    return null;
-                } else if (getPatient().getId() == null) {
-                    if (getPatient().getPatientPhoneNumber() != null
-                            && !(String.valueOf(getPatient().getPatientPhoneNumber()).length() >= 9)) {
-                        billSettlingStarted = false;
-                        JsfUtil.addErrorMessage("Please enter valid phone number with more than or equal 10 digits of the patient");
-                        return null;
-                    } else if (getPatient().getPatientMobileNumber() != null
-                            && !(String.valueOf(getPatient().getPatientMobileNumber()).length() >= 9)) {
-                        billSettlingStarted = false;
-                        JsfUtil.addErrorMessage("Please enter valid mobile number with more than or equal 10 digits of the patient");
+            // Validate department type consistency before settlement.
+            // Mirrors PharmacySaleForCashierController.settlePreBillAndNavigateToPrint() :3622-3632;
+            // the entity getter Item.getDepartmentType() defaults a null column to Pharmacy, so the
+            // item is resolved through itemFacade rather than a JPQL projection to keep that default.
+            if (getPreBill().getDepartmentType() != null) {
+                for (BillItemData bid : billItemDataList) {
+                    if (bid.getItemId() == null) {
+                        continue;
+                    }
+                    Item lineItem = itemFacade.find(bid.getItemId());
+                    if (lineItem != null && lineItem.getDepartmentType() != null
+                            && !lineItem.getDepartmentType().equals(getPreBill().getDepartmentType())) {
+                        JsfUtil.addErrorMessage("Inconsistent department types detected. All items must belong to the same department type.");
                         return null;
                     }
                 }
-            } else if (patientRequired) {
-                JsfUtil.addErrorMessage("Patient is required.");
-                billSettlingStarted = false;
-                return null;
             }
-        }
 
-        // Duplicate bill item detection - prevent double stock deduction (Closes #18874).
-        // Ported from PharmacySaleForCashierController :3749-3772; the native cart holds
-        // BillItemData rows instead of BillItem entities, so the stock id is read straight
-        // off the row rather than through PharmaceuticalBillItem.
-        // Check 1: same row object appearing twice (rapid Add button click)
-        Set<Integer> seenIdentities = new HashSet<>();
-        for (BillItemData bid : billItemDataList) {
-            if (!seenIdentities.add(System.identityHashCode(bid))) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Duplicate item detected. Please remove duplicate items and try again.");
-                return null;
-            }
-        }
-        // Check 2: different rows pointing at the same Stock batch
-        Set<Long> seenStockIds = new HashSet<>();
-        for (BillItemData bid : billItemDataList) {
-            if (bid.getStockId() != null && !seenStockIds.add(bid.getStockId())) {
-                billSettlingStarted = false;
-                JsfUtil.addErrorMessage("Duplicate item batch detected: "
-                        + bid.getItemName() + ". Please remove duplicate items and try again.");
-                return null;
-            }
-        }
+            // Pharmacy Sale Validation - Patient and Patient Details.
+            // Keys and messages are those of the legacy cashier path
+            // (PharmacySaleForCashierController :3635-3746), not the pay-now Sale page.
+            boolean patientRequired = configOptionApplicationController.getBooleanValueByKey(
+                    "Patient is required in Pharmacy Retail Sale", false);
 
-        // Ensure discounts reflect current payment scheme before building the bill
-        recalculateDiscountsForAll();
-        calTotal();
-
-        // Back-fill the credit counterparties from the entered payment components before the
-        // bill is built, so a Credit / Staff bill is not persisted without one.
-        syncStaffSelectionFromPaymentDetails(paymentMethod);
-        syncCreditInstitutionFromPaymentDetails(paymentMethod);
-
-        // Patient-required gate + conditional patient save, ported from
-        // PharmacySaleForCashierController :3790-3815. The earlier
-        // "Patient is required in Pharmacy Retail Sale" null test can never fire because
-        // getPatient() and Patient.getPerson() both self-instantiate (Patient.java:441-444);
-        // legacy's real enforcement is this name-emptiness test. Equally important, an
-        // anonymous sale must NOT persist an empty Person + Patient row - legacy attaches
-        // null to the bill in that case.
-        Patient pt = null;
-        if (getPatient() != null && getPatient().getPerson() != null) {
-            String name = getPatient().getPerson().getName();
-            boolean hasValidName = name != null && !name.trim().isEmpty();
             if (patientRequired) {
-                if (!hasValidName) {
-                    billSettlingStarted = false;
-                    JsfUtil.addErrorMessage("Please Select a Patient");
+                if (getPatient() == null || getPatient().getPerson() == null) {
+                    JsfUtil.addErrorMessage("Patient is required.");
                     return null;
+                }
+            }
+
+            // Only validate patient details if patient is required OR if patient exists
+            boolean hasPatient = getPatient() != null && getPatient().getPerson() != null;
+
+            if (hasPatient || patientRequired) {
+                // Patient Name validation
+                if (configOptionApplicationController.getBooleanValueByKey(
+                        "Patient Name is required in Pharmacy Retail Sale", false)) {
+                    if (getPatient() == null || getPatient().getPerson() == null
+                            || getPatient().getPerson().getName() == null
+                            || getPatient().getPerson().getName().trim().isEmpty()) {
+                        JsfUtil.addErrorMessage("Patient name is required.");
+                        return null;
+                    }
+                }
+
+                // Patient Phone validation
+                if (configOptionApplicationController.getBooleanValueByKey(
+                        "Patient Phone is required in Pharmacy Retail Sale", false)) {
+                    if (getPatient() == null || getPatient().getPerson() == null) {
+                        JsfUtil.addErrorMessage("Patient is required.");
+                        return null;
+                    }
+                    // Check both phone and mobile - at least one should be present
+                    boolean hasPhone = getPatient().getPerson().getPhone() != null
+                            && !getPatient().getPerson().getPhone().trim().isEmpty();
+                    boolean hasMobile = getPatient().getPerson().getMobile() != null
+                            && !getPatient().getPerson().getMobile().trim().isEmpty();
+
+                    if (!hasPhone && !hasMobile) {
+                        JsfUtil.addErrorMessage("Patient phone number is required.");
+                        return null;
+                    }
+                }
+
+                // Patient Gender validation
+                if (configOptionApplicationController.getBooleanValueByKey(
+                        "Patient Gender is required in Pharmacy Retail Sale", false)) {
+                    if (getPatient() == null || getPatient().getPerson() == null
+                            || getPatient().getPerson().getSex() == null) {
+                        JsfUtil.addErrorMessage("Patient gender is required.");
+                        return null;
+                    }
+                }
+
+                // Patient Address validation
+                if (configOptionApplicationController.getBooleanValueByKey(
+                        "Patient Address is required in Pharmacy Retail Sale", false)) {
+                    if (getPatient() == null || getPatient().getPerson() == null
+                            || getPatient().getPerson().getAddress() == null
+                            || getPatient().getPerson().getAddress().trim().isEmpty()) {
+                        JsfUtil.addErrorMessage("Patient address is required.");
+                        return null;
+                    }
+                }
+
+                // Patient Area validation
+                if (configOptionApplicationController.getBooleanValueByKey(
+                        "Patient Area is required in Pharmacy Retail Sale", false)) {
+                    if (getPatient() == null || getPatient().getPerson() == null
+                            || getPatient().getPerson().getArea() == null) {
+                        JsfUtil.addErrorMessage("Patient area is required.");
+                        return null;
+                    }
+                }
+            }
+
+            if (getPatient().isBlacklisted()) {
+                JsfUtil.addErrorMessage("This patient is blacklisted from the system. Can't Bill.");
+                return null;
+            }
+
+            // Referring Doctor validation
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Referring Doctor is required in Pharmacy Retail Sale", false)) {
+                if (getPreBill() == null || getPreBill().getReferredBy() == null) {
+                    JsfUtil.addErrorMessage("Referring doctor is required.");
+                    return null;
+                }
+            }
+
+            // Defaults to TRUE - every deployment enforces this unless it is explicitly turned off.
+            if (configOptionApplicationController.getBooleanValueByKey(
+                    "Patient Phone number is mandotary in sale for cashier", true)) {
+                // NOTE: legacy leaves the latch untouched on these three branches, but legacy's
+                // settlePreBillAndNavigateToPrint() never sets billSettlingStarted at all (only its
+                // separate settleBillWithPay() at :4505 does), so there it is harmless. Here the
+                // enclosing try/finally always clears the latch on the way out, so returning from
+                // any of these branches cannot leave settling disabled for the rest of the session.
+                if (getPatient() != null && getPatient().getPerson() != null) {
+                    if (getPatient().getPatientPhoneNumber() == null && getPatient().getPatientMobileNumber() == null) {
+                        JsfUtil.addErrorMessage("Please enter phone number of the patient");
+                        return null;
+                    } else if (getPatient().getId() == null) {
+                        if (getPatient().getPatientPhoneNumber() != null
+                                && !(String.valueOf(getPatient().getPatientPhoneNumber()).length() >= 9)) {
+                            JsfUtil.addErrorMessage("Please enter valid phone number with more than or equal 10 digits of the patient");
+                            return null;
+                        } else if (getPatient().getPatientMobileNumber() != null
+                                && !(String.valueOf(getPatient().getPatientMobileNumber()).length() >= 9)) {
+                            JsfUtil.addErrorMessage("Please enter valid mobile number with more than or equal 10 digits of the patient");
+                            return null;
+                        }
+                    }
+                } else if (patientRequired) {
+                    JsfUtil.addErrorMessage("Patient is required.");
+                    return null;
+                }
+            }
+
+            // Duplicate bill item detection - prevent double stock deduction (Closes #18874).
+            // Ported from PharmacySaleForCashierController :3749-3772; the native cart holds
+            // BillItemData rows instead of BillItem entities, so the stock id is read straight
+            // off the row rather than through PharmaceuticalBillItem.
+            // Check 1: same row object appearing twice (rapid Add button click)
+            Set<Integer> seenIdentities = new HashSet<>();
+            for (BillItemData bid : billItemDataList) {
+                if (!seenIdentities.add(System.identityHashCode(bid))) {
+                    JsfUtil.addErrorMessage("Duplicate item detected. Please remove duplicate items and try again.");
+                    return null;
+                }
+            }
+            // Check 2: different rows pointing at the same Stock batch
+            Set<Long> seenStockIds = new HashSet<>();
+            for (BillItemData bid : billItemDataList) {
+                if (bid.getStockId() != null && !seenStockIds.add(bid.getStockId())) {
+                    JsfUtil.addErrorMessage("Duplicate item batch detected: "
+                            + bid.getItemName() + ". Please remove duplicate items and try again.");
+                    return null;
+                }
+            }
+
+            // Ensure discounts reflect current payment scheme before building the bill
+            recalculateDiscountsForAll();
+            calTotal();
+
+            // Back-fill the credit counterparties from the entered payment components before the
+            // bill is built, so a Credit / Staff bill is not persisted without one.
+            syncStaffSelectionFromPaymentDetails(paymentMethod);
+            syncCreditInstitutionFromPaymentDetails(paymentMethod);
+
+            // Patient-required gate + conditional patient save, ported from
+            // PharmacySaleForCashierController :3790-3815. The earlier
+            // "Patient is required in Pharmacy Retail Sale" null test can never fire because
+            // getPatient() and Patient.getPerson() both self-instantiate (Patient.java:441-444);
+            // legacy's real enforcement is this name-emptiness test. Equally important, an
+            // anonymous sale must NOT persist an empty Person + Patient row - legacy attaches
+            // null to the bill in that case.
+            Patient pt = null;
+            if (getPatient() != null && getPatient().getPerson() != null) {
+                String name = getPatient().getPerson().getName();
+                boolean hasValidName = name != null && !name.trim().isEmpty();
+                if (patientRequired) {
+                    if (!hasValidName) {
+                        JsfUtil.addErrorMessage("Please Select a Patient");
+                        return null;
+                    } else {
+                        pt = savePatient();
+                    }
                 } else {
-                    pt = savePatient();
+                    if (hasValidName) {
+                        pt = savePatient();
+                    }
                 }
-            } else {
-                if (hasValidName) {
-                    pt = savePatient();
-                }
+            } else if (patientRequired) {
+                JsfUtil.addErrorMessage("Please Select a Patient");
+                return null;
             }
-        } else if (patientRequired) {
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Please Select a Patient");
-            return null;
-        }
 
-        PreBill preBillEntity = buildPreBill(pt);
+            PreBill preBillEntity = buildPreBill(pt);
 
-        // Stamps the single-method payment reference fields on the bill itself: cheque /
-        // slip / card / online-settlement / ewallet numbers, dates and banks, plus the
-        // creditBill flag. BillBeanController.setPaymentMethodData (:2916-2951) has no
-        // MultiplePaymentMethods branch, so a multiple-payment breakdown is deliberately
-        // NOT written here - the cashier collects and records the money later. Mirrors
-        // legacy savePreBillFinallyForRetailSaleForCashier (:2997).
-        preBillEntity.setCashPaid(cashPaid);
-        billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
+            // Stamps the single-method payment reference fields on the bill itself: cheque /
+            // slip / card / online-settlement / ewallet numbers, dates and banks, plus the
+            // creditBill flag. BillBeanController.setPaymentMethodData (:2916-2951) has no
+            // MultiplePaymentMethods branch, so a multiple-payment breakdown is deliberately
+            // NOT written here - the cashier collects and records the money later. Mirrors
+            // legacy savePreBillFinallyForRetailSaleForCashier (:2997).
+            preBillEntity.setCashPaid(cashPaid);
+            billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
 
-        // Stamp dept/institution IDs on each item (needed by the native service for
-        // StockHistory aggregates).
-        long deptId = sessionController.getLoggedUser().getDepartment().getId();
-        long instId = sessionController.getLoggedUser().getDepartment().getInstitution().getId();
-        for (BillItemData bid : billItemDataList) {
-            bid.setDepartmentId(deptId);
-            bid.setInstitutionId(instId);
-        }
+            // Stamp dept/institution IDs on each item (needed by the native service for
+            // StockHistory aggregates).
+            long deptId = sessionController.getLoggedUser().getDepartment().getId();
+            long instId = sessionController.getLoggedUser().getDepartment().getInstitution().getId();
+            for (BillItemData bid : billItemDataList) {
+                bid.setDepartmentId(deptId);
+                bid.setInstitutionId(instId);
+            }
 
-        try {
-            nativeSqlService.settle(preBillEntity, billItemDataList);
-
-            // settle() is a @Stateless REQUIRED boundary, so the bill and the stock
-            // deduction are already committed here. A token failure must not make a
-            // completed sale report as failed and skip the printout.
             try {
-                settleTokenIfEnabled(preBillEntity);
-                // Legacy runs this OUTSIDE the "Enable token system in sale for cashier"
-                // check (:3869-3872), so a token created by any other route is still
-                // attached to the settled bill.
-                if (getCurrentToken() != null) {
-                    getCurrentToken().setBill(preBillEntity);
-                    tokenFacade.edit(getCurrentToken());
-                }
-            } catch (RuntimeException tokenEx) {
-                LOGGER.log(Level.WARNING, "Token handling failed after cashier settle", tokenEx);
-            }
+                nativeSqlService.settle(preBillEntity, billItemDataList);
 
-            buildPrintBill(preBillEntity);
-            // Legacy calls resetAll() here (:3874) so nothing from the settled bill leaks
-            // into the next one. resetAll() also clears the just-built printout, which the
-            // legacy controller keeps in a separate printBill field, so it is restored.
-            PrintBillData settledPrintBill = printBill;
-            List<BillItemData> settledPrintBillItems = printBillItems;
-            resetAll();
-            printBill = settledPrintBill;
-            printBillItems = settledPrintBillItems;
-            billPreview = true;
+                // settle() is a @Stateless REQUIRED boundary, so the bill and the stock
+                // deduction are already committed here. A token failure must not make a
+                // completed sale report as failed and skip the printout.
+                try {
+                    settleTokenIfEnabled(preBillEntity);
+                    // Legacy runs this OUTSIDE the "Enable token system in sale for cashier"
+                    // check (:3869-3872), so a token created by any other route is still
+                    // attached to the settled bill.
+                    if (getCurrentToken() != null) {
+                        getCurrentToken().setBill(preBillEntity);
+                        tokenFacade.edit(getCurrentToken());
+                    }
+                } catch (RuntimeException tokenEx) {
+                    LOGGER.log(Level.WARNING, "Token handling failed after cashier settle", tokenEx);
+                }
+
+                buildPrintBill(preBillEntity);
+                // Legacy calls resetAll() here (:3874) so nothing from the settled bill leaks
+                // into the next one. resetAll() also clears the just-built printout, which the
+                // legacy controller keeps in a separate printBill field, so it is restored.
+                PrintBillData settledPrintBill = printBill;
+                List<BillItemData> settledPrintBillItems = printBillItems;
+                resetAll();
+                printBill = settledPrintBill;
+                printBillItems = settledPrintBillItems;
+                billPreview = true;
+                JsfUtil.addSuccessMessage("Bill settled successfully.");
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
+                JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
+            }
+            return null;
+        } finally {
             billSettlingStarted = false;
-            JsfUtil.addSuccessMessage("Bill settled successfully.");
-        } catch (RuntimeException e) {
-            LOGGER.log(Level.SEVERE, "Native sale-for-cashier settle failed", e);
-            billSettlingStarted = false;
-            JsfUtil.addErrorMessage("Failed to settle bill: " + e.getMessage());
         }
-        return null;
     }
 
     /**
@@ -558,11 +537,19 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             patient.setMobileNumberStringTransient(patient.getMobileNumberStringTransient());
             patient.setPhoneNumberStringTransient(patient.getPhoneNumberStringTransient());
             if (patient.getId() == null) {
+                patient.setCreater(sessionController.getLoggedUser());
+                patient.setCreatedAt(new Date());
+                patient.getPerson().setCreater(sessionController.getLoggedUser());
+                patient.getPerson().setCreatedAt(new Date());
                 if (patient.getPerson().getId() == null) {
                     personFacade.create(patient.getPerson());
                 }
                 patientFacade.create(patient);
             } else {
+                // Deliberate divergence from legacy savePatient() (:1440-1462), which only ever
+                // creates. This page's "Patient Phone number is mandotary in sale for cashier"
+                // gate defaults to on, so operators are expected to enter or correct an existing
+                // patient's phone number at the counter, and that correction must persist.
                 personFacade.edit(patient.getPerson());
                 patientFacade.edit(patient);
             }
@@ -934,7 +921,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
      * Ported from PharmacySaleForCashierController.settlePharmacyToken(TokenType), with
      * the settled bill passed in instead of read from a getPreBill() field this controller
      * uses differently (here getPreBill() is the in-progress cart header, not the saved
-     * bill). The patient is already persisted by savePatientIfNeeded() at this point, so
+     * bill). The patient is already persisted by savePatient() at this point, so
      * the legacy savePatient() call is not repeated.
      */
     public void settlePharmacyToken(TokenType tokenType, Bill settledBill) {
@@ -1079,7 +1066,9 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return;
         }
 
-        // Note: Item.getDepartmentType() already defaults a null column to DepartmentType.Pharmacy
+        // Note: Item.getDepartmentType() defaults a null column to DepartmentType.Pharmacy only
+        // when the instance is a PharmaceuticalItem; for any other Item subtype a null column
+        // is returned as null (see Item.java getDepartmentType()).
         DepartmentType itemDepartmentType = selectedItem.getDepartmentType();
         if (itemDepartmentType == null) {
             itemDepartmentType = DepartmentType.Pharmacy; // Defensive fallback (should never execute)
@@ -1521,8 +1510,9 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
 
     /**
      * @param filterType when non-null, only stock of items with this department type is
-     * returned. Items with no department type at all are treated as Pharmacy, matching
-     * {@code Item.getDepartmentType()}, which defaults a null column to Pharmacy.
+     * returned. {@code Item.getDepartmentType()} only defaults a null column to Pharmacy when
+     * the instance is a {@code PharmaceuticalItem}; for any other Item subtype with a null
+     * column it returns null, which will not match a non-null {@code filterType} here.
      */
     private List<StockDTO> searchAvailableStock(String qry, DepartmentType filterType) {
         if (qry == null || qry.trim().isEmpty()) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -730,9 +730,11 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         pbd.setBillNo(bill.getDeptId());
         pbd.setBillIdStr(bill.getIdStr());
         pbd.setCancelled(bill.isCancelled());
+        pbd.setInvoiceNumber(bill.getInvoiceNumber());
         pbd.setCreatedAt(bill.getCreatedAt());
         if (bill.getCreater() != null) {
             pbd.setCreatorName(bill.getCreater().getName());
+            pbd.setCreatorCode(bill.getCreater().getCode());
         }
         // Token number for the token printouts. settleBillWithPay runs settle() ->
         // settleTokenIfEnabled() -> buildPrintBill(), so the token (if the token system is
@@ -752,6 +754,14 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             pbd.setPatientName(billPatient.getPerson().getNameWithTitle());
             pbd.setPatientPhone(billPatient.getPerson().getPhone());
             pbd.setPatientPhn(billPatient.getPhn());
+            // Rendered as "age / sex" on the cashier bill formats, matching the legacy
+            // composites' "#{...ageAsShortString} / #{...sex.label}" pair.
+            String age = billPatient.getPerson().getAgeAsShortString();
+            String sex = billPatient.getPerson().getSex() != null
+                    ? billPatient.getPerson().getSex().getLabel() : null;
+            if (age != null || sex != null) {
+                pbd.setPatientAgeSex((age != null ? age : "") + " / " + (sex != null ? sex : ""));
+            }
         }
 
         // Payment
@@ -1223,6 +1233,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         BillItemData bid = new BillItemData();
         bid.setItemId(stk.getItemId());
         bid.setItemName(stk.getItemName());
+        bid.setItemCode(stk.getCode());
         bid.setAmpItemId(ampItemId);
         bid.setStockId(stk.getId());
         bid.setItemBatchId(stk.getItemBatchId());

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -221,6 +221,15 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         }
         billSettlingStarted = true;
 
+        // Session guard, ported from PharmacySaleForCashierController :3582-3586 (also :2958-2962).
+        // Without it buildPreBill() would dereference getLoggedUser().getDepartment() and NPE to a
+        // JSF error page with the latch left true, permanently disabling settle for the session.
+        if (sessionController.getLoggedUser() == null) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Session expired. Please log in again.");
+            return null;
+        }
+
         if (paymentMethod == null) {
             billSettlingStarted = false;
             JsfUtil.addErrorMessage("Please select Payment Method");
@@ -231,6 +240,18 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             billSettlingStarted = false;
             JsfUtil.addErrorMessage("Please add items to the bill.");
             return null;
+        }
+
+        // Zero-quantity gate, ported from PharmacySaleForCashierController :3591-3604 (message
+        // spelling is legacy's). recalculateRow() can leave a row at qty 0 while the money fields
+        // still hold the previous quantity's values, so without this gate buildPreBill() would
+        // charge for a line the service dispenses no stock for.
+        for (BillItemData bid : billItemDataList) {
+            if (bid.getQty() <= 0.0) {
+                billSettlingStarted = false;
+                JsfUtil.addErrorMessage("Some BillItem Quntity is Zero or less than Zero");
+                return null;
+            }
         }
 
         BooleanMessage discountValidation = discountSchemeValidationService.validateDiscountScheme(
@@ -365,17 +386,25 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         // Defaults to TRUE - every deployment enforces this unless it is explicitly turned off.
         if (configOptionApplicationController.getBooleanValueByKey(
                 "Patient Phone number is mandotary in sale for cashier", true)) {
+            // NOTE: legacy leaves the latch untouched on these three branches, but legacy's
+            // settlePreBillAndNavigateToPrint() never sets billSettlingStarted at all (only its
+            // separate settleBillWithPay() at :4505 does), so there it is harmless. Here the latch
+            // IS set above, so not clearing it would deadlock the page for the whole session:
+            // the retry after entering the phone number would hit the re-entry guard silently.
             if (getPatient() != null && getPatient().getPerson() != null) {
                 if (getPatient().getPatientPhoneNumber() == null && getPatient().getPatientMobileNumber() == null) {
+                    billSettlingStarted = false;
                     JsfUtil.addErrorMessage("Please enter phone number of the patient");
                     return null;
                 } else if (getPatient().getId() == null) {
                     if (getPatient().getPatientPhoneNumber() != null
                             && !(String.valueOf(getPatient().getPatientPhoneNumber()).length() >= 9)) {
+                        billSettlingStarted = false;
                         JsfUtil.addErrorMessage("Please enter valid phone number with more than or equal 10 digits of the patient");
                         return null;
                     } else if (getPatient().getPatientMobileNumber() != null
                             && !(String.valueOf(getPatient().getPatientMobileNumber()).length() >= 9)) {
+                        billSettlingStarted = false;
                         JsfUtil.addErrorMessage("Please enter valid mobile number with more than or equal 10 digits of the patient");
                         return null;
                     }
@@ -415,10 +444,42 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         recalculateDiscountsForAll();
         calTotal();
 
-        // Save or update the patient record
-        savePatientIfNeeded();
+        // Back-fill the credit counterparties from the entered payment components before the
+        // bill is built, so a Credit / Staff bill is not persisted without one.
+        syncStaffSelectionFromPaymentDetails(paymentMethod);
+        syncCreditInstitutionFromPaymentDetails(paymentMethod);
 
-        PreBill preBillEntity = buildPreBill();
+        // Patient-required gate + conditional patient save, ported from
+        // PharmacySaleForCashierController :3790-3815. The earlier
+        // "Patient is required in Pharmacy Retail Sale" null test can never fire because
+        // getPatient() and Patient.getPerson() both self-instantiate (Patient.java:441-444);
+        // legacy's real enforcement is this name-emptiness test. Equally important, an
+        // anonymous sale must NOT persist an empty Person + Patient row - legacy attaches
+        // null to the bill in that case.
+        Patient pt = null;
+        if (getPatient() != null && getPatient().getPerson() != null) {
+            String name = getPatient().getPerson().getName();
+            boolean hasValidName = name != null && !name.trim().isEmpty();
+            if (patientRequired) {
+                if (!hasValidName) {
+                    billSettlingStarted = false;
+                    JsfUtil.addErrorMessage("Please Select a Patient");
+                    return null;
+                } else {
+                    pt = savePatient();
+                }
+            } else {
+                if (hasValidName) {
+                    pt = savePatient();
+                }
+            }
+        } else if (patientRequired) {
+            billSettlingStarted = false;
+            JsfUtil.addErrorMessage("Please Select a Patient");
+            return null;
+        }
+
+        PreBill preBillEntity = buildPreBill(pt);
 
         // Stamps the single-method payment reference fields on the bill itself: cheque /
         // slip / card / online-settlement / ewallet numbers, dates and banks, plus the
@@ -477,32 +538,85 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         return null;
     }
 
-    private void savePatientIfNeeded() {
+    /**
+     * Persists the entered patient, mirroring PharmacySaleForCashierController.savePatient()
+     * (:1440-1462): a patient with no name is never written and null is returned, so an
+     * anonymous cashier sale leaves no empty Person/Patient row behind and the bill carries
+     * no patient at all.
+     *
+     * @return the persisted patient, or null when there was nothing worth saving.
+     */
+    private Patient savePatient() {
         try {
-            if (patient == null) {
-                return;
+            if (patient == null || patient.getPerson() == null
+                    || patient.getPerson().getName() == null
+                    || patient.getPerson().getName().trim().isEmpty()) {
+                return null;
             }
-            if (patient.getPerson() != null) {
-                patient.setMobileNumberStringTransient(patient.getMobileNumberStringTransient());
-                patient.setPhoneNumberStringTransient(patient.getPhoneNumberStringTransient());
-            }
+            // Round-trips the transient phone/mobile strings so the Long patientPhoneNumber /
+            // patientMobileNumber columns are kept in step with Person.phone / Person.mobile.
+            patient.setMobileNumberStringTransient(patient.getMobileNumberStringTransient());
+            patient.setPhoneNumberStringTransient(patient.getPhoneNumberStringTransient());
             if (patient.getId() == null) {
-                if (patient.getPerson() != null) {
+                if (patient.getPerson().getId() == null) {
                     personFacade.create(patient.getPerson());
                 }
                 patientFacade.create(patient);
             } else {
-                if (patient.getPerson() != null) {
-                    personFacade.edit(patient.getPerson());
-                }
+                personFacade.edit(patient.getPerson());
                 patientFacade.edit(patient);
             }
+            return patient;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Could not save patient", e);
+            return null;
         }
     }
 
-    private PreBill buildPreBill() {
+    /**
+     * Ported verbatim from PharmacySaleForCashierController :3377-3393. Back-fills the bill's
+     * {@code toStaff} from the staff picked inside the Staff / Staff Welfare payment component
+     * when the page has not set it directly, so a staff-credit bill always names its debtor.
+     */
+    private void syncStaffSelectionFromPaymentDetails(PaymentMethod method) {
+        if (method != PaymentMethod.Staff && method != PaymentMethod.Staff_Welfare) {
+            return;
+        }
+        if (paymentMethodData == null) {
+            return;
+        }
+        if (toStaff != null) {
+            return;
+        }
+        ComponentDetail staffComponent = method == PaymentMethod.Staff
+                ? paymentMethodData.getStaffCredit()
+                : paymentMethodData.getStaffWelfare();
+        if (staffComponent != null && staffComponent.getToStaff() != null) {
+            setToStaff(staffComponent.getToStaff());
+        }
+    }
+
+    /**
+     * Credit counterpart of {@link #syncStaffSelectionFromPaymentDetails(PaymentMethod)}. The
+     * credit company is only ever entered inside the Credit payment component; without this the
+     * bill would persist with {@code creditBill = true} but no {@code creditCompany} /
+     * {@code toInstitution}, and so would never surface in credit-company debtor reporting.
+     * Mirrors how legacy stamps the same pair on its settled bill
+     * (PharmacySaleForCashierController :4453-4454).
+     */
+    private void syncCreditInstitutionFromPaymentDetails(PaymentMethod method) {
+        if (method != PaymentMethod.Credit) {
+            return;
+        }
+        if (paymentMethodData == null || toInstitution != null) {
+            return;
+        }
+        if (paymentMethodData.getCredit() != null && paymentMethodData.getCredit().getInstitution() != null) {
+            setToInstitution(paymentMethodData.getCredit().getInstitution());
+        }
+    }
+
+    private PreBill buildPreBill(Patient billPatient) {
         double netTot = 0.0;
         double grossTot = 0.0;
         double discountTot = 0.0;
@@ -517,7 +631,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         pb.setBillTypeAtomic(BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER);
         pb.setDepartment(sessionController.getLoggedUser().getDepartment());
         pb.setInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
-        pb.setPatient(patient);
+        pb.setPatient(billPatient);
         pb.setFromDepartment(sessionController.getLoggedUser().getDepartment());
         pb.setFromInstitution(sessionController.getLoggedUser().getDepartment().getInstitution());
         pb.setBillDate(new Date());
@@ -539,10 +653,15 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             pb.setPaidAmount(netTot);
         }
 
-        // Legacy stamps both counterparties unconditionally and never sets creditCompany on
-        // the cashier PreBill (PharmacySaleForCashierController :2972-2973).
+        // Legacy stamps both counterparties unconditionally
+        // (PharmacySaleForCashierController :2972-2973). creditCompany is stamped alongside
+        // toInstitution so a Credit bill is reportable as a debtor: BillBeanController
+        // .setPaymentMethodData only flips creditBill = true, it never records who owes.
         pb.setToStaff(toStaff);
         pb.setToInstitution(toInstitution);
+        if (paymentMethod == PaymentMethod.Credit && toInstitution != null) {
+            pb.setCreditCompany(toInstitution);
+        }
 
         if (getPreBill().getReferredBy() != null) {
             pb.setReferredBy(getPreBill().getReferredBy());
@@ -624,11 +743,14 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             pbd.setCreatorName(bill.getCreater().getName());
         }
 
-        // Patient
-        if (patient != null && patient.getPerson() != null) {
-            pbd.setPatientName(patient.getPerson().getNameWithTitle());
-            pbd.setPatientPhone(patient.getPerson().getPhone());
-            pbd.setPatientPhn(patient.getPhn());
+        // Patient. Read off the settled bill rather than the working field, so an anonymous
+        // sale (no Patient persisted, bill.patient == null) prints no patient block instead of
+        // an empty one.
+        Patient billPatient = bill.getPatient();
+        if (billPatient != null && billPatient.getPerson() != null) {
+            pbd.setPatientName(billPatient.getPerson().getNameWithTitle());
+            pbd.setPatientPhone(billPatient.getPerson().getPhone());
+            pbd.setPatientPhn(billPatient.getPhn());
         }
 
         // Payment
@@ -646,9 +768,10 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         if (toStaff != null && toStaff.getPerson() != null) {
             pbd.setToStaffName(toStaff.getPerson().getNameWithTitle());
         }
-        if (paymentMethod == PaymentMethod.Credit
-                && getPaymentMethodData().getCredit().getInstitution() != null) {
-            pbd.setToInstitutionName(getPaymentMethodData().getCredit().getInstitution().getName());
+        // Read the same field the bill was stamped from, so the printout can never name a
+        // different credit company than the one persisted on the bill.
+        if (paymentMethod == PaymentMethod.Credit && bill.getToInstitution() != null) {
+            pbd.setToInstitutionName(bill.getToInstitution().getName());
         }
 
         // Totals
@@ -1004,6 +1127,7 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         // sort all candidates by expiry before allocating, so earlier-expiring stock is always
         // dispensed first regardless of which batch the user picked.
         double addedQty = 0.0;
+        boolean lineCreationFailed = false;
 
         List<StockDTO> candidates = new ArrayList<>();
         candidates.add(stockDto);
@@ -1025,10 +1149,20 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 continue;
             }
             if (!addBillItemLineForStock(next, take)) {
-                continue;
+                // Every candidate batch belongs to the same item, so a failure to resolve it
+                // would repeat for each remaining batch. addBillItemLineForStock has already
+                // shown "Selected item not found"; stop so it is shown exactly once.
+                lineCreationFailed = true;
+                break;
             }
             addedQty += take;
             remainingQty -= take;
+        }
+
+        if (lineCreationFailed) {
+            calTotal();
+            clearBillItem();
+            return;
         }
 
         if (addedQty <= 0) {
@@ -1252,7 +1386,15 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return;
         }
         if (bid.getQty() <= 0) {
+            // Zero the money fields too. Returning early with the previous quantity's
+            // grossValue/netValue/pbiQty still on the row would let calTotal()/buildPreBill()
+            // charge for a line that dispenses no stock.
             bid.setQty(0);
+            bid.setPbiQty(0);
+            bid.setGrossValue(0);
+            bid.setDiscountValue(0);
+            bid.setNetValue(0);
+            bid.setNetRate(bid.getRate());
             JsfUtil.addErrorMessage("Quantity must be greater than zero.");
             return;
         }
@@ -1654,10 +1796,12 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         billPreview = false;
         billSettlingStarted = false;
         patientDetailsEditable = false;
-        comment = "";
+        // Legacy clearBill() :5421-5432 leaves the payment method at Cash and the comment null,
+        // so the operator does not have to re-pick a payment method after every settle.
+        comment = null;
         cashPaid = 0.0;
         balance = 0.0;
-        paymentMethod = null;
+        paymentMethod = PaymentMethod.Cash;
         paymentScheme = null;
         paymentMethodData = null;
         toStaff = null;

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -713,7 +713,12 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         pbd.setDepartmentName(dept.getName());
         pbd.setDepartmentPrintingName(dept.getPrintingName() != null ? dept.getPrintingName() : dept.getName());
         pbd.setDepartmentTelephone1(dept.getTelephone1());
+        pbd.setDepartmentTelephone2(dept.getTelephone2());
+        pbd.setDepartmentFax(dept.getFax());
         pbd.setDepartmentAddress(dept.getAddress());
+        if (dept.getSite() != null) {
+            pbd.setDepartmentSiteName(dept.getSite().getName());
+        }
         if (dept.getInstitution() != null) {
             pbd.setInstitutionName(dept.getInstitution().getName());
             pbd.setInstitutionAddress(dept.getInstitution().getAddress());
@@ -728,6 +733,15 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         pbd.setCreatedAt(bill.getCreatedAt());
         if (bill.getCreater() != null) {
             pbd.setCreatorName(bill.getCreater().getName());
+        }
+        // Token number for the token printouts. settleBillWithPay runs settle() ->
+        // settleTokenIfEnabled() -> buildPrintBill(), so the token (if the token system is
+        // enabled for this department) is already created and held in memory here - no Bill
+        // reload needed. Stays null when the token system is off, and the composites then
+        // print nothing where the token circle would be.
+        Token printToken = getToken() != null ? getToken() : getCurrentToken();
+        if (printToken != null) {
+            pbd.setTokenNumber(printToken.getTokenNumber());
         }
 
         // Patient. Read off the settled bill rather than the working field, so an anonymous

--- a/src/main/java/com/divudi/core/data/dto/BillItemData.java
+++ b/src/main/java/com/divudi/core/data/dto/BillItemData.java
@@ -22,6 +22,8 @@ public class BillItemData implements Serializable {
     // ---- BillItem fields ----
     private Long itemId;
     private String itemName;
+    // Item.code — printed alongside the name on the cashier bill formats.
+    private String itemCode;
     private double qty;
     private double netValue;
     private double grossValue;
@@ -86,6 +88,14 @@ public class BillItemData implements Serializable {
 
     public void setItemName(String itemName) {
         this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
     }
 
     public double getQty() {

--- a/src/main/java/com/divudi/core/data/dto/PrintBillData.java
+++ b/src/main/java/com/divudi/core/data/dto/PrintBillData.java
@@ -23,6 +23,8 @@ public class PrintBillData implements Serializable {
     private String billNo;
     private Date createdAt;
     private String creatorName;
+    private String billIdStr;
+    private boolean cancelled;
 
     // Patient
     private String patientName;
@@ -89,6 +91,12 @@ public class PrintBillData implements Serializable {
 
     public String getCreatorName() { return creatorName; }
     public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+
+    public String getBillIdStr() { return billIdStr; }
+    public void setBillIdStr(String billIdStr) { this.billIdStr = billIdStr; }
+
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
 
     // --- Patient ---
 

--- a/src/main/java/com/divudi/core/data/dto/PrintBillData.java
+++ b/src/main/java/com/divudi/core/data/dto/PrintBillData.java
@@ -13,7 +13,10 @@ public class PrintBillData implements Serializable {
     private String departmentName;
     private String departmentPrintingName;
     private String departmentTelephone1;
+    private String departmentTelephone2;
+    private String departmentFax;
     private String departmentAddress;
+    private String departmentSiteName;
     private String institutionName;
     private String institutionAddress;
     private String institutionEmail;
@@ -25,6 +28,9 @@ public class PrintBillData implements Serializable {
     private String creatorName;
     private String billIdStr;
     private boolean cancelled;
+    // Pharmacy token number (Token.tokenNumber). Null when the token system is disabled
+    // or the bill has no token; the token composites render nothing in that case.
+    private String tokenNumber;
 
     // Patient
     private String patientName;
@@ -66,8 +72,17 @@ public class PrintBillData implements Serializable {
     public String getDepartmentTelephone1() { return departmentTelephone1; }
     public void setDepartmentTelephone1(String departmentTelephone1) { this.departmentTelephone1 = departmentTelephone1; }
 
+    public String getDepartmentTelephone2() { return departmentTelephone2; }
+    public void setDepartmentTelephone2(String departmentTelephone2) { this.departmentTelephone2 = departmentTelephone2; }
+
+    public String getDepartmentFax() { return departmentFax; }
+    public void setDepartmentFax(String departmentFax) { this.departmentFax = departmentFax; }
+
     public String getDepartmentAddress() { return departmentAddress; }
     public void setDepartmentAddress(String departmentAddress) { this.departmentAddress = departmentAddress; }
+
+    public String getDepartmentSiteName() { return departmentSiteName; }
+    public void setDepartmentSiteName(String departmentSiteName) { this.departmentSiteName = departmentSiteName; }
 
     public String getInstitutionName() { return institutionName; }
     public void setInstitutionName(String institutionName) { this.institutionName = institutionName; }
@@ -97,6 +112,9 @@ public class PrintBillData implements Serializable {
 
     public boolean isCancelled() { return cancelled; }
     public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+
+    public String getTokenNumber() { return tokenNumber; }
+    public void setTokenNumber(String tokenNumber) { this.tokenNumber = tokenNumber; }
 
     // --- Patient ---
 

--- a/src/main/java/com/divudi/core/data/dto/PrintBillData.java
+++ b/src/main/java/com/divudi/core/data/dto/PrintBillData.java
@@ -28,6 +28,11 @@ public class PrintBillData implements Serializable {
     private String creatorName;
     private String billIdStr;
     private boolean cancelled;
+    // Bill.invoiceNumber — shown on the FiveFive cashier bill formats.
+    private String invoiceNumber;
+    // WebUser.code of the bill's creator — printed as "Cashier : <code>" on the
+    // FiveFive cashier format.
+    private String creatorCode;
     // Pharmacy token number (Token.tokenNumber). Null when the token system is disabled
     // or the bill has no token; the token composites render nothing in that case.
     private String tokenNumber;
@@ -112,6 +117,12 @@ public class PrintBillData implements Serializable {
 
     public boolean isCancelled() { return cancelled; }
     public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+
+    public String getCreatorCode() { return creatorCode; }
+    public void setCreatorCode(String creatorCode) { this.creatorCode = creatorCode; }
 
     public String getTokenNumber() { return tokenNumber; }
     public void setTokenNumber(String tokenNumber) { this.tokenNumber = tokenNumber; }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -622,10 +622,18 @@ public class RetailSaleForCashierNativeSqlService {
         pbd.setTokenNumber(findTokenNumber(bill));
         if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
             pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
-            pbd.setPatientAgeSex(safeStr(bill.getPatient().getPerson().getAgeAsShortString())
-                    + " / "
-                    + (bill.getPatient().getPerson().getSex() != null
-                            ? safeStr(bill.getPatient().getPerson().getSex().getLabel()) : ""));
+            // Same rule as the fresh-print path: never emit a bare " / " when neither
+            // age nor sex is known, so reprints match freshly printed bills.
+            String age = safeStr(bill.getPatient().getPerson().getAgeAsShortString()).trim();
+            String sex = bill.getPatient().getPerson().getSex() != null
+                    ? safeStr(bill.getPatient().getPerson().getSex().getLabel()).trim() : "";
+            if (!age.isEmpty() && !sex.isEmpty()) {
+                pbd.setPatientAgeSex(age + " / " + sex);
+            } else if (!age.isEmpty()) {
+                pbd.setPatientAgeSex(age);
+            } else if (!sex.isEmpty()) {
+                pbd.setPatientAgeSex(sex);
+            }
             pbd.setPatientPhone(safeStr(bill.getPatient().getPerson().getPhone()));
             pbd.setPatientPhn(safeStr(bill.getPatient().getPhn()));
         }

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -1,0 +1,733 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.BillItemData;
+import com.divudi.core.data.dto.PrintBillData;
+import com.divudi.core.data.dto.StockAggregateResult;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillFinanceDetails;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PreBill;
+import com.divudi.core.entity.pharmacy.Stock;
+import com.divudi.core.entity.pharmacy.StockHistory;
+import java.util.ArrayList;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Native-SQL settle path for the pharmacy "Sale for Cashier" page.
+ *
+ * Unlike RetailSaleNativeSqlService this writes a SINGLE bill — a PreBill of
+ * BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER. There is no BilledBill
+ * and there are no Payment rows: that atomic type is NO_PAYMENT / NO_FINANCE_TRANSACTIONS,
+ * and the cashier settles payment later via PharmacyPreSettleController.
+ *
+ * Stock is still deducted here, at pharmacy time, exactly as the legacy
+ * PharmacySaleForCashierController did.
+ *
+ * Deviation from legacy: BillFinanceDetails / BillItemFinanceDetails ARE written at settle.
+ * Legacy wrote none, which is why DataAdministrationController
+ * .backfillBfdForPreToSettleAtCashierBills() exists — without BFD the F15 report reads
+ * totalRetailSaleValue as 0. Bills created here never need that backfill.
+ *
+ * Issue: #20261
+ */
+@Stateless
+public class RetailSaleForCashierNativeSqlService {
+
+    private static final Logger LOGGER = Logger.getLogger(RetailSaleForCashierNativeSqlService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    // Cached resolved table names (cross-deployment case safety via INFORMATION_SCHEMA)
+    private volatile String tStockHistory = null;
+    private volatile String tStock = null;
+    private volatile String tItemBatch = null;
+    private volatile String tDepartment = null;
+    private volatile String tBill = null;
+    private volatile String tBillItem = null;
+    private volatile String tPharmBillItem = null;
+    private volatile String tItem = null;
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public void settle(PreBill preBill, List<BillItemData> items) {
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("No items to settle");
+        }
+
+        // No payment parameters: PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER is a
+        // NO_PAYMENT bill type, so no Payment entity is created here. The controller
+        // stamps payment details onto the bill's own columns before calling settle().
+
+        long t0 = System.currentTimeMillis();
+
+        // Step 1a: Persist PreBill first (bill items will reference its ID).
+        preBill.setBillItems(null);
+        em.persist(preBill);
+        em.flush();
+        long preBillId = preBill.getId();
+
+        LOGGER.log(Level.INFO, "[CashierNativeSettle] PreBill id={0} ms={1}",
+                new Object[]{preBillId, System.currentTimeMillis() - t0});
+
+        // Step 2: Native INSERT BillItem + fully-populated PBI on the single PreBill
+        long[] biPreIds = new long[items.size()];
+        long[] pbPreIds = new long[items.size()];
+
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData d = items.get(i);
+            Date createdAt = d.getCreatedAt() != null ? d.getCreatedAt() : new Date();
+
+            double absQty       = Math.abs(d.getQty());
+            double absNetValue  = Math.abs(d.getNetValue());
+            double absGrossValue = Math.abs(d.getGrossValue());
+            double netRate      = absQty > 0 ? absNetValue / absQty : 0.0;
+
+            em.createNativeQuery(
+                "INSERT INTO " + billItemTable()
+                + " (bill_ID, item_ID, qty, descreption, netValue, grossValue, Rate, netRate,"
+                + " discount, discountRate, marginValue,"
+                + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+                + " consideredForCosting, inwardChargeType)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine')")
+                .setParameter(1, preBillId)
+                .setParameter(2, d.getItemId())
+                .setParameter(3, absQty)
+                .setParameter(4, d.getDescription())
+                .setParameter(5, absNetValue)
+                .setParameter(6, absGrossValue)
+                .setParameter(7, d.getRate())
+                .setParameter(8, netRate)
+                .setParameter(9, d.getDiscountValue())
+                .setParameter(10, absQty > 0 ? (d.getDiscountValue() / absQty) : 0.0)
+                .setParameter(11, d.getMarginValue())
+                .setParameter(12, new Timestamp(createdAt.getTime()))
+                .setParameter(13, d.getCreaterId())
+                .executeUpdate();
+            biPreIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+
+            // Single-bill flow: this PBI is the ONLY one, so it carries the real
+            // cost/retail/purchase values. (The two-bill retail flow zeroes them here
+            // because its BilledBill PBI carries them instead.)
+            em.createNativeQuery(
+                "INSERT INTO " + pharmBillItemTable()
+                + " (billItem_ID, itemBatch_ID, stock_ID, qty, stringValue,"
+                + " costRate, purchaseRate, retailRate, wholesaleRate, doe, description)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+                .setParameter(1, biPreIds[i])
+                .setParameter(2, d.getItemBatchId())
+                .setParameter(3, d.getStockId())
+                .setParameter(4, d.getPbiQty())
+                .setParameter(5, d.getStringValue())
+                .setParameter(6, d.getCostRate())
+                .setParameter(7, d.getPurchaseRate())
+                .setParameter(8, d.getRetailRate())
+                .setParameter(9, d.getWholesaleRate())
+                .setParameter(10, d.getDoe() != null ? new Timestamp(d.getDoe().getTime()) : null)
+                .setParameter(11, d.getDescription())
+                .executeUpdate();
+            pbPreIds[i] = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        }
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] BillItem+PBI inserted ms={0}", System.currentTimeMillis() - t0);
+
+        // Step 3: Per-item: atomic stock deduction + aggregates + StockHistory (linked to PreBill PBI — matches old flow)
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData item = items.get(i);
+            double qty = Math.abs(item.getQty());
+
+            deductStock(item.getStockId(), qty);
+            double postDeductQty = fetchStockQty(item.getStockId());
+
+            long ampItemId     = item.getAmpItemId()     != null ? item.getAmpItemId()     : (item.getItemId() != null ? item.getItemId() : 0L);
+            long itemBatchId   = item.getItemBatchId()   != null ? item.getItemBatchId()   : 0L;
+            long departmentId  = item.getDepartmentId()  != null ? item.getDepartmentId()  : 0L;
+            long institutionId = item.getInstitutionId() != null ? item.getInstitutionId() : 0L;
+
+            StockAggregateResult agg = computeAggregates(
+                    ampItemId, itemBatchId, departmentId, institutionId,
+                    postDeductQty,
+                    item.getBatchRetailRate(), item.getBatchPurchaseRate(),
+                    item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate());
+
+            insertStockHistory(pbPreIds[i], item, agg, ampItemId, itemBatchId, departmentId, institutionId);
+        }
+
+        // Evict natively-written entity classes from EclipseLink L2 cache
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(StockHistory.class);
+        cache.evict(Stock.class);
+        cache.evict(BillItem.class);
+        cache.evict(Bill.class);
+        cache.evict(PreBill.class);
+
+        LOGGER.log(Level.INFO, "[RetailNativeSettle] Stock deducted + history inserted ms={0}", System.currentTimeMillis() - t0);
+
+        // Deviation from legacy (which wrote no finance details for cashier bills):
+        // BFD/BIFD are written against the single PreBill so F15's totalRetailSaleValue
+        // is correct without backfillBfdForPreToSettleAtCashierBills. Issue #20261.
+        double[] billTotals = insertFinanceDetails(preBillId, biPreIds, pbPreIds, items);
+
+        // Step 5: Update totals on the single bill
+        em.createNativeQuery(
+                "UPDATE " + billTable() + " SET total=?, netTotal=?, DISCOUNT=? WHERE ID=?")
+                .setParameter(1, billTotals[0])
+                .setParameter(2, billTotals[1])
+                .setParameter(3, billTotals[2])
+                .setParameter(4, preBillId)
+                .executeUpdate();
+
+        LOGGER.log(Level.INFO, "[CashierNativeSettle] DONE items={0} ms={1}",
+                new Object[]{items.size(), System.currentTimeMillis() - t0});
+    }
+
+    // -----------------------------------------------------------------------
+    // Stock deduction
+    // -----------------------------------------------------------------------
+
+    private void deductStock(long stockId, double qty) {
+        int updated = em.createNativeQuery(
+                "UPDATE " + stockTable() + " SET stock=stock-? WHERE ID=? AND stock>=?")
+                .setParameter(1, qty)
+                .setParameter(2, stockId)
+                .setParameter(3, qty)
+                .executeUpdate();
+        if (updated == 0) {
+            throw new RuntimeException("Insufficient stock for stock ID " + stockId
+                    + " (requested qty=" + qty + ")");
+        }
+    }
+
+    private double fetchStockQty(long stockId) {
+        Object result = em.createNativeQuery(
+                "SELECT stock FROM " + stockTable() + " WHERE ID=?")
+                .setParameter(1, stockId)
+                .getSingleResult();
+        return result == null ? 0.0 : ((Number) result).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate computation
+    // -----------------------------------------------------------------------
+
+    private StockAggregateResult computeAggregates(
+            long ampItemId, long itemBatchId,
+            long departmentId, long institutionId,
+            double postDeductStockQty,
+            double retailRate, double purchaseRate, double costRate) {
+
+        StockAggregateResult r = new StockAggregateResult();
+        r.setStockQty(postDeductStockQty);
+
+        String batchSql =
+            "SELECT "
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN s.stock ELSE 0 END) AS instBatchQty,"
+            + "  SUM(s.stock) AS totalBatchQty "
+            + "FROM " + stockTable() + " s "
+            + "JOIN " + departmentTable() + " d ON s.department_ID = d.ID "
+            + "WHERE s.itemBatch_ID = ?";
+
+        Object[] batchRow = (Object[]) em.createNativeQuery(batchSql)
+                .setParameter(1, institutionId)
+                .setParameter(2, itemBatchId)
+                .getSingleResult();
+
+        double instBatchQty  = batchRow[0] == null ? 0.0 : ((Number) batchRow[0]).doubleValue();
+        double totalBatchQty = batchRow[1] == null ? 0.0 : ((Number) batchRow[1]).doubleValue();
+
+        r.setInstitutionBatchQty(instBatchQty);
+        r.setTotalBatchQty(totalBatchQty);
+        r.setInstitutionBatchStockValueAtPurchaseRate(instBatchQty * purchaseRate);
+        r.setTotalBatchStockValueAtPurchaseRate(totalBatchQty * purchaseRate);
+        r.setInstitutionBatchStockValueAtSaleRate(instBatchQty * retailRate);
+        r.setTotalBatchStockValueAtSaleRate(totalBatchQty * retailRate);
+        r.setInstitutionBatchStockValueAtCostRate(instBatchQty * costRate);
+        r.setTotalBatchStockValueAtCostRate(totalBatchQty * costRate);
+
+        String itemSql =
+            "SELECT "
+            + "  SUM(CASE WHEN s.department_ID = ? THEN s.stock ELSE 0 END) AS deptItemQty,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN s.stock ELSE 0 END) AS instItemQty,"
+            + "  SUM(s.stock) AS totalItemQty,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.purcahseRate,0)*s.stock ELSE 0 END) AS deptItemPurchVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.purcahseRate,0)*s.stock ELSE 0 END) AS instItemPurchVal,"
+            + "  SUM(COALESCE(ib.purcahseRate,0)*s.stock) AS totalItemPurchVal,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.costRate,0)*s.stock ELSE 0 END) AS deptItemCostVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.costRate,0)*s.stock ELSE 0 END) AS instItemCostVal,"
+            + "  SUM(COALESCE(ib.costRate,0)*s.stock) AS totalItemCostVal,"
+            + "  SUM(CASE WHEN s.department_ID = ? THEN COALESCE(ib.retailsaleRate,0)*s.stock ELSE 0 END) AS deptItemRetailVal,"
+            + "  SUM(CASE WHEN d.institution_ID = ? THEN COALESCE(ib.retailsaleRate,0)*s.stock ELSE 0 END) AS instItemRetailVal,"
+            + "  SUM(COALESCE(ib.retailsaleRate,0)*s.stock) AS totalItemRetailVal "
+            + "FROM " + stockTable() + " s "
+            + "JOIN " + itemBatchTable() + " ib ON s.itemBatch_ID = ib.ID "
+            + "JOIN " + departmentTable() + " d ON s.department_ID = d.ID "
+            + "WHERE ib.item_ID = ?";
+
+        Object[] itemRow = (Object[]) em.createNativeQuery(itemSql)
+                .setParameter(1, departmentId)
+                .setParameter(2, institutionId)
+                .setParameter(3, departmentId)
+                .setParameter(4, institutionId)
+                .setParameter(5, departmentId)
+                .setParameter(6, institutionId)
+                .setParameter(7, departmentId)
+                .setParameter(8, institutionId)
+                .setParameter(9, ampItemId)
+                .getSingleResult();
+
+        r.setDepartmentItemStock(toDouble(itemRow[0]));
+        r.setInstitutionItemStock(toDouble(itemRow[1]));
+        r.setTotalItemStock(toDouble(itemRow[2]));
+        r.setItemStockValueAtPurchaseRate(toDouble(itemRow[3]));
+        r.setInstitutionItemStockValueAtPurchaseRate(toDouble(itemRow[4]));
+        r.setTotalItemStockValueAtPurchaseRate(toDouble(itemRow[5]));
+        r.setItemStockValueAtCostRate(toDouble(itemRow[6]));
+        r.setInstitutionItemStockValueAtCostRate(toDouble(itemRow[7]));
+        r.setTotalItemStockValueAtCostRate(toDouble(itemRow[8]));
+        r.setItemStockValueAtSaleRate(toDouble(itemRow[9]));
+        r.setInstitutionItemStockValueAtSaleRate(toDouble(itemRow[10]));
+        r.setTotalItemStockValueAtSaleRate(toDouble(itemRow[11]));
+
+        return r;
+    }
+
+    private static double toDouble(Object o) {
+        return o == null ? 0.0 : ((Number) o).doubleValue();
+    }
+
+    // -----------------------------------------------------------------------
+    // StockHistory native INSERT
+    // -----------------------------------------------------------------------
+
+    private void insertStockHistory(long pbId, BillItemData item, StockAggregateResult agg,
+                                    long ampItemId, long itemBatchId, long departmentId, long institutionId) {
+        Date now = new Date();
+        Calendar cal = Calendar.getInstance();
+
+        em.createNativeQuery(
+            "INSERT INTO " + stockHistoryTable()
+            + " (pbItem_ID, itemBatch_ID, institution_ID, department_ID, item_ID,"
+            + " retailRate, wholesaleRate, purchaseRate, costRate,"
+            + " stockAt, fromDate, createdAt,"
+            + " stockQty, instituionBatchQty, totalBatchQty,"
+            + " itemStock, institutionItemStock, totalItemStock,"
+            + " stockSaleValue, stockPurchaseValue, stockCostValue,"
+            + " institutionBatchStockValueAtSaleRate, totalBatchStockValueAtSaleRate,"
+            + " institutionBatchStockValueAtPurchaseRate, totalBatchStockValueAtPurchaseRate,"
+            + " institutionBatchStockValueAtCostRate, totalBatchStockValueAtCostRate,"
+            + " itemStockValueAtSaleRate, institutionItemStockValueAtSaleRate, totalItemStockValueAtSaleRate,"
+            + " itemStockValueAtPurchaseRate, institutionItemStockValueAtPurchaseRate, totalItemStockValueAtPurchaseRate,"
+            + " itemStockValueAtCostRate, institutionItemStockValueAtCostRate, totalItemStockValueAtCostRate,"
+            + " hxYear, hxMonth, hxDate, hxWeek,"
+            + " retired)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)")
+            .setParameter(1, pbId)
+            .setParameter(2, itemBatchId)
+            .setParameter(3, institutionId)
+            .setParameter(4, departmentId)
+            .setParameter(5, ampItemId)
+            .setParameter(6, item.getBatchRetailRate())
+            .setParameter(7, item.getBatchWholesaleRate())
+            .setParameter(8, item.getBatchPurchaseRate())
+            .setParameter(9, item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate())
+            .setParameter(10, new java.sql.Date(now.getTime()))
+            .setParameter(11, new Timestamp(now.getTime()))
+            .setParameter(12, new Timestamp(now.getTime()))
+            .setParameter(13, agg.getStockQty())
+            .setParameter(14, agg.getInstitutionBatchQty())
+            .setParameter(15, agg.getTotalBatchQty())
+            .setParameter(16, agg.getDepartmentItemStock())
+            .setParameter(17, agg.getInstitutionItemStock())
+            .setParameter(18, agg.getTotalItemStock())
+            .setParameter(19, agg.getStockQty() * item.getBatchRetailRate())
+            .setParameter(20, agg.getStockQty() * item.getBatchPurchaseRate())
+            .setParameter(21, agg.getStockQty() * (item.getBatchCostRate() != null ? item.getBatchCostRate() : item.getBatchPurchaseRate()))
+            .setParameter(22, agg.getInstitutionBatchStockValueAtSaleRate())
+            .setParameter(23, agg.getTotalBatchStockValueAtSaleRate())
+            .setParameter(24, agg.getInstitutionBatchStockValueAtPurchaseRate())
+            .setParameter(25, agg.getTotalBatchStockValueAtPurchaseRate())
+            .setParameter(26, agg.getInstitutionBatchStockValueAtCostRate())
+            .setParameter(27, agg.getTotalBatchStockValueAtCostRate())
+            .setParameter(28, agg.getItemStockValueAtSaleRate())
+            .setParameter(29, agg.getInstitutionItemStockValueAtSaleRate())
+            .setParameter(30, agg.getTotalItemStockValueAtSaleRate())
+            .setParameter(31, agg.getItemStockValueAtPurchaseRate())
+            .setParameter(32, agg.getInstitutionItemStockValueAtPurchaseRate())
+            .setParameter(33, agg.getTotalItemStockValueAtPurchaseRate())
+            .setParameter(34, agg.getItemStockValueAtCostRate())
+            .setParameter(35, agg.getInstitutionItemStockValueAtCostRate())
+            .setParameter(36, agg.getTotalItemStockValueAtCostRate())
+            .setParameter(37, cal.get(Calendar.YEAR))
+            .setParameter(38, cal.get(Calendar.MONTH))
+            .setParameter(39, cal.get(Calendar.DATE))
+            .setParameter(40, cal.get(Calendar.WEEK_OF_YEAR))
+            .executeUpdate();
+    }
+
+    // -----------------------------------------------------------------------
+    // Finance details (JPA IDENTITY)
+    // -----------------------------------------------------------------------
+
+    private double[] insertFinanceDetails(long billId, long[] biIds, long[] pbIds,
+                                          List<BillItemData> items) {
+        BigDecimal totalCostValue = BigDecimal.ZERO;
+        BigDecimal totalPurchaseValue = BigDecimal.ZERO;
+        BigDecimal totalRetailSaleValue = BigDecimal.ZERO;
+        BigDecimal totalWholesaleValue = BigDecimal.ZERO;
+        BigDecimal totalQuantity = BigDecimal.ZERO;
+        BigDecimal totalFreeQuantity = BigDecimal.ZERO;
+        BigDecimal billNetTotal = BigDecimal.ZERO;
+        BigDecimal billGrossTotal = BigDecimal.ZERO;
+        BigDecimal billDiscount = BigDecimal.ZERO;
+
+        for (int i = 0; i < items.size(); i++) {
+            BillItemData item = items.get(i);
+
+            BigDecimal qty = BigDecimal.valueOf(Math.abs(item.getQty()));
+            BigDecimal freeQty = BigDecimal.valueOf(Math.abs(item.getFreeQty()));
+            BigDecimal totalQty = qty.add(freeQty);
+
+            BigDecimal retailRate    = BigDecimal.valueOf(item.getRetailRate());
+            BigDecimal purchaseRate  = BigDecimal.valueOf(item.getPurchaseRate());
+            BigDecimal wholesaleRate = BigDecimal.valueOf(item.getWholesaleRate());
+            BigDecimal batchRetail   = BigDecimal.valueOf(item.getBatchRetailRate());
+            BigDecimal batchPurchase = BigDecimal.valueOf(item.getBatchPurchaseRate());
+            BigDecimal batchWholesale = BigDecimal.valueOf(item.getBatchWholesaleRate());
+            BigDecimal costRate = item.getBatchCostRate() != null && item.getBatchCostRate() > 0
+                    ? BigDecimal.valueOf(item.getBatchCostRate())
+                    : batchPurchase;
+
+            BigDecimal itemCostValue      = costRate.multiply(qty);
+            BigDecimal itemRetailValue    = batchRetail.multiply(totalQty);
+            BigDecimal itemPurchaseValue  = batchPurchase.multiply(totalQty);
+            BigDecimal itemWholesaleValue = batchWholesale.multiply(totalQty);
+
+            BigDecimal netValue   = BigDecimal.valueOf(Math.abs(item.getNetValue()));
+            BigDecimal grossValue = BigDecimal.valueOf(Math.abs(item.getGrossValue()));
+            BigDecimal lineNetRate = qty.compareTo(BigDecimal.ZERO) > 0
+                    ? netValue.divide(qty, 4, java.math.RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+
+            BillItemFinanceDetails bifd = new BillItemFinanceDetails();
+            bifd.setBillItem(em.getReference(BillItem.class, biIds[i]));
+            bifd.setCreatedAt(new Date());
+
+            bifd.setLineNetRate(lineNetRate);
+            bifd.setGrossRate(BigDecimal.valueOf(item.getRate()));
+            bifd.setLineGrossRate(BigDecimal.valueOf(item.getRate()));
+            bifd.setBillCostRate(BigDecimal.ZERO);
+            bifd.setTotalCostRate(costRate);
+            bifd.setLineCostRate(costRate);
+            bifd.setCostRate(costRate);
+            bifd.setPurchaseRate(purchaseRate);
+            bifd.setRetailSaleRate(retailRate);
+            bifd.setWholesaleRate(wholesaleRate);
+
+            bifd.setLineGrossTotal(grossValue);
+            bifd.setGrossTotal(grossValue);
+            bifd.setLineNetTotal(netValue);
+            bifd.setNetTotal(netValue);
+
+            bifd.setLineCost(itemCostValue);
+            bifd.setBillCost(BigDecimal.ZERO);
+            bifd.setTotalCost(itemCostValue);
+
+            bifd.setValueAtCostRate(costRate.multiply(totalQty).negate());
+            bifd.setValueAtPurchaseRate(batchPurchase.multiply(totalQty).negate());
+            bifd.setValueAtRetailRate(batchRetail.multiply(totalQty).negate());
+            bifd.setValueAtWholesaleRate(batchWholesale.multiply(totalQty).negate());
+
+            bifd.setQuantity(qty.negate());
+            bifd.setQuantityByUnits(qty.negate());
+            bifd.setTotalQuantity(totalQty.negate());
+            bifd.setFreeQuantity(freeQty.negate());
+
+            em.persist(bifd);
+            em.flush();
+
+            em.createNativeQuery("UPDATE " + billItemTable()
+                    + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                    .setParameter(1, bifd.getId())
+                    .setParameter(2, biIds[i])
+                    .executeUpdate();
+
+            em.createNativeQuery("UPDATE " + pharmBillItemTable()
+                    + " SET costRate=?, costValue=?, retailValue=?, purchaseValue=? WHERE ID=?")
+                    .setParameter(1, costRate.doubleValue())
+                    .setParameter(2, itemCostValue.doubleValue())
+                    .setParameter(3, itemRetailValue.doubleValue())
+                    .setParameter(4, itemPurchaseValue.doubleValue())
+                    .setParameter(5, pbIds[i])
+                    .executeUpdate();
+
+            totalCostValue        = totalCostValue.add(itemCostValue);
+            totalPurchaseValue    = totalPurchaseValue.add(itemPurchaseValue);
+            totalRetailSaleValue  = totalRetailSaleValue.add(itemRetailValue);
+            totalWholesaleValue   = totalWholesaleValue.add(itemWholesaleValue);
+            totalQuantity         = totalQuantity.add(qty);
+            totalFreeQuantity     = totalFreeQuantity.add(freeQty);
+            billNetTotal          = billNetTotal.add(netValue);
+            billGrossTotal        = billGrossTotal.add(grossValue);
+            billDiscount          = billDiscount.add(grossValue.subtract(netValue));
+        }
+
+        Bill billRef = em.getReference(Bill.class, billId);
+        BillFinanceDetails bfd = new BillFinanceDetails();
+        bfd.setBill(billRef);
+        bfd.setCreatedAt(new Date());
+        bfd.setNetTotal(billNetTotal);
+        bfd.setGrossTotal(billGrossTotal);
+        bfd.setTotalCostValue(totalCostValue.negate());
+        bfd.setTotalPurchaseValue(totalPurchaseValue.negate());
+        bfd.setTotalRetailSaleValue(totalRetailSaleValue.negate());
+        bfd.setTotalWholesaleValue(totalWholesaleValue.negate());
+        bfd.setTotalQuantity(totalQuantity.negate());
+        bfd.setTotalFreeQuantity(totalFreeQuantity.negate());
+        em.persist(bfd);
+        em.flush();
+
+        em.createNativeQuery("UPDATE " + billTable() + " SET BILLFINANCEDETAILS_ID=? WHERE ID=?")
+                .setParameter(1, bfd.getId())
+                .setParameter(2, billId)
+                .executeUpdate();
+
+        return new double[]{billGrossTotal.doubleValue(), billNetTotal.doubleValue(), billDiscount.doubleValue()};
+    }
+
+    // -----------------------------------------------------------------------
+    // Table name resolution
+    // -----------------------------------------------------------------------
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+                + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+                .setParameter(1, upperName)
+                .getSingleResult();
+        return name.toString();
+    }
+
+    private String stockHistoryTable() {
+        if (tStockHistory == null) tStockHistory = resolveTable("STOCKHISTORY");
+        return tStockHistory;
+    }
+
+    private String stockTable() {
+        if (tStock == null) tStock = resolveTable("STOCK");
+        return tStock;
+    }
+
+    private String itemBatchTable() {
+        if (tItemBatch == null) tItemBatch = resolveTable("ITEMBATCH");
+        return tItemBatch;
+    }
+
+    private String departmentTable() {
+        if (tDepartment == null) tDepartment = resolveTable("DEPARTMENT");
+        return tDepartment;
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+
+    private String itemTable() {
+        if (tItem == null) tItem = resolveTable("ITEM");
+        return tItem;
+    }
+
+    private static String safeStr(String s) {
+        return s != null ? s : "";
+    }
+
+    /**
+     * Loads view data for an existing settled retail sale bill.
+     * Returns Object[]{PrintBillData, List&lt;BillItemData&gt;}.
+     * Used by RetailSaleNativeSqlController.viewByBillId to display
+     * the print preview without triggering a full entity-graph load.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public Object[] loadViewDataByBillId(long billId) {
+        Bill bill = em.find(Bill.class, billId);
+        if (bill == null) {
+            return null;
+        }
+
+        PrintBillData pbd = new PrintBillData();
+        Department dept = bill.getDepartment();
+        if (dept != null) {
+            pbd.setDepartmentName(safeStr(dept.getName()));
+            pbd.setDepartmentPrintingName(dept.getPrintingName() != null
+                    ? dept.getPrintingName() : safeStr(dept.getName()));
+            pbd.setDepartmentTelephone1(safeStr(dept.getTelephone1()));
+            pbd.setDepartmentAddress(safeStr(dept.getAddress()));
+            Institution inst = dept.getInstitution();
+            if (inst != null) {
+                pbd.setInstitutionName(safeStr(inst.getName()));
+                pbd.setInstitutionAddress(safeStr(inst.getAddress()));
+                pbd.setInstitutionEmail(safeStr(inst.getEmail()));
+                pbd.setInstitutionWeb(safeStr(inst.getWeb()));
+            }
+        }
+        pbd.setBillNo(safeStr(bill.getDeptId()));
+        pbd.setCreatedAt(bill.getCreatedAt());
+        if (bill.getCreater() != null) {
+            pbd.setCreatorName(safeStr(bill.getCreater().getName()));
+        }
+        if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
+            pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
+            pbd.setPatientPhone(safeStr(bill.getPatient().getPerson().getPhone()));
+            pbd.setPatientPhn(safeStr(bill.getPatient().getPhn()));
+        }
+        if (bill.getPaymentMethod() != null) {
+            pbd.setPaymentMethodLabel(bill.getPaymentMethod().getLabel());
+        }
+        if (bill.getPaymentScheme() != null) {
+            pbd.setPaymentSchemePrintingName(bill.getPaymentScheme().getPrintingName() != null
+                    ? bill.getPaymentScheme().getPrintingName() : safeStr(bill.getPaymentScheme().getName()));
+        }
+        pbd.setComment(safeStr(bill.getComments()));
+        double net = Math.abs(bill.getNetTotal());
+        double gross = bill.getTotal() > 0 ? bill.getTotal() : net;
+        double disc = Math.max(0, gross - net);
+        pbd.setNetTotal(net);
+        pbd.setTotal(gross);
+        pbd.setDiscount(disc);
+        pbd.setDiscountPercentPharmacy(gross > 0 ? (disc / gross) * 100.0 : 0.0);
+
+        // For Multiple Payment Methods, bill.cashPaid stays 0 and the methods are
+        // recorded as individual Payment rows. Rebuild the itemised payment lines
+        // (and derive the amount paid from their sum) so reprinted/reopened bills
+        // match what the settle-time printout shows.
+        double cashPaid = bill.getCashPaid();
+        double balance = cashPaid - net;
+        if (bill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
+            List<PrintBillData.PaymentLine> lines = buildPrintPaymentLinesFromPersisted(bill);
+            pbd.setPayments(lines);
+            cashPaid = 0.0;
+            for (PrintBillData.PaymentLine line : lines) {
+                cashPaid += line.getValue();
+            }
+            // The split is accepted at settle when within 1.0 of the net total;
+            // clamp the reprinted balance to zero within the same tolerance so a
+            // settled bill never shows a residual balance.
+            balance = cashPaid - net;
+            if (Math.abs(balance) <= 1.0) {
+                balance = 0.0;
+            }
+        }
+        pbd.setCashPaid(cashPaid);
+        pbd.setBalance(balance);
+
+        // Items are on the BilledBill. For legacy plain-Bill records (pre two-bill structure)
+        // or PreBill IDs passed in, fall back to referenceBill if the bill has no items.
+        long itemsBillId = billId;
+
+        String sql = "SELECT i.name, ABS(bi.qty), COALESCE(bi.rate, bi.netRate, 0),"
+                + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire"
+                + " FROM " + billItemTable() + " bi"
+                + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
+                + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
+                + " JOIN " + itemTable() + " i ON i.ID = bi.item_ID"
+                + " WHERE bi.bill_ID = ? AND (bi.retired IS NULL OR bi.retired = 0)"
+                + " ORDER BY bi.ID";
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, itemsBillId)
+                .getResultList();
+
+        List<BillItemData> itemList = new ArrayList<>();
+        for (Object[] row : rows) {
+            BillItemData bid = new BillItemData();
+            bid.setItemName(row[0] != null ? row[0].toString() : "");
+            bid.setQty(toDouble(row[1]));
+            bid.setRate(toDouble(row[2]));
+            bid.setNetRate(toDouble(row[3]));
+            bid.setNetValue(toDouble(row[4]));
+            bid.setGrossValue(toDouble(row[5]));
+            bid.setDoe(row[6] instanceof java.sql.Date
+                    ? new java.util.Date(((java.sql.Date) row[6]).getTime())
+                    : (row[6] instanceof java.util.Date ? (java.util.Date) row[6] : null));
+            itemList.add(bid);
+        }
+
+        return new Object[]{pbd, itemList};
+    }
+
+    /**
+     * Rebuilds the itemised payment lines for a reprinted/reopened Multiple
+     * Payment Methods bill from the persisted {@link Payment} rows. Each line
+     * carries the method label, paid value and a method-specific reference
+     * (card/cheque/slip/ewallet/online/credit reference) when available.
+     */
+    private List<PrintBillData.PaymentLine> buildPrintPaymentLinesFromPersisted(Bill bill) {
+        List<PrintBillData.PaymentLine> lines = new ArrayList<>();
+        List<Payment> payments = em.createQuery(
+                "select p from Payment p where p.bill = :bill"
+                + " and p.retired = false"
+                + " order by p.id", Payment.class)
+                .setParameter("bill", bill)
+                .getResultList();
+        for (Payment p : payments) {
+            if (p.getPaymentMethod() == null || p.getPaidValue() <= 0.0) {
+                continue;
+            }
+            String reference = "";
+            switch (p.getPaymentMethod()) {
+                case Card:
+                    reference = safeStr(p.getCreditCardRefNo());
+                    break;
+                case Cheque:
+                    reference = safeStr(p.getChequeRefNo());
+                    break;
+                case ewallet:
+                case Slip:
+                case OnlineSettlement:
+                case IOU:
+                case Credit:
+                    reference = safeStr(p.getReferenceNo());
+                    break;
+                default:
+                    break;
+            }
+            lines.add(new PrintBillData.PaymentLine(
+                    p.getPaymentMethod().getLabel(), p.getPaidValue(), reference));
+        }
+        return lines;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -611,13 +611,21 @@ public class RetailSaleForCashierNativeSqlService {
             }
         }
         pbd.setBillNo(safeStr(bill.getDeptId()));
+        pbd.setBillIdStr(safeStr(bill.getIdStr()));
+        pbd.setCancelled(bill.isCancelled());
+        pbd.setInvoiceNumber(safeStr(bill.getInvoiceNumber()));
         pbd.setCreatedAt(bill.getCreatedAt());
         if (bill.getCreater() != null) {
             pbd.setCreatorName(safeStr(bill.getCreater().getName()));
+            pbd.setCreatorCode(safeStr(bill.getCreater().getCode()));
         }
         pbd.setTokenNumber(findTokenNumber(bill));
         if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
             pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
+            pbd.setPatientAgeSex(safeStr(bill.getPatient().getPerson().getAgeAsShortString())
+                    + " / "
+                    + (bill.getPatient().getPerson().getSex() != null
+                            ? safeStr(bill.getPatient().getPerson().getSex().getLabel()) : ""));
             pbd.setPatientPhone(safeStr(bill.getPatient().getPerson().getPhone()));
             pbd.setPatientPhn(safeStr(bill.getPatient().getPhn()));
         }
@@ -661,12 +669,13 @@ public class RetailSaleForCashierNativeSqlService {
         pbd.setCashPaid(cashPaid);
         pbd.setBalance(balance);
 
-        // Items are on the BilledBill. For legacy plain-Bill records (pre two-bill structure)
-        // or PreBill IDs passed in, fall back to referenceBill if the bill has no items.
+        // Single-bill flow: the items hang off this bill directly. There is no BilledBill
+        // and no referenceBill to fall back to (contrast the two-bill retail sale path).
         long itemsBillId = billId;
 
         String sql = "SELECT i.name, ABS(bi.qty), COALESCE(bi.rate, bi.netRate, 0),"
-                + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire"
+                + " ABS(bi.netRate), ABS(bi.netValue), ABS(bi.grossValue), ib.dateOfExpire,"
+                + " i.code"
                 + " FROM " + billItemTable() + " bi"
                 + " JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID"
                 + " JOIN " + itemBatchTable() + " ib ON ib.ID = pbi.itemBatch_ID"
@@ -691,6 +700,7 @@ public class RetailSaleForCashierNativeSqlService {
             bid.setDoe(row[6] instanceof java.sql.Date
                     ? new java.util.Date(((java.sql.Date) row[6]).getTime())
                     : (row[6] instanceof java.util.Date ? (java.util.Date) row[6] : null));
+            bid.setItemCode(row[7] != null ? row[7].toString() : "");
             itemList.add(bid);
         }
 

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -6,6 +6,7 @@
 package com.divudi.service.pharmacy;
 
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.TokenType;
 import com.divudi.core.data.dto.BillItemData;
 import com.divudi.core.data.dto.PrintBillData;
 import com.divudi.core.data.dto.StockAggregateResult;
@@ -17,6 +18,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.PreBill;
+import com.divudi.core.entity.Token;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.entity.pharmacy.StockHistory;
 import java.util.ArrayList;
@@ -594,7 +596,12 @@ public class RetailSaleForCashierNativeSqlService {
             pbd.setDepartmentPrintingName(dept.getPrintingName() != null
                     ? dept.getPrintingName() : safeStr(dept.getName()));
             pbd.setDepartmentTelephone1(safeStr(dept.getTelephone1()));
+            pbd.setDepartmentTelephone2(safeStr(dept.getTelephone2()));
+            pbd.setDepartmentFax(safeStr(dept.getFax()));
             pbd.setDepartmentAddress(safeStr(dept.getAddress()));
+            if (dept.getSite() != null) {
+                pbd.setDepartmentSiteName(safeStr(dept.getSite().getName()));
+            }
             Institution inst = dept.getInstitution();
             if (inst != null) {
                 pbd.setInstitutionName(safeStr(inst.getName()));
@@ -608,6 +615,7 @@ public class RetailSaleForCashierNativeSqlService {
         if (bill.getCreater() != null) {
             pbd.setCreatorName(safeStr(bill.getCreater().getName()));
         }
+        pbd.setTokenNumber(findTokenNumber(bill));
         if (bill.getPatient() != null && bill.getPatient().getPerson() != null) {
             pbd.setPatientName(safeStr(bill.getPatient().getPerson().getNameWithTitle()));
             pbd.setPatientPhone(safeStr(bill.getPatient().getPerson().getPhone()));
@@ -687,6 +695,27 @@ public class RetailSaleForCashierNativeSqlService {
         }
 
         return new Object[]{pbd, itemList};
+    }
+
+    /**
+     * Token number of the pharmacy token issued for this bill, or null when the token
+     * system was off for the sale (no token exists). Same lookup as
+     * PharmacyPreSettleController.findTokenFromBill(Bill) - bill + SALE_FOR_CASHIER token
+     * type - so a reprinted token slip shows the same number the settle-time printout did.
+     */
+    private String findTokenNumber(Bill bill) {
+        List<Token> tokens = em.createQuery(
+                "select t from Token t"
+                + " where t.bill = :bill"
+                + " and t.tokenType = :ty", Token.class)
+                .setParameter("bill", bill)
+                .setParameter("ty", TokenType.PHARMACY_TOKEN_SALE_FOR_CASHIER)
+                .setMaxResults(1)
+                .getResultList();
+        if (tokens.isEmpty()) {
+            return null;
+        }
+        return tokens.get(0).getTokenNumber();
     }
 
     /**

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -19,7 +19,12 @@
                         };
                     </script>
                     <p:growl id="panelError" />
-                    <p:defaultCommand target="btnAdd" />
+                    <!-- Guarded on the entry panel: btnAdd only exists while !billPreview, and
+                         PrimeFaces throws on widget init when a defaultCommand target is absent.
+                         The sibling pharmacy_bill_retail_sale_native.xhtml has the same unguarded
+                         markup and logs the same console error after a settle. -->
+                    <p:defaultCommand target="btnAdd"
+                                      rendered="#{!retailSaleForCashierNativeSqlController.billPreview}" />
 
                     <!-- ============================================================
                          ENTRY PANEL (hidden after settle)

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -108,7 +108,7 @@
                                                         styleClass="w-100"
                                                         forceSelection="true"
                                                         value="#{retailSaleForCashierNativeSqlController.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleForCashierNativeSqlController.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300" completeMethod="#{retailSaleForCashierNativeSqlController.completeAvailableStockOptimizedDtoFilteredByDepartmentType}"
                                                         converter="#{retailSaleForCashierNativeSqlController.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -1,0 +1,994 @@
+﻿<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
+      xmlns:pp="http://xmlns.jcp.org/jsf/composite/pharmacy/print"
+      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="bill">
+                    <script>
+                        window.onload = function () {
+                            var ac = document.getElementById("bill:acStock");
+                            if (ac) { ac.focus(); }
+                        };
+                    </script>
+                    <p:growl id="panelError" />
+                    <p:defaultCommand target="btnAdd" />
+
+                    <!-- ============================================================
+                         ENTRY PANEL (hidden after settle)
+                         ============================================================ -->
+                    <p:panel rendered="#{!retailSaleForCashierNativeSqlController.billPreview}">
+
+                        <p:panel class="w-100">
+                            <f:facet name="header">
+                                <div class="row w-100 align-items-center">
+                                    <div class="col-4">
+                                        <h:outputText styleClass="fas fa-mortar-pestle" />
+                                        <h:outputLabel value="Pharmacy Sale for Cashier (Native)" class="mx-2" />
+                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                            <p:commandButton
+                                                value="Config"
+                                                icon="fa fa-cog"
+                                                title="Page Configuration"
+                                                action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_bill_retail_sale_for_cashier_native')}"
+                                                ajax="false"
+                                                class="ui-button-secondary mx-1" />
+                                        </h:panelGroup>
+                                    </div>
+                                    <div class="col-4 text-center">
+                                        <p:commandButton
+                                            icon="fa fa-search"
+                                            value="Search Sale for Cashier Bills"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_search_sale_pre_bill?faces-redirect=true"
+                                            actionListener="#{searchController.makeListNull}"
+                                            class="ui-button-info" />
+                                        <p:commandButton
+                                            icon="fas fa-clipboard-list"
+                                            value="Tokens"
+                                            title="Back to token management"
+                                            ajax="false"
+                                            class="ui-button-help mx-1"
+                                            action="#{tokenController.navigateToManagePharmacyTokens()}"
+                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}" />
+                                    </div>
+                                    <div class="col-4 text-end">
+                                        <p:commandButton
+                                            ajax="false"
+                                            accesskey="s"
+                                            value="Settle"
+                                            icon="fa fa-check"
+                                            class="ui-button-success mx-1"
+                                            onclick="if (!confirm('Are you sure?')) return false"
+                                            action="#{retailSaleForCashierNativeSqlController.settleBillWithPay}" />
+                                        <p:commandButton
+                                            icon="fa fa-plus"
+                                            value="New Bill"
+                                            ajax="false"
+                                            action="pharmacy_bill_retail_sale_for_cashier_native"
+                                            class="ui-button-warning"
+                                            actionListener="#{retailSaleForCashierNativeSqlController.resetAll()}" />
+                                    </div>
+                                </div>
+                                <!-- No Sale 1..4 window-switch row: those windows belong to the plain native
+                                     retail sale (#22443). Cashier windows are Phase 4 / #22444. -->
+                            </f:facet>
+
+                            <div class="row">
+                                <!-- Left column: item entry + bill items -->
+                                <div class="col-md-7">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa-solid fa-circle-plus" />
+                                            <h:outputText value="Add New Items" class="mx-4" />
+                                        </f:facet>
+                                        <div class="row w-100 m-1 p-1">
+                                            <div class="col-md-5">
+                                                <p:focus id="focusForAcIx" for="acStock" />
+                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <h:panelGroup id="acStock">
+                                                    <p:autoComplete
+                                                        id="acStockField"
+                                                        accesskey="i"
+                                                        inputStyleClass="w-100"
+                                                        minQueryLength="3"
+                                                        maxResults="10"
+                                                        styleClass="w-100"
+                                                        forceSelection="true"
+                                                        value="#{retailSaleForCashierNativeSqlController.stockDto}"
+                                                        queryDelay="300" completeMethod="#{retailSaleForCashierNativeSqlController.completeAvailableStockOptimizedDto}"
+                                                        converter="#{retailSaleForCashierNativeSqlController.stockDtoConverter}"
+                                                        var="i"
+                                                        itemLabel="#{i.itemName}"
+                                                        itemValue="#{i}">
+                                                        <p:column
+                                                            headerText="Item"
+                                                            width="400"
+                                                            styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputText value="#{i.itemName}" />
+                                                            &#160;<p:tag
+                                                                rendered="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'true' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'true' : 'false'}"
+                                                                value="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'Expired ' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'Expiring Soon' : ''}"
+                                                                severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
+                                                            headerText="Code"
+                                                            styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputText value="#{i.code}" />
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Rate"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.retailRate}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Stocks"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.stockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Expiry"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.dateOfExpire}">
+                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:ajax event="itemSelect" listener="#{retailSaleForCashierNativeSqlController.handleSelect}" update="txtQty txtRate focusQty" />
+                                                        <p:ajax event="query" process="acStock" />
+                                                    </p:autoComplete>
+                                                </h:panelGroup>
+                                            </div>
+                                            <div class="col-md-2">
+                                                <p:outputLabel class="w-100" for="txtQty">Quantity</p:outputLabel>
+                                                <p:inputText
+                                                    id="txtQty"
+                                                    accesskey="q"
+                                                    autocomplete="off"
+                                                    class="w-100"
+                                                    style="text-align: right;"
+                                                    value="#{retailSaleForCashierNativeSqlController.intQty}">
+                                                    <p:ajax event="keyup" listener="#{retailSaleForCashierNativeSqlController.calculateBillItemListner}" process="acStock txtQty" update="txtRate txtVal" />
+                                                    <p:ajax event="blur" listener="#{retailSaleForCashierNativeSqlController.calculateBillItemListner}" process="acStock txtQty" update="txtRate txtVal" />
+                                                </p:inputText>
+                                            </div>
+                                            <div class="col-md-5">
+                                                <div class="row">
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel value="&#160;" class="w-100" />
+                                                        <p:commandButton
+                                                            id="btnAdd"
+                                                            accesskey="a"
+                                                            icon="fa fa-plus"
+                                                            value="Add"
+                                                            styleClass="ui-button-success"
+                                                            action="#{retailSaleForCashierNativeSqlController.addBillItem()}"
+                                                            process="@this acStock txtQty focusForAcIx"
+                                                            update=":#{p:resolveFirstComponentWithId('netTotal', view).clientId} :#{p:resolveFirstComponentWithId('dis', view).clientId} :#{p:resolveFirstComponentWithId('total', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId} tblBillItem txtRate txtQty acStock focusItem :#{p:resolveFirstComponentWithId('panelError', view).clientId}" />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel class="w-100" for="txtRate">Rate</p:outputLabel>
+                                                        <p:inputText
+                                                            id="txtRate"
+                                                            style="text-align: right;"
+                                                            class="w-100"
+                                                            readonly="true"
+                                                            value="#{retailSaleForCashierNativeSqlController.billItem.netRate}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <p:outputLabel class="w-100" value="Value" for="txtVal" />
+                                                        <p:inputText
+                                                            id="txtVal"
+                                                            style="text-align: right;"
+                                                            class="w-100"
+                                                            readonly="true"
+                                                            value="#{retailSaleForCashierNativeSqlController.previewNetValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </p:inputText>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <p:focus id="focusQty" for="txtQty" />
+                                        <p:focus id="focusItem" for="acStock" />
+                                    </p:panel>
+
+                                    <!-- Bill Items table -->
+                                    <p:panel id="pBis">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-money-bill" />
+                                            <h:outputLabel value="Bill Items" class="mx-4" />
+                                        </f:facet>
+                                        <p:dataTable
+                                            id="tblBillItem"
+                                            widgetVar="tblBillItem"
+                                            value="#{retailSaleForCashierNativeSqlController.billItemDataList}"
+                                            var="bi"
+                                            rowKey="#{bi.stockId}"
+                                            rowIndexVar="s"
+                                            editable="true"
+                                            class="w-100">
+                                            <p:ajax event="rowEdit" listener="#{retailSaleForCashierNativeSqlController.onEdit}" update="@this :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId} :#{p:resolveFirstComponentWithId('panelError', view).clientId}" />
+                                            <p:ajax event="rowEditCancel" listener="#{retailSaleForCashierNativeSqlController.onEditCancel}" update="@this :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+
+                                            <p:column headerText="No" style="width: 2em; padding: 6px;">
+                                                <h:outputLabel value="#{s+1}">
+                                                    <f:convertNumber pattern="#,##0" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Item" style="padding: 6px;">
+                                                <h:outputLabel value="#{bi.itemName}" />
+                                                <p:commandButton
+                                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show alternative medicines available during retail sale', true)}"
+                                                    id="btnSelectSubstitute"
+                                                    icon="pi pi-refresh"
+                                                    title="Show Alternatives"
+                                                    action="#{retailSaleForCashierNativeSqlController.prepareSubstitute(bi)}"
+                                                    update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                                    oncomplete="PF('substituteDialog').show();"
+                                                    process="@this"
+                                                    styleClass="ui-button-warning ui-button-icon-only mx-1" />
+                                            </p:column>
+                                            <p:column headerText="Rate" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.rate}">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Value" style="width: 5em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.netValue &lt; 0 ? -bi.netValue : bi.netValue}" id="gros">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Expiry" style="width: 7em; padding: 6px;">
+                                                <h:outputLabel value="#{bi.doe}">
+                                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Qty" style="width: 3em; padding: 6px;">
+                                                <p:cellEditor>
+                                                    <f:facet name="output">
+                                                        <h:outputText value="#{bi.qty}">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0" />
+                                                        </h:outputText>
+                                                    </f:facet>
+                                                    <f:facet name="input">
+                                                        <p:inputText
+                                                            id="ipTblQty"
+                                                            autocomplete="off"
+                                                            value="#{bi.qty}"
+                                                            style="width:96%"
+                                                            converterMessage="Please enter a valid integer value.">
+                                                            <f:convertNumber integerOnly="true" pattern="#,##0" />
+                                                        </p:inputText>
+                                                    </f:facet>
+                                                </p:cellEditor>
+                                            </p:column>
+                                            <p:column style="width: 16em; padding: 6px;">
+                                                <p:rowEditor style="display: inline-block; margin-right: 10px;" />
+                                                <p:commandButton
+                                                    id="btnQtyX2"
+                                                    icon="fas fa-angle-double-up"
+                                                    title="Double quantity #{bi.itemName}"
+                                                    actionListener="#{retailSaleForCashierNativeSqlController.multiplyQuantityByTwo(bi)}"
+                                                    class="ui-button-secondary"
+                                                    process="btnQtyX2"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                    style="display: inline-block;" />
+                                                <p:commandButton
+                                                    id="btnQtyHalf"
+                                                    icon="fas fa-angle-double-down"
+                                                    title="Halve quantity #{bi.itemName}"
+                                                    actionListener="#{retailSaleForCashierNativeSqlController.divideQuantityByHalf(bi)}"
+                                                    class="ui-button-secondary"
+                                                    process="btnQtyHalf"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                    style="display: inline-block;" />
+                                                <p:commandButton
+                                                    id="btnDelete"
+                                                    icon="fas fa-trash"
+                                                    title="Remove #{bi.itemName}"
+                                                    action="#{retailSaleForCashierNativeSqlController.removeBillItem(bi)}"
+                                                    class="ui-button-danger"
+                                                    process="btnDelete"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                    style="display: inline-block;" />
+                                            </p:column>
+                                            <f:facet name="footer">
+                                                <p:commandButton
+                                                    id="btnAllQtyX2"
+                                                    icon="fas fa-angle-double-up"
+                                                    value="All x2"
+                                                    title="Double every quantity on the bill"
+                                                    actionListener="#{retailSaleForCashierNativeSqlController.multiplyAllQuantitiesByTwo()}"
+                                                    class="ui-button-secondary m-1"
+                                                    process="btnAllQtyX2"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+                                                <p:commandButton
+                                                    id="btnAllQtyHalf"
+                                                    icon="fas fa-angle-double-down"
+                                                    value="All &#247;2"
+                                                    title="Halve every quantity on the bill"
+                                                    actionListener="#{retailSaleForCashierNativeSqlController.divideAllQuantitiesByHalf()}"
+                                                    class="ui-button-secondary m-1"
+                                                    process="btnAllQtyHalf"
+                                                    update="tblBillItem :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+                                            </f:facet>
+                                        </p:dataTable>
+
+                                        <p:dialog
+                                            id="substituteDlg"
+                                            widgetVar="substituteDialog"
+                                            modal="true"
+                                            position="top"
+                                            fitViewport="true"
+                                            appendTo="@(body)"
+                                            header="Alternatives"
+                                            width="60%">
+                                            <div class="mb-3 p-3 bg-light border rounded">
+                                                <h:outputLabel value="Selected Item: " styleClass="fw-bold text-primary"/>
+                                                <h:outputText value="#{retailSaleForCashierNativeSqlController.itemDataForSubstitution.itemName}" styleClass="fw-bold text-dark"/>
+                                            </div>
+                                            <p:dataTable
+                                                id="substituteTable"
+                                                value="#{retailSaleForCashierNativeSqlController.substituteStocks}"
+                                                var="sStock"
+                                                rowKey="#{sStock.stockId}"
+                                                paginator="true"
+                                                rows="10"
+                                                paginatorPosition="bottom"
+                                                emptyMessage="No substitute stocks found"
+                                                styleClass="table-striped">
+                                                <p:column headerText="Item">
+                                                    <h:outputText value="#{sStock.itemName}"/>
+                                                </p:column>
+                                                <p:column headerText="Code">
+                                                    <h:outputText value="#{sStock.code}"/>
+                                                </p:column>
+                                                <p:column headerText="Rate" style="text-align: right;">
+                                                    <h:outputText value="#{sStock.retailRate}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Stock" style="text-align: right;">
+                                                    <h:outputText value="#{sStock.stockQty}">
+                                                        <f:convertNumber pattern="#,###.#"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Expiry">
+                                                    <h:outputText value="#{sStock.dateOfExpire}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Action" style="width: 8em;">
+                                                    <p:commandButton
+                                                        id="btnReplace"
+                                                        value="Replace"
+                                                        action="#{retailSaleForCashierNativeSqlController.replaceSelectedSubstitute}"
+                                                        update=":#{p:resolveFirstComponentWithId('tblBillItem', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                        oncomplete="PF('substituteDialog').hide();"
+                                                        process="@this">
+                                                        <f:setPropertyActionListener value="#{sStock}" target="#{retailSaleForCashierNativeSqlController.selectedSubstituteStock}" />
+                                                    </p:commandButton>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </p:dialog>
+                                    </p:panel>
+                                </div>
+
+                                <!-- Right column: patient + payment -->
+                                <div class="col-md-5">
+                                    <h:panelGrid id="sale" columns="1" class="alignTop w-100">
+
+                                        <!-- Patient panel -->
+                                        <p:panel id="panelPatient">
+                                            <f:facet name="header">
+                                                <h:panelGroup layout="block" styleClass="d-flex justify-content-between align-items-center">
+                                                    <h:panelGroup id="headerFacet">
+                                                        <h:outputText styleClass="fas fa-user" />
+                                                        <h:outputText
+                                                            rendered="#{retailSaleForCashierNativeSqlController.patient.id eq null}"
+                                                            value="Patient" class="mx-4" />
+                                                        <h:outputText
+                                                            rendered="#{retailSaleForCashierNativeSqlController.patient.id ne null}"
+                                                            value="Searched Patient Details" class="mx-2" />
+                                                        <p:selectBooleanButton
+                                                            value="#{retailSaleForCashierNativeSqlController.patientDetailsEditable}"
+                                                            offIcon="pi pi-pencil"
+                                                            onIcon="pi pi-eye"
+                                                            class="mx-2">
+                                                            <p:ajax process="@this" update="viewPatient editPatient btnDone" />
+                                                        </p:selectBooleanButton>
+                                                        <p:commandButton
+                                                            id="btnDone"
+                                                            alt="Save Patient Details"
+                                                            class="ui-button-success"
+                                                            icon="fas fa-check"
+                                                            action="#{patientController.saveSelected(retailSaleForCashierNativeSqlController.patient)}"
+                                                            rendered="#{retailSaleForCashierNativeSqlController.patientDetailsEditable}"
+                                                            update=":#{p:resolveFirstComponentWithId('panelPatient', view).clientId}" />
+</h:panelGroup>
+                                                    <h:panelGroup layout="block" styleClass="form-inline">
+                                                        <p:inputText
+                                                            autocomplete="off"
+                                                            id="txtQuickSearchPhoneNumber"
+                                                            value="#{patientController.quickSearchPhoneNumber}"
+                                                            placeholder="Phone Number"
+                                                            class="form-control-sm mx-1"
+                                                            onfocus="this.select()" />
+                                                        <p:commandButton
+                                                            id="btnSearchbyPhoneNo"
+                                                            icon="fa fa-search"
+                                                            title="Quick Search from Phone Number"
+                                                            action="#{patientController.quickSearchPatientLongPhoneNumber(retailSaleForCashierNativeSqlController)}"
+                                                            process="btnSearchbyPhoneNo txtQuickSearchPhoneNumber"
+                                                            update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                            styleClass="btn-sm mx-1" />
+                                                        <p:commandButton
+                                                            id="btnAddNewPatient"
+                                                            icon="fa fa-plus-circle"
+                                                            title="Add New Patient"
+                                                            action="#{patientController.quickSearchNewPatient(retailSaleForCashierNativeSqlController)}"
+                                                            process="btnAddNewPatient"
+                                                            update="panelPatient selectPatient editPatient viewPatient panelPayment panelBillDetails"
+                                                            styleClass="btn-sm mx-1" />
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </f:facet>
+
+                                            <h:panelGroup id="selectPatient">
+                                                <h:panelGroup rendered="#{patientController.quickSearchPatientList ne null and not empty patientController.quickSearchPatientList}">
+                                                    <p:dataTable id="tblPatients" value="#{patientController.quickSearchPatientList}" var="ps">
+                                                        <p:column headerText="Name">#{ps.person.name}</p:column>
+                                                        <p:column headerText="Phone Number">#{ps.person.phone}</p:column>
+                                                        <p:column headerText="Mobile Number">#{ps.person.mobile}</p:column>
+                                                        <p:column>
+                                                            <p:commandButton
+                                                                id="btnSelectPt"
+                                                                action="#{patientController.selectQuickOneFromQuickSearchPatient(retailSaleForCashierNativeSqlController)}"
+                                                                process="btnSelectPt"
+                                                                update=":#{p:resolveFirstComponentWithId('panelPatient', view).clientId} :#{p:resolveFirstComponentWithId('panelPayment', view).clientId} :#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}"
+                                                                value="Select">
+                                                                <f:setPropertyActionListener value="#{ps}" target="#{patientController.current}" />
+                                                            </p:commandButton>
+                                                        </p:column>
+                                                    </p:dataTable>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup id="editPatient">
+                                                <h:panelGroup rendered="#{retailSaleForCashierNativeSqlController.patientDetailsEditable}">
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null or empty patientController.quickSearchPatientList}">
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:selectOneMenu id="cmbTitle" class="form-control w-100" value="#{retailSaleForCashierNativeSqlController.patient.person.title}">
+                                                                    <f:selectItem itemLabel="Select Title" />
+                                                                    <f:selectItems value="#{opdBillController.title}" var="i" itemLabel="#{i.label}" itemValue="#{i}" />
+                                                                    <p:ajax event="change" process="cmbTitle" update="cmbSex" />
+                                                                </p:selectOneMenu>
+                                                            </div>
+                                                            <div class="col-md-9 p-1">
+                                                                <p:inputText
+                                                                    autocomplete="off"
+                                                                    id="txtNewPtName"
+                                                                    placeholder="Patient Name"
+                                                                    value="#{retailSaleForCashierNativeSqlController.patient.person.name}"
+                                                                    class="form-control" />
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:selectOneMenu id="cmbSex" value="#{retailSaleForCashierNativeSqlController.patient.person.sex}" class="form-control w-100">
+                                                                    <f:selectItem itemLabel="Select Gender" />
+                                                                    <f:selectItems value="#{opdBillController.sex}" />
+                                                                </p:selectOneMenu>
+                                                            </div>
+                                                            <div class="col-md-9 p-1">
+                                                                <div class="row">
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="year" placeholder="Years" value="#{retailSaleForCashierNativeSqlController.patient.person.ageYearsComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleForCashierNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="month" placeholder="Months" value="#{retailSaleForCashierNativeSqlController.patient.person.ageMonthsComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleForCashierNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-2">
+                                                                        <p:inputText autocomplete="off" id="day" placeholder="Days" value="#{retailSaleForCashierNativeSqlController.patient.person.ageDaysComponent}" class="form-control">
+                                                                            <f:ajax event="keyup" execute="@this" render="dpDob" listener="#{retailSaleForCashierNativeSqlController.calculateDobFromAge}" />
+                                                                        </p:inputText>
+                                                                    </div>
+                                                                    <div class="col-md-6">
+                                                                        <p:datePicker
+                                                                            value="#{retailSaleForCashierNativeSqlController.patient.person.dob}"
+                                                                            id="dpDob"
+                                                                            class="w-100"
+                                                                            yearNavigator="true"
+                                                                            monthNavigator="true"
+                                                                            inputStyleClass="form-control"
+                                                                            pattern="#{sessionController.applicationPreference.longDateFormat}"
+                                                                            placeholder="Date of Birth">
+                                                                            <p:ajax event="dateSelect" process="@this" update="year month day" />
+                                                                        </p:datePicker>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtMobile" autocomplete="off" placeholder="Mobile Number" value="#{retailSaleForCashierNativeSqlController.patient.mobileNumberStringTransient}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtPhone" autocomplete="off" placeholder="Phone Number" value="#{retailSaleForCashierNativeSqlController.patient.phoneNumberStringTransient}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText autocomplete="off" id="txtEmail" placeholder="Email" value="#{retailSaleForCashierNativeSqlController.patient.person.email}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-3 p-1">
+                                                                <p:inputText id="txtNic" autocomplete="off" placeholder="National ID Number" value="#{retailSaleForCashierNativeSqlController.patient.person.nic}" class="form-control" />
+                                                            </div>
+                                                        </div>
+                                                        <div class="row">
+                                                            <div class="col-md-8 p-1">
+                                                                <p:inputText id="txtAddress" autocomplete="off" placeholder="Address" value="#{retailSaleForCashierNativeSqlController.patient.person.address}" class="form-control" />
+                                                            </div>
+                                                            <div class="col-md-4 p-1">
+                                                                <p:autoComplete
+                                                                    id="acNewPtArea"
+                                                                    placeholder="Search Area"
+                                                                    completeMethod="#{areaController.completeArea}"
+                                                                    var="pta" itemLabel="#{pta.name}"
+                                                                    itemValue="#{pta}" forceSelection="true"
+                                                                    value="#{retailSaleForCashierNativeSqlController.patient.person.area}"
+                                                                    inputStyleClass="form-control"
+                                                                    class="w-100" />
+                                                            </div>
+                                                        </div>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup id="viewPatient">
+                                                <h:panelGroup rendered="#{not retailSaleForCashierNativeSqlController.patientDetailsEditable}">
+                                                    <h:panelGroup rendered="#{patientController.quickSearchPatientList eq null}">
+                                                        <h:panelGrid columns="3" class="my-1" rendered="#{retailSaleForCashierNativeSqlController.patient ne null}">
+                                                            <h:outputLabel value="Name" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleForCashierNativeSqlController.patient.person.nameWithTitle}" />
+                                                            <h:outputLabel value="Gender" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleForCashierNativeSqlController.patient.person.sex}" />
+                                                            <h:outputLabel value="Mobile No." class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleForCashierNativeSqlController.patient.person.mobile}" />
+                                                            <h:outputLabel value="Phone No." class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{retailSaleForCashierNativeSqlController.patient.person.phone}" />
+                                                            <h:outputLabel value="NIC" class="mx-3" />
+                                                            <h:outputLabel value=" : " class="mx-3" />
+                                                            <h:outputText value="#{empty retailSaleForCashierNativeSqlController.patient.person.nic ? 'N/A' : retailSaleForCashierNativeSqlController.patient.person.nic}" />
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
+                                                </h:panelGroup>
+                                            </h:panelGroup>
+                                        </p:panel>
+
+                                        <!-- Payment panel -->
+                                        <div class="row">
+                                            <div class="col">
+                                                <p:panel id="panelPayment" class="w-100">
+                                                    <f:facet name="header">
+                                                        <h:outputText styleClass="fas fa-money-bill-wave" />
+                                                        <h:outputLabel value="Payment Details" class="mx-4" />
+                                                    </f:facet>
+                                                    <div class="row">
+                                                        <div class="col-md-5">
+                                                            <p:selectOneMenu
+                                                                id="pay"
+                                                                value="#{retailSaleForCashierNativeSqlController.paymentMethod}"
+                                                                required="true"
+                                                                requiredMessage="Please select a payment method">
+                                                                <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
+                                                                <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleForCashierNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPaymentScheme"
+                                                                value="#{retailSaleForCashierNativeSqlController.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq true}"
+                                                                required="true"
+                                                                requiredMessage="Please select a payment scheme">
+                                                                <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleForCashierNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="row">
+                                                        <div class="my-1">
+                                                            <h:panelGroup id="panelPaymentDetails" class="row">
+                                                                <div class="col">
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Credit'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row">
+                                                                                <div class="col-12">
+                                                                                    <div class="d-flex gap-2">
+                                                                                        <p:autoComplete
+                                                                                            id="creditCompany"
+                                                                                            class="w-100"
+                                                                                            inputStyleClass="form-control"
+                                                                                            forceSelection="true"
+                                                                                            value="#{retailSaleForCashierNativeSqlController.paymentMethodData.credit.institution}"
+                                                                                            completeMethod="#{institutionController.completeCreditCompany}"
+                                                                                            var="ix"
+                                                                                            required="true"
+                                                                                            requiredMessage="Please Select a Company"
+                                                                                            minQueryLength="2"
+                                                                                            placeholder="Company"
+                                                                                            itemLabel="#{ix.name}"
+                                                                                            itemValue="#{ix}"
+                                                                                            size="10">
+                                                                                            <f:ajax event="itemSelect" listener="#{retailSaleForCashierNativeSqlController.calTotal()}" execute="@this" render=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" />
+                                                                                        </p:autoComplete>
+                                                                                        <p:inputText id="polNo" style="width: 100px;" value="#{retailSaleForCashierNativeSqlController.paymentMethodData.credit.referralNo}" placeholder="Policy NO" required="true" requiredMessage="Please enter a policy number" />
+                                                                                        <p:inputText id="refNo" style="width: 100px;" required="true" requiredMessage="Please enter a Reference Number" value="#{retailSaleForCashierNativeSqlController.paymentMethodData.credit.referenceNo}" placeholder="Reference NO" />
+                                                                                        <p:inputText id="memo" style="width: 300px;" required="true" requiredMessage="Please Enter a comment" value="#{retailSaleForCashierNativeSqlController.paymentMethodData.credit.comment}" placeholder="Memo" />
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Staff'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="2"
+                                                                                        forceSelection="true"
+                                                                                        value="#{retailSaleForCashierNativeSqlController.toStaff}"
+                                                                                        id="creditStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        required="true"
+                                                                                        requiredMessage="Please select a staff member"
+                                                                                        placeholder="Staff (Type at least 2 letters)"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;"><h:outputText value="#{mys.person.nameWithTitle}" /></p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;"><h:outputText value="#{mys.epfNo}" /></p:column>
+                                                                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" event="itemSelect" listener="#{retailSaleForCashierNativeSqlController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup class="row" layout="block" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Staff_Welfare'}">
+                                                                        <div class="my-1">
+                                                                            <div class="row mt-1">
+                                                                                <div class="col-12">
+                                                                                    <p:autoComplete
+                                                                                        minQueryLength="1"
+                                                                                        forceSelection="true"
+                                                                                        value="#{retailSaleForCashierNativeSqlController.toStaff}"
+                                                                                        id="welfareStaff"
+                                                                                        completeMethod="#{staffController.completeStaff}"
+                                                                                        var="mys"
+                                                                                        class="w-100"
+                                                                                        required="true"
+                                                                                        requiredMessage="Please select a staff member"
+                                                                                        placeholder="Staff"
+                                                                                        inputStyleClass="form-control"
+                                                                                        itemLabel="#{mys.person.name}"
+                                                                                        itemValue="#{mys}"
+                                                                                        size="10">
+                                                                                        <p:column headerText="Name" style="padding: 2px;"><h:outputText value="#{mys.person.nameWithTitle}" /></p:column>
+                                                                                        <p:column headerText="EPF" style="padding: 2px;"><h:outputText value="#{mys.epfNo}" /></p:column>
+                                                                                        <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('panelBillDetails', view).clientId}" event="itemSelect" listener="#{retailSaleForCashierNativeSqlController.calTotal()}" />
+                                                                                    </p:autoComplete>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </h:panelGroup>
+
+                                                                    <h:panelGroup id="creditCard" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Card'}">
+                                                                        <pa:creditCardDetailsAsOnlyPayment paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="ptdeposit" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'PatientDeposit'}">
+                                                                        <pa:patient_deposit paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="ewallet" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'ewallet'}">
+                                                                        <pa:ewalletDetailsAsOnlyPayment paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="cheque" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Cheque'}">
+                                                                        <pa:chequeDetailsAsOnlyPayment paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="slip" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'Slip'}">
+                                                                        <pa:slipDetailsAsOnlyPayment paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup id="iou" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'IOU'}">
+                                                                        <pa:iouDetailsAsOnlyPayment paymentMethodData="#{retailSaleForCashierNativeSqlController.paymentMethodData}" />
+                                                                    </h:panelGroup>
+                                                                    <h:panelGroup class="row my-1 w-100" layout="block" id="multiplePaymentMethods" rendered="#{retailSaleForCashierNativeSqlController.paymentMethod eq 'MultiplePaymentMethods'}">
+                                                                        <pa:multiple_payment_methods
+                                                                            id="panelMultiplePaymentDetails"
+                                                                            class="w-100"
+                                                                            controller="#{retailSaleForCashierNativeSqlController}"
+                                                                            paymentMethods="#{enumController.paymentMethodsUnderMultipleForPharmacyBilling}" />
+                                                                    </h:panelGroup>
+                                                                </div>
+                                                            </h:panelGroup>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-5">
+                                                        <p:selectOneMenu
+                                                            id="cmbPs"
+                                                            value="#{retailSaleForCashierNativeSqlController.paymentScheme}"
+                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                            class="my-1">
+                                                            <f:selectItem itemLabel="Discount Scheme" />
+                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleForCashierNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                        </p:selectOneMenu>
+                                                    </div>
+
+                                                    <h:panelGrid columns="2" class="my-2">
+                                                        <p:outputLabel value="Referring Doctor" />
+                                                        <p:autoComplete
+                                                            forceSelection="true"
+                                                            id="cmbDoc"
+                                                            value="#{retailSaleForCashierNativeSqlController.preBill.referredBy}"
+                                                            completeMethod="#{doctorController.completeDoctor}"
+                                                            var="ix" itemLabel="#{ix.person.name}"
+                                                            itemValue="#{ix}" size="40"
+                                                            class="mx-4 w-100 mt-1"
+                                                            inputStyleClass="form-control" />
+                                                        <p:outputLabel value="Comments" />
+                                                        <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleForCashierNativeSqlController.comment}" />
+                                                    </h:panelGrid>
+                                                </p:panel>
+
+                                                <!-- Bill Details panel -->
+                                                <p:panel id="panelBillDetails" class="my-1">
+                                                    <f:facet name="header">
+                                                        <h:outputText styleClass="fas fa-list" />
+                                                        <h:outputLabel value="Bill Details" class="mx-4" />
+                                                    </f:facet>
+                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                        <h:outputLabel value="Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="total" value="#{retailSaleForCashierNativeSqlController.preBill.total}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Discount" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="dis" value="#{retailSaleForCashierNativeSqlController.preBill.discount}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Net Total" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="netTotal" value="#{retailSaleForCashierNativeSqlController.preBill.netTotal}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Tendered" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <p:inputText
+                                                                id="paid"
+                                                                value="#{retailSaleForCashierNativeSqlController.cashPaid}"
+                                                                class="form-control text-end"
+                                                                autocomplete="off"
+                                                                accesskey="t"
+                                                                onfocus="this.select()">
+                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                            </p:inputText>
+                                                        </h:panelGroup>
+                                                        <h:outputLabel value="Balance" />
+                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                            <h:outputLabel id="balance" value="#{retailSaleForCashierNativeSqlController.balance}">
+                                                                <f:convertNumber pattern="#,##0.00" />
+                                                            </h:outputLabel>
+                                                        </h:panelGroup>
+                                                    </h:panelGrid>
+                                                </p:panel>
+                                            </div>
+                                        </div>
+                                    </h:panelGrid>
+                                </div>
+                            </div>
+                        </p:panel>
+                    </p:panel>
+                </h:form>
+
+                <!-- ============================================================
+                     PRINT / PREVIEW PANEL (shown after settle)
+                     ============================================================ -->
+                <h:form>
+                    <p:panel rendered="#{retailSaleForCashierNativeSqlController.billPreview}">
+                        <div class="row">
+                            <div class="col-3">
+                                <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary mx-1"
+                                    type="button"
+                                    onclick="PF('saleForCashierNativeConfigDialog').show();" />
+                            </div>
+                            <div class="col-6 text-center">
+                                <p:commandButton
+                                    value="Search Sale for Cashier Bills"
+                                    icon="fa fa-search"
+                                    ajax="false"
+                                    action="pharmacy_search_sale_pre_bill"
+                                    class="ui-button-info" />
+                            </div>
+                            <div class="col-3">
+                                <div class="float-end">
+                                    <p:commandButton
+                                        accesskey="n"
+                                        value="New Sale"
+                                        icon="fa fa-plus"
+                                        ajax="false"
+                                        action="pharmacy_bill_retail_sale_for_cashier_native"
+                                        class="ui-button-warning mx-2"
+                                        actionListener="#{retailSaleForCashierNativeSqlController.resetAll()}" />
+                                    <p:commandButton
+                                        accesskey="p"
+                                        id="btnPrint"
+                                        icon="fas fa-print"
+                                        value="Print Bill"
+                                        class="ui-button-success"
+                                        rendered="#{!configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"
+                                        ajax="false">
+                                        <p:printer target="gpTokenAndBillPreview" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- No Sale 1..4 window-switch row: those windows belong to the plain native
+                             retail sale (#22443). Cashier windows are Phase 4 / #22444. -->
+
+                        <!-- Token slip prints first on its own page, then the bill.
+                             Mirrors printing/retail_sale_for_cashier.xhtml. -->
+                        <h:panelGroup id="gpTokenAndBillPreview">
+                            <h:panelGroup layout="block"
+                                          style="page-break-after: always!important;"
+                                          rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
+                                          id="gpTokenPreview">
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Token Paper is FiveFivePaper With Blank Space For Printed Heading', true)}">
+                                    <phi:saleBill_five_five_token_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Token Paper is POS Paper', true)}">
+                                    <phi:saleBillToken_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Token Paper is POS Paper Custom 1', false)}">
+                                    <phi:saleBillToken_Custom_1_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="billPrint" id="gpBillPreview">
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS Paper', true)}">
+                                    <phi:saleBill_for_Cashier_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS Paper Custom 1', false)}">
+                                    <phi:saleBill_for_Cashier_Pos_paper_Custom_1_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is FiveFive Paper without Blank Space for Header', true)}">
+                                    <phi:saleBill_five_five_for_Cashier_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
+                                    <phi:saleBill_Header_Inward_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 1', false)}">
+                                    <pp:retail_sale_for_cashier_custom_1_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 2', false)}">
+                                    <pp:retail_sale_for_cashier_custom_2_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                                <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is Custom 3', false)}">
+                                    <pp:retail_sale_for_cashier_custom_3_native
+                                        bill="#{retailSaleForCashierNativeSqlController.printBill}"
+                                        items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+
+                <!-- Printer Config Dialog -->
+                <p:dialog id="saleForCashierNativeConfigDialog"
+                          rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                          header="Sale for Cashier (Native) Printer Configuration"
+                          widgetVar="saleForCashierNativeConfigDialog"
+                          modal="true"
+                          width="600"
+                          resizable="true"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="saleForCashierNativeConfigForm" />
+                    <h:form id="saleForCashierNativeConfigForm">
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posPaper" value="#{pharmacyConfigController.posPaper}" />
+                                <p:outputLabel for="posPaper" value="POS Paper (Default)" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posPaperCustom1" value="#{pharmacyConfigController.posPaperCustom1}" />
+                                <p:outputLabel for="posPaperCustom1" value="POS Paper Custom 1" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="fiveFivePaper" value="#{pharmacyConfigController.fiveFivePaper}" />
+                                <p:outputLabel for="fiveFivePaper" value="5.5 Inch Paper" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="posHeaderPaper" value="#{pharmacyConfigController.posHeaderPaper}" />
+                                <p:outputLabel for="posHeaderPaper" value="POS Paper with Header" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom1Paper" value="#{pharmacyConfigController.custom1Paper}" />
+                                <p:outputLabel for="custom1Paper" value="Custom Format 1" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom2Paper" value="#{pharmacyConfigController.custom2Paper}" />
+                                <p:outputLabel for="custom2Paper" value="Custom Format 2 (5.5 inch with totals)" class="ms-2" />
+                            </div>
+                            <div class="mb-3">
+                                <h:selectBooleanCheckbox id="custom3Paper" value="#{pharmacyConfigController.custom3Paper}" />
+                                <p:outputLabel for="custom3Paper" value="Custom Format 3" class="ms-2" />
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-2">
+                            <p:commandButton value="Apply &amp; Close" icon="fas fa-save" class="ui-button-success" ajax="false" action="#{pharmacyConfigController.saveRetailSaleConfig}" />
+                            <p:commandButton value="Cancel" icon="fas fa-times" class="ui-button-secondary" onclick="PF('saleForCashierNativeConfigDialog').hide(); return false;" type="button" />
+                        </div>
+                    </h:form>
+                </p:dialog>
+
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1115,10 +1115,17 @@
                         <p:separator />
                         <p:menuitem
                             ajax="false"
-                            action="#{pharmacySaleForCashierController.navigateToPharmacyBillForCashierFromMenu()}"
+                            action="#{retailSaleForCashierNativeSqlController.navigateToPharmacyBillForCashierNativeFromMenu()}"
                             value="Sale for cashier"
                             icon="fas fa-cash-register"
+                            styleClass="menu-item-optimised"
                             rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier')}" ></p:menuitem>
+                        <p:menuitem
+                            ajax="false"
+                            action="#{pharmacySaleForCashierController.navigateToPharmacyBillForCashierFromMenu()}"
+                            value="Sale for cashier (Legacy)"
+                            icon="fas fa-cash-register"
+                            rendered="#{webUserController.hasPrivilege('PharmacySaleForCashier') and configOptionApplicationController.getBooleanValueByKey('Legacy Functions Allowed', false)}" ></p:menuitem>
                         <p:menuitem
                             ajax="false" action="/pharmacy/pharmacy_search_sale_pre_bill?faces-redirect=true"
                             value="Search Sale for Cashier Bills"

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_1_native.xhtml
@@ -160,7 +160,7 @@
                     <tr>
                         <td >No of Items:</td>
                         <td style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
                                 <f:convertNumber integerOnly="true" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_1_native.xhtml
@@ -1,0 +1,236 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <h:head>
+        <!-- Include the custom CSS for styling -->
+        <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+    </h:head>
+
+    <h:body>
+        <!-- Composite Component Interface -->
+        <cc:interface>
+            <!-- Attributes passed to the component -->
+            <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+            <cc:attribute name="duplicate" required="false" />
+        </cc:interface>
+
+        <!-- Composite Component Implementation -->
+        <cc:implementation>
+            <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+
+
+            <div class="receipt-container">
+                <!-- Header Section -->
+                <div class="hospital-name">
+                    <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+                </div>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Patient and Bill Information Table -->
+                <table class="info-table">
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="padding: 2px;">Name :</td>
+                            <td style="padding: 2px;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"/>
+                            </td>
+                            <td style="padding: 2px;" class="spacer"></td>
+                            <h:panelGroup rendered="#{cc.attrs.bill.patientAgeSex ne null}" >
+                                <td  style="padding: 2px;">Age/Sex :</td>
+                                <td style="padding: 2px;" >
+                                    <h:outputLabel value="#{cc.attrs.bill.patientAgeSex}"/>
+                                </td>
+                            </h:panelGroup>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="false" >
+                        #{pharmacySaleController.printBill.patient.person.sex.shortLabel}
+                    </h:panelGroup>
+
+                    <tr>
+                        <td  style="padding: 2px;">Bill Date:</td>
+                        <td  style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="yyyy-MM-dd" />
+                            </h:outputLabel>
+                        </td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;">Bill Time:</td>
+                        <td style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="HH:mm a" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 2px;">Bill No:</td>
+                        <td style="padding: 2px;">#{cc.attrs.bill.billNo}</td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="BHT No : " rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="#{cc.attrs.bill.bhtNo}" rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                    </tr>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Item Table -->
+                <table class="receipt-table">
+                    <thead>
+                        <tr>
+                            <th>No</th>
+                            <th>Item Name</th>
+                            <th>Rate</th>
+                            <th>Qty</th>
+                            <th style="text-align: right">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{cc.attrs.items}" var="item" varStatus="s">
+                            <tr>
+                                <!-- Display the item number across all items -->
+                                <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
+                                <td>#{item.itemName}</td>
+                                <td>
+                                    <h:outputLabel value="#{item.rate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td>
+                                    <h:outputLabel value="#{item.qty}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right">
+                                    <h:outputLabel value="#{item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Totals Table -->
+                <table class="total-table">
+                    <tr>
+                        <td >Total:</td>
+                        <td  style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}" >
+                        <tr>
+                            <td >Discount:</td>
+                            <td  style="text-align: right;">
+                                <h:outputLabel  value="#{-cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td >Net Total:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                    </h:panelGroup>
+
+                    <tr>
+                        <td >No of Items:</td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                                <f:convertNumber integerOnly="true" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+
+                <table  style="font-size: 8pt;">
+                    <tr>
+                        <td style="width: 4cm; vertical-align: top;">
+                            <h:outputLabel value="Billed By :"/>
+                            <h:outputLabel value="#{cc.attrs.bill.creatorName}"/>
+                        </td>
+                        <td style="width: 2cm;"></td>
+                        <td style=" vertical-align: top;">
+                            <table >
+                                <ui:repeat value="#{cc.attrs.bill.payments}" var="ps">
+                                    <tr>
+                                        <td style="width: 4cm;">
+                                            <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethodLabel}"/>
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.reference})" rendered="#{ps.paymentMethodLabel eq 'Card'}"/>
+                                        </td>
+                                        <td style="width: 2cm; text-align: end">
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.value}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="width: 2cm;">
+
+                                        </td>
+                                    </tr>
+
+                                </ui:repeat>
+
+
+                            </table>
+                        </td>
+                    </tr>
+
+                    <tr> 
+                      
+                        <td style="width: 6cm">
+                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Staff_Welfare'}">
+                                <h:outputText style="font-size: 8pt;"  value="(Staff :"/>
+                                <h:outputText style="font-size: 8pt;"  value="#{cc.attrs.bill.toStaffName})"/>
+                            </h:panelGroup>
+                        </td>
+
+                    </tr>
+                </table> 
+
+                <h:panelGroup rendered="#{cc.attrs.duplicate eq true}" >
+                    <table >
+                        <tr>
+                            <td  style="width: 4cm;">
+                                <h:outputLabel value="Printed By : " style="font-size: 8pt;"/>
+                                <h:outputLabel style="font-size: 8pt;" value=" #{sessionController.loggedUser.name}"/>
+                            </td>
+                            <td style="width: 2cm;"></td>
+                            <td>
+                                <h:outputLabel style="font-size: 8pt;" value="#{sessionController.currentDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table> 
+                </h:panelGroup>
+
+            </div>
+
+        </cc:implementation>
+
+    </h:body>
+</html>

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_2_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_2_native.xhtml
@@ -160,7 +160,7 @@
                     <tr>
                         <td >No of Items:</td>
                         <td style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
                                 <f:convertNumber integerOnly="true" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_2_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_2_native.xhtml
@@ -1,0 +1,236 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <h:head>
+        <!-- Include the custom CSS for styling -->
+        <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+    </h:head>
+
+    <h:body>
+        <!-- Composite Component Interface -->
+        <cc:interface>
+            <!-- Attributes passed to the component -->
+            <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+            <cc:attribute name="duplicate" required="false" />
+        </cc:interface>
+
+        <!-- Composite Component Implementation -->
+        <cc:implementation>
+            <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+
+
+            <div class="receipt-container">
+                <!-- Header Section -->
+                <div class="hospital-name">
+                    <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+                </div>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Patient and Bill Information Table -->
+                <table class="info-table">
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="padding: 2px;">Name :</td>
+                            <td style="padding: 2px;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"/>
+                            </td>
+                            <td style="padding: 2px;" class="spacer"></td>
+                            <h:panelGroup rendered="#{cc.attrs.bill.patientAgeSex ne null}" >
+                                <td  style="padding: 2px;">Age/Sex :</td>
+                                <td style="padding: 2px;" >
+                                    <h:outputLabel value="#{cc.attrs.bill.patientAgeSex}"/>
+                                </td>
+                            </h:panelGroup>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="false" >
+                        #{pharmacySaleController.printBill.patient.person.sex.shortLabel}
+                    </h:panelGroup>
+
+                    <tr>
+                        <td  style="padding: 2px;">Bill Date:</td>
+                        <td  style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="yyyy-MM-dd" />
+                            </h:outputLabel>
+                        </td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;">Bill Time:</td>
+                        <td style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="HH:mm a" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 2px;">Bill No:</td>
+                        <td style="padding: 2px;">#{cc.attrs.bill.billNo}</td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="BHT No : " rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="#{cc.attrs.bill.bhtNo}" rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                    </tr>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Item Table -->
+                <table class="receipt-table">
+                    <thead>
+                        <tr>
+                            <th>No</th>
+                            <th>Item Name</th>
+                            <th>Rate</th>
+                            <th>Qty</th>
+                            <th style="text-align: right">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{cc.attrs.items}" var="item" varStatus="s">
+                            <tr>
+                                <!-- Display the item number across all items -->
+                                <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
+                                <td>#{item.itemName}</td>
+                                <td>
+                                    <h:outputLabel value="#{item.rate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td>
+                                    <h:outputLabel value="#{item.qty}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right">
+                                    <h:outputLabel value="#{item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Totals Table -->
+                <table class="total-table">
+                    <tr>
+                        <td >Total:</td>
+                        <td  style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}" >
+                        <tr>
+                            <td >Discount:</td>
+                            <td  style="text-align: right;">
+                                <h:outputLabel  value="#{-cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td >Net Total:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                    </h:panelGroup>
+
+                    <tr>
+                        <td >No of Items:</td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                                <f:convertNumber integerOnly="true" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+
+                <table  style="font-size: 8pt;">
+                    <tr>
+                        <td style="width: 4cm; vertical-align: top;">
+                            <h:outputLabel value="Billed By :"/>
+                            <h:outputLabel value="#{cc.attrs.bill.creatorName}"/>
+                        </td>
+                        <td style="width: 2cm;"></td>
+                        <td style=" vertical-align: top;">
+                            <table >
+                                <ui:repeat value="#{cc.attrs.bill.payments}" var="ps">
+                                    <tr>
+                                        <td style="width: 4cm;">
+                                            <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethodLabel}"/>
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.reference})" rendered="#{ps.paymentMethodLabel eq 'Card'}"/>
+                                        </td>
+                                        <td style="width: 2cm; text-align: end">
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.value}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="width: 2cm;">
+
+                                        </td>
+                                    </tr>
+
+                                </ui:repeat>
+
+
+                            </table>
+                        </td>
+                    </tr>
+
+                    <tr> 
+                      
+                        <td style="width: 6cm">
+                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Staff_Welfare'}">
+                                <h:outputText style="font-size: 8pt;"  value="(Staff :"/>
+                                <h:outputText style="font-size: 8pt;"  value="#{cc.attrs.bill.toStaffName})"/>
+                            </h:panelGroup>
+                        </td>
+
+                    </tr>
+                </table> 
+
+                <h:panelGroup rendered="#{cc.attrs.duplicate eq true}" >
+                    <table >
+                        <tr>
+                            <td  style="width: 4cm;">
+                                <h:outputLabel value="Printed By : " style="font-size: 8pt;"/>
+                                <h:outputLabel style="font-size: 8pt;" value=" #{sessionController.loggedUser.name}"/>
+                            </td>
+                            <td style="width: 2cm;"></td>
+                            <td>
+                                <h:outputLabel style="font-size: 8pt;" value="#{sessionController.currentDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table> 
+                </h:panelGroup>
+
+            </div>
+
+        </cc:implementation>
+
+    </h:body>
+</html>

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_3_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_3_native.xhtml
@@ -160,7 +160,7 @@
                     <tr>
                         <td >No of Items:</td>
                         <td style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
                                 <f:convertNumber integerOnly="true" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_3_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/print/retail_sale_for_cashier_custom_3_native.xhtml
@@ -1,0 +1,236 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <h:head>
+        <!-- Include the custom CSS for styling -->
+        <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+    </h:head>
+
+    <h:body>
+        <!-- Composite Component Interface -->
+        <cc:interface>
+            <!-- Attributes passed to the component -->
+            <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+            <cc:attribute name="duplicate" required="false" />
+        </cc:interface>
+
+        <!-- Composite Component Implementation -->
+        <cc:implementation>
+            <h:outputStylesheet library="css" name="sale_bill_five_five_custom_3.css" />
+
+
+            <div class="receipt-container">
+                <!-- Header Section -->
+                <div class="hospital-name">
+                    <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+                    <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                    <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+                </div>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Patient and Bill Information Table -->
+                <table class="info-table">
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="padding: 2px;">Name :</td>
+                            <td style="padding: 2px;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"/>
+                            </td>
+                            <td style="padding: 2px;" class="spacer"></td>
+                            <h:panelGroup rendered="#{cc.attrs.bill.patientAgeSex ne null}" >
+                                <td  style="padding: 2px;">Age/Sex :</td>
+                                <td style="padding: 2px;" >
+                                    <h:outputLabel value="#{cc.attrs.bill.patientAgeSex}"/>
+                                </td>
+                            </h:panelGroup>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="false" >
+                        #{pharmacySaleController.printBill.patient.person.sex.shortLabel}
+                    </h:panelGroup>
+
+                    <tr>
+                        <td  style="padding: 2px;">Bill Date:</td>
+                        <td  style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="yyyy-MM-dd" />
+                            </h:outputLabel>
+                        </td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;">Bill Time:</td>
+                        <td style="padding: 2px;">
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" >
+                                <f:convertDateTime pattern="HH:mm a" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 2px;">Bill No:</td>
+                        <td style="padding: 2px;">#{cc.attrs.bill.billNo}</td>
+                        <td style="padding: 2px;" class="spacer"></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="BHT No : " rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                        <td style="padding: 2px;" ><h:outputLabel value="#{cc.attrs.bill.bhtNo}" rendered="#{cc.attrs.bill.bhtNo ne null}"/></td>
+                    </tr>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Item Table -->
+                <table class="receipt-table">
+                    <thead>
+                        <tr>
+                            <th>No</th>
+                            <th>Item Name</th>
+                            <th>Rate</th>
+                            <th>Qty</th>
+                            <th style="text-align: right">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <ui:repeat value="#{cc.attrs.items}" var="item" varStatus="s">
+                            <tr>
+                                <!-- Display the item number across all items -->
+                                <td>#{s.index +1}</td> <!-- status.index starts from 0, so add 1 for a human-readable count -->
+                                <td>#{item.itemName}</td>
+                                <td>
+                                    <h:outputLabel value="#{item.rate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td>
+                                    <h:outputLabel value="#{item.qty}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right">
+                                    <h:outputLabel value="#{item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </ui:repeat>
+                    </tbody>
+                </table>
+
+                <!-- Separator Line -->
+                <div class="separator"></div>
+
+                <!-- Totals Table -->
+                <table class="total-table">
+                    <tr>
+                        <td >Total:</td>
+                        <td  style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}" >
+                        <tr>
+                            <td >Discount:</td>
+                            <td  style="text-align: right;">
+                                <h:outputLabel  value="#{-cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td >Net Total:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                    </h:panelGroup>
+
+                    <tr>
+                        <td >No of Items:</td>
+                        <td style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.items.size()()}">
+                                <f:convertNumber integerOnly="true" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+
+                <table  style="font-size: 8pt;">
+                    <tr>
+                        <td style="width: 4cm; vertical-align: top;">
+                            <h:outputLabel value="Billed By :"/>
+                            <h:outputLabel value="#{cc.attrs.bill.creatorName}"/>
+                        </td>
+                        <td style="width: 2cm;"></td>
+                        <td style=" vertical-align: top;">
+                            <table >
+                                <ui:repeat value="#{cc.attrs.bill.payments}" var="ps">
+                                    <tr>
+                                        <td style="width: 4cm;">
+                                            <h:outputText style="font-size: 8pt;"  value="#{ps.paymentMethodLabel}"/>
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value=" (#{ps.reference})" rendered="#{ps.paymentMethodLabel eq 'Card'}"/>
+                                        </td>
+                                        <td style="width: 2cm; text-align: end">
+                                            <h:outputText style="font-size: 8pt; width: 2cm;"  value="#{ps.value}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputText>
+                                        </td>
+                                        <td style="width: 2cm;">
+
+                                        </td>
+                                    </tr>
+
+                                </ui:repeat>
+
+
+                            </table>
+                        </td>
+                    </tr>
+
+                    <tr> 
+                      
+                        <td style="width: 6cm">
+                            <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Staff_Welfare'}">
+                                <h:outputText style="font-size: 8pt;"  value="(Staff :"/>
+                                <h:outputText style="font-size: 8pt;"  value="#{cc.attrs.bill.toStaffName})"/>
+                            </h:panelGroup>
+                        </td>
+
+                    </tr>
+                </table> 
+
+                <h:panelGroup rendered="#{cc.attrs.duplicate eq true}" >
+                    <table >
+                        <tr>
+                            <td  style="width: 4cm;">
+                                <h:outputLabel value="Printed By : " style="font-size: 8pt;"/>
+                                <h:outputLabel style="font-size: 8pt;" value=" #{sessionController.loggedUser.name}"/>
+                            </td>
+                            <td style="width: 2cm;"></td>
+                            <td>
+                                <h:outputLabel style="font-size: 8pt;" value="#{sessionController.currentDate}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table> 
+                </h:panelGroup>
+
+            </div>
+
+        </cc:implementation>
+
+    </h:body>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
@@ -39,7 +39,7 @@
                 <h:outputLabel value="-----------------------------"   />
             </div>
 
-            <h:panelGroup >
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline">
                     <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;
                                    display: inline-block;

--- a/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
@@ -24,9 +24,7 @@
                  font-weight: bold!important;
                  font-size: 15px!important;
                  font-weight: bold;">
-                <!-- FIXME (#20261): department.site.name has no PrintBillData equivalent.
-                     PrintBillData carries no site/site-name property. Left blank pending a
-                     deliberate decision on whether to add a departmentSiteName field to the DTO. -->
+                <h:outputLabel value="#{cc.attrs.bill.departmentSiteName}" />
             </div>
 
             <div class="headingBill mt-0">
@@ -41,15 +39,9 @@
                 <h:outputLabel value="-----------------------------"   />
             </div>
 
-            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
-                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
-                 PrintBillData carries no tokenNumber property. Rendered false pending a
-                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
-                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
-                 at settle time). See task-4-report.md. -->
-            <h:panelGroup rendered="false">
+            <h:panelGroup >
                 <div class="billline">
-                    <h:outputLabel value="" style="font-size: 30px;
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;
                                    display: inline-block;
                                    width: 60px;
                                    height: 60px;

--- a/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBillToken_Custom_1_native.xhtml
@@ -1,0 +1,150 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacytoken.css" ></h:outputStylesheet>
+        <div class="posbill" style="page-break-after: always!important; page-break-before: always!important;">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;
+                 font-weight: bold;">
+                <!-- FIXME (#20261): department.site.name has no PrintBillData equivalent.
+                     PrintBillData carries no site/site-name property. Left blank pending a
+                     deliberate decision on whether to add a departmentSiteName field to the DTO. -->
+            </div>
+
+            <div class="headingBill mt-0">
+                <h:outputLabel value="#{cc.attrs.bill.departmentName}"/>
+                <br/>
+                <h:outputLabel value="&nbsp;Token"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------"   />
+            </div>
+
+            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
+                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
+                 PrintBillData carries no tokenNumber property. Rendered false pending a
+                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
+                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
+                 at settle time). See task-4-report.md. -->
+            <h:panelGroup rendered="false">
+                <div class="billline">
+                    <h:outputLabel value="" style="font-size: 30px;
+                                   display: inline-block;
+                                   width: 60px;
+                                   height: 60px;
+                                   text-align: center;
+                                   line-height: 60px;
+                                   border-radius: 50%;
+                                   border: solid 2px;
+                                   color: black;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div style="font-size: 12px;" >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td style="width: 30%; text-align: right;" >
+                            <h:outputLabel value="Date" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center" >:</td>
+                        <td style="width: 30%; text-align: left;" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}"  >
+                                <f:convertDateTime pattern="dd MMM YYYY HH:mm" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: right;" >
+                            <h:outputLabel value="Inv.No" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                        <td style="width: 30%; text-align: left;" >
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}"  class="billDetails">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"  class="billDetails"></h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="MRN No" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 30%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientPhn}"  class="billDetails"></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total Amount On Pharmacy Token')}">
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Total" ></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 30%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}"  class="billDetails">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billline">
+                <p:barcode value="#{cc.attrs.bill.billIdStr}" cache="false" type="code128" ></p:barcode>
+            </div>
+
+            <div class="footer">
+                THANK YOU !
+                <br/>
+                Powered by CareCode (Pvt) Ltd.
+            </div>
+
+        </div>
+
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml
@@ -38,15 +38,9 @@
                 <h:outputLabel value="-----------------------------------------------"   />
             </div>
 
-            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
-                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
-                 PrintBillData carries no tokenNumber property. Rendered false pending a
-                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
-                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
-                 at settle time). See task-4-report.md. -->
-            <h:panelGroup rendered="false">
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline">
-                    <h:outputLabel value="" style="font-size: 30px;
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;
                                    display: inline-block;
                                    width: 60px;
                                    height: 60px;

--- a/src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBillToken_native.xhtml
@@ -1,0 +1,148 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacytoken.css" ></h:outputStylesheet>
+        <div class="posbill">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+            </div>
+
+            <div class="headingBill mt-0">
+                <h:outputLabel value="#{cc.attrs.bill.departmentName}"   />
+                <h:outputLabel value="&nbsp;Token"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
+                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
+                 PrintBillData carries no tokenNumber property. Rendered false pending a
+                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
+                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
+                 at settle time). See task-4-report.md. -->
+            <h:panelGroup rendered="false">
+                <div class="billline">
+                    <h:outputLabel value="" style="font-size: 30px;
+                                   display: inline-block;
+                                   width: 60px;
+                                   height: 60px;
+                                   text-align: center;
+                                   line-height: 60px;
+                                   border-radius: 50%;
+                                   border: solid 2px;
+                                   color: black;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billDetails" >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td style="width: 30%; text-align: right;" >
+                            <h:outputLabel value="Date" class="billDetails" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}"  >
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                        <td style="width: 30%" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"  ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: right;" >
+                            <h:outputLabel value="Inv.No" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}"  class="billDetails">
+                            </h:outputLabel>
+                        </td>
+
+
+                        <td style="width: 30%" >
+                            <h:outputLabel value="#{cc.attrs.bill.creatorName}" class="billDetails">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total Amount On Pharmacy Token')}">
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Total" ></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.netTotal}"  class="billDetails">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"  class="billDetails"></h:outputLabel>
+                            </td>
+
+                            <td style="width: 30%" >
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billline">
+                <p:barcode value="#{cc.attrs.bill.billIdStr}" cache="false" type="code128" ></p:barcode>
+            </div>
+
+            <div class="footer">
+                THANK YOU !
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
@@ -36,7 +36,7 @@
             </div>
 
             <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">
-                <h:outputLabel value="#{sessionController.loggedUser.department.name}"   />    
+                <h:outputLabel value="#{cc.attrs.bill.departmentName}"   />    
                 <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
                 <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
             </div>

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
@@ -1,0 +1,488 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="fiveinchbill" style="page-break-after: always!important;">
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1} "/>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.departmentFax}"/>                                                 
+                </div>
+            </div>
+
+            <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">
+                <h:outputLabel value="#{sessionController.loggedUser.department.name}"   />    
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />                          
+            </div>
+            <h:panelGroup rendered="#{not empty tokenController.findPharmacyTokens(cc.attrs.bill)}">
+                <div class="billline">
+                    <h:outputLabel value="#{tokenController.findPharmacyTokens(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />    
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table >
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Date" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive" >
+                                <f:convertDateTime pattern="dd/MM/yy " ></f:convertDateTime>
+                            </h:outputLabel>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"  ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Bht No" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.bhtNo ne null}" style="font-size: 15px; font-weight: bold;"></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.bhtNo ne null}" style="font-size: 15px; font-weight: bold;"></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.bhtNo}" rendered="#{cc.attrs.bill.bhtNo ne null}" style="font-size: 15px; font-weight: bold;"></h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel class="billDetailsFiveFive" value="Inv.No" ></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td>:</td>
+                        <td></td>
+                        <td>
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.billNo}"  >
+                            </h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td>
+                            <h:outputLabel value="Room" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.roomName ne null}"></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.roomName ne null}"></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.bill.roomName}" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.roomName ne null}"></h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.invoiceNumber ne null}" >
+                        <tr>
+                            <td style="text-align: left;" >
+                                <h:outputLabel class="billDetailsFiveFive" value="Request No" ></h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>:</td>
+                            <td></td>
+                            <td>                            
+                                <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.invoiceNumber}"  >
+                                </h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>
+
+                            </td>
+                            <td>
+
+                            </td>
+
+                            <td>
+
+                            </td>
+
+                        </tr>
+                    </h:panelGroup>   
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Paymentmethod" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.paymentMethodLabel ne null}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td >
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.paymentMethodLabel ne null}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td>
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.paymentMethodLabel}" rendered="#{cc.attrs.bill.paymentMethodLabel ne null}">
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="PayScheme" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.paymentSchemePrintingName ne null}"></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{cc.attrs.bill.paymentSchemePrintingName ne null}"></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.paymentSchemePrintingName}" rendered="#{cc.attrs.bill.paymentSchemePrintingName ne null}"></h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel class="billDetailsFiveFive" value="Name" rendered="#{cc.attrs.bill.patientName ne null}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.patientName ne null}"/></td>
+                        <td></td>
+                        <td colspan="5">                            
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.patientName}"  rendered="#{cc.attrs.bill.patientName ne null}">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel class="billDetailsFiveFive" value="Staff Name" rendered="#{cc.attrs.bill.toStaffName ne null}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td><h:outputLabel value=":" rendered="#{cc.attrs.bill.toStaffName ne null}"/></td>
+                        <td></td>
+                        <td colspan="5">                            
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.toStaffName}"  rendered="#{cc.attrs.bill.toStaffName ne null}">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toDepartmentName}" >
+                        <tr>
+                            <td style="text-align: left;" >
+                                <h:outputLabel value="To Unit" ></h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>:</td>
+                            <td></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}"  >
+                                </h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toInstitutionName}" >
+                        <tr>
+                            <td style="text-align: left; font-size: 12px;" >
+                                <h:outputLabel value="Company" style="font-size: 12px;"></h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>:</td>
+                            <td></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}"  style="font-size: 12px;">
+                                </h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.comment ne null}" >
+                        <tr>
+                            <td style="text-align: left;" >
+                                <h:outputLabel value="Comment" ></h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>:</td>
+                            <td></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.comment}"  >
+                                </h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />                        
+            </div>
+
+
+            <div class="itemHeadingsFiveFive" >
+
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td style="width:75%!important;">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td  style="width:5%!important;text-align: right; padding-right: 0px!important">
+                            <h:outputLabel value="QTY"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+
+                            <td  style="width:10%!important;text-align: right; padding-right: 0px!important">
+                                <h:outputLabel value="RATE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                            </td>
+
+                            <td  style="width:10%!important;text-align: right; padding-right: 0px!important">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                            </td>
+                        </h:panelGroup>
+
+                    </tr>
+
+                    <tr>
+                        <td colspan="4" style="text-align: center;" >
+                            <h:outputLabel value="------------------------------------------------------------"   />                           
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
+
+                        <ui:repeat value="#{cc.attrs.items}" var="bip" varStatus="vs">
+                            <tr>
+                                <td >
+    <!--                                <h:outputLabel value="#{bip.itemCode}"  style="text-transform: capitalize;" >
+                                    </h:outputLabel>
+                                    -
+                                    &nbsp;-->
+                                    <h:outputLabel  value="#{vs.index + 1} - #{bip.itemName}"  style="font-size: 13px!important; font-family:verdana, Helvetica, sans-serif!important;"  >
+                                    </h:outputLabel>
+                                </td>
+                                <td style="width:10%!important;text-align: right; padding-right: 0px!important">
+                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.qty}" >
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                                    <td style="width:10%!important;text-align: right; padding-right: 0px!important">
+                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.netValue/bip.qty}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="width:10%!important; text-align:end!important;">
+                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.netValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                </h:panelGroup>
+                            </tr>
+
+                        </ui:repeat>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{cc.attrs.bill.margin ne 0.0}">
+                        <ui:repeat value="#{cc.attrs.items}" var="bip" varStatus="vs">
+                            <tr>
+                                <td  style="overflow: visible;">
+    <!--                                <h:outputLabel value="#{bip.itemCode}"  style="text-transform: capitalize;" >
+                                    </h:outputLabel>
+                                    -
+                                    &nbsp;-->
+                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{vs.index + 1} - #{bip.itemName}"  style="text-transform: capitalize!important;"  >
+                                    </h:outputLabel>
+                                </td>
+                                <td>
+                                    <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.qty}"  >
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right!important;">
+                                    <h:outputLabel class="itemsBlockRightFiveFive"    value="#{bip.rate+(bip.marginValue/bip.qty)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+
+                                <td  >
+                                    <h:outputLabel class="itemsBlockRightFiveFive"   value="#{bip.netValue}"    >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+
+                            </tr>
+                        </ui:repeat>
+                    </h:panelGroup>
+
+
+
+
+                </table>
+
+
+            </div>
+
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />                          
+            </div>
+
+
+
+            <div  >
+
+                <table style="width: 100%;">
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total On Pharmacy Sale Bill For Cashier')}">
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.margin > 0? 'false':'true'}">
+                            <tr>
+                                <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                    <h:outputLabel value="Total" style="font-size: 15px; font-weight: bold;"/>
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 0px;">
+                                    <h:outputLabel value="#{cc.attrs.bill.total}" style="font-size: 15px; font-weight: bold;">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.margin ne 0.0}">
+                            <tr>
+                                <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                    <h:outputLabel value="Total" style="font-size: 15px; font-weight: bold;"/>
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 0px;">
+                                    <h:outputLabel value="#{cc.attrs.bill.netTotal}" style="font-size: 15px; font-weight: bold;">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0}">
+                            <tr>
+                                <td  class="totalsBlock" style="text-align: left;">
+                                    <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 0px;">
+                                    <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;" >
+                                        <f:convertNumber pattern="#,##0" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 0px; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
+                            <tr>
+                                <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                    <h:outputLabel value="Balance" />
+                                </td>
+                                <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 0px;">
+                                    <h:outputLabel value="#{cc.attrs.bill.cashPaid-cc.attrs.bill.netTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+
+                    </h:panelGroup>
+
+                    <!--                    <tr>
+                                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                                <h:outputLabel value="Price Matrix" />
+                                            </td>
+                                            <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                                <h:outputLabel value="#{cc.attrs.bill.margin}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </td>
+                                        </tr>-->
+
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel   value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsBlock">
+                            <h:outputLabel style="float: right;"  value="#{cc.attrs.items.size()()}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+
+                </table>
+
+            </div>
+
+            <div style="text-decoration: overline; margin-top: 20px;">
+                <h:outputLabel value="Cashier : #{cc.attrs.bill.creatorCode}"/>
+            </div>
+            <div class="footer" style="text-align: center;">
+                <br/>
+                <h:outputLabel value="#{sessionController.userPreference.pharmacyBillFooter}"/>
+                <br/>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five_for_Cashier_native.xhtml
@@ -44,9 +44,9 @@
             <div class="billline">
                 <h:outputLabel value="-------------------------------------------------------------------------------"   />                          
             </div>
-            <h:panelGroup rendered="#{not empty tokenController.findPharmacyTokens(cc.attrs.bill)}">
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline">
-                    <h:outputLabel value="#{tokenController.findPharmacyTokens(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;"/>
                 </div>
             </h:panelGroup>
 
@@ -464,7 +464,7 @@
                             <h:outputLabel   value="Number of Items Count" />
                         </td>
                         <td  class="totalsBlock">
-                            <h:outputLabel style="float: right;"  value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel style="float: right;"  value="#{cc.attrs.items.size()}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml
@@ -28,13 +28,10 @@
                 </div>
                 <div >
                     <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1} "/>
-                    <!-- FIXME (#20261): department.telephone2 has no PrintBillData equivalent.
-                         PrintBillData only carries departmentTelephone1. Left blank pending a
-                         deliberate decision on whether to add a second telephone field to the DTO. -->
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone2}"/>
                 </div>
                 <div >
-                    <!-- FIXME (#20261): department.fax has no PrintBillData equivalent.
-                         Left blank pending a deliberate decision on whether to add a fax field to the DTO. -->
+                    <h:outputLabel value="#{cc.attrs.bill.departmentFax}"/>
                 </div>
             </div>
 
@@ -48,15 +45,9 @@
                 <h:outputLabel value="-------------------------------------------------------------------------------"   />
             </div>
 
-            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
-                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
-                 PrintBillData carries no tokenNumber property. Rendered false pending a
-                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
-                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
-                 at settle time). See task-4-report.md. -->
-            <h:panelGroup rendered="false">
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline">
-                    <h:outputLabel value="" style="font-size: 30px;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;"/>
                 </div>
             </h:panelGroup>
 

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five_token_native.xhtml
@@ -1,0 +1,226 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui">
+
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="fiveinchbill" style="page-break-after: always!important;">
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1} "/>
+                    <!-- FIXME (#20261): department.telephone2 has no PrintBillData equivalent.
+                         PrintBillData only carries departmentTelephone1. Left blank pending a
+                         deliberate decision on whether to add a second telephone field to the DTO. -->
+                </div>
+                <div >
+                    <!-- FIXME (#20261): department.fax has no PrintBillData equivalent.
+                         Left blank pending a deliberate decision on whether to add a fax field to the DTO. -->
+                </div>
+            </div>
+
+            <div class="headingBillFiveFive">
+                <h:outputLabel value="Pharmacy Token"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />
+            </div>
+
+            <!-- FIXME (#20261): token number lookup has no PrintBillData equivalent.
+                 pharmacyPreSettleController.findTokenFromBill(Bill) requires a Bill entity;
+                 PrintBillData carries no tokenNumber property. Rendered false pending a
+                 deliberate decision (add a tokenNumber field to PrintBillData, populated by
+                 RetailSaleForCashierNativeSqlController from its in-memory currentToken/getToken()
+                 at settle time). See task-4-report.md. -->
+            <h:panelGroup rendered="false">
+                <div class="billline">
+                    <h:outputLabel value="" style="font-size: 30px;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table >
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Date" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive" >
+                                <f:convertDateTime pattern="dd/MM/yy " ></f:convertDateTime>
+                            </h:outputLabel>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetailsFiveFive">
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"  ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel class="billDetailsFiveFive" value="Inv.No" ></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td>:</td>
+                        <td></td>
+                        <td>
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.billNo}"  >
+                            </h:outputLabel>
+                        </td>
+
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Paymentmethod" class="billDetailsFiveFive" rendered="#{not empty cc.attrs.bill.paymentMethodLabel}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td >
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{not empty cc.attrs.bill.paymentMethodLabel}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td>
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.paymentMethodLabel}" rendered="#{not empty cc.attrs.bill.paymentMethodLabel}">
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="PayScheme" class="billDetailsFiveFive" rendered="#{not empty cc.attrs.bill.paymentSchemePrintingName}"></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" rendered="#{not empty cc.attrs.bill.paymentSchemePrintingName}"></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.paymentSchemePrintingName}" rendered="#{not empty cc.attrs.bill.paymentSchemePrintingName}"></h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel class="billDetailsFiveFive" value="Name" rendered="#{not empty cc.attrs.bill.patientName}"></h:outputLabel>
+                        </td>
+                        <td></td>
+                        <td><h:outputLabel value=":" rendered="#{not empty cc.attrs.bill.patientName}"/></td>
+                        <td></td>
+                        <td colspan="5">
+                            <h:outputLabel class="billDetailsFiveFive" value="#{cc.attrs.bill.patientName}"  rendered="#{not empty cc.attrs.bill.patientName}">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toDepartmentName}" >
+                        <tr>
+                            <td style="text-align: left;" >
+                                <h:outputLabel value="To Unit" ></h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>:</td>
+                            <td></td>
+                            <td>
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}"  >
+                                </h:outputLabel>
+                            </td>
+                            <td></td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                            <td>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+
+                </table>
+
+            </div>
+
+            <div class="billline">
+                <h:outputLabel value="-------------------------------------------------------------------------------"   />
+            </div>
+
+
+            <div class="itemHeadingsFiveFive" >
+
+                <div class="billline m-1">
+                    <p:barcode value="#{cc.attrs.bill.billIdStr}" cache="false" type="code128" ></p:barcode>
+                </div>
+
+            </div>
+
+
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total Amount On Pharmacy Token')}">
+
+                <div class="billline">
+                    <h:outputLabel value="-----------------------------------------------"   />
+                </div>
+
+                <div  >
+                    <table style="width: 100%;">
+                        <tr>
+                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                <h:outputLabel value="Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
+                                <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </table>
+
+                </div>
+
+                <div class="billline">
+                    <h:outputLabel value="-----------------------------------------------"   />
+                </div>
+
+            </h:panelGroup>
+
+            <div class="footer">
+                <br/>
+                THANK YOU !
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
@@ -59,9 +59,9 @@
             <div class="billline">
                 <h:outputLabel value="-----------------------------------------------"   />                           
             </div>
-            <h:panelGroup rendered="#{not empty pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill)}">
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline" >
-                    <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;"/>
                 </div>
             </h:panelGroup>
 
@@ -311,7 +311,7 @@
                             <h:outputLabel   value="Number of Items Count" />
                         </td>
                         <td  class="totalsItemBlock" style="text-align: right; ">
-                            <h:outputLabel   value="#{billBeanController.fetchBillItems(cc.attrs.bill).size()}">
+                            <h:outputLabel   value="#{cc.attrs.items.size()()}">
                                 <f:convertNumber pattern="#,##0" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
@@ -321,9 +321,7 @@
                             <h:outputLabel   value="Prepared by" />
                         </td>
                         <td style="text-align: right; ">
-                            <h:outputLabel   value="#{cc.attrs.bill.creatorName}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
+                            <h:outputLabel   value="#{cc.attrs.bill.creatorName}" />
                         </td>
                     </tr>
 

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
@@ -1,0 +1,364 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbill" style="page-break-after: always!important;">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentSiteName}" />
+            </div>
+            <div style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 12px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentName}"/>
+            </div>
+<!--            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Tel: " ></h:outputLabel>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1}"/>
+                    <h:outputLabel value="&nbsp; #{cc.attrs.bill.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax: " ></h:outputLabel>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentFax}"/>                                                 
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.institutionEmail}/"/> 
+                    <h:outputLabel value="&nbsp;#{cc.attrs.bill.institutionWeb}" ></h:outputLabel>                                              
+                </div>
+            </div>-->
+
+            <div class="headingBill">
+                <h:outputLabel value="Sale for Cashier Bill"   />   
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+            </div>
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />                           
+            </div>
+            <h:panelGroup rendered="#{not empty pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill)}">
+                <div class="billline" >
+                    <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billDetails" >
+                <table style="width: 90%; margin-left: 5%" >
+
+                    <tr>
+                        <td style="width: 30%; text-align: right;" >
+                            <h:outputLabel value="Date" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center" >:</td>
+                        <td style="width: 60%; text-align: left;" >
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}"  >
+                                <f:convertDateTime pattern="dd MMM YYYY HH:mm" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="width: 30% ;text-align: right;" >
+                            <h:outputLabel value="Inv.No" ></h:outputLabel>
+                        </td>
+                        <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                        <td style="width: 60%; text-align: left;" >
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}"  class="billDetails">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"  class="billDetails"></h:outputLabel>
+                            </td> 
+                        </tr>
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="MRN No" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 30%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientPhn}"  class="billDetails"></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+<!--                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toStaffName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Staff Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toStaffName}"  class="billDetails"></h:outputLabel>
+                            </td> 
+                        </tr>
+                    </h:panelGroup>-->
+
+<!--                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toDepartmentName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="To Unit" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}"  class="billDetails"></h:outputLabel>
+                            </td> 
+                        </tr>
+                    </h:panelGroup>-->
+
+<!--                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toInstitutionName}" >
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Company" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}"  class="billDetails"></h:outputLabel>
+                            </td> 
+                        </tr>
+                    </h:panelGroup>-->
+                </table>
+
+            </div>
+
+            <div class="billline" style="width: 100%; margin-left: 5%;">
+                <h:outputLabel value="-------------------------------------------------"   />                        
+            </div>
+
+            <div style="padding-left: 5%;">
+
+                <table width="95%" >
+                    <tr>
+                        <td style="width: 35%; ">
+                            <h:outputLabel value="ITEM" style="font-size: 13px; font-weight: bold;" ></h:outputLabel>
+                        </td>
+                        <td  style="width:18%;text-align: right;">
+                            <h:outputLabel value="QTY"  style="font-size: 13px; font-weight: bold;" ></h:outputLabel>
+                        </td>
+
+                        <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                            <td  style="width:18%;text-align: right;">
+                                <h:outputLabel value="RATE"  style="font-size: 13px; font-weight: bold;" ></h:outputLabel>
+                            </td>
+
+<!--                            <td  style="width:22%;text-align: right;">
+                                <h:outputLabel value="VALUE"  style="font-size: 13px; font-weight: bold;" ></h:outputLabel>
+                            </td>-->
+                        </h:panelGroup>
+                    </tr>
+                    <tr>
+                        <td colspan="5" style="width: 100%">
+                            <div class="billline">
+                                <h:outputLabel value="-------------------------------------------------"   />                           
+                            </div>
+                        </td>
+
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.items}" var="bip">
+
+                        <tr>
+                            <td colspan="4">
+                                <h:outputLabel value="#{bip.itemName}"  styleClass="itemsBlock" style="text-transform: capitalize!important; text-align: left;"  >
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="1">
+
+                            </td>
+                            <td styleClass="itemsBlockRight" style="width: 20%; text-align: right;">
+                                <h:outputLabel    value="#{bip.qty}"    styleClass="itemsBlockRight"   style="text-align: right;" >
+                                    <f:convertNumber integerOnly="true" />
+                                </h:outputLabel>
+                            </td>
+                            <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                                <td  styleClass="itemsBlockRight"  style="text-align: right; width: 18%" >
+                                    <h:outputLabel    value="#{bip.rate}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+<!--                                <td  styleClass="itemsBlockRight" style="text-align: right; width: 42%" >
+                                    <h:outputLabel    value="#{bip.grossValue}"    >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>-->
+                            </h:panelGroup>
+                        </tr>
+                    </ui:repeat>
+
+
+
+                </table>
+            </div>
+
+            <div class="billline" style="width: 90%; margin-left: 5%;">
+                <h:outputLabel value="-----------------------------------------------------"   />                         
+            </div>
+
+            <div style="width: 95%; padding-left: 5%;" >
+                <table width="100%" >
+<!--                    <tr>
+                        <td class="totalsItemBlock" style="text-align: left; width: 60%;">
+                            <h:outputLabel value="Total" />
+                        </td>
+                        <td  class="totalsItemBlock" style="text-align: right!important; width: 40%;">
+                            <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>-->
+<!--                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total On Pharmacy Sale Bill For Cashier')}">
+
+                        <tr>
+                            <td  class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
+                            </td>
+                            <td  class="totalsItemBlock" style="text-align: right!important; ;">
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td  class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
+                            </td>
+                            <td  class="totalsItemBlock" style="text-align: right!important;font-weight: bold; ;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                        <tr>
+
+                            <td  class="totalsItemBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
+                            </td>
+
+                            <td  class="totalsItemBlock" style="text-align: right!important;font-weight: bold; ; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}"    value="#{cc.attrs.bill.discountPercentPharmacy} %">
+                                    <f:convertNumber pattern="#,##0.0" />
+                                </h:outputLabel>
+
+
+                            </td>
+                        </tr>
+
+                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
+                            <tr >
+                                <td  class="totalsItemBlock" style="text-align: left;">
+                                    <h:outputLabel   value="Tendered" />
+                                </td>
+                                <td  class="totalsItemBlock" style="text-align: right; ">
+                                    <h:outputLabel   value="#{cc.attrs.bill.cashPaid}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td  class="totalsItemBlock" style="text-align: left;">
+                                    <h:outputLabel   value="Balance" />
+                                </td>
+                                <td  class="totalsItemBlock" style="text-align: right;">
+                                    <h:outputLabel   value="#{cc.attrs.bill.balance}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+                    </h:panelGroup>-->
+
+                    <tr>
+                        <td  class="totalsItemBlock" style="text-align: left;">
+                            <h:outputLabel   value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsItemBlock" style="text-align: right; ">
+                            <h:outputLabel   value="#{billBeanController.fetchBillItems(cc.attrs.bill).size()}">
+                                <f:convertNumber pattern="#,##0" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr >
+                        <td style="text-align: left;">
+                            <h:outputLabel   value="Prepared by" />
+                        </td>
+                        <td style="text-align: right; ">
+                            <h:outputLabel   value="#{cc.attrs.bill.creatorName}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+<!--                    <h:panelGroup rendered="#{cc.attrs.bill.referenceBill ne null}">
+                        <tr>
+                            <td style="width: 30% ;text-align: right;" >
+                                <h:outputLabel value="Method" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td style="width: 50px;" class="d-flex justify-content-center">:</td>
+                            <td style="width: 60%; text-align: left;" >
+                                <h:outputLabel value="#{cc.attrs.bill.paymentMethodLabel}"  class="billDetails"></h:outputLabel>
+                            </td> 
+                        </tr>
+                        <tr >
+                            <td style="text-align: left;">
+                                <h:outputLabel   value="Billed by" />
+                            </td>
+                            <td style="text-align: right; ">
+                                <h:outputLabel   value="#{cc.attrs.bill.referenceBill.creater.name}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>-->
+
+                </table>
+
+            </div>
+            
+            <div class="footer">
+                THANK YOU !
+                <br/>
+                Powered by CareCode (Pvt) Ltd.
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_Pos_paper_Custom_1_native.xhtml
@@ -311,7 +311,7 @@
                             <h:outputLabel   value="Number of Items Count" />
                         </td>
                         <td  class="totalsItemBlock" style="text-align: right; ">
-                            <h:outputLabel   value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel   value="#{cc.attrs.items.size()}">
                                 <f:convertNumber pattern="#,##0" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_native.xhtml
@@ -47,9 +47,9 @@
             <div class="billline">
                 <h:outputLabel value="-----------------------------------------------"   />                           
             </div>
-            <h:panelGroup rendered="#{not empty pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill)}">
+            <h:panelGroup rendered="#{not empty cc.attrs.bill.tokenNumber}">
                 <div class="billline">
-                    <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                    <h:outputLabel value="#{cc.attrs.bill.tokenNumber}" style="font-size: 30px;"/>
                 </div>
             </h:panelGroup>
 
@@ -396,7 +396,7 @@
                             <h:outputLabel   value="Number of Items Count" />
                         </td>
                         <td  class="totalsItemBlock" style="text-align: right; ">
-                            <h:outputLabel   value="#{cc.attrs.items.size()()}">
+                            <h:outputLabel   value="#{cc.attrs.items.size()}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_for_Cashier_native.xhtml
@@ -1,0 +1,432 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbill" style="page-break-after: always!important;">
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 15px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1} "/>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.bill.departmentFax}"/>                                                 
+                </div>
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Sale Bill"   />   
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" /> 
+                <h:outputLabel value="**Cancelled**"  rendered="#{cc.attrs.bill.cancelled eq true}" /> 
+            </div>
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />                           
+            </div>
+            <h:panelGroup rendered="#{not empty pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill)}">
+                <div class="billline">
+                    <h:outputLabel value="#{pharmacyPreSettleController.findTokenFromBill(cc.attrs.bill).tokenNumber}" style="font-size: 30px;"/>
+                </div>
+            </h:panelGroup>
+
+            <div class="billline">
+                <h:outputLabel value="-----------------------------------------------"   />
+            </div>
+
+            <div class="billDetails" >
+                <table style="width: 100%;" >
+                    <tr>
+                        <td style="width: 15%; text-align: left;" >
+                            <h:outputLabel value="Date" class="billDetails" ></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails" >
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 10%" >
+
+                        </td>
+                        <td style="width: 15%" >
+                            <!--<h:outputLabel value="Time" ></h:outputLabel>-->
+                        </td>
+
+                        <td style="width: 30%" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails">
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"  ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel value="Inv.No" class="billDetails"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.billNo}"  class="billDetails">
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 10%" >
+
+                        </td>
+                        <td style="width: 15%" >
+                            <!--<h:outputLabel value="User" ></h:outputLabel>-->
+                        </td>
+
+                        <td style="width: 30%" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.creatorName}" class="billDetails">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel value="Method" class="billDetails"></h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+                            <h:outputLabel value="#{cc.attrs.bill.paymentMethodLabel}"  class="billDetails">
+                            </h:outputLabel>
+                        </td>
+                        <td style="width: 10%" >
+
+                        </td>
+                        <td style="width: 15%" >
+                            <!--<h:outputLabel value="User" ></h:outputLabel>-->
+                        </td>
+
+                        <td style="width: 30%" >
+                            <!--<h:outputLabel value=": &npsp;" ></h:outputLabel>-->
+<!--                            <h:outputLabel value="#{cc.attrs.bill.creater.staff.code}" >
+                            </h:outputLabel>-->
+                        </td>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.patientName}" >
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel value="Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.patientName}"  class="billDetails">
+                                </h:outputLabel>
+                            </td>
+                            <td style="width: 10%" >
+                            </td>
+                            <td style="width: 15%" >
+                            </td>
+                            <td style="width: 30%" >
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+
+
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toStaffName}" >
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel value="Staff Name" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toStaffName}"  class="billDetails">
+                                </h:outputLabel>
+                            </td>
+                            <td style="width: 10%" >
+                            </td>
+                            <td style="width: 15%" >
+                            </td>
+                            <td style="width: 30%" >
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toDepartmentName}" >
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel value="To Unit" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}"  class="billDetails">
+                                </h:outputLabel>
+                            </td>
+                            <td style="width: 10%" >
+                            </td>
+                            <td style="width: 15%" >
+                            </td>
+                            <td style="width: 30%" >
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{not empty cc.attrs.bill.toInstitutionName}" >
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel value="Company" class="billDetails"></h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}"  class="billDetails">
+                                </h:outputLabel>
+                            </td>
+                            <td style="width: 10%" >
+                            </td>
+                            <td style="width: 15%" >
+                            </td>
+                            <td style="width: 30%" >
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+
+
+            </div>
+
+
+            <div class="billline" style="width: 100%; margin-left: 5%;">
+                <h:outputLabel value="-------------------------------------------------"   />                        
+            </div>
+
+
+            <div >
+
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td style="width: 12%; text-align: left;">
+                            <h:outputLabel value="CODE" styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        <td style="width: 35%; ">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        <td  style="width:18%;text-align: right;">
+                            <h:outputLabel value="QTY"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+
+                        <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                            <td  style="width:18%;text-align: right;">
+                            <h:outputLabel value="RATE"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+
+                        <td  style="width:22%;text-align: right;">
+                            <h:outputLabel value="VALUE"  styleClass="itemHeadings" ></h:outputLabel>
+                        </td>
+                        </h:panelGroup>
+                    </tr>
+                    <tr>
+                        <td colspan="5" style="width: 100%">
+                            <div class="billline">
+                                <h:outputLabel value="-------------------------------------------------"   />                           
+                            </div>
+                        </td>
+
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.items}" var="bip">
+
+                        <tr>
+                            <td colspan="1">
+                                <h:outputLabel value="#{bip.itemCode}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
+                                </h:outputLabel>
+                            </td>
+                            <td colspan="4">
+                                <h:outputLabel value="#{bip.itemName}"  styleClass="itemsBlock" style="text-transform: capitalize!important; text-align: left;"  >
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">
+
+                            </td>
+                            <td styleClass="itemsBlockRight" style="width: 20%; text-align: right;">
+                                <h:outputLabel    value="#{bip.qty}"    styleClass="itemsBlock"   style="text-align: right;" >
+                                    <f:convertNumber integerOnly="true" />
+                                </h:outputLabel>
+                            </td>
+                            <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Remove Rate and Values From Printing on Cashier Sale Bill')}">
+                                <td  styleClass="itemsBlockRight"  style="text-align: right; width: 18%" >
+                                <h:outputLabel    value="#{bip.rate}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                            <td  styleClass="itemsBlockRight" style="text-align: right; width: 42%" >
+                                <h:outputLabel    value="#{bip.grossValue}"    >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                            </h:panelGroup>
+
+                        </tr>
+
+
+
+
+                    </ui:repeat>
+
+
+
+
+                </table>
+
+
+            </div>
+
+
+            <div class="billline" style="width: 90%; margin-left: 5%;">
+                <h:outputLabel value="-----------------------------------------------------"   />                         
+            </div>
+
+
+
+            <div  >
+
+                <table style="width: 100%;">
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Print Total On Pharmacy Sale Bill For Cashier')}">
+                        <tr>
+                            <td class="totalsBlock" style="text-align: left; width: 60%;">
+                                <h:outputLabel value="Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; width: 40%;">
+                                <h:outputLabel value="#{cc.attrs.bill.total}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ;">
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+
+                        <tr>
+
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
+                            </td>
+
+                            <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0}"    value="#{cc.attrs.bill.discountPercentPharmacy} %">
+                                    <f:convertNumber pattern="#,##0.0" />
+                                </h:outputLabel>
+
+
+                            </td>
+                        </tr>
+
+                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
+                            <tr >
+                                <td  class="totalsItemBlock" style="text-align: left;">
+                                    <h:outputLabel   value="Tendered" />
+                                </td>
+                                <td  class="totalsItemBlock" style="text-align: right; ">
+                                    <h:outputLabel   value="#{cc.attrs.bill.cashPaid}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td  class="totalsItemBlock" style="text-align: left;">
+                                    <h:outputLabel   value="Balance" />
+                                </td>
+                                <td  class="totalsItemBlock" style="text-align: right;">
+                                    <h:outputLabel   value="#{cc.attrs.bill.balance}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td  class="totalsItemBlock" style="text-align: left;">
+                            <h:outputLabel   value="Number of Items Count" />
+                        </td>
+                        <td  class="totalsItemBlock" style="text-align: right; ">
+                            <h:outputLabel   value="#{cc.attrs.items.size()()}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+
+                    <!-- The original's "Prepared by" row read bill.referenceBill.creater.name,
+                         guarded on referenceBill ne null. Sale for Cashier persists a single
+                         PreBill with no referenceBill (legacy does the same), so that row never
+                         rendered on this format. Dropped rather than carried across as a block
+                         that can never be reached. -->
+
+
+
+                </table>
+
+            </div>
+
+
+            <div class="footer">
+                <br/>
+                THANK YOU !
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+            </div>
+
+
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

Native-SQL replacement for the pharmacy **Sale for Cashier** page, avoiding the EAGER
`Stock → ItemBatch → Item` cascade load. Phase 2 of the retail sale native migration
(master #22442); mirrors what #20260 / PR #20362 did for plain "Sale".

Built by cloning `RetailSaleNativeSqlController` / `RetailSaleNativeSqlService` and
re-applying the cashier deltas, driven by a feature-inventory diff of all three
controllers. This matches the existing `WholesaleSaleNativeSqlController` precedent.

## What the cashier flow actually is

The pharmacist prepares the bill and **stock is deducted**, but the patient pays later at a
cashier counter. So the settle writes **one** bill — a `PreBill` of
`PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER` — with **no `BilledBill` and no `Payment`
rows** (that atomic type is `NO_PAYMENT` / `NO_FINANCE_TRANSACTIONS`). The payment
breakdown goes onto the bill's own columns via `billBean.setPaymentMethodData(...)`.

## Changes

**New**
- `RetailSaleForCashierNativeSqlService` — single-bill native settle: `BillItem` +
  fully-populated PBI, stock deduct, `StockHistory`, BFD/BIFD, totals.
- `RetailSaleForCashierNativeSqlController` — `@Named @SessionScoped` page controller.
- `pharmacy_bill_retail_sale_for_cashier_native.xhtml` — prints inline from `PrintBillData`.
- 9 `*_native` print composites (3 token + 6 bill). `saleBill_Header` is not ported —
  `saleBill_Header_Inward_native` already covers the same config key.

**Modified (additive only, no constructor changed)**
- `PrintBillData`: `billIdStr`, `cancelled`, `tokenNumber`, `invoiceNumber`, `creatorCode`,
  `departmentTelephone2`, `departmentFax`, `departmentSiteName`.
- `BillItemData`: `itemCode`.
- `menu.xhtml`: "Sale for cashier" → native; legacy moves behind `Legacy Functions Allowed`,
  mirroring the existing "Sale" / "Sale (Legacy)" pattern.

## Two deliberate deviations from legacy

1. **BFD/BIFD are written at settle.** Legacy writes none, which is exactly why
   `DataAdministrationController.backfillBfdForPreToSettleAtCashierBills()` exists — without
   BFD, F15's `totalRetailSaleValue` reads 0. Bills created here never need that backfill.
2. **Credit bills record `toInstitution` + `creditCompany`.** Legacy persists null for both,
   so legacy cashier Credit bills never appear in credit-company debtor reporting. That is a
   pre-existing legacy bug; the native page fixes it. Filed separately.

Everything else is intended as 100% functional replication: token system, the four qty
helpers, departmentType guards, the four cashier bill-number strategies, the full patient
validation gauntlet with legacy's exact config keys, discounts and multiple payments.

## Verification

`mvn clean package` clean. E2E on local Payara (dept OPD Pharmacy), bill `OP/SALE/35594`,
Panadol 500mg tab × 8 @ 3.49 = 27.92:

- Exactly **one** Bill row, `dtype=PreBill`, correct atomic type. **Zero** `Payment` rows.
  No `BilledBill`.
- `insId` distinct from `deptId` — two-generator numbering works.
- 1 `BillItem` + 1 PBI with **non-zero** cost/retail/purchase rates (3.2018 / 3.49 / 3.2018).
- Stock 960 → 952, exactly −8. `StockHistory` written.
- **BFD `TOTALRETAILSALEVALUE` = −27.92, BIFD present.**
- Token created and printed on the native token composite.
- Qty ×2 helper recalculated the row and the bill total.

**Downstream gate — the important one.** The natively-created bill settled cleanly through
the **legacy** cashier path (`pharmacy_search_pre_bill` → Call Customer → Accept Payment →
`pharmacy_bill_pre_settle`): `BilledBill` created with
`PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER`, both bills cross-linked, `Payment` 27.92
created **at the cashier step**, tendered 30 / balance 2.08, and **stock not deducted a
second time**. The legacy entity-based print page also renders the native bill correctly.

### Not yet exercised

Discount path, `MultiplePaymentMethods`, the token-system-OFF path, and each of the 10 print
formats individually (two were confirmed rendering). Worth covering before the Phase 3
production gate.

### Note for reviewers

`p:defaultCommand target="btnAdd"` is guarded on `!billPreview` here. The sibling
`pharmacy_bill_retail_sale_native.xhtml` carries the identical unguarded markup and logs a
PrimeFaces widget-init error after every settle — pre-existing, deliberately left alone.

Closes #20261

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a native “Sale for Cashier” workflow with single-bill settlement, immediate stock deductions, inline preview, and cashier-specific cart tools (quantity edits, substitutions, and department-filtered stock search).
  * Added richer patient checks and multi-payment handling with automatic remaining-amount filling.
  * Added native receipt/token printing layouts with barcode support plus duplicate/cancelled indicators and optional tender/balance details.
  * Updated Pharmacy menu to route to the native flow, while keeping a “Legacy” option behind a feature flag.
* **Documentation**
  * Added new implementation specifications, build/deploy guidance, and DB-backed end-to-end verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->