### PR TITLE
Add discharge-only Pharmacy Net Summary report (#22460)

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -257,6 +257,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment, "By Current Department - Logged Department"), admissionSearchScopeNode);
 
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardReport, "Inward Reports"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPostDischargeReports, "Inward Post-Discharge Reports"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdministration, "Administration"), inwardNode);
 
         TreeNode inwardLaboratoryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Laboratory"), inwardNode);

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -39,6 +39,7 @@ import com.divudi.core.facade.PatientItemFacade;
 import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.service.BillService;
 import com.divudi.core.data.dto.InpatientPharmacyIssueDTO;
+import com.divudi.core.data.dto.InpatientPharmacyNetSummaryDTO;
 import com.divudi.core.data.dto.InpatientServiceIssueDTO;
 import com.divudi.core.data.dto.BillListReportDTO;
 import com.divudi.core.entity.Service;
@@ -105,6 +106,9 @@ public class InwardReportControllerBht implements Serializable {
 
     private List<InpatientPharmacyIssueDTO> pharmacyIssueDtosToPatientEncounter;
     private double pharmacyIssueDtosToPatientEncounterNetTotal;
+
+    private List<InpatientPharmacyNetSummaryDTO> pharmacyNetSummaryDtosToPatientEncounter;
+    private double pharmacyNetSummaryDtosToPatientEncounterNetTotal;
 
     private List<InpatientServiceIssueDTO> serviceIssueDtosToPatientEncounter;
     private double serviceIssueDtosToPatientEncounterNetTotal;
@@ -268,6 +272,54 @@ public class InwardReportControllerBht implements Serializable {
         }
 
         return "/inward/reports/inpatient_pharmacy_item_list_dto?faces-redirect=true";
+    }
+
+    public String navigateToPostDischargeReports() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter selected");
+            return null;
+        }
+        return "/inward/reports/post_discharge_reports?faces-redirect=true";
+    }
+
+    public String navigateToInpatientPharmacyNetSummaryDto() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        pharmacyNetSummaryDtosToPatientEncounter = new ArrayList<>();
+        pharmacyNetSummaryDtosToPatientEncounterNetTotal = 0.0;
+        try {
+            List<BillTypeAtomic> issueTypes = new ArrayList<>();
+            issueTypes.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE);
+            issueTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE);
+            issueTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE);
+            issueTypes.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
+
+            List<BillTypeAtomic> returnTypes = new ArrayList<>();
+            returnTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN);
+            returnTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_RETURN);
+            returnTypes.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN);
+
+            List<BillTypeAtomic> cancellationTypes = new ArrayList<>();
+            cancellationTypes.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED);
+            cancellationTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION);
+            cancellationTypes.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION);
+            cancellationTypes.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION);
+
+            pharmacyNetSummaryDtosToPatientEncounter = fetchPharmacyNetSummaryDtos(issueTypes, returnTypes, cancellationTypes);
+
+            for (InpatientPharmacyNetSummaryDTO dto : pharmacyNetSummaryDtosToPatientEncounter) {
+                pharmacyNetSummaryDtosToPatientEncounterNetTotal += dto.getNetValue() != null ? dto.getNetValue() : 0.0;
+            }
+
+        } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error loading pharmacy net summary DTOs", e);
+            JsfUtil.addErrorMessage("Error loading pharmacy data");
+            return null;
+        }
+
+        return "/inward/reports/inpatient_pharmacy_net_summary_dto?faces-redirect=true";
     }
 
     public String navigateToInpatientServiceItemListDto() {
@@ -565,6 +617,39 @@ public class InwardReportControllerBht implements Serializable {
         jpql += "ORDER BY bi.bill.createdAt, bi.id";
 
         List<InpatientPharmacyIssueDTO> result = (List<InpatientPharmacyIssueDTO>) billItemFacade.findLightsByJpql(jpql, params);
+
+        return result != null ? result : new ArrayList<>();
+    }
+
+    private List<InpatientPharmacyNetSummaryDTO> fetchPharmacyNetSummaryDtos(List<BillTypeAtomic> issueTypes,
+            List<BillTypeAtomic> returnTypes, List<BillTypeAtomic> cancellationTypes) {
+        String jpql = "SELECT new com.divudi.core.data.dto.InpatientPharmacyNetSummaryDTO("
+                + "bi.item.id, "
+                + "bi.item.name, "
+                + "SUM(0 - bi.pharmaceuticalBillItem.qty), "
+                + "SUM(bi.grossValue), "
+                + "SUM(bi.discount), "
+                + "SUM(bi.marginValue), "
+                + "SUM(bi.netValue)) "
+                + "FROM BillItem bi "
+                + "WHERE bi.bill.patientEncounter = :patientEncounter "
+                + "AND bi.retired = FALSE "
+                + "AND bi.bill.retired = FALSE "
+                + "AND ("
+                + "  (bi.bill.billTypeAtomic IN :issueTypes AND bi.bill.cancelled = FALSE) "
+                + "  OR bi.bill.billTypeAtomic IN :returnTypes "
+                + "  OR bi.bill.billTypeAtomic IN :cancellationTypes"
+                + ") "
+                + "GROUP BY bi.item.id, bi.item.name "
+                + "ORDER BY bi.item.name";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("patientEncounter", patientEncounter);
+        params.put("issueTypes", issueTypes);
+        params.put("returnTypes", returnTypes);
+        params.put("cancellationTypes", cancellationTypes);
+
+        List<InpatientPharmacyNetSummaryDTO> result = (List<InpatientPharmacyNetSummaryDTO>) billItemFacade.findLightsByJpql(jpql, params);
 
         return result != null ? result : new ArrayList<>();
     }
@@ -2078,6 +2163,22 @@ public class InwardReportControllerBht implements Serializable {
 
     public void setPharmacyIssueDtosToPatientEncounterNetTotal(double pharmacyIssueDtosToPatientEncounterNetTotal) {
         this.pharmacyIssueDtosToPatientEncounterNetTotal = pharmacyIssueDtosToPatientEncounterNetTotal;
+    }
+
+    public List<InpatientPharmacyNetSummaryDTO> getPharmacyNetSummaryDtosToPatientEncounter() {
+        return pharmacyNetSummaryDtosToPatientEncounter;
+    }
+
+    public void setPharmacyNetSummaryDtosToPatientEncounter(List<InpatientPharmacyNetSummaryDTO> pharmacyNetSummaryDtosToPatientEncounter) {
+        this.pharmacyNetSummaryDtosToPatientEncounter = pharmacyNetSummaryDtosToPatientEncounter;
+    }
+
+    public double getPharmacyNetSummaryDtosToPatientEncounterNetTotal() {
+        return pharmacyNetSummaryDtosToPatientEncounterNetTotal;
+    }
+
+    public void setPharmacyNetSummaryDtosToPatientEncounterNetTotal(double pharmacyNetSummaryDtosToPatientEncounterNetTotal) {
+        this.pharmacyNetSummaryDtosToPatientEncounterNetTotal = pharmacyNetSummaryDtosToPatientEncounterNetTotal;
     }
 
     public List<InpatientServiceIssueDTO> getServiceIssueDtosToPatientEncounter() {

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -279,12 +279,20 @@ public class InwardReportControllerBht implements Serializable {
             JsfUtil.addErrorMessage("No encounter selected");
             return null;
         }
+        if (!Boolean.TRUE.equals(patientEncounter.getDischarged()) || !patientEncounter.isPaymentFinalized()) {
+            JsfUtil.addErrorMessage("Post-discharge reports are only available after the admission is discharged and payment finalized");
+            return null;
+        }
         return "/inward/reports/post_discharge_reports?faces-redirect=true";
     }
 
     public String navigateToInpatientPharmacyNetSummaryDto() {
         if (patientEncounter == null) {
             JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        if (!Boolean.TRUE.equals(patientEncounter.getDischarged()) || !patientEncounter.isPaymentFinalized()) {
+            JsfUtil.addErrorMessage("Post-discharge reports are only available after the admission is discharged and payment finalized");
             return null;
         }
         pharmacyNetSummaryDtosToPatientEncounter = new ArrayList<>();

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -1282,6 +1282,7 @@ public enum Privileges {
             case InwardImagesView:
             case InwardDiagnosisCardView:
             case InwardEventHistoryView:
+            case InwardPostDischargeReports:
                 return "Inward";
 
             case AdminInactivePatients:

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -113,6 +113,7 @@ public enum Privileges {
     InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
     InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
+    InwardPostDischargeReports("Inward Post-Discharge Reports"),
     InwardLaboratory("Inward Laboratory"),
     InwardLaboratoryBarcodeGeneration("Inward Laboratory Barcode Generation"),
     InwardLaboratorySampleManagement("Inward Laboratory Sample Management"),

--- a/src/main/java/com/divudi/core/data/dto/InpatientPharmacyNetSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InpatientPharmacyNetSummaryDTO.java
@@ -1,0 +1,84 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+public class InpatientPharmacyNetSummaryDTO implements Serializable {
+
+    private Long itemId;
+    private String itemName;
+    private Double netQty;
+    private Double netGrossValue;
+    private Double netDiscount;
+    private Double netServiceCharge;
+    private Double netValue;
+
+    public InpatientPharmacyNetSummaryDTO() {
+    }
+
+    public InpatientPharmacyNetSummaryDTO(Long itemId, String itemName, Double netQty,
+            Double netGrossValue, Double netDiscount, Double netServiceCharge, Double netValue) {
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.netQty = netQty;
+        this.netGrossValue = netGrossValue;
+        this.netDiscount = netDiscount;
+        this.netServiceCharge = netServiceCharge;
+        this.netValue = netValue;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Double getNetQty() {
+        return netQty;
+    }
+
+    public void setNetQty(Double netQty) {
+        this.netQty = netQty;
+    }
+
+    public Double getNetGrossValue() {
+        return netGrossValue;
+    }
+
+    public void setNetGrossValue(Double netGrossValue) {
+        this.netGrossValue = netGrossValue;
+    }
+
+    public Double getNetDiscount() {
+        return netDiscount;
+    }
+
+    public void setNetDiscount(Double netDiscount) {
+        this.netDiscount = netDiscount;
+    }
+
+    public Double getNetServiceCharge() {
+        return netServiceCharge;
+    }
+
+    public void setNetServiceCharge(Double netServiceCharge) {
+        this.netServiceCharge = netServiceCharge;
+    }
+
+    public Double getNetValue() {
+        return netValue;
+    }
+
+    public void setNetValue(Double netValue) {
+        this.netValue = netValue;
+    }
+}

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -437,6 +437,19 @@
                                             target="#{inwardSearch.admission}"/>
                                     </p:commandButton>
                                 </div>
+                                <div class="col-12">
+                                    <p:commandButton
+                                        rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardPostDischargeReports')}"
+                                        value="Post-Discharge Reports"
+                                        ajax="false"
+                                        action="#{inwardReportControllerBht.navigateToPostDischargeReports}"
+                                        icon="fa fa-chart-bar"
+                                        class="w-100">
+                                        <f:setPropertyActionListener
+                                            value="#{admissionController.current}"
+                                            target="#{inwardReportControllerBht.patientEncounter}"/>
+                                    </p:commandButton>
+                                </div>
                                 <div class="col-6">
                                     <p:commandButton
                                         value="Payments"

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_net_summary_dto.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_net_summary_dto.xhtml
@@ -116,14 +116,14 @@
                                         <h:outputLabel value="Date of Admission:" />
                                         <h:outputLabel>
                                             <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfAdmission}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputText>
                                         </h:outputLabel>
                                         <h:outputLabel value="" />
                                         <h:outputLabel value="Date of Discharge:" />
                                         <h:outputLabel>
                                             <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfDischarge}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputText>
                                         </h:outputLabel>
 

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_net_summary_dto.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_net_summary_dto.xhtml
@@ -1,0 +1,213 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="pharmacyNetSummaryGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <h:outputText styleClass="fa fa-prescription-bottle-alt"></h:outputText>
+                    <p:outputLabel value="&nbsp;&nbsp;&nbsp;Pharmacy Net Summary" class="m-2"></p:outputLabel>
+
+                    <p:commandButton
+                        value="Download"
+                        ajax="false"
+                        class="ui-button-primary m-1"
+                        icon="fa fa-download">
+                        <p:dataExporter fileName="Inpatient Pharmacy Net Summary" target="tbl1" type="xlsx"></p:dataExporter>
+                    </p:commandButton>
+
+                    <p:commandButton
+                        value="Print"
+                        ajax="false"
+                        class="ui-button-primary m-1"
+                        icon="fa fa-print">
+                        <p:printer target="tbl1"></p:printer>
+                    </p:commandButton>
+
+                    <p:commandButton
+                        value="Post-Discharge Reports"
+                        action="#{inwardReportControllerBht.navigateToPostDischargeReports}"
+                        style="float: right;"
+                        ajax="false"
+                        class="ui-button-secondary m-1"
+                        icon="fa fa-arrow-circle-left">
+                    </p:commandButton>
+
+                </f:facet>
+
+                <style>
+                    @media print{
+
+                        body {
+                            margin :0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Net drugs billed to the patient, after cancellations and returns" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                value="#{inwardReportControllerBht.pharmacyNetSummaryDtosToPatientEncounter}"
+                                var="dto">
+
+                                <f:facet name="header">
+                                    <h:panelGrid columns="5" style="width: 100%; text-align: left;">
+                                        <h:outputLabel value="Name:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.patient.person.nameWithTitle}" />
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="Age:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.patient.age}" />
+
+                                        <h:outputLabel value="Gender:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.patient.person.sex.label}" />
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="Room Number:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.currentPatientRoom.roomFacilityCharge.room.name}" />
+
+                                        <h:outputLabel value="Date of Admission:" />
+                                        <h:outputLabel>
+                                            <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfAdmission}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </h:outputLabel>
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="Date of Discharge:" />
+                                        <h:outputLabel>
+                                            <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfDischarge}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </h:outputLabel>
+
+                                        <h:outputLabel value="BHT:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.bhtNo}" />
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="Phone Number:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.patient.phoneNumberStringTransient}" />
+
+                                    </h:panelGrid>
+                                </f:facet>
+
+                                <p:column width="2em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="20em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Item Name" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.itemName}" />
+                                </p:column>
+
+                                <p:column width="2em" style="text-align: right; padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Qty" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netQty}">
+                                        <f:convertNumber pattern="#0" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="3em" style="text-align: right; padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Gross Value" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netGrossValue}">
+                                        <f:convertNumber pattern="#0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="3em" style="text-align: right; padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Discount" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netDiscount}">
+                                        <f:convertNumber pattern="#0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="3em" style="text-align: right; padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Service Charge" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netServiceCharge}">
+                                        <f:convertNumber pattern="#0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="4em" style="text-align: right; padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Net Value" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netValue}">
+                                        <f:convertNumber pattern="#0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardReportControllerBht.pharmacyNetSummaryDtosToPatientEncounterNetTotal}">
+                                            <f:convertNumber pattern="#0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/reports/post_discharge_reports.xhtml
+++ b/src/main/webapp/inward/reports/post_discharge_reports.xhtml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="postDischargeReportsGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <h:outputText styleClass="fa fa-chart-bar"></h:outputText>
+                    <p:outputLabel value="&nbsp;&nbsp;&nbsp;Post-Discharge Reports" class="m-2"></p:outputLabel>
+
+                    <p:commandButton
+                        value="Inpatient Dashboard"
+                        action="#{inwardReportControllerBht.navigateToAdmissionProfile()}"
+                        style="float: right;"
+                        ajax="false"
+                        class="ui-button-secondary m-1"
+                        icon="fa fa-arrow-circle-left">
+                    </p:commandButton>
+                </f:facet>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel header="Reports">
+                            <div class="d-grid gap-3">
+                                <p:commandButton
+                                    value="Pharmacy Net Summary"
+                                    rendered="#{webUserController.hasPrivilege('InwardPostDischargeReports')}"
+                                    action="#{inwardReportControllerBht.navigateToInpatientPharmacyNetSummaryDto}"
+                                    icon="fa fa-prescription-bottle-alt"
+                                    ajax="false"
+                                    class="w-100 ui-button-success"
+                                    title="Net drugs billed to the patient, after cancellations and returns">
+                                    <f:setPropertyActionListener
+                                        value="#{admissionController.current}"
+                                        target="#{inwardReportControllerBht.patientEncounter}"/>
+                                </p:commandButton>
+                            </div>
+                        </p:panel>
+                    </div>
+                </div>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Summary
- Fixes #22460: the Pharmacy Issue Summary report was confusing because it (correctly, by design) lists cancellations/returns as separate signed transaction lines rather than editing the original billed line — that's this system's report-immutability principle, and it does **not** change.
- Instead, adds a new **Post-Discharge Reports** hub, reachable from a new button on the Inpatient Dashboard, visible only once an admission is **discharged and payment-finalized**. It currently hosts one report — **Pharmacy Net Summary** — showing one row per item with Qty/Gross Value/Discount/Service Charge/Net Value netted across issue, cancellation, and return transactions. More post-discharge reports can be added to this hub later.
- Net quantity is computed from the already-signed `PharmaceuticalBillItem.qty` (issue = stock leaving = negative, return/cancellation = stock returning = positive), summed and inverted so a positive net quantity means "currently billed." Net Value/Gross Value/Discount/Service Charge (margin) are summed directly from `BillItem`, which are already correctly signed per transaction type.
- New privilege `InwardPostDischargeReports` gates both the dashboard button and the report; added to the User Privileges admin tree next to the existing `InwardReport` node.

## Test plan
- [x] Built locally (`mvn clean package`) and redeployed to local Payara.
- [x] Verified via Playwright: logged in, opened admission BHT/46963 (a discharged + payment-finalized encounter with real pharmacy issue/return activity), confirmed the "Post-Discharge Reports" button renders only under the discharged+finalized+privilege gate, clicked through the hub to the Pharmacy Net Summary report.
- [x] Cross-checked every row's Qty/Gross Value/Discount/Service Charge/Net Value against an independent SQL query summing `billitem`/`pharmaceuticalbillitem` directly — all 25 items matched exactly, including two fully-returned items correctly netting to 0.
- [x] Confirmed (via code inspection) that pharmacy issue/return controllers already block writes once an admission is discharged/payment-finalized, so no additional "freeze" mechanism is needed for the net summary to stay stable.
- [x] Existing Pharmacy Issue Summary report (`inpatient_pharmacy_item_list_dto.xhtml`) is unchanged.

**Dashboard button:**
![Post-Discharge Reports button](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22460-00-dashboard-button.png)

**Pharmacy Net Summary report:**
![Pharmacy Net Summary report](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22460-01-pharmacy-net-summary.png)

Wiki documentation: [Report Immutability and Cancellations/Returns](https://github.com/hmislk/hmis/wiki/Report-Immutability-and-Cancellations-Returns)

Closes #22460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Post-Discharge Reports”** action for discharged, payment-finalized inpatient admissions, available only to users with the new privilege.
  * Introduced a **Pharmacy Net Summary** report showing itemized net quantity and financial totals.
  * Added **XLSX download** and **print** options for the Pharmacy Net Summary.
  * Enabled navigation from **admission details** to **Post-Discharge Reports** and then to **Pharmacy Net Summary**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->