### PR TITLE
fix(pharmacy): show Store-departmentType items in adjustment pages (hotfix)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -474,6 +474,19 @@ public class AmpController implements Serializable {
         return suggestions;
     }
 
+    public List<Amp> completeAmpAny(String qry) {
+        List<Amp> suggestions;
+        if (qry == null || qry.trim().isEmpty()) {
+            suggestions = new ArrayList<>();
+        } else {
+            String jpql = "SELECT c FROM Amp c WHERE c.retired = false AND LOWER(c.name) LIKE :query ORDER BY c.name";
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("query", "%" + qry.trim().toLowerCase() + "%");
+            suggestions = getFacade().findByJpqlWithoutCache(jpql, parameters);
+        }
+        return suggestions;
+    }
+
     public List<Amp> completeAmpWithRetired(String qry) {
         List<Amp> a = null;
         Map m = new HashMap();

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
@@ -79,7 +79,7 @@
                                             <i class="fas fa-pills me-2"></i>Select Item
                                         </label>
                                         <p:autoComplete id="acAmp" class="w-100" inputStyleClass="w-100"
-                                                       completeMethod="#{ampController.completeAmp}" var="amp"
+                                                       completeMethod="#{ampController.completeAmpAny}" var="amp"
                                                        itemLabel="#{amp.name}" itemValue="#{amp}"
                                                        value="#{pharmacyAdjustmentController.amp}"
                                                        maxResults="10" minQueryLength="3">

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
@@ -92,7 +92,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
@@ -93,7 +93,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
@@ -27,7 +27,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"


### PR DESCRIPTION
## Summary
- RHD (Baddegama) reported that **BLOOD COLLECTION TUBE INR (SODIUM CITRATE) CO-AGULATION (BLUE)** (expiry 31 Dec 24) could not be found in the Pharmacy Adjustment - Expiry Date / Department pages, blocking an expiry correction.
- Root cause: the item is classified `departmentType = Store`, but `AmpController.completeAmp()` (used by the adjustment pages) hard-filters `departmentType = Pharmacy`, excluding it.
- This was already fixed on `development` in commit `45c56dc96e`, which added `AmpController.completeAmpAny()` (no departmentType restriction) and switched 6 adjustment pages to use it. That fix never made it into `ruhunu-prod`.
- This PR cherry-picks that commit onto `ruhunu-prod` as a hotfix.

## Test plan
- [ ] Deploy to RH environment
- [ ] In Pharmacy Adjustment - Expiry Date, search "BLOOD COLLECTION TUBE INR" and confirm it now appears
- [ ] Repeat for Pharmacy Adjustment - Department, Cost Rate, Purchase Rate, Retail Sale Rate, Whole Sale Rate pages
- [ ] Confirm existing Pharmacy-departmentType items still show up as before (no regression)

Closes #22472