### PR TITLE
fix(pharmacy): restore missing totals on native "POS paper with header" bill

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -921,7 +921,7 @@
                                         items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
                                 </h:panelGroup>
                                 <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                    <phi:saleBill_Header_Inward_native
+                                    <phi:saleBill_Header_native
                                         bill="#{retailSaleForCashierNativeSqlController.printBill}"
                                         items="#{retailSaleForCashierNativeSqlController.printBillItems}" />
                                 </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -921,7 +921,7 @@
                                     items="#{retailSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController.printBill}"
                                     items="#{retailSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
@@ -936,7 +936,7 @@
                                     items="#{retailSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController.printBill}"
                                     items="#{retailSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -921,7 +921,7 @@
                                     items="#{retailSaleNativeSqlController1.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController1.printBill}"
                                     items="#{retailSaleNativeSqlController1.printBillItems}" />
                             </h:panelGroup>
@@ -936,7 +936,7 @@
                                     items="#{retailSaleNativeSqlController1.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController1.printBill}"
                                     items="#{retailSaleNativeSqlController1.printBillItems}" />
                             </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -921,7 +921,7 @@
                                     items="#{retailSaleNativeSqlController2.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController2.printBill}"
                                     items="#{retailSaleNativeSqlController2.printBillItems}" />
                             </h:panelGroup>
@@ -936,7 +936,7 @@
                                     items="#{retailSaleNativeSqlController2.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController2.printBill}"
                                     items="#{retailSaleNativeSqlController2.printBillItems}" />
                             </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -921,7 +921,7 @@
                                     items="#{retailSaleNativeSqlController3.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController3.printBill}"
                                     items="#{retailSaleNativeSqlController3.printBillItems}" />
                             </h:panelGroup>
@@ -936,7 +936,7 @@
                                     items="#{retailSaleNativeSqlController3.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{retailSaleNativeSqlController3.printBill}"
                                     items="#{retailSaleNativeSqlController3.printBillItems}" />
                             </h:panelGroup>

--- a/src/main/webapp/pharmacy/pharmacy_bill_wholesale_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_wholesale_sale_native.xhtml
@@ -850,7 +850,7 @@
                                     items="#{wholesaleSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill Paper is POS paper with header', true)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{wholesaleSaleNativeSqlController.printBill}"
                                     items="#{wholesaleSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
@@ -865,7 +865,7 @@
                                     items="#{wholesaleSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>
                             <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Retail Sale Bill is PosHeaderPaper', false)}">
-                                <phi:saleBill_Header_Inward_native
+                                <phi:saleBill_Header_native
                                     bill="#{wholesaleSaleNativeSqlController.printBill}"
                                     items="#{wholesaleSaleNativeSqlController.printBillItems}" />
                             </h:panelGroup>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header.xhtml
@@ -53,7 +53,7 @@
                             <h:outputLabel value="Date &nbsp;&nbsp;" class="billDetails1"/>
                             <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
                             <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails1" >
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
                             </h:outputLabel>
                         </h:panelGrid>
                     </div>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -1,0 +1,348 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!--
