### PR TITLE
fix(pharmacy): cashier token config scope (#22486) and multiple-payment reprint split (#22487)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -49,6 +49,7 @@ import com.divudi.core.facade.StockFacade;
 import com.divudi.core.facade.TokenFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.core.util.PaymentBreakdownCodec;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyService;
 import com.divudi.service.pharmacy.RetailSaleForCashierNativeSqlService;
@@ -475,6 +476,17 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             preBillEntity.setCashPaid(cashPaid);
             billBean.setPaymentMethodData(preBillEntity, paymentMethod, getPaymentMethodData());
 
+            // setPaymentMethodData has no MultiplePaymentMethods branch, so without this the
+            // component split would exist only in the session-scoped paymentMethodData that
+            // resetAll() clears - the settle-time slip would itemise "Cash 40.00 / Card 29.80"
+            // and a reprint of the same bill would show no breakdown at all (#22487). Stored
+            // for printing only; no Payment rows are created here, the cashier still writes
+            // those against the settled bill later.
+            if (paymentMethod == PaymentMethod.MultiplePaymentMethods) {
+                preBillEntity.setPaymentBreakdown(
+                        PaymentBreakdownCodec.serialize(buildPrintPaymentLines()));
+            }
+
             // Stamp dept/institution IDs on each item (needed by the native service for
             // StockHistory aggregates).
             long deptId = sessionController.getLoggedUser().getDepartment().getId();
@@ -592,13 +604,18 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
      * when the page has not set it directly, so a staff-credit bill always names its debtor.
      */
     private void syncStaffSelectionFromPaymentDetails(PaymentMethod method) {
+        if (paymentMethodData == null || toStaff != null) {
+            return;
+        }
+        // Staff / Staff Welfare can also be one component of a Multiple Payment Methods
+        // bill. Legacy only ever looked at the bill-level method, so the welfare member
+        // resolved correctly in the UI but toStaff was never stamped on the bill (#22487) -
+        // leaving a staff-welfare debt with no named debtor.
+        if (method == PaymentMethod.MultiplePaymentMethods) {
+            syncStaffSelectionFromMultiplePaymentComponents();
+            return;
+        }
         if (method != PaymentMethod.Staff && method != PaymentMethod.Staff_Welfare) {
-            return;
-        }
-        if (paymentMethodData == null) {
-            return;
-        }
-        if (toStaff != null) {
             return;
         }
         ComponentDetail staffComponent = method == PaymentMethod.Staff
@@ -606,6 +623,36 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
                 : paymentMethodData.getStaffWelfare();
         if (staffComponent != null && staffComponent.getToStaff() != null) {
             setToStaff(staffComponent.getToStaff());
+        }
+    }
+
+    /**
+     * Finds the staff member named inside a Staff or Staff Welfare component of a Multiple
+     * Payment Methods bill. The first one found wins - the bill carries a single
+     * {@code toStaff}, so a split naming two different members cannot be represented and
+     * the remainder is left to the cashier's own Payment rows at settle.
+     */
+    private void syncStaffSelectionFromMultiplePaymentComponents() {
+        if (paymentMethodData.getPaymentMethodMultiple() == null
+                || paymentMethodData.getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null) {
+            return;
+        }
+        for (ComponentDetail cd : paymentMethodData.getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails()) {
+            if (cd == null || cd.getPaymentMethod() == null || cd.getPaymentMethodData() == null) {
+                continue;
+            }
+            ComponentDetail staffComponent;
+            if (cd.getPaymentMethod() == PaymentMethod.Staff) {
+                staffComponent = cd.getPaymentMethodData().getStaffCredit();
+            } else if (cd.getPaymentMethod() == PaymentMethod.Staff_Welfare) {
+                staffComponent = cd.getPaymentMethodData().getStaffWelfare();
+            } else {
+                continue;
+            }
+            if (staffComponent != null && staffComponent.getToStaff() != null) {
+                setToStaff(staffComponent.getToStaff());
+                return;
+            }
         }
     }
 

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -116,6 +116,21 @@ public class Bill implements Serializable, RetirableEntity {
     private String comments;
     @Lob
     private String paymentMemo;
+    /**
+     * Serialised breakdown of a Multiple Payment Methods settlement, held as a JSON
+     * array of {@code {label, value, reference}} entries.
+     *
+     * Written where the components are entered but no {@link Payment} rows are created
+     * yet - notably the pharmacy Sale for Cashier pre-bill, where the cashier collects
+     * the money and writes the real Payment rows later against the settled bill. Without
+     * this the split exists only in session state, so a reprint of the pre-bill loses the
+     * breakdown that the slip handed to the customer showed (#22487).
+     *
+     * Print-only. It is never summed and must not be treated as evidence that money was
+     * received - persisted Payment rows remain the single source of truth for that.
+     */
+    @Lob
+    private String paymentBreakdown;
     @Lob
     private String indication;
     // Bank Detail
@@ -1914,6 +1929,14 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setPaymentMemo(String paymentMemo) {
         this.paymentMemo = paymentMemo;
+    }
+
+    public String getPaymentBreakdown() {
+        return paymentBreakdown;
+    }
+
+    public void setPaymentBreakdown(String paymentBreakdown) {
+        this.paymentBreakdown = paymentBreakdown;
     }
 
     public Bill getReferenceBill() {

--- a/src/main/java/com/divudi/core/util/PaymentBreakdownCodec.java
+++ b/src/main/java/com/divudi/core/util/PaymentBreakdownCodec.java
@@ -1,0 +1,81 @@
+package com.divudi.core.util;
+
+import com.divudi.core.data.dto.PrintBillData;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Serialises and restores the itemised payment lines of a Multiple Payment Methods
+ * bill to and from {@code Bill.paymentBreakdown}.
+ *
+ * Needed where the components are entered but no {@code Payment} rows are written yet -
+ * the pharmacy Sale for Cashier pre-bill takes no money, so the cashier creates the real
+ * Payment rows later against the settled bill. Before this the split lived only in the
+ * session-scoped {@code PaymentMethodData}, so a reprint showed no breakdown at all while
+ * the slip handed to the customer minutes earlier did (#22487).
+ *
+ * The stored value is print-only. It is never summed, never reconciled and must not be
+ * read as evidence that money was received - persisted {@code Payment} rows remain the
+ * single source of truth for that.
+ *
+ * Both directions are lenient by design: a bill whose breakdown is absent, empty or
+ * unparseable prints without the itemisation rather than failing. Losing a decorative
+ * line on a receipt is preferable to blocking a settle or a reprint.
+ */
+public class PaymentBreakdownCodec {
+
+    private static final Logger LOGGER = Logger.getLogger(PaymentBreakdownCodec.class.getName());
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private PaymentBreakdownCodec() {
+    }
+
+    /**
+     * Renders the given payment lines as a JSON array for storage on the bill.
+     *
+     * @param lines the itemised components; may be null or empty
+     * @return the JSON array, or null when there is nothing worth storing or the write
+     *         failed - callers store the result as-is and must tolerate null
+     */
+    public static String serialize(List<PrintBillData.PaymentLine> lines) {
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(lines);
+        } catch (Exception e) {
+            // Never fail a settle over a print-only field: the bill and the stock
+            // movement matter, the receipt itemisation does not.
+            LOGGER.log(Level.WARNING, "Could not serialise payment breakdown; bill will be stored without it", e);
+            return null;
+        }
+    }
+
+    /**
+     * Restores the payment lines previously stored by {@link #serialize(List)}.
+     *
+     * @param json the stored value; may be null, blank or malformed
+     * @return the payment lines, or an empty list when nothing could be restored - never null
+     */
+    public static List<PrintBillData.PaymentLine> deserialize(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        try {
+            List<PrintBillData.PaymentLine> lines
+                    = MAPPER.readValue(json, new TypeReference<List<PrintBillData.PaymentLine>>() {
+                    });
+            return lines == null ? new ArrayList<>() : lines;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not restore payment breakdown; bill will print without it", e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -9,6 +9,7 @@ import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.TokenType;
 import com.divudi.core.data.dto.BillItemData;
 import com.divudi.core.data.dto.PrintBillData;
+import com.divudi.core.util.PaymentBreakdownCodec;
 import com.divudi.core.data.dto.StockAggregateResult;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFinanceDetails;
@@ -653,10 +654,11 @@ public class RetailSaleForCashierNativeSqlService {
         pbd.setDiscount(disc);
         pbd.setDiscountPercentPharmacy(gross > 0 ? (disc / gross) * 100.0 : 0.0);
 
-        // For Multiple Payment Methods, bill.cashPaid stays 0 and the methods are
-        // recorded as individual Payment rows. Rebuild the itemised payment lines
-        // (and derive the amount paid from their sum) so reprinted/reopened bills
-        // match what the settle-time printout shows.
+        // For Multiple Payment Methods, bill.cashPaid stays 0 and the components live
+        // either in Payment rows (once the cashier has settled) or in the breakdown
+        // stored on the bill at pharmacy time. Rebuild the itemised payment lines from
+        // whichever is present (and derive the amount paid from their sum) so
+        // reprinted/reopened bills match what the settle-time printout showed.
         double cashPaid = bill.getCashPaid();
         double balance = cashPaid - net;
         if (bill.getPaymentMethod() == PaymentMethod.MultiplePaymentMethods) {
@@ -741,6 +743,11 @@ public class RetailSaleForCashierNativeSqlService {
      * Payment Methods bill from the persisted {@link Payment} rows. Each line
      * carries the method label, paid value and a method-specific reference
      * (card/cheque/slip/ewallet/online/credit reference) when available.
+     *
+     * Falls back to the breakdown stored on the bill when there are no Payment rows.
+     * A pharmacy Sale for Cashier pre-bill takes no money, so it has none until the
+     * cashier settles it - before this fallback existed, a reprint in that window
+     * dropped the split that the customer's slip showed (#22487).
      */
     private List<PrintBillData.PaymentLine> buildPrintPaymentLinesFromPersisted(Bill bill) {
         List<PrintBillData.PaymentLine> lines = new ArrayList<>();
@@ -750,6 +757,9 @@ public class RetailSaleForCashierNativeSqlService {
                 + " order by p.id", Payment.class)
                 .setParameter("bill", bill)
                 .getResultList();
+        if (payments.isEmpty()) {
+            return PaymentBreakdownCodec.deserialize(bill.getPaymentBreakdown());
+        }
         for (Payment p : payments) {
             if (p.getPaymentMethod() == null || p.getPaidValue() <= 0.0) {
                 continue;

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier.xhtml
@@ -78,7 +78,7 @@
                                     <!-- RIGHT SECTION: Counter Selection and Action Buttons -->
                                     <div style="display: flex; align-items: center; gap: 10px; flex-shrink: 0;">
                                         <!-- Counter Selection (moved from center) -->
-                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}"
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                                       style="display: flex; align-items: center; gap: 8px;">
                                             <p:outputLabel value="Counter" style="font-weight: 500;"></p:outputLabel>
                                             <p:selectOneMenu value="#{pharmacySaleForCashierController.counter}"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_1.xhtml
@@ -79,7 +79,7 @@
                                     <!-- RIGHT SECTION: Counter Selection and Action Buttons -->
                                     <div style="display: flex; align-items: center; gap: 10px; flex-shrink: 0;">
                                         <!-- Counter Selection (moved from center) -->
-                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}"
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                                       style="display: flex; align-items: center; gap: 8px;">
                                             <p:outputLabel value="Counter" style="font-weight: 500;"></p:outputLabel>
                                             <p:selectOneMenu value="#{pharmacySaleForCashierController1.counter}"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_2.xhtml
@@ -79,7 +79,7 @@
                                     <!-- RIGHT SECTION: Counter, New Bill, Settle Bill -->
                                     <div style="display: flex; align-items: center; gap: 10px; flex-shrink: 0;">
                                         <!-- Counter Dropdown -->
-                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}"
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}"
                                                       style="display: flex; align-items: center; gap: 8px;">
                                             <p:outputLabel value="Counter" style="white-space: nowrap;"></p:outputLabel>
                                             <p:selectOneMenu value="#{pharmacySaleForCashierController2.counter}" style="min-width: 120px;">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_3.xhtml
@@ -79,7 +79,7 @@
                                     <!-- RIGHT SECTION: Counter, New Bill, Settle Bill -->
                                     <div style="display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0;">
                                         <!-- Counter Dropdown (if token system enabled) -->
-                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}" style="display: flex; align-items: center; gap: 0.25rem;">
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" style="display: flex; align-items: center; gap: 0.25rem;">
                                             <p:outputLabel value="Counter" style="white-space: nowrap;"></p:outputLabel>
                                             <p:selectOneMenu value="#{pharmacySaleForCashierController3.counter}" style="min-width: 120px;">
                                                 <f:selectItem itemLabel="Any" ></f:selectItem>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -62,7 +62,7 @@
                                             ajax="false"
                                             class="ui-button-help mx-1"
                                             action="#{tokenController.navigateToManagePharmacyTokens()}"
-                                            rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable token system in sale for cashier', true)}" />
+                                            rendered="#{configOptionController.getBooleanValueByKey('Enable token system in sale for cashier', false)}" />
                                     </div>
                                     <div class="col-4 text-end">
                                         <p:commandButton


### PR DESCRIPTION
Both defects were found while verifying the native Sale for Cashier core paths under #22475 (master #22442). Both gate the Phase 5 retirement of the legacy pages.

---

## #22486 — token config key resolved at two different scopes

`Enable token system in sale for cashier` was read through two controllers on the same page, and they resolve different rows:

| Controller | Key actually resolved |
|---|---|
| `configOptionApplicationController` | the plain **global** key |
| `configOptionController` | **`"<Department> - <key>"`** first, global only as its default |

The Tokens nav button and Counter selector used the global read (default `true`); the token print panel and `settleTokenIfEnabled()` used the department-scoped read (default `false`).

**Observed live:** with a department row of `true` and the global row `false`, a token was created and linked to the bill while the Tokens button was hidden — the operator gets tokens with no way to reach token management. The mirror case shows a Tokens button for a department that never issues tokens.

**Fix:** all five call sites now use `configOptionController` with a `false` default, matching the settle path that decides whether a token is actually created. Applied to the four legacy cashier pages as well as the native one — all five carried the same pattern, and the legacy pages stay the production fallback until Phase 5.

Not a regression from the native migration; the nav button predates it.

---

## #22487 — multiple-payment breakdown lost on reprint

A Multiple Payment Methods bill persisted its component breakdown **nowhere**. No `Payment` rows at pharmacy time (by design — the cashier records them later), and `BillBeanController.setPaymentMethodData` has no `MultiplePaymentMethods` branch, so the bill's own columns stayed empty too. The split lived only in session state that `resetAll()` clears.

Cashier-visible consequence:

- the slip handed to the customer itemised `Cash 40.00 / Credit Card 29.80`
- a reprint of the same bill minutes later showed **no breakdown at all**, with nothing indicating anything was missing
- if the bill was never settled at the cashier, the intended split was lost entirely

**Fix:** store the breakdown as JSON in a new `Bill.paymentBreakdown` column; the reprint path falls back to it when no `Payment` rows exist yet.

**Deliberately not provisional `Payment` rows.** 31 files query `Payment`, including `FinancialTransactionController`, `QuickBookReportController` and `DailyReturnDtoService`. Rows written at pharmacy time would count money nobody has collected, then be counted again when the cashier writes the real rows against the settled bill. The "zero `Payment` rows at pharmacy time" invariant that #22475 verifies is preserved intact.

The stored value is **print-only** — never summed, never reconciled. Persisted `Payment` rows remain the single source of truth for money received. Both codec directions are lenient: an absent, empty or malformed breakdown prints without the itemisation rather than failing a settle or a reprint.

### Also in this commit

`syncStaffSelectionFromPaymentDetails` only ever looked at the **bill-level** payment method, so a Staff Welfare *component* of a multiple payment resolved correctly in the UI but left `toStaff_ID` NULL — a staff-welfare debt with no named debtor. Now stamped from the first component naming a member (the bill carries a single `toStaff`).

The equivalent for a **Credit** component is deliberately left alone: stamping `toInstitution` from one component would feed credit-company debtor reporting with a partial amount the bill does not represent.

---

## Schema

`Bill.paymentBreakdown` is a plain new `@Lob` column with no new table and no backfill, so it goes through **generate-ddl**, not a hand-written migration script.

## Verification

`mvn compile` clean on the `development` base. Runtime verification of both paths is still to run against the local deployment.

Closes #22486
Closes #22487
Refs #22475, #22442

🤖 Generated with [Claude Code](https://claude.com/claude-code)