### PR TITLE
feat(pharmacy): warn when a multiple-payment split does not match the bill total

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -425,6 +425,13 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             recalculateDiscountsForAll();
             calTotal();
 
+            // Warn, do not reject, when a Multiple Payment Methods split does not add up to
+            // the net total (#22488). No money is taken on this page - the cashier collects
+            // and records the real payments later - so an off split is a data-entry problem
+            // to flag, not grounds to block a completed sale. Deliberately warn-only:
+            // rejecting would also break operators who settle slightly-off splits knowingly.
+            warnIfMultiplePaymentTotalDoesNotMatch();
+
             // Back-fill the credit counterparties from the entered payment components before the
             // bill is built, so a Credit / Staff bill is not persisted without one.
             syncStaffSelectionFromPaymentDetails(paymentMethod);
@@ -2158,6 +2165,42 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
             return getPreBill().getNetTotal() - multiplePaymentMethodTotalValue;
         }
         return getPreBill().getTotal();
+    }
+
+    /**
+     * Flags a Multiple Payment Methods settle whose entered components do not add up to the
+     * bill's net total (#22488). Nothing is rejected: this page takes no money, so the split
+     * is provisional until the cashier records the real payments, and blocking a completed
+     * sale over it would be worse than the mis-keyed figure it catches.
+     *
+     * Uses the same 1.0 tolerance the printed balance is clamped with, so ordinary rounding
+     * stays silent and only a genuine mis-key warns.
+     */
+    private void warnIfMultiplePaymentTotalDoesNotMatch() {
+        if (paymentMethod != PaymentMethod.MultiplePaymentMethods) {
+            return;
+        }
+        if (getPaymentMethodData().getPaymentMethodMultiple() == null
+                || getPaymentMethodData().getPaymentMethodMultiple().getMultiplePaymentMethodComponentDetails() == null) {
+            return;
+        }
+        double shortfall = calculatRemainForMultiplePaymentTotal();
+        if (Math.abs(shortfall) <= 1.0) {
+            return;
+        }
+        double netTotal = getPreBill().getNetTotal();
+        double entered = netTotal - shortfall;
+        if (shortfall > 0) {
+            JsfUtil.addWarningMessage(String.format(
+                    "Payment components total %.2f but the bill net total is %.2f — %.2f short."
+                    + " The bill was settled; correct the payment at the cashier.",
+                    entered, netTotal, shortfall));
+        } else {
+            JsfUtil.addWarningMessage(String.format(
+                    "Payment components total %.2f but the bill net total is %.2f — %.2f over."
+                    + " The bill was settled; correct the payment at the cashier.",
+                    entered, netTotal, -shortfall));
+        }
     }
 
     @Override


### PR DESCRIPTION
Found while verifying the native Sale for Cashier core paths under #22475 (master #22442). Gates the Phase 5 retirement of the legacy pages.

## Problem

Nothing checked that the components entered against a **Multiple Payment Methods** bill added up to what was owed. `calculatRemainForMultiplePaymentTotal()` computed the shortfall and the UI showed it as *Balance Amount*, but `settleBillWithPay()` never looked at it — Cash 5.00 on a 500.00 bill settled without comment.

`PharmacySaleForCashierController` (legacy) has no such check either, so this is **legacy parity, not a regression** from the native migration. Legacy parity is enough to ship the native page; it is not enough to retire legacy, which is why this is tracked against the Phase 5 gate.

## Fix — warn, do not reject

Warn-only by decision. No money is taken on this page — the cashier collects and records the real payments later — so an off split is a data-entry problem to flag, not grounds to block a sale that is otherwise complete. Rejecting would also break operators who settle slightly-off splits knowingly.

- Reuses the **1.0 tolerance** the printed balance is already clamped with, so ordinary rounding stays silent and only a genuine mis-key warns.
- The message names both figures and the direction of the gap, and says plainly that **the bill was settled** — so it cannot be misread as a failure and prompt a second settle, which would deduct stock twice.
- `settleBillWithPay()` returns `null` rather than redirecting, so the message survives to the growl on the same render.

Example:

> Payment components total 495.00 but the bill net total is 500.00 — 5.00 short. The bill was settled; correct the payment at the cashier.

## Scope

**Native page only.** Legacy has the same hole, but it *lacks a warning* rather than *behaving wrongly*, and this issue exists to gate the retirement of legacy — once it is gone only the native path matters.

Contrast #22486 (merged in #22499), which was fixed on the legacy pages too, because there the scope mismatch produces wrong behaviour in production today.

## Note on branching

This commit was written alongside #22486/#22487 but missed the #22499 merge by seconds, so it is rebased onto current `development` here. No functional change from the reviewed version.

## Verification

`mvn compile` clean. Runtime verification against the local deployment still to run.

Closes #22488
Refs #22475, #22442

🤖 Generated with [Claude Code](https://claude.com/claude-code)