### PR TITLE
feat(inward): split interim bill medicine issues by issuing department into configurable, colourful tabs

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3504,7 +3504,7 @@ public class BhtSummeryController implements Serializable {
 
         createPatientRooms();
         createPatientItems();
-        
+
         if (!configOptionApplicationController.getBooleanValueByKey("Medicine, Sort by the type of department that issued it.", false)) {
             pharmacyIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters);
         } else {
@@ -3656,6 +3656,13 @@ public class BhtSummeryController implements Serializable {
         creditCompanyAllocations = null;
         newEncounterCreditCompany = null;
         estimatedBillView = false;
+
+        etuMedicineIssues = null;
+        pharmacyMedicineIssues = null;
+        inwardMedicineIssues = null;
+        theatreMedicineIssues = null;
+        storeMedicineIssues = null;
+        inventryMedicineIssues = null;
     }
 
     public void onInstitutionChange() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3514,13 +3514,6 @@ public class BhtSummeryController implements Serializable {
             theatreMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Theatre);
             storeMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Store);
             inventryMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Inventry);
-        
-            System.out.println("etuMedicineIssues = " + etuMedicineIssues);
-            System.out.println("pharmacyMedicineIssues = " + pharmacyMedicineIssues);
-            System.out.println("inwardMedicineIssues = " + inwardMedicineIssues);
-            System.out.println("theatreMedicineIssues = " + theatreMedicineIssues);
-            System.out.println("storeMedicineIssues = " + storeMedicineIssues);
-            System.out.println("inventryMedicineIssues = " + inventryMedicineIssues);
         }
 
         storeIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.StoreBhtPre, childPatientEncouters);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -73,7 +73,6 @@ import com.divudi.core.facade.ServiceFacade;
 import com.divudi.core.facade.TimedItemFeeFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillTypeAtomic;
-import static com.divudi.core.data.DepartmentType.Opd;
 import com.divudi.core.data.dataStructure.CreditCompanyAllocation;
 import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Staff;
