### PR TITLE
fix(pharmacy): refresh the settled cashier bill so reprints show its items

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleForCashierNativeSqlService.java
@@ -203,6 +203,16 @@ public class RetailSaleForCashierNativeSqlService {
                 .setParameter(4, preBillId)
                 .executeUpdate();
 
+        // The bill was persisted with billItems nulled (step 1a) because the items are
+        // inserted natively, so the in-memory entity claims the bill has none — and
+        // Bill.getBillItems() hands out an empty list rather than a lazy one. The caller
+        // keeps using this same instance after settle() returns (token handling merges it),
+        // which writes that empty collection into the shared cache; every later read of the
+        // bill then shows a bill with no items, e.g. a reprint printing "No of Items: 0"
+        // while the total is correct. Issue #22506. Refreshing rebuilds the lazy collection
+        // from the rows just written, and also picks up the totals updated above.
+        em.refresh(preBill);
+
         LOGGER.log(Level.INFO, "[CashierNativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});
     }


### PR DESCRIPTION
Closes #22506

## Problem

Reprinting a natively-settled Sale-for-Cashier bill immediately after settling it printed `No of Items: 0` with an empty item table, while `Total:` was correct. A second reprint of the same bill rendered fine. The slip therefore looked plausible rather than obviously broken.

## Root cause

`RetailSaleForCashierNativeSqlService.settle()` persists the `PreBill` with `setBillItems(null)` (step 1a) because the items are inserted with native SQL immediately afterwards. `Bill.getBillItems()` returns a **new empty list** when the field is null rather than a lazy collection, so the in-memory entity claims the bill has no items.

The controller keeps using that same instance after `settle()` returns — the token handling merges it — which writes the empty collection into the shared EclipseLink cache. Every later read of the bill then sees a bill with no items.

The existing in-transaction `cache.evict(Bill.class)` cannot prevent this: the commit merges the persistence context back into the shared cache *after* the eviction runs. Instrumentation confirmed the bill was back in the cache immediately after a (correctly deferred) post-commit eviction fired, so racing the cache is not a viable fix — the entity itself has to stop lying.

## Fix

One `em.refresh(preBill)` at the end of `settle()`. It rebuilds the lazy collection from the rows just written, and also picks up the totals updated by the native SQL `UPDATE` a few lines above.

## Verification

Local deploy, full browser round trip:

| Bill | Payment | First reprint after settle |
|---|---|---|
| OP/SALE/35620 (before fix) | Cash | `No of Items: 0` ❌ |
| OP/SALE/35622 (after fix) | Cash | `No of Items: 1`, item row `Allermine 4 mg  2.00  4  8.00` ✅ |

Control before the fix: a cache-cold bill (settled before the JVM started) reprinted correctly on the first attempt, and reflection on the reloaded entity showed `IndirectList size=1` for it versus `size=0` for a freshly settled bill — which is what pinned the cause to the entity rather than to the print page.

## Scope note

`RetailSaleNativeSqlService`, `WholesaleSaleNativeSqlService`, `TransferIssueNativeSqlService` and `TransferReceiveNativeSqlService` use the identical `setBillItems(null)` + `em.persist` + native-insert pattern and so carry the same latent defect. It is invisible on those pages today because their reprints route to native view controllers that read items with native SQL. They are **deliberately not changed here** — I could not exercise them in a browser in this session, and they are shared financial paths. Filed separately as a follow-up.

`InpatientDirectIssueNativeSqlService` does not null the collection and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where completed pharmacy cash sales could later display or reprint with no line items.
  * Ensured sale details are refreshed correctly after settlement while preserving updated totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->