### PR TITLE
fix(inward): rename Settle button to Save Final Bill

### DIFF
--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -98,7 +98,7 @@
                                 </p:commandButton>
 
                                 <p:commandButton
-                                    value="Settle"
+                                    value="Save Final Bill"
                                     action="#{bhtSummeryController.settle}"
                                     id="settle"
                                     ajax="false"


### PR DESCRIPTION
## Summary
- Renames the Final Bill page's "Settle" button to "Save Final Bill" for clearer terminology, matching the "Create Final Bill" entry point language.

## Change
`src/main/webapp/inward/inward_bill_final.xhtml:101` — single `value` attribute change on the existing `id="settle"` button. No behavior, action binding, or privilege change.

Closes #22519