### PR TITLE
fix(inward): populate department dropdowns, add Billed Department column, guard timed-service double-count

### DIFF
--- a/src/main/java/com/divudi/bean/common/DepartmentController.java
+++ b/src/main/java/com/divudi/bean/common/DepartmentController.java
@@ -985,9 +985,16 @@ public class DepartmentController implements Serializable {
         return ejbFacade;
     }
 
+    /**
+     * Active departments, for the {@code departmentController.items} dropdowns.
+     * <p>
+     * This used to call {@code fillSearchItems()}, which only ever assigns
+     * {@code searchItems} — {@code items} stayed null, so every page binding
+     * this getter rendered an empty dropdown and re-ran the query on each call.
+     */
     public List<Department> getItems() {
         if (items == null) {
-            fillSearchItems();
+            items = fillAllItems();
         }
         return items;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -252,6 +252,7 @@ public class InwardBeanController implements Serializable {
                 + " FROM PatientItem i where "
                 + " type(i.item)=:cls "
                 + " and i.retired=false "
+                + " and i.billItem is null "
                 + " and i.patientEncounter=:pe "
                 + " and i.item.inwardChargeType=:inw ";
         hm.put("pe", patientEncounter);
@@ -335,6 +336,7 @@ public class InwardBeanController implements Serializable {
                 + " FROM PatientItem i where "
                 + " type(i.item)=:cls "
                 + " and i.retired=false "
+                + " and i.billItem is null "
                 + " and i.patientEncounter IN :pe "
                 + " and i.item.inwardChargeType=:inw ";
         List<PatientEncounter> pts = new ArrayList<>();
@@ -352,6 +354,14 @@ public class InwardBeanController implements Serializable {
 
     /**
      * OPTIMIZED: Bulk version - fetches all timed item fee totals in ONE query
+     * <p>
+     * Only PatientItems with no BillItem are counted here. A timed service that
+     * already has a BillItem is charged through
+     * {@link #calServiceBillItemsTotalByInwardChargeTypeBulk}, which sums every
+     * BillItem on an InwardBill regardless of item type — counting it on both
+     * sides would double-charge the patient. The same {@code billItem is null}
+     * guard therefore applies to every PatientItem query that feeds a total or
+     * a discount.
      */
     public Map<InwardChargeType, Double> getTimedItemFeeTotalByInwardChargeTypeBulk(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
         HashMap hm = new HashMap();
@@ -359,6 +369,7 @@ public class InwardBeanController implements Serializable {
                 + " FROM PatientItem i WHERE "
                 + " type(i.item)=:cls "
                 + " AND i.retired=false "
+                + " AND i.billItem is null "
                 + " AND i.patientEncounter IN :pe "
                 + " GROUP BY i.item.inwardChargeType";
 
@@ -391,6 +402,7 @@ public class InwardBeanController implements Serializable {
                 + " FROM PatientItem i where "
                 + " type(i.item)=:cls "
                 + " and i.retired=false "
+                + " and i.billItem is null "
                 + " and i.patientEncounter=:pe "
                 + " and i.item.inwardChargeType=:inw ";
         hm.put("pe", patientEncounter);
@@ -818,6 +830,7 @@ public class InwardBeanController implements Serializable {
         String sql = "UPDATE PatientItem s SET s.discount = 0.0"
                 + " WHERE s.retired = false"
                 + " AND type(s.item) = :cls"
+                + " AND s.billItem is null"
                 + " AND s.patientEncounter = :pe"
                 + " AND s.item.inwardChargeType = :inw";
         HashMap hm = new HashMap();

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -4421,12 +4421,12 @@ public class ReportController implements Serializable, ControllerWithReportFilte
 
             String[] headers = new String[]{
                 "S. No.", "BHT No", "MRN No", "Consultant", "Surgery", "Service Dept.",
-                "Service", "Service Group", "Start Time", "End Time", "Duration",
+                "Billed Dept.", "Service", "Service Group", "Start Time", "End Time", "Duration",
                 "Base Price", "Discount", "Sponsor Discount", "Sponsor Net.",
                 "Patient Amt", "Adjusted Amt", "Creator", "Checked By", "Checked At"
             };
             float[] widths = new float[]{
-                0.6f, 1.1f, 1.1f, 2.0f, 1.8f, 1.8f, 2.3f, 1.8f, 1.5f, 1.5f,
+                0.6f, 1.1f, 1.1f, 2.0f, 1.8f, 1.8f, 1.8f, 2.3f, 1.8f, 1.5f, 1.5f,
                 1.1f, 1.1f, 1.1f, 1.1f, 1.1f, 1.1f, 1.1f, 1.5f, 1.5f, 1.5f
             };
 
@@ -4454,6 +4454,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 table.addCell(textCell(row.getConsultantName(), bodyFont));
                 table.addCell(textCell(row.getSurgeryName(), bodyFont));
                 table.addCell(textCell(row.getServiceDepartmentName(), bodyFont));
+                table.addCell(textCell(row.getCreatingLocation(), bodyFont));
                 table.addCell(textCell(row.getServiceName(), bodyFont));
                 table.addCell(textCell(row.getServiceGroupName(), bodyFont));
                 table.addCell(textCell(formatDate(row.getStartTime(), dateTimeFormat), bodyFont));

--- a/src/main/webapp/reports/managementReports/duration_service_report.xhtml
+++ b/src/main/webapp/reports/managementReports/duration_service_report.xhtml
@@ -270,6 +270,9 @@
                                     <p:column headerText="Service Department">
                                         <h:outputText value="#{c.serviceDepartmentName}"/>
                                     </p:column>
+                                    <p:column headerText="Billed Department">
+                                        <h:outputText value="#{c.creatingLocation}"/>
+                                    </p:column>
                                     <p:column headerText="Service Group">
                                         <h:outputText value="#{c.serviceGroupName}"/>
                                     </p:column>

--- a/src/main/webapp/reports/managementReports/duration_service_report_view.xhtml
+++ b/src/main/webapp/reports/managementReports/duration_service_report_view.xhtml
@@ -226,6 +226,7 @@
                                                 <th style="font-weight: 700;"><h:outputText value="Consultant Name" style="margin-left: 1mm;"/></th>
                                                 <th style="font-weight: 700;"><h:outputText value="Surgery Name" style="margin-left: 1mm;"/></th>
                                                 <th style="font-weight: 700;"><h:outputText value="Service Department" style="margin-left: 1mm;"/></th>
+                                                <th style="font-weight: 700;"><h:outputText value="Billed Department" style="margin-left: 1mm;"/></th>
                                                 <th style="font-weight: 700;"><h:outputText value="Service Name" style="margin-left: 1mm;"/></th>
                                                 <th style="font-weight: 700;"><h:outputText value="Service Group" style="margin-left: 1mm;"/></th>
                                                 <th style="font-weight: 700;"><h:outputText value="Start Time" style="margin-left: 1mm;"/></th>
@@ -251,6 +252,7 @@
                                                     <td><h:outputText value="#{row.consultantName}" style="margin-left: 1mm;"/></td>
                                                     <td><h:outputText value="#{row.surgeryName}" style="margin-left: 1mm;"/></td>
                                                     <td><h:outputText value="#{row.serviceDepartmentName}" style="margin-left: 1mm;"/></td>
+                                                    <td><h:outputText value="#{row.creatingLocation}" style="margin-left: 1mm;"/></td>
                                                     <td><h:outputText value="#{row.serviceName}" style="margin-left: 1mm;"/></td>
                                                     <td><h:outputText value="#{row.serviceGroupName}" style="margin-left: 1mm;"/></td>
                                                     <td>


### PR DESCRIPTION
Closes #22498

Steps 1 and 2 of the agreed sequence for the Duration Service Report. Step 3 (Bill + BillItem at add time) and step 4 (migration) follow separately.

## 1. Department dropdowns were empty

`DepartmentController.getItems()` called `fillSearchItems()`, which only ever assigns **`searchItems`** — `items` stayed `null`. Every page binding `departmentController.items` rendered an empty dropdown, and re-ran the query on every call since the null-check never cached.

On the Duration Service Report both **Service Department** and **Billed Department** listed nothing, despite 116 active departments in the database. 11 other pages bind the same expression.

Fixed by populating `items` via the existing `fillAllItems()`.

## 2. Billed Department was computed but never rendered

The controller already selects `COALESCE(bDept.name, rfcDept.name)` into `DurationServiceReportDTO.creatingLocation`, but nothing displayed it — not the on-screen table, not the print view, not the PDF.

Adds a **Billed Department** column to all three. The PDF's `headers`, `widths` and per-row `addCell` calls are kept in lockstep at 21 columns.

## 3. Timed-service double-count guard

`BhtSummeryController.createChargeItemTotals()` builds each `InwardChargeType` total from two **independent** queries:

- `calServiceBillItemsTotalByInwardChargeTypeBulk` — sums every `BillItem` on an `InwardBill`, **no filter on item type**
- the PatientItem-side queries — sum timed services, **no check for an existing BillItem**

They are disjoint today only because the plain inward consume path (`InwardTimedItemController.save()`) creates a `PatientItem` and no `BillItem`. The moment timed services get their own bills, every one is charged twice.

Adds `billItem is null` to all five PatientItem queries that feed a total or a discount (`InwardBeanController` :252, :336, :369, :402, :830), so a timed service with a BillItem is charged through that BillItem alone. The display-only `fetchPatientItem` (:1706) is deliberately left unfiltered so nothing disappears from the timed-service breakdown tables.

This also lets step 4's migration run without shifting historical totals: a migrated PatientItem gains a `billItem`, so it leaves the timed side exactly as its new BillItem joins the service side.

## Verification

Local deployment, fresh session, real data created through the UI:

- Department dropdowns: **1 → 117** options
- Report renders Service Department (`Inward` / `THEATRE`), Billed Department (`Inward`) and Service Group (`Respiratory Care` / `Patient Monitoring`) per row across 4 rows on BHT/55356
- **Regression check** — interim bill charge totals unchanged and matching the DB sums exactly:

  | Charge type | DB sum | Interim bill |
  |---|---|---|
  | Oxygen Charges | 30,000 + 31,500 = 61,500 | 61,500.00 |
  | Intensive Care Management | 72,000 + 75,600 = 147,600 | 147,600.00 |

## Note

While tracing this, `InpatientPackageApplicationBean.createLockedTimedItem()` was found to create **both** a `BillItem` (billType `InwardBill`, item = the timed item) **and** a `PatientItem` for the same charge — which by the two queries above appears to double-charge package timed items today. Not confirmed empirically (the local DB has zero `FROMPACKAGE=1` rows), so no issue filed yet; it is being checked against real package data first. The `billItem is null` guard in this PR would fix it as a side effect, since package PatientItems do have `billItem` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
