### PR TITLE
fix(pharmacy): route cashier pre-bill reprints to the native view

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -132,6 +132,7 @@ import com.divudi.bean.pharmacy.SaleReturnController;
 import com.divudi.bean.pharmacy.TransferIssueNativeSqlController;
 import com.divudi.bean.pharmacy.TransferReceiveNativeSqlController;
 import com.divudi.bean.pharmacy.InpatientDirectIssueNativeSqlController;
+import com.divudi.bean.pharmacy.RetailSaleForCashierNativeSqlController;
 import com.divudi.bean.pharmacy.RetailSaleNativeSqlController;
 import com.divudi.bean.pharmacy.PurchaseOrderNativeSqlController;
 import com.divudi.bean.pharmacy.GrnNativeSqlController;
@@ -338,6 +339,8 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
     InpatientDirectIssueNativeSqlController inpatientDirectIssueNativeSqlController;
     @Inject
     RetailSaleNativeSqlController retailSaleNativeSqlController;
+    @Inject
+    RetailSaleForCashierNativeSqlController retailSaleForCashierNativeSqlController;
     @Inject
     PurchaseOrderNativeSqlController purchaseOrderNativeSqlController;
     @Inject
@@ -4798,6 +4801,8 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
                 return inpatientDirectIssueNativeSqlController.viewByBillId(BillId);
             case PHARMACY_RETAIL_SALE:
                 return retailSaleNativeSqlController.viewByBillId(BillId);
+            case PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER:
+                return retailSaleForCashierNativeSqlController.viewByBillId(BillId);
             case PHARMACY_TRANSFER_REQUEST_PRE:
             case PHARMACY_TRANSFER_REQUEST:
                 return pharmacyBillSearch.viewRequestByBillId(BillId);


### PR DESCRIPTION
Closes #22505

## Problem

`Bill.paymentBreakdown`, added in #22487 so a multiple-payment split survives a reprint, was **written on settle and read by nothing**. Reprinting a Sale-for-Cashier bill from *Search Sale for Cashier Bills* still showed no breakdown — the exact symptom #22487 reports as fixed.

## Root cause

The column's only consumer is `RetailSaleForCashierNativeSqlService.buildPrintPaymentLinesFromPersisted()`, reached only from `RetailSaleForCashierNativeSqlController.viewByBillId()`. Nothing called that method — no XHTML, no Java.

`BillSearch.navigateToViewBillByAtomicBillTypeByBillId()` had no case for `PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`, so native cashier pre-bills fell through to `default:` → the entity-based path → `pharmacySaleForCashierController` → `pharmacy/printing/retail_sale_for_cashier.xhtml`, i.e. the **legacy** composites, which have no payment-breakdown block at all.

## Fix

```java
case PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER:
    return retailSaleForCashierNativeSqlController.viewByBillId(BillId);
```

This also moves the reprint from the legacy print page to the native one. That is the intent: the native page produced the bill, and its composites are the only ones that render `#{...bill.payments}`.

## Verification

Local deploy, browser round trip from *Search Sale for Cashier Bills* → *View Pre-Bill*:

| Bill | Stored breakdown | Reprint before | Reprint after |
|---|---|---|---|
| OP/SALE/35618 | `Cash 5.00` + `Staff Welfare 8.96` | no breakdown at all ❌ | `Cash 5.00` and `Staff Welfare 8.96` ✅ |
| OP/SALE/35622 | none (plain Cash) | — | item row + `No of Items: 1` ✅ |

The reprint now lands on `pharmacy_bill_retail_sale_for_cashier_native.xhtml` rather than `pharmacy/printing/retail_sale_for_cashier.xhtml`.

## Notes

- The native view reads items with native SQL, so the reprint no longer depends on the bill's mapped `billItems` collection. That means this change also sidesteps #22506 **on this path** — but #22506 is a real defect in the settle service and is fixed separately in #22510, since the poisoned entity affects any other consumer of that bill.
- `buildPrintPaymentLinesFromPersisted()` prefers real `Payment` rows and falls back to the stored breakdown. This PR verifies the **fallback** branch. The Payment-rows branch is pre-existing #22487 code, unchanged here; the local database has no multiple-payment cashier bill that has since been settled by a cashier, so that combination was not exercised.
- The malformed-`PAYMENTBREAKDOWN` tolerance check from the §2.5 plan becomes testable now that something reads the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)