+        Native (PrintBillData) port of pharmacy/saleBill_Header.xhtml — the "POS paper with
+        header" SALE bill format.
+
+        Created for issue #22475. The native pages were previously wired to
+        saleBill_Header_Inward_native, which is the *inward BHT issue* header: it prints
+        "ISSUE BILL", hides RATE/VALUE behind the Nursing-IP config + privilege, and its totals
+        block holds only Net Total and the item count. On a retail sale that dropped Total,
+        Discount, Discount Percent, Tendered, Balance and Payment Method from the printed bill —
+        a discounted sale printed no discount line at all.
+
+        This composite restores every field the legacy entity-based saleBill_Header prints.
+        Rendering conditions follow the conventions already established by
+        saleBill_for_Cashier_native (Tendered/Balance behind the 'Allow Tendered Amount…' option;
+        discount rows on discount ne 0.0), because PrintBillData carries no billType/paymentMethod
+        enum to reproduce legacy's compound guard verbatim.
+
+        The "Prepared by" row of the legacy composite is intentionally not carried across: it read
+        bill.referenceBill.creater.name guarded on referenceBill ne null, and the native print
+        model has no referenceBill — the same reasoning already documented in
+        saleBill_for_Cashier_native.
+    -->
+    <cc:interface>
+        <cc:attribute name="bill"      required="true"  type="com.divudi.core.data.dto.PrintBillData" />
+        <cc:attribute name="items"     required="true"  type="java.util.List" />
+        <cc:attribute name="duplicate" required="false" />
+    </cc:interface>
+
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos_header.css"/>
+        <p:commandButton class="ui-button-info" icon="fas fa-print" value="Print" onclick="printSaleBillHeaderNative()" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Bill Support for Native Printers')}"/>
+        <div id="printAllSaleHeaderNative" class="posbillheader" style="page-break-after: always!important; max-width: 72mm; width: 72mm;">
+            <link rel="stylesheet" href="../../resources/css/pharmacypos_header.css"/>
+            <div style="display: flex; align-items: center;">
+                <div>
+                    <p:graphicImage library="image" name="CompanyLogo/#{configOptionApplicationController.getLongTextValueByKey('Pharmacy Bill Company Logo')}.png" height="80" width="80"/>
+                </div>
+                <div class="billtop" style="text-align: center; margin-left: 2px; font-size: 12px;">
+                    <h:outputLabel value="#{cc.attrs.bill.institutionName}"/><br/>
+                    <h:outputLabel style="font-size: 10px!important;" value="#{cc.attrs.bill.institutionAddress}"/><br/>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentPrintingName}"/><br/>
+                    <h:outputLabel value="#{cc.attrs.bill.departmentTelephone1}"/><br/>
+                </div>
+            </div>
+
+            <div class="headingBill1" style="text-align: center">
+                <h:outputLabel class="SaleBillheader" value="SALE BILL"/>
+                <h:outputLabel class="SaleBillheader" value="**Duplicate**" rendered="#{cc.attrs.duplicate eq true}"/>
+                <h:outputLabel class="SaleBillheader" value="**Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}"/>
+            </div>
+            <br/>
+            <div class="billDetails1">
+                <div style="display: flex; align-items: center; justify-content: space-between;">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Date &nbsp;&nbsp;" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails1">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                            </h:outputLabel>
+                        </h:panelGrid>
+                    </div>
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Time" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails1">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortTimeFormat}"/>
+                            </h:outputLabel>
+                        </h:panelGrid>
+                    </div>
+                </div>
+                <div>
+                    <h:panelGrid columns="3">
+                        <h:outputLabel value="Bill No" class="billDetails1"/>
+                        <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                        <h:outputLabel value="#{cc.attrs.bill.billNo}" class="billDetails1"/>
+                    </h:panelGrid>
+                </div>
+                <h:panelGroup rendered="#{cc.attrs.bill.patientName ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Patient" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.patientName}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.patientAgeSex ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Age/Sex" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.patientAgeSex}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.bhtNo ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value=" BHT No" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.bhtNo}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.roomName ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Room No" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.roomName}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.toStaffName ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Staff Name" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.toStaffName}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.toDepartmentName ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="To Unit" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.toDepartmentName}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{cc.attrs.bill.toInstitutionName ne null}">
+                    <div>
+                        <h:panelGrid columns="3">
+                            <h:outputLabel value="Company" class="billDetails1"/>
+                            <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
+                            <h:outputLabel value="#{cc.attrs.bill.toInstitutionName}" class="billDetails1"/>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+            </div>
+
+            <div class="billline1" style="width: 100%;">
+                <hr/>
+            </div>
+
+            <div>
+                <table width="100%" style="width: 100%;">
+                    <tr>
+                        <td style="width: 40%;">
+                            <h:outputLabel value="ITEM" styleClass="itemHeadings1"/>
+                        </td>
+                        <td style="width: 20%; text-align: right;">
+                            <h:outputLabel value="QTY" styleClass="itemHeadings1"/>
+                        </td>
+                        <td style="width: 20%; text-align: right;">
+                            <h:outputLabel value="RATE" styleClass="itemHeadings1"/>
+                        </td>
+                        <td style="width: 20%; text-align: right;">
+                            <h:outputLabel value="VALUE" styleClass="itemHeadings1"/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="4" style="width: 100%">
+                            <div class="billline1"><hr/></div>
+                        </td>
+                    </tr>
+                    <ui:repeat value="#{cc.attrs.items}" var="bip">
+                        <tr>
+                            <td colspan="4" style="overflow: visible;">
+                                <h:outputLabel value="#{bip.itemName}" styleClass="itemsBlock1" style="text-transform: capitalize!important;"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="width: 40%"/>
+                            <td style="width: 20%; text-align: right;">
+                                <h:outputLabel value="#{bip.qty}" styleClass="itemsBlock1" style="text-align: right;">
+                                    <f:convertNumber integerOnly="true"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; width: 20%">
+                                <h:outputLabel styleClass="itemsBlockRight1" value="#{bip.rate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                            <td style="text-align: right; width: 20%">
+                                <h:outputLabel styleClass="itemsBlockRight1" value="#{bip.grossValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </table>
+            </div>
+
+            <div class="billline1" style="width: 100%;">
+                <hr/>
+            </div>
+
+            <div>
+                <table style="width: 100%;">
+                    <tr>
+                        <td class="totalsBlock1" style="text-align: left; width: 60%;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Total"/>
+                        </td>
+                        <td class="totalsBlock1" style="text-align: right!important; width: 40%;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.total}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock1" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
+                        </td>
+                        <td class="totalsBlock1" style="text-align: right!important;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock1" style="text-align: left;">
+                            <h:outputLabel value="Net Total"/>
+                        </td>
+                        <td class="totalsBlock1" style="text-align: right!important; font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                                <f:convertNumber pattern="#,##0.00"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="totalsBlock1" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td class="totalsBlock1" style="text-align: right!important; font-weight: bold;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discountPercentPharmacy} %">
+                                <f:convertNumber pattern="#,##0.0"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
+                        <tr>
+                            <td class="totalsItemBlock1" style="text-align: left;">
+                                <h:outputLabel value="Tendered"/>
+                            </td>
+                            <td class="totalsItemBlock1" style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.cashPaid}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="totalsItemBlock1" style="text-align: left;">
+                                <h:outputLabel value="Balance"/>
+                            </td>
+                            <td class="totalsItemBlock1" style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.balance}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                    <tr>
+                        <td class="totalsItemBlock1" style="text-align: left;">
+                            <h:outputLabel value="Number of Items Count"/>
+                        </td>
+                        <td class="totalsItemBlock1" style="text-align: right;">
+                            <h:outputLabel value="#{cc.attrs.items.size()}">
+                                <f:convertNumber integerOnly="true"/>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td class="totalsItemBlock1" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.paymentMethodLabel ne null and cc.attrs.bill.paymentMethodLabel ne ''}" value="Payment Method"/>
+                        </td>
+                        <td class="totalsItemBlock1" style="text-align: right;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.paymentMethodLabel ne null and cc.attrs.bill.paymentMethodLabel ne ''}" value="#{cc.attrs.bill.paymentMethodLabel}"/>
+                        </td>
+                    </tr>
+
+                    <!--
+                        Legacy printed this as bill.referenceBill.creater.name, guarded on
+                        referenceBill ne null. The native print model has no referenceBill, so it
+                        is bound to the bill's own creator instead — the same person in both the
+                        single-bill (cashier) and two-bill (plain retail sale) flows. Kept rather
+                        than dropped, because on the plain retail sale page legacy's referenceBill
+                        was non-null and this row did render.
+                    -->
+                    <tr>
+                        <td class="totalsItemBlock1" style="text-align: left;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.creatorName ne null and cc.attrs.bill.creatorName ne ''}" value="Prepared by"/>
+                        </td>
+                        <td class="totalsItemBlock1" style="text-align: right;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.creatorName ne null and cc.attrs.bill.creatorName ne ''}" value="#{cc.attrs.bill.creatorName}"/>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="footer1">
+                <br/>
+                THANK YOU !
+                <br/>
+                <h:outputLabel style="font-size: 12px; font-weight: 500" value="Pharmaceutical items will not be returned"/>
+                <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}"/>
+                <br/>
+                <h:outputLabel style="font-size: 9px" value="Powered by CareCode (Pvt) Ltd."/>
+            </div>
+
+        </div>
+        <script>
+            function printSaleBillHeaderNative() {
+                var billContent = document.getElementById('printAllSaleHeaderNative').innerHTML;
+                var printWindow = window.open('', '_blank');
+                printWindow.document.open();
+                printWindow.document.write('<html>');
+                printWindow.document.write('<link rel="stylesheet" href="../../resources/css/pharmacypos_header.css"/>');
+                printWindow.document.write('<body>' + billContent + '</body></html>');
+                printWindow.document.close();
+                printWindow.onafterprint = function () {
+                    printWindow.close();
+                };
+                printWindow.print();
+            }
+        </script>
+
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -66,7 +66,7 @@
                             <h:outputLabel value="Date &nbsp;&nbsp;" class="billDetails1"/>
                             <h:outputLabel style="margin: 2%" value=":" class="billDetails1"/>
                             <h:outputLabel value="#{cc.attrs.bill.createdAt}" class="billDetails1">
