### PR TITLE
Fix null pointer exception in AMP item code validation

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -802,7 +802,7 @@ public class AmpController implements Serializable {
 
         int maxCodeLeanth = Integer.parseInt(configOptionApplicationController.getShortTextValueByKey("Minimum Number of Characters to Search for Item", "4"));
 
-        if (current.getCode().trim().length() < maxCodeLeanth) {
+        if (current.getCode() == null || current.getCode().trim().length() < maxCodeLeanth) {
             JsfUtil.addErrorMessage("Minimum " + maxCodeLeanth + " characters are Required for Item Code");
             return;
         }


### PR DESCRIPTION
## Summary
Add null check for item code before calling `trim()` in the AMP controller's save method to prevent `NullPointerException` when validating code length.

## Changes
- Added null check for `current.getCode()` before attempting to call `trim()` on it
- The validation now safely handles cases where the code field is null, treating it as invalid input that fails the minimum character length requirement

## Implementation Details
The fix ensures that if a user attempts to save an AMP item without providing a code, the application will gracefully display an error message ("Minimum X characters are Required for Item Code") instead of throwing an unhandled null pointer exception.

https://claude.ai/code/session_01QodQzSu2RP7fTNi5ATxo2w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AMP saving validation to handle missing codes safely.
  * Prevented an error when validating an AMP with a null code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->