### PR TITLE
feat(pharmacy): Ordering Requirement Report under a new Ordering tab in Pharmacy Analytics

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyOrderingAnalyticsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyOrderingAnalyticsController.java
@@ -113,6 +113,17 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
     private boolean paginator = true;
     private int rowsPerPage = 50;
 
+    /**
+     * Entry point from the Ordering tab.
+     *
+     * Clears any previous result, defaults the scope to the logged-in
+     * institution / site / department, and seeds the three numeric inputs from
+     * configuration before deriving the initial date window.
+     *
+     * Initialisation lives here rather than in an f:viewAction because this
+     * controller is @SessionScoped - a view action would re-run on every
+     * refresh and back-button navigation and corrupt state the user had set.
+     */
     public String navigateToOrderingRequirementReport() {
         rows = new ArrayList<>();
         unclassifiedMovementCount = 0;
@@ -160,6 +171,14 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         toDate = CommonFunctions.getEndOfDay(end);
     }
 
+    /**
+     * Validates the filters and builds the report.
+     *
+     * All computation is delegated to PharmacyOrderingRequirementService; this
+     * method only guards the inputs, wraps the call in the report timer, and
+     * picks up the unclassified-movement count that drives the on-screen
+     * warning.
+     */
     public void processReport() {
         if (fromDate == null || toDate == null) {
             JsfUtil.addErrorMessage("Please select a date range");
@@ -192,6 +211,13 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         }
     }
 
+    /**
+     * Streams the current result as an .xlsx download.
+     *
+     * Writes straight to the HttpServletResponse and calls responseComplete()
+     * so JSF does not also try to render the page, following the same pattern
+     * as ReportsStock.exportCurrentStockByBatchToExcel().
+     */
     public void exportToExcel() {
         if (rows == null || rows.isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to export - process the report first");
@@ -305,6 +331,12 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         }
     }
 
