### PR TITLE
fix(pharmacy): repair broken Sale 1-4 nav EL on legacy cashier pages

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
@@ -788,10 +788,10 @@
                                                     icon="fas fa-arrow-left"
                                                     action="#{tokenController.navigateToManagePharmacyTokens()}" >
                                                 </p:commandButton>
-                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_1" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController1.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController2.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController3.pharmacyRetailSale()}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 1" disabled="true" ajax="false" action="#{pharmacySaleForCashierController.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 2" ajax="false" action="#{pharmacySaleForCashierController1.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 3" ajax="false" action="#{pharmacySaleForCashierController2.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 4" ajax="false" action="#{pharmacySaleForCashierController3.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
                 
                                             </div>
                 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
@@ -782,10 +782,10 @@
                                                     icon="fas fa-arrow-left"
                                                     action="#{tokenController.navigateToManagePharmacyTokens()}" >
                                                 </p:commandButton>
-                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController1.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_1" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController11.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController12.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController13.pharmacyRetailSale()}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 1" ajax="false" action="#{pharmacySaleForCashierController.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 2" disabled="true" ajax="false" action="#{pharmacySaleForCashierController1.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 3" ajax="false" action="#{pharmacySaleForCashierController2.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 4" ajax="false" action="#{pharmacySaleForCashierController3.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
                 
                                             </div>
                 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
@@ -782,10 +782,10 @@
                                                     icon="fas fa-arrow-left"
                                                     action="#{tokenController.navigateToManagePharmacyTokens()}" >
                                                 </p:commandButton>
-                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController2.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_1" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController21.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController22.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController23.pharmacyRetailSale()}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 1" ajax="false" action="#{pharmacySaleForCashierController.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 2" ajax="false" action="#{pharmacySaleForCashierController1.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 3" disabled="true" ajax="false" action="#{pharmacySaleForCashierController2.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 4" ajax="false" action="#{pharmacySaleForCashierController3.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
                 
                                             </div>
                 

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
@@ -779,10 +779,10 @@
                                                     icon="fas fa-arrow-left"
                                                     action="#{tokenController.navigateToManagePharmacyTokens()}" >
                                                 </p:commandButton>
-                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" disabled="true" value="Sale 1" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController3.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 2" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_1" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController31.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 3" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_2" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController32.pharmacyRetailSale()}" />
-                                                <p:commandButton class="m-1"  icon="fas fa-file-invoice" value="Sale 4" action="/pharmacy/pharmacy_bill_retail_sale_for_cashier_3" rendered="#{webUserController.hasPrivilege('PharmacySale')}" actionListener="#{pharmacySaleForCashierController33.pharmacyRetailSale()}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 1" ajax="false" action="#{pharmacySaleForCashierController.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 2" ajax="false" action="#{pharmacySaleForCashierController1.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 3" ajax="false" action="#{pharmacySaleForCashierController2.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                                <p:commandButton class="m-1" icon="fas fa-file-invoice" value="Sale 4" disabled="true" ajax="false" action="#{pharmacySaleForCashierController3.toPharmacyRetailSaleForCashier()}" rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
                 
                                             </div>
                 


### PR DESCRIPTION
Refs #15845

## Problem

The **print-panel** window-switch block on all four legacy "Sale for Cashier" pages bound its `Sale 1/2/3/4` buttons to EL that cannot resolve — **16 broken references**, from two independent defects:

**1. Nine phantom beans** (the defect already diagnosed on #15845)

`pharmacySaleForCashierController11/12/13`, `21/22/23`, `31/32/33` on the three numbered pages. Caused by the multi-window guide's unanchored global find/replace, which rewrote the already-numbered nav refs in the source page as well as the bare bean name.

**2. A phantom *method*** (not previously identified)

`pharmacyRetailSale()` **does not exist on any of the four cashier controllers** — only `toPharmacyRetailSaleForCashier()` does. All 16 refs called it, **including the four on the base page**, which the earlier analysis had assumed was clean. Family A's `PharmacySaleController` *does* have `pharmacyRetailSale()`; the name was copied across page families without checking.

**3.** The numbered pages also had the wrong `disabled` state and wrong targets in this block — each one disabled "Sale 1" and self-linked "Sale 2".

The **top-of-page** nav block (~lines 53–76) was already correct on all four pages and uses `toPharmacyRetailSaleForCashier()`.

## Fix

Replaced the print-panel block on all four pages with the same pattern the working top nav uses: `toPharmacyRetailSaleForCashier()`, the four real beans, and the correct per-page `disabled` button. JSF-only change, 16 lines.

## Verification

- **Static:** every EL bean root across the eight cashier pages (four sale + four printing) resolves to a real `@Named` bean. The checker was validated against the pre-fix tree — it flags all nine phantoms there and none after.
- **E2E** (local Payara, `Legacy Functions Allowed` temporarily enabled then reverted): full four-window walk base → `_1` → settle → printing page → `_2` → `_3` → base. Bill `OP/SALE/35596` settled correctly as `PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`. No `SEVERE`, `PropertyNotFound`, or `ELException` in the server log.

## ⚠️ Scope caveat — please read before closing #15845

**The original symptom was not reproduced, and the fixed buttons were not exercised live.**

`panelPrint`, which contains them, is **unreachable in the current flow**: the page's only settle button binds `settlePreBillAndNavigateToPrint()`, which on success always returns `/pharmacy/printing/retail_sale_for_cashier_N?faces-redirect=true`, and `toPharmacyRetailSaleForCashier()` routes back to the printing page whenever `billPreview` is true. Confirmed in the browser — `panelPrint` is absent from the DOM even after a settle. The two other paths that set `billPreview = true` (`settlePreBill()`, `settleBillWithPay()`) are bound from no button on these pages.

So this removes **real, latent** broken EL that would produce exactly the reported error page if that panel were ever rendered — but it is **not proven** to be the cause of the user's report. Hence `Refs #15845` rather than `Closes`. Suggest asking the reporter for repro steps, and filing a separate issue for the dead `panelPrint` nav block (delete it, or wire a settle path that renders it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated pharmacy cashier screens with streamlined navigation for Sales 1–4.
  * Sale options now open through the appropriate in-app navigation.
* **Access Control**
  * Sale navigation is now displayed only to users with pharmacy sales privileges.
* **Usability**
  * Improved consistency of sale buttons across cashier screens, with screen-specific sale availability preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->