@@ -86,7 +85,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
@@ -180,6 +178,15 @@ public class BhtSummeryController implements Serializable {
     List<BillItem> pharmacyItems;
     private List<Bill> paymentBill;
     private List<Bill> pharmacyIssues;
+
+    //Groping Medicine by Issueing Department
+    private List<Bill> etuMedicineIssues;
+    private List<Bill> pharmacyMedicineIssues;
+    private List<Bill> inwardMedicineIssues;
+    private List<Bill> theatreMedicineIssues;
+    private List<Bill> storeMedicineIssues;
+    private List<Bill> inventryMedicineIssues;
+
     List<Bill> storeIssues;
     private List<Bill> surgeryBills;
     private Bill surgeryBill;
@@ -297,17 +304,17 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Gantt bars merging ward room stays and theatre visits for the unified patient timeline.
-     * Theatre bars are amber (active) or grey (completed).
+     * Gantt bars merging ward room stays and theatre visits for the unified
+     * patient timeline. Theatre bars are amber (active) or grey (completed).
      */
     private transient List<RoomGanttBar> cachedUnifiedGanttBars;
     private transient long cachedUnifiedGanttBarsComputedAtMillis;
     private static final long UNIFIED_GANTT_BARS_CACHE_TTL_MILLIS = 5000;
 
     /**
-     * Clears the Gantt bar cache immediately. The 5s TTL above is a safety
-     * net for the wall-clock "Now" marker, which has no explicit save event
-     * to hook into - but any action that actually persists a room's
+     * Clears the Gantt bar cache immediately. The 5s TTL above is a safety net
+     * for the wall-clock "Now" marker, which has no explicit save event to hook
+     * into - but any action that actually persists a room's
      * admitted/discharged/retired state must call this so the same AJAX
      * response reflects the change instead of waiting out the TTL.
      */
@@ -486,9 +493,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Charges grouped by inward charge type (excluding Professional Charge, which is
-     * printed separately on the Professional Bill section), alphabetical by display
-     * name, for the Custom2 "Final Bill" totals-only section.
+     * Charges grouped by inward charge type (excluding Professional Charge,
+     * which is printed separately on the Professional Bill section),
+     * alphabetical by display name, for the Custom2 "Final Bill" totals-only
+     * section.
      */
     public List<Map.Entry<String, Double>> getCustom2CategoryTotals(Bill bill) {
         Map<String, Double> totals = new TreeMap<>();
@@ -621,7 +629,8 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Snapshot of a room's per-charge discount values for audit events (#22238).
+     * Snapshot of a room's per-charge discount values for audit events
+     * (#22238).
      */
     private Map<String, Object> roomDiscountAuditMap(PatientRoom pr) {
         Map<String, Object> m = new LinkedHashMap<>();
@@ -846,9 +855,9 @@ public class BhtSummeryController implements Serializable {
      * Handles drag-and-drop reordering of the doctor rows in the grouped
      * Professional Fee table. The grouped list is rebuilt fresh on each render
      * (so PrimeFaces' in-place reorder would be lost); instead we take the
-     * displayed order, apply the move via the event's from/to indices, and write
-     * a sequential orderNo onto every underlying fee. The next render re-groups
-     * ordered by orderNo, and the printed bill reproduces it via
+     * displayed order, apply the move via the event's from/to indices, and
+     * write a sequential orderNo onto every underlying fee. The next render
+     * re-groups ordered by orderNo, and the printed bill reproduces it via
      * &#64;OrderBy("orderNo, feeAdjusted").
      */
     public void onGroupedProfessionalFeeReorder(ReorderEvent event) {
@@ -873,9 +882,9 @@ public class BhtSummeryController implements Serializable {
 
     /**
      * Captures the professional fee list in its current displayed (grouped,
-     * doctor-by-doctor) order into orderNo. Called when Save Provisional Bill or
-     * Settle is clicked so the saved bill keeps exactly the order shown on screen,
-     * which the combined-doctor print preview then reproduces via
+     * doctor-by-doctor) order into orderNo. Called when Save Provisional Bill
+     * or Settle is clicked so the saved bill keeps exactly the order shown on
+     * screen, which the combined-doctor print preview then reproduces via
      * &#64;OrderBy("orderNo, feeAdjusted").
      */
     private void persistGroupedProfessionalFeeOrder() {
@@ -887,13 +896,14 @@ public class BhtSummeryController implements Serializable {
             }
         }
     }
-    
+
     /**
-     * Groups the professional fee list by doctor so the final bill shows a single
-     * line per doctor with the combined total. Each group keeps its individual
-     * fees so the breakdown popup can show how the total was calculated.
-     * Only the fees that are actually billed (not cancelled, real billed bill,
-     * non-zero amount) are included, matching what the per-fee table displayed.
+     * Groups the professional fee list by doctor so the final bill shows a
+     * single line per doctor with the combined total. Each group keeps its
+     * individual fees so the breakdown popup can show how the total was
+     * calculated. Only the fees that are actually billed (not cancelled, real
+     * billed bill, non-zero amount) are included, matching what the per-fee
+     * table displayed.
      */
     public List<DoctorFeeGroup> getGroupedProfessionalFees() {
         Map<Staff, DoctorFeeGroup> groups = new LinkedHashMap<>();
@@ -976,11 +986,12 @@ public class BhtSummeryController implements Serializable {
     /**
      * Refreshes the ProfessionalCharge category adjusted total from the grouped
      * doctor fees the user actually sees. When the config flag merges assisting
-     * fees into {@code profesionallFee}, those fees live on a different bill type,
-     * so summing only {@code getProfessionalCharge(...)} (InwardProfessional) would
-     * silently drop the assisting-fee adjustments from settlement. Summing the
-     * grouped totals keeps the category total consistent with the displayed table
-     * in both the merged and non-merged configurations.
+     * fees into {@code profesionallFee}, those fees live on a different bill
+     * type, so summing only {@code getProfessionalCharge(...)}
+     * (InwardProfessional) would silently drop the assisting-fee adjustments
+     * from settlement. Summing the grouped totals keeps the category total
+     * consistent with the displayed table in both the merged and non-merged
+     * configurations.
      */
     private void refreshProfessionalChargeAdjustedTotal() {
         double groupedAdjusted = 0;
@@ -1027,9 +1038,57 @@ public class BhtSummeryController implements Serializable {
         this.selectedDoctorFeeGroup = selectedDoctorFeeGroup;
     }
 
+    public List<Bill> getEtuMedicineIssues() {
+        return etuMedicineIssues;
+    }
+
+    public void setEtuMedicineIssues(List<Bill> etuMedicineIssues) {
+        this.etuMedicineIssues = etuMedicineIssues;
+    }
+
+    public List<Bill> getPharmacyMedicineIssues() {
+        return pharmacyMedicineIssues;
+    }
+
+    public void setPharmacyMedicineIssues(List<Bill> pharmacyMedicineIssues) {
+        this.pharmacyMedicineIssues = pharmacyMedicineIssues;
+    }
+
+    public List<Bill> getInwardMedicineIssues() {
+        return inwardMedicineIssues;
+    }
+
+    public void setInwardMedicineIssues(List<Bill> inwardMedicineIssues) {
+        this.inwardMedicineIssues = inwardMedicineIssues;
+    }
+
+    public List<Bill> getTheatreMedicineIssues() {
+        return theatreMedicineIssues;
+    }
+
+    public void setTheatreMedicineIssues(List<Bill> theatreMedicineIssues) {
+        this.theatreMedicineIssues = theatreMedicineIssues;
+    }
+
+    public List<Bill> getStoreMedicineIssues() {
+        return storeMedicineIssues;
+    }
+
+    public void setStoreMedicineIssues(List<Bill> storeMedicineIssues) {
+        this.storeMedicineIssues = storeMedicineIssues;
+    }
+
+    public List<Bill> getInventryMedicineIssues() {
+        return inventryMedicineIssues;
+    }
+
+    public void setInventryMedicineIssues(List<Bill> inventryMedicineIssues) {
+        this.inventryMedicineIssues = inventryMedicineIssues;
+    }
+
     /**
-     * View model for one doctor's combined professional fee row on the final bill,
-     * carrying the summed total and the individual fees behind it.
+     * View model for one doctor's combined professional fee row on the final
+     * bill, carrying the summed total and the individual fees behind it.
      */
     public static class DoctorFeeGroup implements Serializable {
 
@@ -1701,10 +1760,10 @@ public class BhtSummeryController implements Serializable {
 
     /**
      * The other non-Guardian/Theatre room stay(s) for the same patient
-     * encounter or same bed (RoomFacilityCharge) whose admitted/discharged
-     * time range overlaps this room's. Returned (rather than just a count)
-     * so callers can report exactly which room(s) are the conflict instead
-     * of a generic "overlap detected" message.
+     * encounter or same bed (RoomFacilityCharge) whose admitted/discharged time
+     * range overlaps this room's. Returned (rather than just a count) so
+     * callers can report exactly which room(s) are the conflict instead of a
+     * generic "overlap detected" message.
      */
     public List<PatientRoom> getOverlappingRooms(PatientRoom patientRoom) {
         if (patientRoom == null || patientRoom.getAdmittedAt() == null || patientRoom.getPatientEncounter() == null) {
@@ -1758,11 +1817,11 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Human-readable summary of which specific room(s) this room's time
-     * range conflicts with, e.g. "Room 412 (Active)". Used by the row-level
-     * "Overlap" tag and the save confirmation dialog so a conflict can be
-     * identified and resolved instead of showing a generic warning that
-     * stays stuck when there are 3+ open (non-discharged) room stays.
+     * Human-readable summary of which specific room(s) this room's time range
+     * conflicts with, e.g. "Room 412 (Active)". Used by the row-level "Overlap"
+     * tag and the save confirmation dialog so a conflict can be identified and
+     * resolved instead of showing a generic warning that stays stuck when there
+     * are 3+ open (non-discharged) room stays.
      */
     public String getOverlapDescription(PatientRoom patientRoom) {
         List<PatientRoom> overlaps = getOverlappingRooms(patientRoom);
@@ -2048,8 +2107,6 @@ public class BhtSummeryController implements Serializable {
             return;
         }
 
-        
-
         originalBill.setDiscount(discount);
         originalBill.setNetTotal(originalBill.getGrantTotal() - discount);
         getBillFacade().edit(originalBill);
@@ -2245,8 +2302,8 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Starts a brand-new final bill version for the same admission, seeded
-     * from {@code sourceBill}'s discount and credit-company allocations, but
+     * Starts a brand-new final bill version for the same admission, seeded from
+     * {@code sourceBill}'s discount and credit-company allocations, but
      * recomputing all live charge tables fresh (the source bill's exact
      * BillItems are not frozen/replayed).
      */
@@ -2284,8 +2341,8 @@ public class BhtSummeryController implements Serializable {
     /**
      * Rebuilds the on-screen credit-company allocation split from the CC
      * commitment bills recorded against {@code sourceBill}, so a new version
-     * starts from the same split rather than forcing the cashier to
-     * re-allocate from scratch.
+     * starts from the same split rather than forcing the cashier to re-allocate
+     * from scratch.
      */
     private List<CreditCompanyAllocation> rebuildAllocationsFromSourceBill(Bill sourceBill) {
         List<CreditCompanyAllocation> allocations = new ArrayList<>();
@@ -2345,10 +2402,10 @@ public class BhtSummeryController implements Serializable {
 
     /**
      * Discards the on-screen credit-company allocation split and rebuilds it
-     * from the present net due (total − discounts − paid). Called when
-     * Process is clicked or any discount is changed so the allocation always
-     * follows the latest discounts. Cashier-entered splits are intentionally
-     * reset here — their total no longer matches the new net due.
+     * from the present net due (total − discounts − paid). Called when Process
+     * is clicked or any discount is changed so the allocation always follows
+     * the latest discounts. Cashier-entered splits are intentionally reset here
+     * — their total no longer matches the new net due.
      */
     private void rebuildCreditCompanyAllocations() {
         if (getPatientEncounter() == null
@@ -2600,7 +2657,6 @@ public class BhtSummeryController implements Serializable {
             saveCCBillByInstitution(pe, alloc.getCreditCompany(), alloc.getAllocatedAmount());
         }
     }
-
 
     private boolean checkPatientItems() {
         List<PatientItem> lst = createPatientItems();
@@ -2899,27 +2955,27 @@ public class BhtSummeryController implements Serializable {
         if (getPatientEncounter().getAdmissionType() == null) {
             return "";
         }
-        
+
         System.out.println("Patient Encounter = " + getPatientEncounter());
-        System.out.println("Admission Type = " + getPatientEncounter().getAdmissionType()); 
+        System.out.println("Admission Type = " + getPatientEncounter().getAdmissionType());
         System.out.println("Admission Type Enum = " + getPatientEncounter().getAdmissionType().getAdmissionTypeEnum());
-        
+
         System.out.println("Match = " + (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission));
-        
+
         System.out.println("Privilege = " + getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck"));
-        
+
         System.out.println("Option = " + configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge"));
-        
+
         System.out.println("Starting Bills Checking Process.... ");
         if (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission && !getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck")) {
             System.out.println("Checking.... ---> ");
             if (checkBill()) {
                 return "";
             }
-        }else{
+        } else {
             System.out.println("Ignore Checking.... ---> ");
         }
-        
+
         System.out.println("End Bills Checking Process.... ");
 
         if (getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
@@ -3280,11 +3336,11 @@ public class BhtSummeryController implements Serializable {
      * preserving the manual doctor order via orderNo.
      * <p>
      * The original per-encounter fees are left untouched on their
-     * InwardProfessional bills, so doctor-payment/commission reports (which read
-     * those bills) stay correct. The merged fees belong to the final bill
-     * (InwardFinalBill), so they are distinguishable from the source fees by bill
-     * type. When {@code persist} is false (temp preview) the merged fees are kept
-     * in memory only.
+     * InwardProfessional bills, so doctor-payment/commission reports (which
+     * read those bills) stay correct. The merged fees belong to the final bill
+     * (InwardFinalBill), so they are distinguishable from the source fees by
+     * bill type. When {@code persist} is false (temp preview) the merged fees
+     * are kept in memory only.
      */
     private void addMergedDoctorFeesToProFees(List<BillFee> sourceFees, BillItem bItem, boolean persist) {
         Map<Staff, BillFee> merged = new LinkedHashMap<>();
@@ -3384,11 +3440,12 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Guards inward_bill_intrim.xhtml / inward_bill_intrim_estimate.xhtml against
-     * being reached (e.g. via browser back/forward or a stale tab) while
-     * patientEncounter still points at a baby (child) admission — closes the gap
-     * where visiting any Inpatient Dashboard unconditionally mirrors the current
-     * admission into patientEncounter, independent of the createIntrimBillTable()/
+     * Guards inward_bill_intrim.xhtml / inward_bill_intrim_estimate.xhtml
+     * against being reached (e.g. via browser back/forward or a stale tab)
+     * while patientEncounter still points at a baby (child) admission — closes
+     * the gap where visiting any Inpatient Dashboard unconditionally mirrors
+     * the current admission into patientEncounter, independent of the
+     * createIntrimBillTable()/
      * createTablesWithEstimatedProfessionalFees()/navigateToIntrimBillFromPatientProfile()
      * guards. Safe to call on every page load.
      */
@@ -3447,7 +3504,25 @@ public class BhtSummeryController implements Serializable {
 
         createPatientRooms();
         createPatientItems();
-        pharmacyIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters);
+        
+        if (!configOptionApplicationController.getBooleanValueByKey("Medicine, Sort by the type of department that issued it.", false)) {
+            pharmacyIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters);
+        } else {
+            etuMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Etu);
+            pharmacyMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Pharmacy);
+            inwardMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Inward);
+            theatreMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Theatre);
+            storeMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Store);
+            inventryMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Inventry);
+        
+            System.out.println("etuMedicineIssues = " + etuMedicineIssues);
+            System.out.println("pharmacyMedicineIssues = " + pharmacyMedicineIssues);
+            System.out.println("inwardMedicineIssues = " + inwardMedicineIssues);
+            System.out.println("theatreMedicineIssues = " + theatreMedicineIssues);
+            System.out.println("storeMedicineIssues = " + storeMedicineIssues);
+            System.out.println("inventryMedicineIssues = " + inventryMedicineIssues);
+        }
+
         storeIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.StoreBhtPre, childPatientEncouters);
         departmentBillItems = getInwardBean().createDepartmentBillItemsOptimized(patientEncounter, null, childPatientEncouters);
         additionalChargeBill = getInwardBean().fetchOutSideBill(getPatientEncounter(), childPatientEncouters);
@@ -3871,8 +3946,8 @@ public class BhtSummeryController implements Serializable {
     /**
      * Margin (positive or negative) from the room-category price-adjustment
      * matrix (InwardPriceAdjustment rows configured on the room facility
-     * category price-matrix admin page) for a single room-related charge
-     * amount of a given PatientRoom. Returns 0 when the room has no
+     * category price-matrix admin page) for a single room-related charge amount
+     * of a given PatientRoom. Returns 0 when the room has no
      * department/room-category context or no matching matrix row exists.
      */
     private double roomChargeMatrixMargin(PatientRoom p, double chargeValue) {
@@ -4362,12 +4437,12 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Populates Gross/Service Charge (Margin)/VAT on each ChargeItemTotal so the
-     * "Charges" summary table and the Summary panel can show the full breakdown,
-     * not just the net total. Services/investigations (BillItem-backed) come from
-     * a bulk JPQL sum grouped by InwardChargeType; Professional/Assisting fees
-     * (BillFee-backed, staff fee records) are summed from the lists already
-     * fetched for their respective tabs.
+     * Populates Gross/Service Charge (Margin)/VAT on each ChargeItemTotal so
+     * the "Charges" summary table and the Summary panel can show the full
+     * breakdown, not just the net total. Services/investigations
+     * (BillItem-backed) come from a bulk JPQL sum grouped by InwardChargeType;
+     * Professional/Assisting fees (BillFee-backed, staff fee records) are
+     * summed from the lists already fetched for their respective tabs.
      */
     private void setGrossMarginVatBreakdown() {
         Map<InwardChargeType, double[]> serviceBreakdown = getInwardBean().calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk(getPatientEncounter(), childPatientEncouters);
@@ -4532,8 +4607,8 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * The amount the allocation rows (companies + patient) must add up to:
-     * net total after all discounts, less what is already paid.
+     * The amount the allocation rows (companies + patient) must add up to: net
+     * total after all discounts, less what is already paid.
      */
     public double getCreditDueToAllocate() {
         return Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);
@@ -4610,14 +4685,14 @@ public class BhtSummeryController implements Serializable {
                         double professionalFee = getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView);
                         double assistingFee = getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters);
                         i.setTotal(professionalFee + assistingFee);
-                    }else{
+                    } else {
                         i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
                     }
                     break;
                 case DoctorAndNurses:
                     if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
                         i.setTotal(0.0);
-                    }else{
+                    } else {
                         i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
                     }
                     break;

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -881,6 +881,65 @@ public class InwardBeanController implements Serializable {
 
         return sortedList;
     }
+    
+    public List<Bill> fetchIssueTable(PatientEncounter patientEncounter, BillType billType, List<PatientEncounter> cpts, DepartmentType billingDepartmentType) {
+        List<Bill> list = new ArrayList<>();
+        String sql;
+        HashMap hm;
+        sql = "SELECT  b FROM Bill b "
+                + " WHERE b.retired=false "
+                + " and b.billType=:btp "
+                + " and b.department.departmentType = :type"
+                + " and (b.billedBill is null )  "
+                + " and  b.patientEncounter IN :pe"
+                + " and (type(b)=:class) ";
+        hm = new HashMap();
+        hm.put("btp", billType);
+        hm.put("class", PreBill.class);
+        hm.put("type", billingDepartmentType);
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
+        hm.put("pe", pts);
+
+        List<Bill> bills = getBillFacade().findByJpql(sql, hm);
+
+        hm.clear();
+        sql = "SELECT  b FROM Bill b "
+                + " WHERE b.retired=false "
+                + " and b.billType=:btp"
+                + " and  b.department.departmentType = :type"
+                + " and type(b.billedBill)=:billedClass "
+                + " and  b.patientEncounter IN :pe"
+                + " and (type(b)=:class) ";
+        hm = new HashMap();
+        hm.put("btp", billType);
+        hm.put("class", RefundBill.class);
+        hm.put("billedClass", PreBill.class);
+        hm.put("type", billingDepartmentType);
+        List<PatientEncounter> pts1 = new ArrayList<>();
+        pts1.add(patientEncounter);
+        List<PatientEncounter> cpts1 = cpts;
+        if (cpts1.size() > 0) {
+            for (PatientEncounter pt : cpts1) {
+                pts1.add(pt);
+            }
+        }
+        hm.put("pe", pts1);
+
+        List<Bill> bills2 = getBillFacade().findByJpql(sql, hm);
+
+        list.addAll(bills);
+        list.addAll(bills2);
+
+        List<Bill> sortedList = list.stream()
+                .sorted(Comparator.comparing(Bill::getCreatedAt))
+                .collect(Collectors.toList());
+
+        return sortedList;
+    }
 
     public List<BillItem> fetchPharmacyIssueBillItem(PatientEncounter patientEncounter, BillType billType) {
         List<BillItem> grantList = new ArrayList<>();

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -272,7 +272,7 @@
                         </h:panelGrid>
 
                         <div class="row">
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <p:panel id="panSearch2" class="w-100">
                                     <f:facet name="header">
                                         <h:outputText styleClass="fa fa-user-circle"/>
@@ -339,6 +339,8 @@
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </h:panelGrid>
+                                            
+                                            <hr/>
 
                                             <h:panelGrid columns="3" style="font-weight: bold; font-size: 22px;">
                                                 <h:outputLabel  value="Total Charges"/>
@@ -414,7 +416,8 @@
                                     </p:panel>
                                 </h:panelGrid>
                             </div>
-                            <div class="col-md-4">
+
+                            <div class="col-md-5">
                                 <p:panel>
                                     <f:facet name="header">
                                         <h:outputText styleClass="fas fa-money-bill" />
@@ -425,8 +428,8 @@
                                         id="sum"
                                         value="#{bhtSummeryController.chargeItemTotals}"
                                         var="c"
-                                        style="height: 310px"
-                                        scrollHeight="310"
+                                        style="height: 510px"
+                                        scrollHeight="410"
                                         scrollable="true"
                                         scrollRows="10"
                                         >
@@ -788,96 +791,194 @@
                                 </p:tab>
 
                                 <p:tab title="Medicine Issue">
-                                    <p:dataTable 
-                                        value="#{bhtSummeryController.pharmacyIssues}" 
-                                        var="iss" 
-                                        scrollable="true"
-                                        scrollHeight="300"
-                                        rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
-                                                         or
-                                                         (iss.billedBill ne null
-                                                         and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
-                                        <p:column headerText="Bill No">
-                                            <h:outputLabel  value="#{iss.deptId}"></h:outputLabel>
-                                        </p:column>
+                                    <h:panelGroup rendered="#{not configOptionApplicationController.getBooleanValueByKey('Medicine, Sort by the type of department that issued it.', false)}">
+                                        <p:dataTable 
+                                            value="#{bhtSummeryController.pharmacyIssues}" 
+                                            var="iss" 
+                                            scrollable="true"
+                                            scrollHeight="300"
+                                            rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
+                                                             or
+                                                             (iss.billedBill ne null
+                                                             and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
+                                            <p:column headerText="Bill No">
+                                                <h:outputLabel  value="#{iss.deptId}"></h:outputLabel>
+                                            </p:column>
 
-                                        <p:column headerText="Billed At">
-                                            <h:outputLabel value="#{iss.createdAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
-                                            </h:outputLabel>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.createdAt}" >
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                            <p:column headerText="Billed At">
+                                                <h:outputLabel value="#{iss.createdAt}">
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
                                                 </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Bill Total" class="text-end">
-                                            <h:outputLabel  value="#{iss.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column headerText="Billed By">
-                                            <h:outputLabel value="#{iss.creater.webUserPerson.name}"/>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.creater.webUserPerson.name}" >
+                                                <br/>
+                                                <h:panelGroup rendered="#{iss.cancelled}" >
+                                                    <h:outputLabel style="color: red;" value="Cancelled at " />
+                                                    <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                                                                   value="#{iss.cancelledBill.createdAt}" >
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                                    </h:outputLabel>
+                                                </h:panelGroup>
+                                            </p:column>
+                                            <p:column headerText="Bill Total" class="text-end">
+                                                <h:outputLabel  value="#{iss.netTotal}">
+                                                    <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Checked By">
-                                            <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
-                                        </p:column>
-                                        <p:column headerText="Checked At">
-                                            <h:outputLabel value="#{iss.checkeAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column headerText="Comments"> 
-                                            <h:panelGroup id="commentContainer" layout="block" class="row">
-                                                <div class="row" >
-                                                    <div class="col-8" >
-                                                        <p:inputText id="commentInput"
-                                                                     class="w-100"
-                                                                     value="#{iss.comments}"/>
+                                            </p:column>
+                                            <p:column headerText="Billed By">
+                                                <h:outputLabel value="#{iss.creater.webUserPerson.nameWithTitle}"/>
+                                                <br/>
+                                                <h:panelGroup rendered="#{iss.cancelled}" >
+                                                    <h:outputLabel style="color: red;" value="Cancelled By " />
+                                                    <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                                                                   value="#{iss.cancelledBill.creater.webUserPerson.name}" >
+                                                    </h:outputLabel>
+                                                </h:panelGroup>
+                                            </p:column>
+                                            <p:column headerText="Checked By">
+                                                <h:outputLabel value="#{iss.checkedBy.webUserPerson.nameWithTitle}"/>
+                                            </p:column>
+                                            <p:column headerText="Checked At">
+                                                <h:outputLabel value="#{iss.checkeAt}">
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column headerText="Comments"> 
+                                                <h:panelGroup id="commentContainer" layout="block" class="row">
+                                                    <div class="row" >
+                                                        <div class="col-8" >
+                                                            <p:inputText id="commentInput"
+                                                                         class="w-100"
+                                                                         value="#{iss.comments}"/>
+                                                        </div>
+                                                        <div class="col-4" >
+                                                            <p:commandButton 
+                                                                id="saveBtn"
+                                                                icon="fa fa-save"
+                                                                class="col-3"
+                                                                action="#{billController.save(iss)}"
+                                                                process="commentContainer"
+                                                                update="pageForm:pageMessages"
+                                                                title="Save">
+                                                            </p:commandButton>
+                                                        </div>
                                                     </div>
-                                                    <div class="col-4" >
-                                                        <p:commandButton 
-                                                            id="saveBtn"
-                                                            icon="fa fa-save"
-                                                            class="col-3"
-                                                            action="#{billController.save(iss)}"
-                                                            process="commentContainer"
-                                                            update="pageForm:pageMessages"
-                                                            title="Save">
-                                                        </p:commandButton>
-                                                    </div>
-                                                </div>
 
 
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}" 
-                                                value="View Issue"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
-                                            </p:commandButton>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
-                                                value="View Return"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
-                                            </p:commandButton>
-                                        </p:column>
-                                    </p:dataTable>
+                                                </h:panelGroup>
+                                            </p:column>
+                                            <p:column>
+                                                <p:commandButton 
+                                                    ajax="false" 
+                                                    action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
+                                                    rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}" 
+                                                    value="View Issue"  >
+                                                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                                                </p:commandButton>
+                                                <p:commandButton 
+                                                    ajax="false" 
+                                                    action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
+                                                    rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
+                                                    value="View Return"  >
+                                                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                                                </p:commandButton>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine, Sort by the type of department that issued it.', false)}">
+                                        <style>
+                                            .med-issue-tabs.ui-tabs { border: none; background: transparent; width: 100%; }
+                                            .med-issue-tabs .ui-tabs-nav { display: flex; flex-wrap: wrap; justify-content: center; gap: 35px; background: linear-gradient(135deg,#f4f6fb,#eef1f8); border: none; border-radius: 14px; padding: 14px; width: 100%; box-sizing: border-box; }
+                                            .med-issue-tabs .ui-tabs-nav li { border: none !important; border-radius: 10px !important; background: transparent !important; margin: 0 !important; padding: 0 !important; width: 13em !important; flex: 0 0 13em !important; box-sizing: border-box !important; }
+                                            .med-issue-tabs .ui-tabs-nav li a { border-radius: 10px; padding: 0 !important; display: block; width: 100%; }
+                                            .med-issue-tabs .ui-tabs-nav li.ui-state-active { box-shadow: 0 3px 10px rgba(0,0,0,.18); }
+                                            .med-issue-tabs .ui-tabs-panels { background: #fff; border: 1px solid #eef1f8; border-radius: 0 0 14px 14px; }
+                                            .med-issue-tabs .med-tab-pill { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 13em; padding: 14px 16px; border-radius: 10px; font-weight: 600; font-size: 1.1em; color: var(--tab-accent); background: color-mix(in srgb, var(--tab-accent) 14%, #fff); border: 1px solid color-mix(in srgb, var(--tab-accent) 35%, #fff); transition: all .2s ease; box-sizing: border-box; }
+                                            .med-issue-tabs .med-tab-pill .med-tab-label { display: flex; align-items: center; gap: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+                                            .med-issue-tabs .med-tab-pill .fa { color: var(--tab-accent); flex: 0 0 auto; }
+                                            .med-issue-tabs .ui-tabs-nav li.ui-state-active .med-tab-pill { color: #fff; background: var(--tab-accent); border-color: var(--tab-accent); }
+                                            .med-issue-tabs .ui-tabs-nav li.ui-state-active .med-tab-pill .fa { color: #fff; }
+                                            .med-issue-tabs .med-tab-pill .ui-badge { margin-left: auto; flex: 0 0 auto; min-width: 1.8em; height: 1.8em; line-height: 1.8em; font-size: 1em; border-radius: 50%; }
+                                        </style>
+                                        <div class="d-flex justify-content-center w-100">
+                                            <p:tabView id="medIssueDeptTabs" styleClass="med-issue-tabs" style="width:100%;">
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - ETU', '#e74c3c')}">
+                                                            <span class="med-tab-label"><i class="fa fa-ambulance"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - ETU', 'ETU')}</span>
+                                                            <p:badge value="#{empty bhtSummeryController.etuMedicineIssues ? 0 : bhtSummeryController.etuMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.etuMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - Pharmacy', '#3498db')}">
+                                                            <span class="med-tab-label"><i class="fa fa-medkit"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - Pharmacy', 'Pharmacy')}</span>
+                                                            <p:badge class="mx-2" value="#{empty bhtSummeryController.pharmacyMedicineIssues ? 0 : bhtSummeryController.pharmacyMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.pharmacyMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - Inward', '#9b59b6')}">
+                                                            <span class="med-tab-label"><i class="fa fa-bed"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - Inward', 'Inward')}</span>
+                                                            <p:badge value="#{empty bhtSummeryController.inwardMedicineIssues ? 0 : bhtSummeryController.inwardMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.inwardMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - Theatre', '#e67e22')}">
+                                                            <span class="med-tab-label"><i class="fa fa-heartbeat"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - Theatre', 'Theatre')}</span>
+                                                            <p:badge value="#{empty bhtSummeryController.theatreMedicineIssues ? 0 : bhtSummeryController.theatreMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.theatreMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - Store', '#16a085')}">
+                                                            <span class="med-tab-label"><i class="fa fa-archive"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - Store', 'Store')}</span>
+                                                            <p:badge value="#{empty bhtSummeryController.storeMedicineIssues ? 0 : bhtSummeryController.storeMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.storeMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                                <p:tab>
+                                                    <f:facet name="title">
+                                                        <span class="med-tab-pill" style="--tab-accent: #{configOptionApplicationController.getColorValueByKey('Inward Interim Bill - Medicine Issue Tab Colour - Inventory', '#2ecc71')}">
+                                                            <span class="med-tab-label"><i class="fa fa-cubes"/> #{configOptionApplicationController.getShortTextValueByKey('Inward Interim Bill - Medicine Issue Tab Title - Inventory', 'Inventory')}</span>
+                                                            <p:badge value="#{empty bhtSummeryController.inventryMedicineIssues ? 0 : bhtSummeryController.inventryMedicineIssues.size()}"/>
+                                                        </span>
+                                                    </f:facet>
+                                                    <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
+                                                        <ui:param name="issues" value="#{bhtSummeryController.inventryMedicineIssues}"/>
+                                                    </ui:decorate>
+                                                </p:tab>
+
+                                            </p:tabView>
+                                        </div>
+
+                                    </h:panelGroup>
+
                                 </p:tab>
 
                                 <p:tab title="Store Issue">
@@ -954,75 +1055,6 @@
                                                 rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
                                                 value="View Return"  >
                                                 <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
-                                            </p:commandButton>
-                                        </p:column>
-                                    </p:dataTable>
-                                </p:tab>
-
-                                <p:tab title="Medicines and Surgical Supplies" rendered="#{configOptionApplicationController.getBooleanValueByKey('Separate Medicines and Surgical Supplies Tab', false)}">
-                                    <p:dataTable 
-                                        value="#{bhtSummeryController.medicinesAndSurgicalSupplies}" 
-                                        var="iss" 
-                                        scrollable="true"
-                                        scrollHeight="300"
-                                        rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
-                                                         or
-                                                         (iss.billedBill ne null
-                                                         and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
-                                        <p:column headerText="Bill No">
-                                            <h:outputLabel  value="#{iss.deptId}"></h:outputLabel>
-                                        </p:column>
-
-                                        <p:column headerText="Billed At">
-                                            <h:outputLabel value="#{iss.createdAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
-                                            </h:outputLabel>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.createdAt}" >
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
-                                                </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Bill Total" class="text-end">
-                                            <h:outputLabel  value="#{iss.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column headerText="Billed By">
-                                            <h:outputLabel value="#{iss.creater.webUserPerson.name}"/>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.creater.webUserPerson.name}" >
-                                                </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Checked By">
-                                            <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
-                                        </p:column>
-                                        <p:column headerText="Checked At">
-                                            <h:outputLabel value="#{iss.checkeAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}" 
-                                                value="View Issue"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
-                                            </p:commandButton>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
-                                                value="View Return"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
                                     </p:dataTable>
@@ -1115,7 +1147,7 @@
                                         value="#{bhtSummeryController.profesionallFee}" 
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
-                                        
+
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
@@ -1156,7 +1188,7 @@
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Added Time">
                                             <h:outputLabel value="#{pf.createdAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
@@ -1169,7 +1201,7 @@
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Added User">
                                             <h:outputLabel value="#{pf.bill.creater.webUserPerson.nameWithTitle}"/>
                                             <br/>
@@ -1178,7 +1210,7 @@
                                                 <h:outputLabel style="color: red;" value="#{pf.bill.cancelledBill.creater.webUserPerson.nameWithTitle}" ></h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Checked User">
                                             <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
@@ -1187,13 +1219,13 @@
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Action" width="6em;">
                                             <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
-                                        
+
                                     </p:dataTable>
                                 </p:tab>
 
@@ -1204,7 +1236,7 @@
                                         value="#{bhtSummeryController.doctorAndNurseFee}"
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
-                                        
+
                                         <p:column headerText="Name">
                                             #{pf.staff.person.nameWithTitle}
                                         </p:column>
@@ -1244,7 +1276,7 @@
                                                 <f:convertDateTime pattern="dd MMMM yyyy hh mm ss a"/>
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Added Time">
                                             <h:outputLabel value="#{pf.createdAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
@@ -1266,23 +1298,23 @@
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Checked User">
                                             <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{pf.bill.checkeAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Action" width="6em;">
                                             <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                             </p:commandButton>
                                         </p:column>
-                                        
+
                                     </p:dataTable>
                                 </p:tab>
 
@@ -1311,7 +1343,7 @@
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Added User">
                                             <h:outputLabel value="#{p.creater.webUserPerson.nameWithTitle}"/>
                                             <br/>
@@ -1322,27 +1354,27 @@
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Payment Method" >
                                             <h:outputLabel value="#{p.paymentMethod}"/>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Value" class="text-end" width="6em;">
                                             <h:outputLabel  value="#{p.netTotal}" class="text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Checked User">
                                             <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.nameWithTitle}"/>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{p.checkeAt}">
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                         </p:column>
-                                        
+
                                         <p:column headerText="Action" width="6em;">
                                             <p:commandButton ajax="false" action="inward_reprint_bill_payment?faces-redirect=true" value="View Bill" >
                                                 <f:setPropertyActionListener value="#{p}" target="#{inwardSearch.bill}"/>

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -829,7 +829,7 @@
                                                 <h:panelGroup rendered="#{iss.cancelled}" >
                                                     <h:outputLabel style="color: red;" value="Cancelled By " />
                                                     <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                                   value="#{iss.cancelledBill.creater.webUserPerson.name}" >
+                                                                   value="#{iss.cancelledBill.creater.webUserPerson.nameWithTitle}" >
                                                     </h:outputLabel>
                                                 </h:panelGroup>
                                             </p:column>

--- a/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
@@ -1,0 +1,108 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui">
+
+    <p:dataTable
+        value="#{issues}"
+        var="iss"
+        rowIndexVar="rowIndex"
+        scrollable="true"
+        scrollHeight="300"
+        rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
+                         or
+                         (iss.billedBill ne null
+                         and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
+        <p:column headerText="#" class="text-center" width="3em;">
+            <h:outputLabel value="#{rowIndex + 1}"/>
+        </p:column>
+        <p:column headerText="Bill No">
+            <h:outputLabel  value="#{iss.deptId}"></h:outputLabel>
+        </p:column>
+
+        <p:column headerText="Billed At">
+            <h:outputLabel value="#{iss.createdAt}">
+                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
+            </h:outputLabel>
+            <br/>
+            <h:panelGroup rendered="#{iss.cancelled}" >
+                <h:outputLabel style="color: red;" value="Cancelled at " />
+                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                               value="#{iss.cancelledBill.createdAt}" >
+                    <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                </h:outputLabel>
+            </h:panelGroup>
+        </p:column>
+
+        <p:column headerText="Bill Total" class="text-end">
+            <h:outputLabel  value="#{iss.netTotal}">
+                <f:convertNumber pattern="#,##0.00"/>
+            </h:outputLabel>
+        </p:column>
+
+        <p:column headerText="Billed By">
+            <h:outputLabel value="#{iss.creater.webUserPerson.nameWithTitle}"/>
+            <br/>
+            <h:panelGroup rendered="#{iss.cancelled}" >
+                <h:outputLabel style="color: red;" value="Cancelled By " />
+                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
+                               value="#{iss.cancelledBill.creater.webUserPerson.nameWithTitle}" >
+                </h:outputLabel>
+            </h:panelGroup>
+        </p:column>
+
+        <p:column headerText="Checked By">
+            <h:outputLabel value="#{iss.checkedBy.webUserPerson.nameWithTitle}"/>
+        </p:column>
+
+        <p:column headerText="Checked At">
+            <h:outputLabel value="#{iss.checkeAt}">
+                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+            </h:outputLabel>
+        </p:column>
+
+        <p:column headerText="Comments">
+            <h:panelGroup id="commentContainer" layout="block" class="row">
+                <div class="d-flex gap-2" >
+                    <p:inputText 
+                        id="commentInput"
+                        class="w-100"
+                        value="#{iss.comments}">
+                    </p:inputText>
+
+                    <p:commandButton
+                        id="saveBtn"
+                        icon="fa fa-save"
+                        action="#{billController.save(iss)}"
+                        process="commentContainer"
+                        update="pageForm:pageMessages"
+                        title="Save">
+                    </p:commandButton>
+                </div>
+            </h:panelGroup>
+        </p:column>
+
+        <p:column style="width: 14em;" headerText="Action" class="text-center">
+            <div class="d-flex gap-2 justify-content-center">
+                <p:commandButton
+                    ajax="false"
+                    action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
+                    rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}"
+                    value="View Issue">
+                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                </p:commandButton>
+                <p:commandButton
+                    ajax="false"
+                    action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
+                    rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
+                    class="ui-button-warning"
+                    value="View Returns"  >
+                    <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
+                </p:commandButton>
+            </div>
+
+        </p:column>
+    </p:dataTable>
+
+</ui:composition>


### PR DESCRIPTION
## Summary

Fixes #22435 and closes #22468 (which tracks this work; related to #18046).

The Inward Interim Bill's "Medicine Issue" section had a config option, **'Medicine, Sort by the type of department that issued it.'**, that when enabled rendered a lorem-ipsum placeholder `p:tabView` bound to a non-existent property (`bhtSummeryController.medicinesAndSurgicalSupplies`), causing a 500 `PropertyNotFoundException` (#22435). This PR implements the intended feature: medicine issues split into a tab per issuing department.

## Changes

- **`InwardBeanController`**: new `fetchIssueTable(PatientEncounter, BillType, List<PatientEncounter>, DepartmentType)` overload that filters pharmacy issue bills (both `PreBill` and `RefundBill` types) by issuing `DepartmentType`.
- **`BhtSummeryController`**: added `etuMedicineIssues`, `pharmacyMedicineIssues`, `inwardMedicineIssues`, `theatreMedicineIssues`, `storeMedicineIssues`, `inventryMedicineIssues` lists (+ getters/setters), populated per department.
- **New `inward_bill_intrim_medicine_issue_table.xhtml`**: shared Facelets template for the per-department bill table (bill no, billed at, total, billed/checked by, comments, view/return actions, plus a new `#` row-index column), reused via `ui:decorate`/`ui:param` by all 6 tabs instead of duplicating markup.
- **`inward_bill_intrim.xhtml`**: replaced the placeholder tab view with 6 real tabs — ETU, Pharmacy, Inward, Theatre, Store, Inventory:
  - Tab titles and accent colours are configurable per department through config options (`getShortTextValueByKey` / `getColorValueByKey`), e.g. `Inward Interim Bill - Medicine Issue Tab Title - ETU`, `Inward Interim Bill - Medicine Issue Tab Colour - ETU` — renameable/recolourable without a code change.
  - Colourful, modern tab styling: rounded pill-style headers, a FontAwesome icon per department, a live bill-count badge, wider fixed-width (13em) tabs with spacing between them, and an enlarged, rounder count badge.

## Config Options Introduced

All are lazily auto-created on first render (no manual registration needed) and editable afterwards from the Config Options admin screen.

| Config Option Key | Type | Default | Purpose |
|---|---|---|---|
| `Medicine, Sort by the type of department that issued it.` | Boolean | `false` | Pre-existing gate (see #22435) that switches the Medicine Issue tab from the flat list to the per-department tab view. |
| `Inward Interim Bill - Medicine Issue Tab Title - ETU` | Short Text | `ETU` | Label shown on the ETU tab. |
| `Inward Interim Bill - Medicine Issue Tab Title - Pharmacy` | Short Text | `Pharmacy` | Label shown on the Pharmacy tab. |
| `Inward Interim Bill - Medicine Issue Tab Title - Inward` | Short Text | `Inward` | Label shown on the Inward tab. |
| `Inward Interim Bill - Medicine Issue Tab Title - Theatre` | Short Text | `Theatre` | Label shown on the Theatre tab. |
| `Inward Interim Bill - Medicine Issue Tab Title - Store` | Short Text | `Store` | Label shown on the Store tab. |
| `Inward Interim Bill - Medicine Issue Tab Title - Inventory` | Short Text | `Inventory` | Label shown on the Inventory tab. |
| `Inward Interim Bill - Medicine Issue Tab Colour - ETU` | Colour | `#e74c3c` | Accent colour for the ETU tab pill/icon. |
| `Inward Interim Bill - Medicine Issue Tab Colour - Pharmacy` | Colour | `#3498db` | Accent colour for the Pharmacy tab pill/icon. |
| `Inward Interim Bill - Medicine Issue Tab Colour - Inward` | Colour | `#9b59b6` | Accent colour for the Inward tab pill/icon. |
| `Inward Interim Bill - Medicine Issue Tab Colour - Theatre` | Colour | `#e67e22` | Accent colour for the Theatre tab pill/icon. |
| `Inward Interim Bill - Medicine Issue Tab Colour - Store` | Colour | `#16a085` | Accent colour for the Store tab pill/icon. |
| `Inward Interim Bill - Medicine Issue Tab Colour - Inventory` | Colour | `#2ecc71` | Accent colour for the Inventory tab pill/icon. |

## Test plan

- [ ] Enable `'Medicine, Sort by the type of department that issued it.'` application option.
- [ ] Open Inward → Billing → Interim Bill for a BHT with medicine issues from multiple departments.
- [ ] Confirm the page renders without the `PropertyNotFoundException` from #22435.
- [ ] Confirm each of the 6 tabs (ETU/Pharmacy/Inward/Theatre/Store/Inventory) shows only that department's issues, with correct bill totals and working "View Issue"/"View Returns" actions.
- [ ] Confirm tab titles/colours can be overridden via the new config options.
- [ ] Confirm the flat (non-split) view still works unchanged when the config option is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Medicine issues are now available in department-specific tabs (ETU, Pharmacy, Inward, Theatre, Store, Inventory).
  * Issue lists support filtering by billing department.
  * Improved medicine-issue workflow: reprint/return actions plus inline comment saving.
* **Bug Fixes**
  * Unified patient timeline visuals refresh more predictably, with support for forcing an immediate refresh.
* **Improvements**
  * Interim bill layout, table sizing, and payments/professional & assisting fee presentation were refined for clearer viewing.
  * Final-bill charge aggregation and discharge checking logic were adjusted for more accurate totals and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Related 

- closes #22435,
- closes #18046