+    /**
+     * Streams the current result as a landscape A4 PDF download.
+     *
+     * Landscape because eight numeric columns do not fit portrait at a legible
+     * font size.
+     */
     public void exportToPdf() {
         if (rows == null || rows.isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to export - process the report first");
@@ -398,6 +430,10 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         cell.setCellStyle(style);
     }
 
+    /**
+     * One-line description of the active filters, printed on the Excel and PDF
+     * exports so a saved copy stays self-explanatory.
+     */
     public String getFilterSummary() {
         SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy");
         return "Window: " + (fromDate == null ? "-" : sdf.format(fromDate))
@@ -409,6 +445,7 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
                 + " | Department Type: " + getSelectedDepartmentTypesPrintDisplay();
     }
 
+    /** Comma-separated department types for the export header, "All" when none are picked. */
     public String getSelectedDepartmentTypesPrintDisplay() {
         if (selectedDepartmentTypes == null || selectedDepartmentTypes.isEmpty()) {
             return "All";
@@ -418,6 +455,7 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
                 .collect(Collectors.joining(", "));
     }
 
+    /** Department types offered in the filter, matching the Batch Stock report. */
     public List<DepartmentType> getAvailableDepartmentTypes() {
         return Arrays.asList(
                 DepartmentType.Pharmacy,
@@ -433,6 +471,7 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         return department == null;
     }
 
+    /** Sum of Est. Cost across every row - the table footer and the summary tile. */
     public double getTotalEstimatedCost() {
         if (rows == null) {
             return 0.0;
@@ -440,6 +479,7 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         return rows.stream().mapToDouble(OrderingRequirementRowDto::getEstimatedCost).sum();
     }
 
+    /** Number of rows decided Urgent Order, shown as a summary tile. */
     public long getUrgentCount() {
         if (rows == null) {
             return 0;
@@ -447,6 +487,7 @@ public class PharmacyOrderingAnalyticsController implements Serializable, Contro
         return rows.stream().filter(OrderingRequirementRowDto::isUrgent).count();
     }
 
+    /** Number of rows decided Order, shown as a summary tile. */
     public long getOrderCount() {
         if (rows == null) {
             return 0;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyOrderingAnalyticsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyOrderingAnalyticsController.java
@@ -1,0 +1,616 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ControllerWithReportFilters;
+import com.divudi.bean.common.ReportTimerController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.ReportViewType;
+import com.divudi.core.data.dto.OrderingRequirementRowDto;
+import com.divudi.core.data.reports.PharmacyReports;
+import com.divudi.core.entity.Category;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.DosageForm;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.service.pharmacy.PharmacyOrderingRequirementService;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormat;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+
+/**
+ * Ordering Requirement Report (issue #22466).
+ *
+ * Tells a pharmacy buyer what to order and how much. Deliberately thin - every
+ * figure is computed by PharmacyOrderingRequirementService, which has no JSF
+ * dependency and can therefore be exercised on its own.
+ *
+ * @author Buddhika
+ */
+@Named(value = "pharmacyOrderingAnalyticsController")
+@SessionScoped
+public class PharmacyOrderingAnalyticsController implements Serializable, ControllerWithReportFilters {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String KEY_WINDOW_MONTHS = "Pharmacy Ordering - Default Consumption Window Months";
+    private static final String KEY_TARGET_COVER_MONTHS = "Pharmacy Ordering - Default Target Cover Months";
+    private static final String KEY_URGENT_THRESHOLD_MONTHS = "Pharmacy Ordering - Urgent Order Threshold Months";
+
+    @EJB
+    private PharmacyOrderingRequirementService pharmacyOrderingRequirementService;
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ReportTimerController reportTimerController;
+
+    // Standard report filters
+    private Date fromDate;
+    private Date toDate;
+    private Institution institution;
+    private Institution site;
+    private Department department;
+    private AdmissionType admissionType;
+    private PaymentScheme paymentScheme;
+    private ReportViewType reportViewType;
+
+    // Item filters
+    private Category category;
+    private DosageForm dosageForm;
+    private List<DepartmentType> selectedDepartmentTypes;
+
+    // Report inputs, seeded from configuration so admins can set the house
+    // default while buyers flex them per run.
+    private double consumptionWindowMonths;
+    private double targetCoverMonths;
+    private double urgentThresholdMonths;
+
+    private List<OrderingRequirementRowDto> rows;
+    private long unclassifiedMovementCount;
+
+    private boolean paginator = true;
+    private int rowsPerPage = 50;
+
+    public String navigateToOrderingRequirementReport() {
+        rows = new ArrayList<>();
+        unclassifiedMovementCount = 0;
+        selectedDepartmentTypes = new ArrayList<>();
+        category = null;
+        dosageForm = null;
+
+        if (institution == null) {
+            institution = sessionController.getInstitution();
+        }
+        if (site == null) {
+            site = sessionController.getLoggedSite();
+        }
+        if (department == null) {
+            department = sessionController.getDepartment();
+        }
+
+        consumptionWindowMonths = configOptionApplicationController
+                .getDoubleValueByKey(KEY_WINDOW_MONTHS, 3.0);
+        targetCoverMonths = configOptionApplicationController
+                .getDoubleValueByKey(KEY_TARGET_COVER_MONTHS, 3.0);
+        urgentThresholdMonths = configOptionApplicationController
+                .getDoubleValueByKey(KEY_URGENT_THRESHOLD_MONTHS, 1.0);
+
+        applyWindowFromMonths();
+
+        return "/pharmacy/reports/ordering_reports/ordering_requirement_report?faces-redirect=true";
+    }
+
+    /**
+     * Recomputes the date window from the consumption-window months input.
+     * Invoked when the buyer changes the number of months, so the dates stay in
+     * step without them having to set both.
+     */
+    public void applyWindowFromMonths() {
+        if (consumptionWindowMonths <= 0) {
+            consumptionWindowMonths = 3.0;
+        }
+        Date end = toDate == null ? new Date() : toDate;
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(end);
+        cal.add(Calendar.DATE, -(int) Math.round(consumptionWindowMonths
+                * PharmacyOrderingRequirementService.DAYS_PER_MONTH) + 1);
+        fromDate = CommonFunctions.getStartOfDay(cal.getTime());
+        toDate = CommonFunctions.getEndOfDay(end);
+    }
+
+    public void processReport() {
+        if (fromDate == null || toDate == null) {
+            JsfUtil.addErrorMessage("Please select a date range");
+            return;
+        }
+        if (fromDate.after(toDate)) {
+            JsfUtil.addErrorMessage("From date must be on or before the To date");
+            return;
+        }
+        if (targetCoverMonths <= 0) {
+            JsfUtil.addErrorMessage("Target stock cover must be greater than zero");
+            return;
+        }
+        if (urgentThresholdMonths < 0) {
+            JsfUtil.addErrorMessage("Urgent threshold cannot be negative");
+            return;
+        }
+
+        reportTimerController.trackReportExecution(() -> {
+            rows = pharmacyOrderingRequirementService.generateReport(
+                    fromDate, toDate, institution, site, department,
+                    category, dosageForm, selectedDepartmentTypes,
+                    targetCoverMonths, urgentThresholdMonths);
+            unclassifiedMovementCount = pharmacyOrderingRequirementService
+                    .countUnclassifiedMovements(fromDate, toDate, institution, site, department);
+        }, PharmacyReports.ORDERING_REQUIREMENT_REPORT, sessionController.getLoggedUser());
+
+        if (rows == null || rows.isEmpty()) {
+            JsfUtil.addErrorMessage("No items found for the selected filters");
+        }
+    }
+
+    public void exportToExcel() {
+        if (rows == null || rows.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing to export - process the report first");
+            return;
+        }
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition",
+                "attachment; filename=Ordering_Requirement_Report.xlsx");
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
+
+            XSSFSheet sheet = workbook.createSheet("Ordering Requirement");
+            int rowIndex = 0;
+            int totalColumns = 8;
+
+            Font boldFont = workbook.createFont();
+            boldFont.setBold(true);
+
+            Font titleFont = workbook.createFont();
+            titleFont.setBold(true);
+            titleFont.setFontHeightInPoints((short) 16);
+
+            CellStyle titleStyle = workbook.createCellStyle();
+            titleStyle.setFont(titleFont);
+            titleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            CellStyle filterStyle = workbook.createCellStyle();
+            filterStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            headerStyle.setFont(boldFont);
+            headerStyle.setAlignment(HorizontalAlignment.CENTER);
+            headerStyle.setBorderBottom(BorderStyle.THIN);
+            headerStyle.setBorderTop(BorderStyle.THIN);
+            headerStyle.setBorderLeft(BorderStyle.THIN);
+            headerStyle.setBorderRight(BorderStyle.THIN);
+
+            CellStyle dataStyle = workbook.createCellStyle();
+            dataStyle.setBorderBottom(BorderStyle.THIN);
+            dataStyle.setBorderTop(BorderStyle.THIN);
+            dataStyle.setBorderLeft(BorderStyle.THIN);
+            dataStyle.setBorderRight(BorderStyle.THIN);
+
+            DataFormat dataFormat = workbook.createDataFormat();
+            CellStyle numberStyle = workbook.createCellStyle();
+            numberStyle.cloneStyleFrom(dataStyle);
+            numberStyle.setDataFormat(dataFormat.getFormat("#,##0.00"));
+
+            Row instRow = sheet.createRow(rowIndex++);
+            Cell instCell = instRow.createCell(0);
+            instCell.setCellValue(institution != null ? institution.getName() : "All Institutions");
+            instCell.setCellStyle(titleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, totalColumns - 1));
+
+            Row deptRow = sheet.createRow(rowIndex++);
+            Cell deptCell = deptRow.createCell(0);
+            deptCell.setCellValue(department != null ? department.getName() : "All Departments");
+            deptCell.setCellStyle(titleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, totalColumns - 1));
+
+            Row titleRow = sheet.createRow(rowIndex++);
+            Cell titleCell = titleRow.createCell(0);
+            titleCell.setCellValue("Ordering Requirement Report");
+            titleCell.setCellStyle(titleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, totalColumns - 1));
+
+            Row filterRow = sheet.createRow(rowIndex++);
+            Cell filterCell = filterRow.createCell(0);
+            filterCell.setCellValue(getFilterSummary());
+            filterCell.setCellStyle(filterStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, totalColumns - 1));
+
+            rowIndex++;
+
+            Row headerRow = sheet.createRow(rowIndex++);
+            String[] headers = {
+                "Drug Name", "Current Balance", "Avg Monthly Consumption",
+                "Stock Cover (Months)", "Target Stock", "Qty to Order",
+                "Est. Cost (Rs.)", "Decision"
+            };
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            for (OrderingRequirementRowDto r : rows) {
+                Row dataRow = sheet.createRow(rowIndex++);
+                createCell(dataRow, 0, r.getItemName(), dataStyle);
+                createCell(dataRow, 1, r.getCurrentBalance(), numberStyle);
+                createCell(dataRow, 2, r.getAvgMonthlyConsumption(), numberStyle);
+                createCell(dataRow, 3, r.getStockCoverDisplay(), dataStyle);
+                createCell(dataRow, 4, r.getTargetStock(), numberStyle);
+                createCell(dataRow, 5, r.getQuantityToOrder(), numberStyle);
+                createCell(dataRow, 6, r.getEstimatedCost(), numberStyle);
+                createCell(dataRow, 7, r.getDecision(), dataStyle);
+            }
+
+            for (int i = 0; i < totalColumns; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            out.flush();
+            context.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Could not create the Excel file: " + e.getMessage());
+        }
+    }
+
+    public void exportToPdf() {
+        if (rows == null || rows.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing to export - process the report first");
+            return;
+        }
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+        response.setContentType("application/pdf");
+        response.setHeader("Content-Disposition",
+                "attachment; filename=Ordering_Requirement_Report.pdf");
+
+        Document document = new Document(PageSize.A4.rotate(), 20, 20, 20, 20);
+        try (OutputStream out = response.getOutputStream()) {
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            com.itextpdf.text.Font titleFont =
+                    new com.itextpdf.text.Font(com.itextpdf.text.Font.FontFamily.HELVETICA, 14, com.itextpdf.text.Font.BOLD);
+            com.itextpdf.text.Font smallFont =
+                    new com.itextpdf.text.Font(com.itextpdf.text.Font.FontFamily.HELVETICA, 8);
+            com.itextpdf.text.Font headerFont =
+                    new com.itextpdf.text.Font(com.itextpdf.text.Font.FontFamily.HELVETICA, 8, com.itextpdf.text.Font.BOLD);
+
+            Paragraph institutionPara = new Paragraph(
+                    institution != null ? institution.getName() : "All Institutions", titleFont);
+            institutionPara.setAlignment(Element.ALIGN_CENTER);
+            document.add(institutionPara);
+
+            Paragraph titlePara = new Paragraph("Ordering Requirement Report", titleFont);
+            titlePara.setAlignment(Element.ALIGN_CENTER);
+            document.add(titlePara);
+
+            Paragraph filterPara = new Paragraph(getFilterSummary(), smallFont);
+            filterPara.setAlignment(Element.ALIGN_CENTER);
+            document.add(filterPara);
+            document.add(new Paragraph(" ", smallFont));
+
+            PdfPTable table = new PdfPTable(8);
+            table.setWidthPercentage(100);
+            table.setWidths(new float[]{26, 11, 13, 11, 11, 11, 11, 12});
+
+            String[] headers = {
+                "Drug Name", "Current Balance", "Avg Monthly Consumption",
+                "Stock Cover", "Target Stock", "Qty to Order",
+                "Est. Cost (Rs.)", "Decision"
+            };
+            for (String header : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(header, headerFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                table.addCell(cell);
+            }
+
+            for (OrderingRequirementRowDto r : rows) {
+                table.addCell(new PdfPCell(new Phrase(r.getItemName(), smallFont)));
+                addNumericCell(table, r.getCurrentBalance(), smallFont);
+                addNumericCell(table, r.getAvgMonthlyConsumption(), smallFont);
+                PdfPCell coverCell = new PdfPCell(new Phrase(r.getStockCoverDisplay(), smallFont));
+                coverCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                table.addCell(coverCell);
+                addNumericCell(table, r.getTargetStock(), smallFont);
+                addNumericCell(table, r.getQuantityToOrder(), smallFont);
+                addNumericCell(table, r.getEstimatedCost(), smallFont);
+                table.addCell(new PdfPCell(new Phrase(r.getDecision(), smallFont)));
+            }
+
+            document.add(table);
+            document.close();
+            out.flush();
+            context.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Could not create the PDF file: " + e.getMessage());
+        }
+    }
+
+    private void addNumericCell(PdfPTable table, double value, com.itextpdf.text.Font font) {
+        PdfPCell cell = new PdfPCell(new Phrase(String.format("%,.2f", value), font));
+        cell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+        table.addCell(cell);
+    }
+
+    private void createCell(Row row, int index, String value, CellStyle style) {
+        Cell cell = row.createCell(index);
+        cell.setCellValue(value == null ? "" : value);
+        cell.setCellStyle(style);
+    }
+
+    private void createCell(Row row, int index, double value, CellStyle style) {
+        Cell cell = row.createCell(index);
+        cell.setCellValue(value);
+        cell.setCellStyle(style);
+    }
+
+    public String getFilterSummary() {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy");
+        return "Window: " + (fromDate == null ? "-" : sdf.format(fromDate))
+                + " to " + (toDate == null ? "-" : sdf.format(toDate))
+                + " | Target Cover: " + targetCoverMonths + " months"
+                + " | Urgent Below: " + urgentThresholdMonths + " months"
+                + " | Category: " + (category != null ? category.getName() : "All")
+                + " | Dosage Form: " + (dosageForm != null ? dosageForm.getName() : "All")
+                + " | Department Type: " + getSelectedDepartmentTypesPrintDisplay();
+    }
+
+    public String getSelectedDepartmentTypesPrintDisplay() {
+        if (selectedDepartmentTypes == null || selectedDepartmentTypes.isEmpty()) {
+            return "All";
+        }
+        return selectedDepartmentTypes.stream()
+                .map(DepartmentType::getLabel)
+                .collect(Collectors.joining(", "));
+    }
+
+    public List<DepartmentType> getAvailableDepartmentTypes() {
+        return Arrays.asList(
+                DepartmentType.Pharmacy,
+                DepartmentType.Store,
+                DepartmentType.Lab,
+                DepartmentType.Kitchen
+        );
+    }
+
+    /** True when the scope spans more than one department, so the internal
+     * transfer caveat applies. */
+    public boolean isMultiDepartmentScope() {
+        return department == null;
+    }
+
+    public double getTotalEstimatedCost() {
+        if (rows == null) {
+            return 0.0;
+        }
+        return rows.stream().mapToDouble(OrderingRequirementRowDto::getEstimatedCost).sum();
+    }
+
+    public long getUrgentCount() {
+        if (rows == null) {
+            return 0;
+        }
+        return rows.stream().filter(OrderingRequirementRowDto::isUrgent).count();
+    }
+
+    public long getOrderCount() {
+        if (rows == null) {
+            return 0;
+        }
+        return rows.stream().filter(OrderingRequirementRowDto::isOrder).count();
+    }
+
+    // Getters and setters
+    @Override
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    @Override
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    @Override
+    public Date getToDate() {
+        return toDate;
+    }
+
+    @Override
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    @Override
+    public Institution getInstitution() {
+        return institution;
+    }
+
+    @Override
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+
+    @Override
+    public Institution getSite() {
+        return site;
+    }
+
+    @Override
+    public void setSite(Institution site) {
+        this.site = site;
+    }
+
+    @Override
+    public Department getDepartment() {
+        return department;
+    }
+
+    @Override
+    public void setDepartment(Department department) {
+        this.department = department;
+    }
+
+    @Override
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    @Override
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    @Override
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    @Override
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    @Override
+    public ReportViewType getReportViewType() {
+        return reportViewType;
+    }
+
+    @Override
+    public void setReportViewType(ReportViewType reportViewType) {
+        this.reportViewType = reportViewType;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public DosageForm getDosageForm() {
+        return dosageForm;
+    }
+
+    public void setDosageForm(DosageForm dosageForm) {
+        this.dosageForm = dosageForm;
+    }
+
+    public List<DepartmentType> getSelectedDepartmentTypes() {
+        if (selectedDepartmentTypes == null) {
+            selectedDepartmentTypes = new ArrayList<>();
+        }
+        return selectedDepartmentTypes;
+    }
+
+    public void setSelectedDepartmentTypes(List<DepartmentType> selectedDepartmentTypes) {
+        this.selectedDepartmentTypes = selectedDepartmentTypes;
+    }
+
+    public double getConsumptionWindowMonths() {
+        return consumptionWindowMonths;
+    }
+
+    public void setConsumptionWindowMonths(double consumptionWindowMonths) {
+        this.consumptionWindowMonths = consumptionWindowMonths;
+    }
+
+    public double getTargetCoverMonths() {
+        return targetCoverMonths;
+    }
+
+    public void setTargetCoverMonths(double targetCoverMonths) {
+        this.targetCoverMonths = targetCoverMonths;
+    }
+
+    public double getUrgentThresholdMonths() {
+        return urgentThresholdMonths;
+    }
+
+    public void setUrgentThresholdMonths(double urgentThresholdMonths) {
+        this.urgentThresholdMonths = urgentThresholdMonths;
+    }
+
+    public List<OrderingRequirementRowDto> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<OrderingRequirementRowDto> rows) {
+        this.rows = rows;
+    }
+
+    public long getUnclassifiedMovementCount() {
+        return unclassifiedMovementCount;
+    }
+
+    public boolean isPaginator() {
+        return paginator;
+    }
+
+    public void setPaginator(boolean paginator) {
+        this.paginator = paginator;
+    }
+
+    public int getRowsPerPage() {
+        return rowsPerPage;
+    }
+
+    public void setRowsPerPage(int rowsPerPage) {
+        this.rowsPerPage = rowsPerPage;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/ItemCurrentStockDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ItemCurrentStockDto.java
@@ -1,0 +1,63 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * Current stock held for one item within the selected scope.
+ *
+ * Populated by a constructor JPQL query over Stock grouped by item, for the
+ * Ordering Requirement Report (issue #22466).
+ *
+ * @author Buddhika
+ */
+public class ItemCurrentStockDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long itemId;
+    private String itemName;
+    private String code;
+    private Double qty;
+
+    public ItemCurrentStockDto() {
+    }
+
+    public ItemCurrentStockDto(Long itemId, String itemName, String code, Double qty) {
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.code = code;
+        this.qty = qty;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/OrderingRequirementRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/OrderingRequirementRowDto.java
@@ -178,10 +178,12 @@ public class OrderingRequirementRowDto implements Serializable {
         return String.format("%.1f", stockCover);
     }
 
+    /** True when this row was decided Urgent Order - drives the red badge. */
     public boolean isUrgent() {
         return DECISION_URGENT_ORDER.equals(decision);
     }
 
+    /** True when this row was decided Order - drives the amber badge. */
     public boolean isOrder() {
         return DECISION_ORDER.equals(decision);
     }

--- a/src/main/java/com/divudi/core/data/dto/OrderingRequirementRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/OrderingRequirementRowDto.java
@@ -1,0 +1,188 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+/**
+ * One row of the Ordering Requirement Report (issue #22466).
+ *
+ * Assembled in Java by PharmacyOrderingRequirementService - this DTO is not
+ * produced by a constructor JPQL query, because every figure on it depends on
+ * the day-by-day balance walk rather than on any single aggregate.
+ *
+ * @author Buddhika
+ */
+public class OrderingRequirementRowDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String DECISION_URGENT_ORDER = "Urgent Order";
+    public static final String DECISION_ORDER = "Order";
+    public static final String DECISION_NO_ORDER = "No Order";
+
+    private Long itemId;
+    private String itemName;
+    private String code;
+
+    /** Current stock in scope, from the Stock table. */
+    private double currentBalance;
+    /** Consumption over the whole window, net of returns, positive. */
+    private double consumption;
+    /** Consumption divided by the days in the window, scaled to a mean month. */
+    private double avgMonthlyConsumption;
+    private int windowDays;
+
+    /** Months of cover the current balance provides at the adjusted average. */
+    private Double stockCover;
+    private double targetStock;
+    private double quantityToOrder;
+    private double lastPurchaseRate;
+    private double estimatedCost;
+    private String decision;
+
+    /**
+     * True when the item had no inbound bill in the window, so lastPurchaseRate
+     * (and therefore estimatedCost) could not be established. Flagged on the
+     * page rather than silently shown as zero.
+     */
+    private boolean purchaseRateUnknown;
+
+    public OrderingRequirementRowDto() {
+    }
+
+    public OrderingRequirementRowDto(Long itemId, String itemName, String code) {
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.code = code;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public double getCurrentBalance() {
+        return currentBalance;
+    }
+
+    public void setCurrentBalance(double currentBalance) {
+        this.currentBalance = currentBalance;
+    }
+
+    public double getConsumption() {
+        return consumption;
+    }
+
+    public void setConsumption(double consumption) {
+        this.consumption = consumption;
+    }
+
+    public double getAvgMonthlyConsumption() {
+        return avgMonthlyConsumption;
+    }
+
+    public void setAvgMonthlyConsumption(double avgMonthlyConsumption) {
+        this.avgMonthlyConsumption = avgMonthlyConsumption;
+    }
+
+    public int getWindowDays() {
+        return windowDays;
+    }
+
+    public void setWindowDays(int windowDays) {
+        this.windowDays = windowDays;
+    }
+
+    public Double getStockCover() {
+        return stockCover;
+    }
+
+    public void setStockCover(Double stockCover) {
+        this.stockCover = stockCover;
+    }
+
+    public double getTargetStock() {
+        return targetStock;
+    }
+
+    public void setTargetStock(double targetStock) {
+        this.targetStock = targetStock;
+    }
+
+    public double getQuantityToOrder() {
+        return quantityToOrder;
+    }
+
+    public void setQuantityToOrder(double quantityToOrder) {
+        this.quantityToOrder = quantityToOrder;
+    }
+
+    public double getLastPurchaseRate() {
+        return lastPurchaseRate;
+    }
+
+    public void setLastPurchaseRate(double lastPurchaseRate) {
+        this.lastPurchaseRate = lastPurchaseRate;
+    }
+
+    public double getEstimatedCost() {
+        return estimatedCost;
+    }
+
+    public void setEstimatedCost(double estimatedCost) {
+        this.estimatedCost = estimatedCost;
+    }
+
+    public String getDecision() {
+        return decision;
+    }
+
+    public void setDecision(String decision) {
+        this.decision = decision;
+    }
+
+    public boolean isPurchaseRateUnknown() {
+        return purchaseRateUnknown;
+    }
+
+    public void setPurchaseRateUnknown(boolean purchaseRateUnknown) {
+        this.purchaseRateUnknown = purchaseRateUnknown;
+    }
+
+    /**
+     * Stock cover formatted for display - "-" when there was no consumption in
+     * the window, so the ratio is undefined rather than infinite.
+     */
+    public String getStockCoverDisplay() {
+        if (stockCover == null) {
+            return "-";
+        }
+        return String.format("%.1f", stockCover);
+    }
+
+    public boolean isUrgent() {
+        return DECISION_URGENT_ORDER.equals(decision);
+    }
+
+    public boolean isOrder() {
+        return DECISION_ORDER.equals(decision);
+    }
+}

--- a/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
+++ b/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
@@ -22,7 +22,8 @@ public enum PharmacyReports implements IReportType {
     STOCK_REPORT_BY_EXPIRY("Stock report by Expiry"),
     STOCK_REPORT_BY_ITEM("Stock report by Item"),
     STOCK_REPORT_BY_ZERO_ITEM("Stock report by Zero Item"),
-    DEPARTMENT_VICE_STOCK_REPORT("Department Vice Stock Report");
+    DEPARTMENT_VICE_STOCK_REPORT("Department Vice Stock Report"),
+    ORDERING_REQUIREMENT_REPORT("Ordering Requirement Report");
 
 
     private final String displayName;

--- a/src/main/java/com/divudi/ejb/PharmacyService.java
+++ b/src/main/java/com/divudi/ejb/PharmacyService.java
@@ -788,4 +788,168 @@ public class PharmacyService {
         );
     }
 
+    /**
+     * Bill types that take stock OUT of a department as genuine demand, used by
+     * the Ordering Requirement Report (issue #22466) to compute consumption.
+     *
+     * Only the stock-moving side of each transaction appears here. A retail sale
+     * writes two PharmaceuticalBillItem rows for one physical movement - the
+     * "pre" row (which is where deductFromStock actually runs, see
+     * PharmacySaleController) and the settled/financial row (whose deductFromStock
+     * calls are commented out in PharmacyPreSettleController). Listing both would
+     * roughly double every retail figure, so the financial mirrors
+     * (PHARMACY_RETAIL_SALE, PHARMACY_RETAIL_SALE_CANCELLED,
+     * PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER,
+     * PHARMACY_RETAIL_SALE_RETURN_ITEM_PAYMENTS,
+     * PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS) are deliberately absent.
+     * This is the same split already documented on
+     * getPharmacyF15StockMovementBillTypes() vs getPharmacyIncomeBillTypes().
+     *
+     * Reversals (cancellations and returns) are included: they carry
+     * positive-signed quantities, so summing signed quantities over this list
+     * yields consumption already net of returns.
+     *
+     * Internal transfers out are treated as demand on the issuing department,
+     * which is correct for the report's intended per-department use. At a scope
+     * spanning several departments an internal transfer inflates consumption;
+     * the report page carries a note to that effect.
+     */
+    public List<BillTypeAtomic> getOrderingOutwardBillTypes() {
+        return Arrays.asList(
+                // Retail sale - stock-moving ("pre") side only
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED_PRE,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS_PREBILL,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_ADD_TO_STOCK,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_ADD_TO_STOCK_BATCH_BILL,
+                // Wholesale - "pre" side by analogy with retail (the coop data set
+                // contains no wholesale rows, so this pairing is unverified against
+                // live data; PHARMACY_WHOLESALE is treated as the financial mirror)
+                BillTypeAtomic.PHARMACY_WHOLESALE_PRE,
+                BillTypeAtomic.PHARMACY_WHOLESALE_CANCELLED,
+                BillTypeAtomic.PHARMACY_WHOLESALE_REFUND,
+                // Inward / theatre direct issues
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_RETURN,
+                BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE,
+                BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION,
+                BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN,
+                BillTypeAtomic.WARD_MEDICINE_ADMINISTRATION_CONSUMPTION,
+                // Issues against a request
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD,
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION,
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN,
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_THEATRE,
+                BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_THEATRE_CANCELLATION,
+                BillTypeAtomic.RETURN_MEDICINE_INWARD,
+                BillTypeAtomic.RETURN_MEDICINE_INWARD_CANCELLATION,
+                BillTypeAtomic.RETURN_MEDICINE_THEATRE,
+                BillTypeAtomic.ACCEPT_RETURN_MEDICINE_INWARD,
+                BillTypeAtomic.ACCEPT_RETURN_MEDICINE_THEATRE,
+                // Internal transfers out and disposals
+                BillTypeAtomic.PHARMACY_ISSUE,
+                BillTypeAtomic.PHARMACY_ISSUE_CANCELLED,
+                BillTypeAtomic.PHARMACY_ISSUE_RETURN,
+                BillTypeAtomic.PHARMACY_DIRECT_ISSUE,
+                BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED,
+                BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE,
+                BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED,
+                BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN
+        );
+    }
+
+    /**
+     * Bill types that change department stock without being demand: receipts,
+     * supplier returns and stock-taking adjustments.
+     *
+     * These NEVER contribute to consumption, the average, the target, the order
+     * quantity or any displayed figure. They exist only so the Ordering
+     * Requirement Report can reconstruct the historical balance and count
+     * stock-out days - a past balance cannot be known without every movement
+     * that changed it.
+     *
+     * Rate adjustments (PHARMACY_PURCHASE_RATE_ADJUSTMENT and friends) are
+     * excluded on purpose: they carry a non-zero qty that is the stock quantity
+     * being re-rated, not a delta, so including them corrupts the timeline.
+     * PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT is excluded for the same reason.
+     */
+    public List<BillTypeAtomic> getOrderingInboundBillTypes() {
+        return Arrays.asList(
+                BillTypeAtomic.PHARMACY_GRN,
+                BillTypeAtomic.PHARMACY_GRN_CANCELLED,
+                BillTypeAtomic.PHARMACY_GRN_RETURN,
+                BillTypeAtomic.PHARMACY_GRN_RETURN_CANCELLATION,
+                BillTypeAtomic.PHARMACY_GRN_REFUND,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND,
+                BillTypeAtomic.PHARMACY_RECEIVE,
+                BillTypeAtomic.PHARMACY_RECEIVE_CANCELLED,
+                // Return to supplier - reduces stock but is not consumption
+                BillTypeAtomic.PHARMACY_RETURN_WITHOUT_TREASING,
+                BillTypeAtomic.PHARMACY_DONATION_BILL,
+                BillTypeAtomic.PHARMACY_DONATION_BILL_CANCELLED,
+                BillTypeAtomic.PHARMACY_DONATION_BILL_REFUND,
+                BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_STOCK_ADJUSTMENT_BILL,
+                BillTypeAtomic.PHARMACY_STAFF_STOCK_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_ADJUSTMENT_CANCELLED
+        );
+    }
+
+    /**
+     * Every bill type that moves department stock - the union of the outward and
+     * inbound lists. Drives the balance timeline used for stock-out counting.
+     */
+    public List<BillTypeAtomic> getOrderingStockMovingBillTypes() {
+        List<BillTypeAtomic> all = new ArrayList<>(getOrderingOutwardBillTypes());
+        all.addAll(getOrderingInboundBillTypes());
+        return all;
+    }
+
+    /**
+     * Bill types that write a PharmaceuticalBillItem carrying a stock reference
+     * but which have been deliberately judged NOT to move stock.
+     *
+     * Two groups:
+     *
+     * 1. Financial mirrors of a movement already counted on its stock-moving
+     *    "pre" side. The stock reference is copied onto the settlement bill, so
+     *    the presence of p.stock cannot be used to tell the two apart - only the
+     *    bill type atomic can.
+     * 2. Rate and expiry-date adjustments. These carry a non-zero qty that is
+     *    the stock quantity being re-rated, not a delta.
+     *
+     * Kept separate from the stock-moving lists so that
+     * PharmacyOrderingRequirementService.countUnclassifiedMovements() can tell
+     * "deliberately ignored" apart from "never seen before", and only warn about
+     * the latter.
+     */
+    public List<BillTypeAtomic> getOrderingNonStockMovingBillTypes() {
+        return Arrays.asList(
+                // Financial mirrors - the movement is counted on the "pre" side
+                BillTypeAtomic.PHARMACY_RETAIL_SALE,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEM_PAYMENTS,
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS,
+                BillTypeAtomic.PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION,
+                BillTypeAtomic.PHARMACY_WHOLESALE,
+                // Rate and expiry adjustments - qty is a re-rated quantity, not a delta
+                BillTypeAtomic.PHARMACY_PURCHASE_RATE_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_RETAIL_RATE_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_COST_RATE_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_WHOLESALE_RATE_ADJUSTMENT,
+                BillTypeAtomic.PHARMACY_STOCK_EXPIRY_DATE_AJUSTMENT
+        );
+    }
+
 }

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyOrderingRequirementService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyOrderingRequirementService.java
@@ -1,0 +1,431 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.dto.ItemCurrentStockDto;
+import com.divudi.core.data.dto.OrderingRequirementRowDto;
+import com.divudi.core.entity.Category;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.DosageForm;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.ejb.PharmacyService;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+
+/**
+ * Calculation engine for the Ordering Requirement Report (issue #22466).
+ *
+ * Answers "what do I need to order, and how much?" for a pharmacy buyer.
+ * Deliberately free of any JSF dependency so the calculation - the part most
+ * likely to need adjustment once buyers see real output - can be exercised
+ * directly.
+ *
+ * Three aggregate queries, no per-day reconstruction: total consumption per
+ * item over the window, current stock per item, and the most recent purchase
+ * rate per item. The monthly average is simply consumption divided by the
+ * number of days in the window, scaled to a mean month.
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class PharmacyOrderingRequirementService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 365.25 / 12 - the mean month length in days. */
+    public static final double DAYS_PER_MONTH = 30.4375;
+
+    @EJB
+    private StockFacade stockFacade;
+
+    @EJB
+    private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+
+    @EJB
+    private PharmacyService pharmacyService;
+
+    /**
+     * Builds the report.
+     *
+     * @param fromDate           start of the consumption window
+     * @param toDate             end of the consumption window
+     * @param institution        optional scope filter
+     * @param site               optional scope filter
+     * @param department         optional scope filter
+     * @param category           optional item filter
+     * @param dosageForm         optional item filter
+     * @param departmentTypes    optional item filter
+     * @param targetCoverMonths  months of cover to order up to
+     * @param urgentThresholdMonths cover below which the decision is Urgent Order
+     */
+    public List<OrderingRequirementRowDto> generateReport(
+            Date fromDate, Date toDate,
+            Institution institution, Institution site, Department department,
+            Category category, DosageForm dosageForm, List<DepartmentType> departmentTypes,
+            double targetCoverMonths, double urgentThresholdMonths) {
+
+        Date windowStart = CommonFunctions.getStartOfDay(fromDate);
+        Date windowEnd = CommonFunctions.getEndOfDay(toDate);
+        int windowDays = daysBetweenInclusive(windowStart, windowEnd);
+
+        Map<Long, ItemCurrentStockDto> currentStock = fetchCurrentStockByItem(
+                institution, site, department, category, dosageForm, departmentTypes);
+
+        Map<Long, ItemCurrentStockDto> consumptionByItem = fetchConsumptionByItem(
+                windowStart, windowEnd, institution, site, department,
+                category, dosageForm, departmentTypes);
+
+        Map<Long, Double> lastPurchaseRates = fetchLastPurchaseRates(
+                windowStart, windowEnd, institution, site, department);
+
+        // An item belongs on the report if it holds stock now OR moved during the
+        // window. The second half is what surfaces items sitting at zero today
+        // that were previously selling well - precisely the urgent-order cases
+        // the report exists to catch.
+        Map<Long, String[]> itemLabels = new LinkedHashMap<>();
+        for (ItemCurrentStockDto s : currentStock.values()) {
+            itemLabels.put(s.getItemId(), new String[]{s.getItemName(), s.getCode()});
+        }
+        for (ItemCurrentStockDto c : consumptionByItem.values()) {
+            if (!itemLabels.containsKey(c.getItemId())) {
+                itemLabels.put(c.getItemId(), new String[]{c.getItemName(), c.getCode()});
+            }
+        }
+
+        List<OrderingRequirementRowDto> rows = new ArrayList<>();
+        for (Map.Entry<Long, String[]> entry : itemLabels.entrySet()) {
+            Long itemId = entry.getKey();
+            OrderingRequirementRowDto row = new OrderingRequirementRowDto(
+                    itemId, entry.getValue()[0], entry.getValue()[1]);
+
+            ItemCurrentStockDto stockDto = currentStock.get(itemId);
+            double balance = stockDto == null || stockDto.getQty() == null ? 0.0 : stockDto.getQty();
+
+            ItemCurrentStockDto consumptionDto = consumptionByItem.get(itemId);
+            // Outward quantities are stored negative and reversals positive, so
+            // negating the signed sum yields consumption already net of returns.
+            double signedOutward = consumptionDto == null || consumptionDto.getQty() == null
+                    ? 0.0 : consumptionDto.getQty();
+            // Negating a zero sum yields -0.0, which formats as "-0.00" on the
+            // page and in the exports. Flatten it.
+            double consumption = signedOutward == 0.0 ? 0.0 : -signedOutward;
+
+            calculateRow(row, balance, consumption, windowDays,
+                    lastPurchaseRates.get(itemId), targetCoverMonths, urgentThresholdMonths);
+            rows.add(row);
+        }
+
+        rows.sort(Comparator.comparing(OrderingRequirementRowDto::getItemName,
+                Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        return rows;
+    }
+
+    /**
+     * Fills in every calculated figure for one item.
+     *
+     * Package-private rather than private so the calculation can be exercised
+     * directly against the five hand-computed sample rows from the customer's
+     * requirement without going through JSF or the database.
+     */
+    void calculateRow(OrderingRequirementRowDto row,
+            double currentBalance, double consumption, int windowDays,
+            Double lastPurchaseRate,
+            double targetCoverMonths, double urgentThresholdMonths) {
+
+        row.setCurrentBalance(currentBalance);
+        row.setWindowDays(windowDays);
+        row.setConsumption(consumption);
+
+        double avgMonthly = windowDays > 0 ? consumption / windowDays * DAYS_PER_MONTH : 0.0;
+        row.setAvgMonthlyConsumption(avgMonthly);
+
+        if (avgMonthly > 0) {
+            row.setStockCover(currentBalance / avgMonthly);
+        } else {
+            // No consumption in the window - cover is undefined, not infinite.
+            row.setStockCover(null);
+        }
+
+        double target = avgMonthly * targetCoverMonths;
+        row.setTargetStock(target);
+        row.setQuantityToOrder(Math.max(0.0, target - currentBalance));
+
+        if (lastPurchaseRate == null) {
+            row.setPurchaseRateUnknown(true);
+            row.setLastPurchaseRate(0.0);
+        } else {
+            row.setLastPurchaseRate(lastPurchaseRate);
+        }
+        row.setEstimatedCost(row.getQuantityToOrder() * row.getLastPurchaseRate());
+
+        row.setDecision(decide(row.getStockCover(), targetCoverMonths, urgentThresholdMonths));
+    }
+
+    private String decide(Double cover, double targetCoverMonths, double urgentThresholdMonths) {
+        if (cover == null) {
+            return OrderingRequirementRowDto.DECISION_NO_ORDER;
+        }
+        if (cover < urgentThresholdMonths) {
+            return OrderingRequirementRowDto.DECISION_URGENT_ORDER;
+        }
+        if (cover < targetCoverMonths) {
+            return OrderingRequirementRowDto.DECISION_ORDER;
+        }
+        return OrderingRequirementRowDto.DECISION_NO_ORDER;
+    }
+
+    /**
+     * Current stock per item within scope. Grouped on the item behind the batch:
+     * Stock and ItemBatch only ever exist for an Amp, so aggregating here avoids
+     * the pack-vs-unit (Ampp vs Amp) split that billItem.item would introduce.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<Long, ItemCurrentStockDto> fetchCurrentStockByItem(
+            Institution institution, Institution site, Department department,
+            Category category, DosageForm dosageForm, List<DepartmentType> departmentTypes) {
+
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select new com.divudi.core.data.dto.ItemCurrentStockDto("
+                + " s.itemBatch.item.id,"
+                + " s.itemBatch.item.name,"
+                + " s.itemBatch.item.code,"
+                + " sum(s.stock))"
+                + " from Stock s"
+                + " where s.retired = false");
+
+        appendStockScope(jpql, m, institution, site, department);
+        appendItemFilters(jpql, m, "s.itemBatch.item", category, dosageForm, departmentTypes);
+
+        jpql.append(" group by s.itemBatch.item.id, s.itemBatch.item.name, s.itemBatch.item.code");
+
+        List<ItemCurrentStockDto> results =
+                (List<ItemCurrentStockDto>) stockFacade.findLightsByJpql(jpql.toString(), m);
+
+        return indexByItem(results);
+    }
+
+    /**
+     * Total signed outward quantity per item over the window.
+     *
+     * One aggregate over the outward bill types. Reversals (cancellations and
+     * returns) carry positive quantities and are included in the same list, so
+     * the sum is already net of returns and no second pass is needed.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<Long, ItemCurrentStockDto> fetchConsumptionByItem(
+            Date windowStart, Date windowEnd,
+            Institution institution, Institution site, Department department,
+            Category category, DosageForm dosageForm, List<DepartmentType> departmentTypes) {
+
+        List<BillTypeAtomic> outward = pharmacyService.getOrderingOutwardBillTypes();
+
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select new com.divudi.core.data.dto.ItemCurrentStockDto("
+                + " p.itemBatch.item.id,"
+                + " p.itemBatch.item.name,"
+                + " p.itemBatch.item.code,"
+                + " sum(p.qty + p.freeQty))"
+                + " from PharmaceuticalBillItem p"
+                + " join p.billItem bi"
+                + " join bi.bill bill"
+                + " where p.retired = false"
+                + " and bi.retired = false"
+                + " and bill.retired = false"
+                + " and bill.createdAt between :fd and :td"
+                + " and bill.billTypeAtomic in :outward");
+
+        m.put("fd", windowStart);
+        m.put("td", windowEnd);
+        m.put("outward", outward);
+
+        appendBillScope(jpql, m, institution, site, department);
+        appendItemFilters(jpql, m, "p.itemBatch.item", category, dosageForm, departmentTypes);
+
+        jpql.append(" group by p.itemBatch.item.id, p.itemBatch.item.name, p.itemBatch.item.code");
+
+        List<ItemCurrentStockDto> results = (List<ItemCurrentStockDto>)
+                pharmaceuticalBillItemFacade.findLightsByJpql(jpql.toString(), m, TemporalType.TIMESTAMP);
+
+        return indexByItem(results);
+    }
+
+    /**
+     * Counts in-window movements that touched stock but fall outside every
+     * classification list, so the page can warn rather than silently ignoring
+     * them.
+     *
+     * The classification is a whitelist, which is auditable but can silently
+     * drop a movement it has never seen - a bill type added later, or the
+     * null-atomic rows a data migration can leave behind. Bill types we have
+     * deliberately judged not to move stock (financial mirrors and rate
+     * adjustments) are subtracted as well, otherwise the count would flag every
+     * settled retail sale and never read zero, which would train users to
+     * ignore it.
+     *
+     * Uses findLongByJpql because COUNT returns a Long; findDoubleByJpql would
+     * swallow the resulting ClassCastException and report zero every time.
+     */
+    public long countUnclassifiedMovements(Date fromDate, Date toDate,
+            Institution institution, Institution site, Department department) {
+
+        List<BillTypeAtomic> known = new ArrayList<>(pharmacyService.getOrderingStockMovingBillTypes());
+        known.addAll(pharmacyService.getOrderingNonStockMovingBillTypes());
+
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select count(p)"
+                + " from PharmaceuticalBillItem p"
+                + " join p.billItem bi"
+                + " join bi.bill bill"
+                + " where p.retired = false"
+                + " and bi.retired = false"
+                + " and bill.retired = false"
+                + " and p.stock is not null"
+                + " and bill.createdAt between :fd and :td"
+                + " and bill.billTypeAtomic not in :known");
+
+        m.put("fd", CommonFunctions.getStartOfDay(fromDate));
+        m.put("td", CommonFunctions.getEndOfDay(toDate));
+        m.put("known", known);
+
+        appendBillScope(jpql, m, institution, site, department);
+
+        return pharmaceuticalBillItemFacade.findLongByJpql(
+                jpql.toString(), m, TemporalType.TIMESTAMP);
+    }
+
+    /**
+     * Last purchase rate per item, taken from the most recent inbound movement
+     * in the window. Items with no inbound bill are absent from the map and get
+     * flagged on the row rather than silently costed at zero.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<Long, Double> fetchLastPurchaseRates(Date windowStart, Date windowEnd,
+            Institution institution, Institution site, Department department) {
+
+        List<BillTypeAtomic> inbound = pharmacyService.getOrderingInboundBillTypes();
+
+        Map<String, Object> m = new HashMap<>();
+        StringBuilder jpql = new StringBuilder(
+                "select p.itemBatch.item.id, p.purchaseRate, bill.createdAt"
+                + " from PharmaceuticalBillItem p"
+                + " join p.billItem bi"
+                + " join bi.bill bill"
+                + " where p.retired = false"
+                + " and bi.retired = false"
+                + " and bill.retired = false"
+                + " and p.purchaseRate > 0"
+                + " and bill.createdAt between :fd and :td"
+                + " and bill.billTypeAtomic in :inbound"
+                + " order by bill.createdAt");
+
+        m.put("fd", windowStart);
+        m.put("td", windowEnd);
+        m.put("inbound", inbound);
+
+        List<Object[]> rows = (List<Object[]>) pharmaceuticalBillItemFacade.findLightsByJpql(
+                jpql.toString(), m, TemporalType.TIMESTAMP);
+
+        // Ordered oldest first, so the last write per item wins - the most
+        // recent rate.
+        Map<Long, Double> rates = new HashMap<>();
+        for (Object[] r : rows) {
+            if (r[0] == null || r[1] == null) {
+                continue;
+            }
+            rates.put(((Number) r[0]).longValue(), ((Number) r[1]).doubleValue());
+        }
+        return rates;
+    }
+
+    private Map<Long, ItemCurrentStockDto> indexByItem(List<ItemCurrentStockDto> results) {
+        Map<Long, ItemCurrentStockDto> byItem = new LinkedHashMap<>();
+        for (ItemCurrentStockDto dto : results) {
+            if (dto.getItemId() == null) {
+                continue;
+            }
+            byItem.put(dto.getItemId(), dto);
+        }
+        return byItem;
+    }
+
+    private void appendStockScope(StringBuilder jpql, Map<String, Object> m,
+            Institution institution, Institution site, Department department) {
+        if (department != null) {
+            jpql.append(" and s.department = :dept");
+            m.put("dept", department);
+        } else if (site != null) {
+            jpql.append(" and s.department.site = :site");
+            m.put("site", site);
+        } else if (institution != null) {
+            jpql.append(" and s.department.institution = :ins");
+            m.put("ins", institution);
+        }
+    }
+
+    /**
+     * bill.department is always the stock-owning department: it equals
+     * fromDepartment on transfer-issue, sale and pre bills, equals toDepartment
+     * on transfer-receive, and is set directly on GRN. One filter is therefore
+     * correct for every bill type, with no special-casing.
+     *
+     * Only the narrowest supplied scope is applied - a department already
+     * implies its site and institution, so adding all three just makes the
+     * query harder for the optimiser.
+     */
+    private void appendBillScope(StringBuilder jpql, Map<String, Object> m,
+            Institution institution, Institution site, Department department) {
+        if (department != null) {
+            jpql.append(" and bill.department = :dept");
+            m.put("dept", department);
+        } else if (site != null) {
+            jpql.append(" and bill.department.site = :site");
+            m.put("site", site);
+        } else if (institution != null) {
+            jpql.append(" and bill.department.institution = :ins");
+            m.put("ins", institution);
+        }
+    }
+
+    private void appendItemFilters(StringBuilder jpql, Map<String, Object> m, String itemPath,
+            Category category, DosageForm dosageForm, List<DepartmentType> departmentTypes) {
+        if (category != null) {
+            jpql.append(" and ").append(itemPath).append(".category = :cat");
+            m.put("cat", category);
+        }
+        if (dosageForm != null) {
+            jpql.append(" and ").append(itemPath).append(".dosageForm = :df");
+            m.put("df", dosageForm);
+        }
+        if (departmentTypes != null && !departmentTypes.isEmpty()) {
+            jpql.append(" and ").append(itemPath).append(".departmentType in :depTypes");
+            m.put("depTypes", departmentTypes);
+        }
+    }
+
+    int daysBetweenInclusive(Date from, Date to) {
+        if (from == null || to == null) {
+            return 0;
+        }
+        long fromDay = CommonFunctions.getStartOfDay(from).getTime();
+        long toDay = CommonFunctions.getStartOfDay(to).getTime();
+        if (toDay < fromDay) {
+            return 0;
+        }
+        return (int) Math.round((toDay - fromDay) / (1000.0 * 60 * 60 * 24)) + 1;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PharmacyOrderingRequirementService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyOrderingRequirementService.java
@@ -330,12 +330,18 @@ public class PharmacyOrderingRequirementService implements Serializable {
                 + " and bill.retired = false"
                 + " and p.purchaseRate > 0"
                 + " and bill.createdAt between :fd and :td"
-                + " and bill.billTypeAtomic in :inbound"
-                + " order by bill.createdAt");
+                + " and bill.billTypeAtomic in :inbound");
 
         m.put("fd", windowStart);
         m.put("td", windowEnd);
         m.put("inbound", inbound);
+
+        // Scope must be applied before the ORDER BY is appended, and the rate has
+        // to come from the same scope as the rest of the report - otherwise
+        // Estimated Cost is priced off some other department's purchases.
+        appendBillScope(jpql, m, institution, site, department);
+
+        jpql.append(" order by bill.createdAt");
 
         List<Object[]> rows = (List<Object[]>) pharmaceuticalBillItemFacade.findLightsByJpql(
                 jpql.toString(), m, TemporalType.TIMESTAMP);

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -304,6 +304,19 @@
                                     </p:tab>
 
 
+                                    <p:tab title="Ordering" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Pharmacy Analytics Ordering Tab', true)}">
+                                        <div class="d-grid gap-2">
+                                            <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Ordering Requirement Report', true)}"
+                                                             value="Ordering Requirement Report"
+                                                             icon="fa fa-cart-plus"
+                                                             ajax="false"
+                                                             styleClass="w-100 ui-button-success"
+                                                             style="text-align: left"
+                                                             title="What to order and how much, corrected for stock-out periods"
+                                                             action="#{pharmacyOrderingAnalyticsController.navigateToOrderingRequirementReport()}" />
+                                        </div>
+                                    </p:tab>
+
                                     <p:tab title="Movement Reports" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Pharmacy Analytics Movement Reports Tab')}">
                                         <div class="d-grid gap-2">
                                             <p:commandButton rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Movement Out by Sale, Issue, and Consumption with Current Stock Report')}"

--- a/src/main/webapp/pharmacy/reports/ordering_reports/ordering_requirement_report.xhtml
+++ b/src/main/webapp/pharmacy/reports/ordering_reports/ordering_requirement_report.xhtml
@@ -1,0 +1,337 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <h:body>
+
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="frmOrdering">
+
+                    <p:panel header="Ordering Requirement Report">
+
+                        <common:institution_site_department_filter controller="#{pharmacyOrderingAnalyticsController}"/>
+
+                        <h:panelGroup id="pnlItemFilters" layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- Category Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-tags mr-2" />
+                                            <h:outputLabel value="Category" for="categoryFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="categoryFilter"
+                                            value="#{pharmacyOrderingAnalyticsController.category}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Categories"/>
+                                            <f:selectItems value="#{pharmaceuticalItemCategoryController.items}" var="cat" itemLabel="#{cat.name}" itemValue="#{cat}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Dosage Form Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-capsules mr-2" />
+                                            <h:outputLabel value="Dosage Form" for="dosageFormFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="dosageFormFilter"
+                                            value="#{pharmacyOrderingAnalyticsController.dosageForm}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Dosage Forms"/>
+                                            <f:selectItems value="#{dosageFormController.items}" var="df" itemLabel="#{df.name}" itemValue="#{df}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Department Type Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                            <h:outputLabel value="Department Types" for="departmentTypeFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectCheckboxMenu
+                                            id="departmentTypeFilter"
+                                            value="#{pharmacyOrderingAnalyticsController.selectedDepartmentTypes}"
+                                            label="Select Department Types"
+                                            updateLabel="true"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains"
+                                            showHeader="true"
+                                            scrollHeight="200"
+                                            title="Select one or more department types to filter results. Leave empty to include all.">
+                                            <f:selectItems
+                                                value="#{pharmacyOrderingAnalyticsController.availableDepartmentTypes}"
+                                                var="depType"
+                                                itemLabel="#{depType.label}"
+                                                itemValue="#{depType}"/>
+                                        </p:selectCheckboxMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <h:panelGroup id="pnlOrderingInputs" layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- Consumption window -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-calendar-alt mr-2" />
+                                            <h:outputLabel value="Consumption Window (Months)" for="txtWindowMonths" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:inputNumber id="txtWindowMonths"
+                                                       value="#{pharmacyOrderingAnalyticsController.consumptionWindowMonths}"
+                                                       decimalPlaces="0"
+                                                       minValue="1"
+                                                       maxValue="36"
+                                                       styleClass="w-100"
+                                                       title="Recalculates the From date from the To date when changed">
+                                            <p:ajax event="change"
+                                                    listener="#{pharmacyOrderingAnalyticsController.applyWindowFromMonths}"
+                                                    process="@this"
+                                                    update="pnlOrderingInputs"/>
+                                        </p:inputNumber>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- From date -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-calendar mr-2" />
+                                            <h:outputLabel value="From" for="fromDate" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:calendar id="fromDate"
+                                                    value="#{pharmacyOrderingAnalyticsController.fromDate}"
+                                                    styleClass="w-100"
+                                                    inputStyleClass="w-100 form-control"
+                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                    title="Start of the consumption window"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- To date -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-calendar mr-2" />
+                                            <h:outputLabel value="To" for="toDate" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:calendar id="toDate"
+                                                    value="#{pharmacyOrderingAnalyticsController.toDate}"
+                                                    styleClass="w-100"
+                                                    inputStyleClass="w-100 form-control"
+                                                    navigator="false"
+                                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                                    title="End of the consumption window"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Target cover -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-bullseye mr-2" />
+                                            <h:outputLabel value="Target Stock Cover (Months)" for="txtTargetCover" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:inputNumber id="txtTargetCover"
+                                                       value="#{pharmacyOrderingAnalyticsController.targetCoverMonths}"
+                                                       decimalPlaces="1"
+                                                       minValue="0.5"
+                                                       maxValue="24"
+                                                       styleClass="w-100"
+                                                       title="Order up to this many months of cover"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Urgent threshold -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-exclamation-triangle mr-2" />
+                                            <h:outputLabel value="Urgent Below (Months)" for="txtUrgent" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:inputNumber id="txtUrgent"
+                                                       value="#{pharmacyOrderingAnalyticsController.urgentThresholdMonths}"
+                                                       decimalPlaces="1"
+                                                       minValue="0"
+                                                       maxValue="24"
+                                                       styleClass="w-100"
+                                                       title="Cover below this many months is flagged Urgent Order"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Action buttons -->
+                                <h:panelGroup layout="block" styleClass="col-lg-3 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                        <h:outputLabel value="&nbsp;" styleClass="mb-0"/>
+                                    </h:panelGroup>
+                                    <p:commandButton
+                                        id="btnProcess"
+                                        ajax="false"
+                                        value="Process"
+                                        icon="fas fa-cogs"
+                                        styleClass="ui-button-warning mx-1"
+                                        action="#{pharmacyOrderingAnalyticsController.processReport()}" />
+
+                                    <p:commandButton
+                                        id="btnPdf"
+                                        styleClass="ui-button-danger mx-1"
+                                        icon="fas fa-file-pdf"
+                                        value="PDF"
+                                        ajax="false"
+                                        action="#{pharmacyOrderingAnalyticsController.exportToPdf()}" />
+
+                                    <p:commandButton
+                                        id="btnExcel"
+                                        icon="fas fa-file-excel"
+                                        styleClass="ui-button-success mx-1"
+                                        value="Excel"
+                                        ajax="false"
+                                        action="#{pharmacyOrderingAnalyticsController.exportToExcel()}" />
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <!-- Warning: movements that touched stock but could not be classified -->
+                        <h:panelGroup layout="block"
+                                      styleClass="alert alert-warning my-2"
+                                      rendered="#{pharmacyOrderingAnalyticsController.unclassifiedMovementCount gt 0}">
+                            <h:outputText styleClass="fa fa-exclamation-circle me-2" />
+                            <h:outputText value="#{pharmacyOrderingAnalyticsController.unclassifiedMovementCount} stock movement(s) in this window could not be classified and were ignored. Figures below may understate movement - please report this to the development team." />
+                        </h:panelGroup>
+
+                        <!-- Caveat: internal transfers at a scope wider than one department -->
+                        <h:panelGroup layout="block"
+                                      styleClass="alert alert-info my-2"
+                                      rendered="#{pharmacyOrderingAnalyticsController.multiDepartmentScope and not empty pharmacyOrderingAnalyticsController.rows}">
+                            <h:outputText styleClass="fa fa-info-circle me-2" />
+                            <h:outputText value="No single department is selected. Transfers between departments inside this scope are counted as consumption, which inflates demand. Select a department for ordering decisions." />
+                        </h:panelGroup>
+
+                        <h:panelGroup layout="block" styleClass="row my-2" rendered="#{not empty pharmacyOrderingAnalyticsController.rows}">
+                            <h:panelGroup layout="block" styleClass="col-md-4">
+                                <p:panel styleClass="text-center">
+                                    <h:outputText value="Urgent Orders" styleClass="d-block text-muted" />
+                                    <h:outputText value="#{pharmacyOrderingAnalyticsController.urgentCount}" styleClass="d-block fs-4 fw-bold text-danger" />
+                                </p:panel>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="col-md-4">
+                                <p:panel styleClass="text-center">
+                                    <h:outputText value="Orders" styleClass="d-block text-muted" />
+                                    <h:outputText value="#{pharmacyOrderingAnalyticsController.orderCount}" styleClass="d-block fs-4 fw-bold text-warning" />
+                                </p:panel>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="col-md-4">
+                                <p:panel styleClass="text-center">
+                                    <h:outputText value="Total Estimated Cost (Rs.)" styleClass="d-block text-muted" />
+                                    <h:outputText value="#{pharmacyOrderingAnalyticsController.totalEstimatedCost}" styleClass="d-block fs-4 fw-bold">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </p:panel>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <h:panelGroup id="gpOrderingPreview" styleClass="noBorder summeryBorder" style="min-width: 100%!important;">
+
+                            <p:dataTable id="tblOrdering" rowIndexVar="ii"
+                                         value="#{pharmacyOrderingAnalyticsController.rows}" var="i"
+                                         rows="#{pharmacyOrderingAnalyticsController.rowsPerPage}"
+                                         paginator="#{pharmacyOrderingAnalyticsController.paginator}"
+                                         paginatorPosition="bottom"
+                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="20, 50, 100">
+
+                                <f:facet name="header">
+                                    <h:outputLabel value="Ordering Requirement - #{pharmacyOrderingAnalyticsController.department.name}" />
+                                </f:facet>
+
+                                <p:column headerText="Drug Name"
+                                          sortBy="#{i.itemName}"
+                                          filterBy="#{i.itemName}"
+                                          filterMatchMode="contains">
+                                    <h:outputLabel value="#{i.itemName}" />
+                                </p:column>
+
+                                <p:column headerText="Current Balance" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.currentBalance}">
+                                    <h:outputLabel value="#{i.currentBalance}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Avg Monthly Consumption" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.avgMonthlyConsumption}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Avg Monthly Consumption"
+                                                       title="Consumption over the window, divided by its days and scaled to a month" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.avgMonthlyConsumption}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Stock Cover (Months)" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.stockCover}">
+                                    <h:outputLabel value="#{i.stockCoverDisplay}" />
+                                </p:column>
+
+                                <p:column headerText="Target Stock" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.targetStock}">
+                                    <h:outputLabel value="#{i.targetStock}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Qty to Order" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.quantityToOrder}">
+                                    <h:outputLabel value="#{i.quantityToOrder}" style="font-weight: bold;">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Est. Cost (Rs.)" style="text-align: right;" styleClass="averageNumericColumn"
+                                          sortBy="#{i.estimatedCost}">
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyOrderingAnalyticsController.totalEstimatedCost}" style="font-weight: bold;">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.estimatedCost}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <h:outputText styleClass="fa fa-question-circle ms-1 text-muted"
+                                                  rendered="#{i.purchaseRateUnknown and i.quantityToOrder gt 0}"
+                                                  title="No purchase in the selected window, so no rate is available" />
+                                </p:column>
+
+                                <p:column headerText="Decision"
+                                          sortBy="#{i.decision}"
+                                          filterBy="#{i.decision}"
+                                          filterMatchMode="contains">
+                                    <h:outputLabel value="#{i.decision}"
+                                                   styleClass="#{i.urgent ? 'badge bg-danger' : (i.order ? 'badge bg-warning text-dark' : 'badge bg-secondary')}" />
+                                </p:column>
+
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                    </p:panel>
+                </h:form>
+
+            </ui:define>
+
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
## What this adds

A new **Ordering** tab in Pharmacy Analytics containing an **Ordering Requirement Report** — a flat, read-only screen telling a pharmacy buyer what to order and how much, in the column format COOP supplied:

| Drug Name | Current Balance | Avg Monthly Consumption | Stock Cover (Months) | Target Stock | Qty to Order | Est. Cost (Rs.) | Decision |

Stock cover, target stock and quantity to order are all calculated; the decision falls out as **Urgent Order / Order / No Order** against two thresholds. Header tiles summarise the urgent count, order count and total estimated cost. Excel and PDF export included.

```
avg        = consumption / windowDays × 30.4375
cover      = currentBalance / avg
target     = avg × targetCoverMonths
qtyToOrder = max(0, target − currentBalance)
estCost    = qtyToOrder × lastPurchaseRate
```

Filters mirror the Batch Stock report (institution / site / department composite, Category, Dosage Form, Department Types) plus From/To dates and three numeric inputs seeded from config keys, so admins set the house default and buyers flex per run:

- `Pharmacy Ordering - Default Consumption Window Months` (3)
- `Pharmacy Ordering - Default Target Cover Months` (3)
- `Pharmacy Ordering - Urgent Order Threshold Months` (1)

No new entities or columns, so no DDL regeneration and no migration script — the config keys are auto-created on first read.

## The finding that shaped this: classify by `BillTypeAtomic`, not `BillType`

The issue body specified a `BillType` classification. Checking that against the coop database first showed it would roughly **double every retail figure**. Each retail-sale stock movement is written to `PharmaceuticalBillItem` twice — once on the stock-moving "pre" side, once on the financial settlement side — in exact mirror pairs:

| stock-moving side | qty | financial mirror | qty |
|---|---|---|---|
| `PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER` | −977,557 | `PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER` | −959,328 |
| `PHARMACY_RETAIL_SALE_PRE` | −243,426 | `PHARMACY_RETAIL_SALE` | −243,389 |
| `PHARMACY_RETAIL_SALE_CANCELLED_PRE` | +25,876 | `PHARMACY_RETAIL_SALE_CANCELLED` | +25,876 |

Stock is deducted when the pre-bill is saved (`PharmacySaleController`); the settle step does not deduct — its `deductFromStock` calls are commented out in `PharmacyPreSettleController`. The codebase already draws this distinction: `PharmacyService.getPharmacyF15StockMovementBillTypes()` vs `getPharmacyIncomeBillTypes()`.

`PHARMACY_RETAIL_SALE_CANCELLED_PRE` also carries a **null** `billType`, so a `BillType` filter misses the cancellation reversal entirely.

Two further corrections came out of the same check:

- **Rate adjustments are excluded.** `PHARMACY_PURCHASE_RATE_ADJUSTMENT` and friends carry a non-zero `qty` that is the stock quantity being re-rated, not a delta — one such bill contributes +11,654.
- **No AMPP → AMP normalisation needed.** Aggregating on `p.itemBatch.item` instead of `billItem.item` removes the pack-vs-unit split at source: `Stock` and `ItemBatch` exist only for an `Amp` (112,505 `Amp` rows, zero of anything else), while `billItem.item` does contain stray `Ampp`/`Vmp` rows.

Because the classification is a whitelist, the service also counts in-window rows that touched stock but match no list, and the page warns when that count is non-zero — so a bill type added later can't silently skew the numbers.

## Scope note

The issue body also described a **stock-out-adjusted average** (demand measured over days the item actually had stock) with raw/adjusted and stock-out-day columns. That was dropped during implementation in favour of the plain average above, on the reporting that the extra machinery wasn't worth the complexity. The report now matches the customer's paper sample exactly. Worth reopening as a follow-up if buyers find the plain average under-orders items that were out of stock.

## Verification

Built and deployed locally, then driven end-to-end with Playwright as **Main Pharmacy** over **16 Jan – 16 Apr 2026** (local coop pharmacy activity effectively stops ~16 Apr, so a today-anchored window returns almost nothing).

Result: 3,250 items, 914 Urgent Orders, 724 Orders, Rs 52,870,979.25 total estimated cost. The unclassified-movement counter read **0**.

Reconciled one item end to end against SQL — **Rapidene**, Main Pharmacy, same window:

| figure | SQL | report |
|---|---|---|
| consumption (outward atomic whitelist) | 43,785 | — |
| current stock | 15,580 | 15,580.00 |
| avg monthly = 43,785 ÷ 91 × 30.4375 | 14,645.13 | 14,645.12 |
| cover = 15,580 ÷ 14,645.12 | 1.06 | 1.1 |
| target = avg × 3 | 43,935.36 | 43,935.36 |
| qty to order = target − balance | 28,355.36 | 28,355.36 |
| decision | Order | Order |

**The double-count check that matters:** the same consumption computed over `BillType IN ('PharmacySale','PharmacyPre',…)` gives **74,546** instead of 43,785 — a 1.70× inflation that would have driven a badly wrong order quantity. Prednisolone shows the same pattern (30,893 vs 57,654, 1.87×).

Two defects were found and fixed during the pass: a historical window's balance roll-back, and `-0.00` rendering for zero-consumption items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Ordering” accordion tab to pharmacy analytics and a new **Ordering Requirement Report** page.
  * Added report filters for institution/site/department, category, dosage form, and department types.
  * Compute a consumption date window, then determine urgency/order decisions, stock coverage, target stock, recommended quantities, and estimated costs.
  * Show summary cards and a paginated item-level results table with decision badges and contextual warnings/caveats.
  * Export the report to **PDF** or **Excel** with formatted headers and filter details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->