### PR TITLE
feat(inward): add Manage Final Bills entry point reachable with a single version

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -613,6 +613,23 @@ public class InwardSearch implements Serializable {
         return "/inward/inward_final_bill_list?faces-redirect=true";
     }
 
+    public String navigateToManageFinalBills() {
+        if (admission == null) {
+            JsfUtil.addErrorMessage("No Admission Selected");
+            return "";
+        }
+
+        finalBillVersions = null;
+        List<Bill> versions = fetchFinalBillVersions(admission);
+
+        if (versions.isEmpty()) {
+            JsfUtil.addErrorMessage("No Final Bill Created");
+            return "";
+        }
+
+        return "/inward/inward_final_bill_list?faces-redirect=true";
+    }
+
     /**
      * Lazily fetches and caches all final-bill versions for the currently
      * selected {@link #admission}. Callers that switch admissions must reset

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -439,6 +439,19 @@
                                 </div>
                                 <div class="col-12">
                                     <p:commandButton
+                                        rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSettleFinalBill')}"
+                                        value="Manage Final Bills"
+                                        ajax="false"
+                                        action="#{inwardSearch.navigateToManageFinalBills}"
+                                        icon="fa fa-tasks"
+                                        class="w-100">
+                                        <f:setPropertyActionListener
+                                            value="#{admissionController.current}"
+                                            target="#{inwardSearch.admission}"/>
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-12">
+                                    <p:commandButton
                                         rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardPostDischargeReports')}"
                                         value="Post-Discharge Reports"
                                         ajax="false"


### PR DESCRIPTION
## Summary
- Adds a new `navigateToManageFinalBills()` method that always routes to `inward_final_bill_list.xhtml` regardless of how many final bill versions exist.
- Adds a "Manage Final Bills" button on the admission dashboard, next to the existing "Final Bill" button, using the same `InwardSettleFinalBill` privilege gate.
- Existing "Final Bill" button behavior is unchanged (still shortcuts straight to the reprint page when exactly one version exists).

## Why
`navigateToFinalBillForAdmission()` short-circuits to the reprint/view page when only one final bill version exists, so the version-management page (Set as Confirmed, Create New Version) was unreachable from the dashboard until a second version already existed.

## Test plan
- [x] Rebuilt and redeployed locally
- [x] Verified in browser (Playwright): both "Final Bill" and "Manage Final Bills" buttons render on a discharged/payment-finalized encounter with exactly one final bill version
- [x] "Final Bill" still routes straight to `inward_reprint_bill_final.xhtml` (unchanged)
- [x] "Manage Final Bills" routes to `inward_final_bill_list.xhtml`, showing the single version with status "Confirmed" and "Create New Version" action available

Closes #22520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Manage Final Bills** action for discharged admissions with finalized payments.
  * The action displays available final-bill versions and opens the final-bill management view.
  * An error message is shown when no final-bill versions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->