### PR TITLE
18560-bill-numbers-are-not-clickable-to-view-bill-details

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsTransfer.java
@@ -852,6 +852,7 @@ public class ReportsTransfer implements Serializable {
 
         jpql.append("select new com.divudi.core.data.dto.PharmacyTransferIssueBillItemDTO(")
                 .append("TYPE(b), ")
+                .append("b.id, ")
                 .append("b.deptId, b.createdAt, it.name, it.code,")
                 .append(" bi.qty, ib.costRate, bfd.valueAtCostRate,")
                 .append(" p.retailRate, bfd.valueAtRetailRate,")
@@ -932,6 +933,7 @@ public class ReportsTransfer implements Serializable {
         StringBuilder jpql = new StringBuilder();
 
         jpql.append("select new com.divudi.core.data.dto.PharmacyTransferReceiveBillItemDTO(")
+                .append("b.id, ")
                 .append("TYPE(b), ")  // ADDED: Bill class discriminator to identify CancelledBill
                 .append("b.deptId, b.createdAt, it.name, it.code,")
                 .append(" bi.qty, ib.costRate, bfd.valueAtCostRate,")

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
@@ -21,6 +21,7 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
     private Double purchaseValue;
     private Double transferRate;
     private Double transferValue;
+    private Long billId;
 
     public PharmacyTransferIssueBillItemDTO() {
     }
@@ -92,6 +93,44 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
         this.purchaseValue = purchaseValue != null ? purchaseValue.doubleValue() : null;
         this.transferRate = transferRate != null ? transferRate.doubleValue() : null;
         this.transferValue = transferValue != null ? transferValue.doubleValue() : null;
+    }
+    
+    public PharmacyTransferIssueBillItemDTO(
+            Object billClass,
+            Long billId,
+            String deptId,
+            Date createdAt,
+            String itemName,
+            String itemCode,
+            Double qty,
+            Double costRate,
+            java.math.BigDecimal costValue,
+            Double retailRate,
+            java.math.BigDecimal retailValue,
+            Double purchaseRate,
+            java.math.BigDecimal purchaseValue,
+            java.math.BigDecimal transferRate,
+            java.math.BigDecimal transferValue) {
+
+        this.billClassSimpleName = extractSimpleClassName(billClass);
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.costRate = costRate;
+        this.costValue = costValue != null ? costValue.doubleValue() : null;
+        this.retailRate = retailRate;
+        this.retailValue = retailValue != null
+                ? retailValue.doubleValue() : null;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue != null
+                ? purchaseValue.doubleValue() : null;
+        this.transferRate = transferRate != null
+                ? transferRate.doubleValue() : null;
+        this.transferValue = transferValue != null
+                ? transferValue.doubleValue() : null;
     }
 
     public String getDeptId() {
@@ -200,6 +239,14 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
 
     public String getBillClassSimpleName() {
         return billClassSimpleName;
+    }
+    
+    public Long getBillId() {
+        return billId;
+    }
+     
+    public void setBillId(Long billId) {
+        this.billId = billId;
     }
 
     private String extractSimpleClassName(Object billClass) {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceiveBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferReceiveBillItemDTO.java
@@ -24,6 +24,7 @@ public class PharmacyTransferReceiveBillItemDTO implements Serializable {
     private Double purchaseValue;
     private Double transferRate;
     private Double transferValue;
+    private Long billId;
 
     public PharmacyTransferReceiveBillItemDTO() {
     }
@@ -93,7 +94,45 @@ public class PharmacyTransferReceiveBillItemDTO implements Serializable {
         this.transferRate = transferRate != null ? transferRate.doubleValue() : null;
         this.transferValue = transferValue != null ? transferValue.doubleValue() : null;
     }
+    
+    public PharmacyTransferReceiveBillItemDTO(
+            Long billId,
+            Object billClass,
+            String deptId,
+            Date createdAt,
+            String itemName,
+            String itemCode,
+            Double qty,
+            Double costRate,
+            java.math.BigDecimal costValue,
+            Double retailRate,
+            java.math.BigDecimal retailValue,
+            Double purchaseRate,
+            java.math.BigDecimal purchaseValue,
+            java.math.BigDecimal transferRate,
+            java.math.BigDecimal transferValue) {
 
+        this.billClassSimpleName = extractSimpleClassName(billClass);
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.costRate = costRate;
+        this.costValue = costValue != null ? costValue.doubleValue() : null;
+        this.retailRate = retailRate;
+        this.retailValue = retailValue != null
+                ? retailValue.doubleValue() : null;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue != null
+                ? purchaseValue.doubleValue() : null;
+        this.transferRate = transferRate != null
+                ? transferRate.doubleValue() : null;
+        this.transferValue = transferValue != null
+                ? transferValue.doubleValue() : null;
+    }
+    
     /**
      * Helper method to extract simple class name from TYPE(b) result.
      */
@@ -227,7 +266,15 @@ public class PharmacyTransferReceiveBillItemDTO implements Serializable {
     public void setBillClassSimpleName(String billClassSimpleName) {
         this.billClassSimpleName = billClassSimpleName;
     }
-
+    
+    public Long getBillId() {
+        return billId;
+    }
+    
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+    
     /**
      * Helper method to check if this is a cancelled receive item.
      * Used in XHTML for conditional styling.

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_dto.xhtml
@@ -151,7 +151,12 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Bill No" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.deptId}"/>
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{i.deptId}"
+                                        title="View transfer issue bill #{i.deptId}"
+                                        styleClass="text-primary text-decoration-underline"
+                                        action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferIssueByIdWithParam(i.billId)}" />
                                 </p:column>
 
                                 <p:column headerText="Date">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_issue_bill_item.xhtml
@@ -164,7 +164,12 @@
                                 <f:facet name="header">
                                     <h:outputLabel value="Bill No"/>
                                 </f:facet>
-                                <h:outputLabel value="#{i.deptId}" ></h:outputLabel>
+                                <p:commandLink
+                                    ajax="false"
+                                    value="#{i.deptId}"
+                                    title="View transfer issue bill #{i.deptId}"
+                                    styleClass="text-primary text-decoration-underline"
+                                    action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferIssueByIdWithParam(i.billId)}" />
                             </p:column>
 
                             <p:column headerText="Date"

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill.xhtml
@@ -146,7 +146,18 @@
                                     <f:facet name="header">
                                         <h:outputLabel value="Bill No" />
                                     </f:facet>
-                                    <h:outputLabel value="#{i.deptId}"/>
+                                    <p:commandLink
+                                        ajax="false"
+                                        value="#{i.deptId}"
+                                        title="View transfer receive bill #{i.deptId}"
+                                        styleClass="text-primary text-decoration-underline"
+                                        action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferReceiveById()}">
+
+                                        <f:setPropertyActionListener
+                                            target="#{pharmacyBillSearch.billId}"
+                                            value="#{i.billId}" />
+
+                                    </p:commandLink>
                                 </p:column>
 
                                 <p:column headerText="Date">

--- a/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/reports/disbursement_reports/pharmacy_report_transfer_receive_bill_item.xhtml
@@ -158,7 +158,17 @@
                                 <f:facet name="header">
                                     <h:outputLabel value="Bill No"/>
                                 </f:facet>
-                                <h:outputLabel value="#{i.deptId}" ></h:outputLabel>
+                                <p:commandLink
+                                    ajax="false"
+                                    value="#{i.deptId}"
+                                    title="View transfer receive bill #{i.deptId}"
+                                    styleClass="text-primary text-decoration-underline"
+                                    action="#{pharmacyBillSearch.navigateToReprintPharmacyTransferReceiveById()}">
+
+                                    <f:setPropertyActionListener
+                                        target="#{pharmacyBillSearch.billId}"
+                                        value="#{i.billId}" />
+                                </p:commandLink>
                             </p:column>
 
                             <p:column headerText="Date"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clickable bill numbers to pharmacy transfer issue and receive reports.
  - Selecting a bill number now opens the corresponding transfer bill for reprinting.
  - Bill identifiers are retained in item-level report results to support direct navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->