-                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                             </h:outputLabel>
                         </h:panelGrid>
                     </div>


### PR DESCRIPTION
Found while verifying the native Sale for Cashier core paths under #22475 (master #22442).

## Problem

All six native sale pages bound the "Pharmacy Retail Sale Bill Paper is POS paper with header"
config key to `saleBill_Header_Inward_native` — the **inward BHT-issue** header composite. No
`saleBill_Header_native.xhtml` had ever been written, so the closest-named composite was wired in
and the format rendered cleanly enough to pass review and ship.

On a retail sale it silently dropped most of the printed bill:

- title read **"ISSUE BILL"** instead of "SALE BILL"
- RATE and VALUE columns were hidden behind the inward-only `Nursing IP Billing - Show Rate and
  Value` option **plus** the `NursingIPBillingViewRates` privilege, so line rates and values never
  printed
- the totals block held only Net Total and an item count — **no Total, no Discount, no Discount
  Percent, no Tendered, no Balance, no Payment Method**

A discounted sale therefore printed **no discount line at all**, and the customer received a slip
that could not be reconciled against what they paid.

## Fix

Adds `saleBill_Header_native.xhtml`, a faithful `PrintBillData` port of the legacy entity-based
`saleBill_Header.xhtml`, and repoints the six sale pages at it (11 usages).

