### PR TITLE
feat(inward): add patient area search to inpatient admission search

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -63,6 +63,7 @@ import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
 import com.divudi.core.data.dto.PatientEncounterDto;
+import com.divudi.core.entity.Area;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
@@ -1122,6 +1123,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     public void searchAdmissions() {
         searchAdmissions(null, null);
     }
+    
+    private Area patientArea;
 
     /**
      * @param currentRoomInstitutionFilter when non-null, restricts to admissions whose
@@ -1161,6 +1164,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (bhtNumberFilter != null) {
             j += "  and c.bhtNo like :bht ";
             m.put("bht", "%" + bhtNumberFilter + "%");
+        }
+        
+        if(patientArea != null){
+            j += " and c.patient.person.area = :area ";
+            m.put("area",  patientArea);
         }
 
         if (patientNumberFilter != null) {
@@ -1641,6 +1649,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         admissionStatusForSearch = null;
         admissionTypeForSearch = null;
         parentAdmission = null;
+        patientArea = null;
     }
 
     public String navigateToListAdmissions() {
@@ -3618,6 +3627,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     public void setPatientForiegner(boolean patientForiegner) {
         this.patientForiegner = patientForiegner;
+    }
+
+    public Area getPatientArea() {
+        return patientArea;
+    }
+
+    public void setPatientArea(Area patientArea) {
+        this.patientArea = patientArea;
     }
 
     /**

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -151,7 +151,7 @@
                                     value="#{admissionController.patientIdentityNumberForSearch}" >
                                 </p:inputText>
 
-                                <p:outputLabel value="Patient Area" ></p:outputLabel>
+                                <h:outputText value="Patient Area" />
                                 <p:autoComplete 
                                     id="area" 
                                     class="w-100 -mx-2"

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -151,6 +151,22 @@
                                     value="#{admissionController.patientIdentityNumberForSearch}" >
                                 </p:inputText>
 
+                                <p:outputLabel value="Patient Area" ></p:outputLabel>
+                                <p:autoComplete 
+                                    id="area" 
+                                    class="w-100 -mx-2"
+                                    inputStyleClass="form-control"
+                                    forceSelection="true"
+                                    value="#{admissionController.patientArea}"  
+                                    completeMethod="#{areaController.completeArea}" 
+                                    var="pa"
+                                    placeholder="Patient Area"
+                                    itemLabel="#{pa.name}" 
+                                    itemValue="#{pa}" 
+                                    maxResults="15"
+                                    size="10">
+                                </p:autoComplete> 
+
                                 <p:outputLabel value="Referring Doctor" ></p:outputLabel>
                                 <p:autoComplete
                                     forceSelection="true"
@@ -167,6 +183,8 @@
                                         <h:outputLabel value="#{ix.speciality.name}"></h:outputLabel>
                                     </p:column>
                                 </p:autoComplete>
+
+
 
                                 <p:outputLabel value="Occupation" ></p:outputLabel>
                                 <p:inputText
@@ -255,19 +273,21 @@
                             </div>
                             <div class="col-10">
                                 <div class="p-1" >
-                                    <p:dataTable id="tblBills"
-                                                 value="#{admissionController.items}"
-                                                 var="a"
-                                                 emptyMessage="No records found"
-                                                 rowKey="#{a.id}"
-                                                 paginator="true"
-                                                 rows="10"
-                                                 paginatorAlwaysVisible="false"
-                                                 paginatorPosition="bottom"
-                                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                                 currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
-                                                 rowsPerPageTemplate="5,10,{ShowAll|'All'}"
-                                                 >
+                                    <p:dataTable 
+                                        id="tblBills"
+                                        value="#{admissionController.items}"
+                                        var="a"
+                                        emptyMessage="No records found"
+                                        rowKey="#{a.id}"
+                                        paginator="true"
+                                        rows="10"
+                                        paginatorAlwaysVisible="false"
+                                        paginatorPosition="bottom"
+                                        paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                        currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                        rowsPerPageTemplate="5,10,{ShowAll|'All'}"
+                                        >
+                                        
                                         <p:column headerText="BHT No" >
                                             <h:outputText value="#{a.bhtNo}"></h:outputText>
                                         </p:column>
@@ -294,6 +314,9 @@
                                         </p:column>
                                         <p:column headerText="Address" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Address in Admission Search',true)}" >
                                             <h:outputText value="#{a.patient.person.address}" ></h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Area" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Patient Area in Admission Search',true)}">
+                                            <h:outputText value="#{a.patient.person.area.name}" ></h:outputText>
                                         </p:column>
                                         <p:column headerText="Dr. Name" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Doctor Name in Admission Search',false)}" >
                                             <h:outputText value="#{a.referringConsultant.person.nameWithTitle}" ></h:outputText>


### PR DESCRIPTION
## Summary
Fixes #22493 — "Area search is not available" on the inpatient admission search page.

- Added a `patientArea` filter field (backend: `AdmissionController.java`) applied to the admission search JPQL as `c.patient.person.area = :area` when set.
- Added a **Patient Area** `p:autoComplete` field to `inward/inpatient_search.xhtml`, reusing the existing `areaController.completeArea` autocomplete method already used elsewhere in the app.
- Added an **Area** results column, gated behind a new config option `Show Patient Area in Admission Search` (boolean, default `true`), mirroring the existing `Show Address in Admission Search` toggle already on this page — so it can be disabled per-deployment without code changes.

## Details
See issue comment with full implementation notes: https://github.com/hmislk/hmis/issues/22493#issuecomment-5105656721

## Test plan
- [x] Verified `AreaController.completeArea` autocomplete method already exists and is used by other pages (no new backend endpoint required).
- [x] Verified `Person.area` field exists and is the correct relationship path used in the JPQL filter.
- [x] Verified the config-option gating pattern matches the existing `Show Address in Admission Search` toggle on the same page.
- [ ] Manual verification in local Payara (search by area, confirm results filter correctly and the Area column renders) — recommended before merge if not already done.

Closes #22493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Patient Area filter to the inpatient admission search.
  * Added an optional Area column to admission search results.
  * The Area column is controlled by an application configuration setting.
* **Usability Improvements**
  * Patient Area selection now uses autocomplete to speed up searching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->