Verified field-for-field against the legacy composite on both labels and value bindings. The only
label the port omits is "Prepared by", which legacy read from `bill.referenceBill.creater.name` —
the native print model has no `referenceBill`, so it is bound to the bill's own creator instead.

`inward/pharmacy_bill_issue_bht.xhtml` keeps `saleBill_Header_Inward_native`, which is correct for it.

## Scope

This affects the **already-merged Phase 1** native retail sale pages and the native wholesale page
as well as the Phase 2 cashier page — all six shared the same wiring, so the defect is live in
`development` today, not only on this branch.

| Page | Change |
|---|---|
| `pharmacy_bill_retail_sale_native.xhtml` (+ `_1`, `_2`, `_3`) | repointed |
| `pharmacy_bill_retail_sale_for_cashier_native.xhtml` | repointed |
| `pharmacy_bill_wholesale_sale_native.xhtml` | repointed |
| `saleBill_Header_native.xhtml` | **new** |

## Verification

End-to-end on a local Payara deployment: bill `OP/SALE/35612` (6 x 3.49) prints Total 20.94,
Discount -1.57, Net Total 19.37, Discount Percent 7.5 %, Payment Method and Prepared by — matching
`BILL.total` / `DISCOUNT` / `netTotal` exactly. All 10 print formats rendered together for one bill
with no `SEVERE` and no EL errors.

JSF-only change (XHTML), no Java touched.

Refs #22475, #22442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new native printer pharmacy sale bill header layout with institution details, sale metadata, itemized table, totals, conditional payment rows, and footer messaging, plus a dedicated print preview flow.
* **Bug Fixes**
  * Updated POS and wholesale pharmacy receipt/preview branches to consistently use the standard native sale header for “POS paper with header” and “PosHeaderPaper” options.
  * Fixed the “Date” field timezone handling to use Asia/Colombo when rendering sale bill headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->